### PR TITLE
Use cookiejar in soap client

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package govmomi
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/vmware/govmomi/test"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+func TestLogin(t *testing.T) {
+	u := test.URL()
+	if u == nil {
+		t.SkipNow()
+	}
+
+	c, err := NewClient(*u)
+	if err != nil {
+		t.Error(err)
+	}
+
+	f := func() error {
+		var x mo.Folder
+		err = mo.RetrieveProperties(c, c.ServiceContent.PropertyCollector, c.ServiceContent.RootFolder, &x)
+		if err != nil {
+			return err
+		}
+		if len(x.Name) == 0 {
+			return errors.New("invalid response") // TODO: RetrieveProperties should propagate fault
+		}
+		return nil
+	}
+
+	// check cookie is valid with an sdk request
+	if err := f(); err != nil {
+		t.Error(err)
+	}
+
+	// check cookie is valid with a non-sdk request
+	u.User = nil // turn off Basic auth
+	u.Path = "/folder"
+	r, err := c.Get(u.String())
+	if err != nil {
+		t.Error(err)
+	}
+	if r.StatusCode != http.StatusOK {
+		t.Error(r)
+	}
+
+	// sdk request should fail w/o a valid cookie
+	c.Jar = nil
+	if err := f(); err == nil {
+		t.Error("should fail")
+	}
+
+	// invalid login
+	u.Path = "/sdk"
+	u.User = url.UserPassword("ENOENT", "EINVAL")
+	_, err = NewClient(*u)
+	if err == nil {
+		t.Error("should fail")
+	}
+}
+
+func TestInvalidSdk(t *testing.T) {
+	u := test.URL()
+	if u == nil {
+		t.SkipNow()
+	}
+
+	// a URL other than a valid /sdk should error, not panic
+	u.Path = "/mob"
+	_, err := NewClient(*u)
+	if err == nil {
+		t.Error("should fail")
+	}
+}

--- a/test/helper.go
+++ b/test/helper.go
@@ -1,0 +1,35 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"net/url"
+	"os"
+)
+
+// URL parses the GOVMOMI_TEST_URL environment variable if set
+func URL() *url.URL {
+	s := os.Getenv("GOVMOMI_TEST_URL")
+	if s == "" {
+		return nil
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}


### PR DESCRIPTION
govmomi.Client can use the auth cookie for non-soap requests,
such as to the datastore /folder URL.
- Add login related tests
- error instead of panic if endpoint emits a response other than soap
