### PR TITLE
Avoid panic if ClientFlag url is not set

### DIFF
--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -52,9 +52,11 @@ func (c *ClientFlag) String() string {
 func (c *ClientFlag) Set(s string) error {
 	var err error
 
-	c.url, err = url.Parse(s)
-	if err != nil {
-		return err
+	if s != "" {
+		c.url, err = url.Parse(s)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
url.Parse doesn't mind an empty string, skip the call in that case
otherwise panic happens later on.
