### PR TITLE
Configure parent disk on create

### DIFF
--- a/govc/flags/disk.go
+++ b/govc/flags/disk.go
@@ -111,8 +111,8 @@ func (f *DiskFlag) Controller() (types.BaseVirtualDevice, error) {
 	}}, nil
 }
 
-func (f *DiskFlag) Disk() (types.BaseVirtualDevice, error) {
-	dsPath, err := f.DatastorePath(f.name)
+func (f *DiskFlag) Disk() (*types.VirtualDisk, error) {
+	ds, err := f.Datastore()
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (f *DiskFlag) Disk() (types.BaseVirtualDevice, error) {
 				DiskMode:        string(types.VirtualDiskModePersistent),
 				ThinProvisioned: true,
 				VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
-					FileName: dsPath,
+					FileName: ds.Path(f.name),
 				},
 			},
 		},


### PR DESCRIPTION
It is not necessary to reconfigure a VM to achieve this. Also, if this
isn't done on create, it is not possible to create VMs using the same
parent disk concurrently, as they need to acquire a write lock on the
disk if it used as primary (and therefore writable) disk.
