### PR TITLE
Move computation of progress percentage and detail

### DIFF
--- a/govc/datastore/download.go
+++ b/govc/datastore/download.go
@@ -19,10 +19,10 @@ package datastore
 import (
 	"errors"
 	"flag"
-	"fmt"
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
@@ -60,14 +60,8 @@ func (cmd *download) Run(f *flag.FlagSet) error {
 
 	p := soap.DefaultDownload
 	if cmd.OutputFlag.TTY {
-		path, err := cmd.DatastorePath(args[0])
-		if err != nil {
-			return err
-		}
-
-		cmd.Log(fmt.Sprintf("Downloading %s...\n", path))
-		ch := make(chan soap.Progress)
-		wg := cmd.ProgressLogger("", ch)
+		ch := make(chan vim25.Progress)
+		wg := cmd.ProgressLogger("Downloading... ", ch)
 		defer wg.Wait()
 
 		p.ProgressCh = ch

--- a/govc/datastore/upload.go
+++ b/govc/datastore/upload.go
@@ -19,10 +19,10 @@ package datastore
 import (
 	"errors"
 	"flag"
-	"fmt"
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
@@ -61,9 +61,8 @@ func (cmd *upload) Run(f *flag.FlagSet) error {
 
 	p := soap.DefaultUpload
 	if cmd.OutputFlag.TTY {
-		cmd.Log(fmt.Sprintf("Uploading %s...\n", args[0]))
-		ch := make(chan soap.Progress)
-		wg := cmd.ProgressLogger("", ch)
+		ch := make(chan vim25.Progress)
+		wg := cmd.ProgressLogger("Uploading... ", ch)
 		defer wg.Wait()
 
 		p.ProgressCh = ch

--- a/vim25/progress.go
+++ b/vim25/progress.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vim25
+
+// Progress defines the interface for types that can report progress. Examples
+// include uploads/downloads in the http client and the task info field in the
+// task managed object.
+type Progress interface {
+	Percentage() float32
+	Detail() string
+	Error() error
+}

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -32,6 +32,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/debug"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vim25/xml"
@@ -212,7 +213,7 @@ func (c *Client) ParseURL(urlStr string) (*url.URL, error) {
 type Upload struct {
 	Type       string
 	Method     string
-	ProgressCh chan<- Progress
+	ProgressCh chan<- vim25.Progress
 }
 
 var DefaultUpload = Upload{
@@ -233,7 +234,7 @@ func (c *Client) UploadFile(file string, u *url.URL, param *Upload) error {
 	}
 
 	if pr.ch == nil {
-		pr.ch = make(chan Progress, 1)
+		pr.ch = make(chan vim25.Progress, 1)
 	}
 
 	// Mark progress reader as done when returning from this function.
@@ -279,7 +280,7 @@ func (c *Client) UploadFile(file string, u *url.URL, param *Upload) error {
 
 type Download struct {
 	Method     string
-	ProgressCh chan<- Progress
+	ProgressCh chan<- vim25.Progress
 }
 
 var DefaultDownload = Download{
@@ -299,7 +300,7 @@ func (c *Client) DownloadFile(file string, u *url.URL, param *Download) error {
 	}
 
 	if pr.ch == nil {
-		pr.ch = make(chan Progress, 1)
+		pr.ch = make(chan vim25.Progress, 1)
 	}
 
 	// Mark progress reader as done when returning from this function.

--- a/vim25/soap/progress.go
+++ b/vim25/soap/progress.go
@@ -1,0 +1,181 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package soap
+
+import (
+	"container/list"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"time"
+
+	"github.com/vmware/govmomi/vim25"
+)
+
+const (
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+)
+
+type Progress struct {
+	t time.Time
+
+	pos  int64
+	size int64
+	bps  *uint64
+
+	err error
+}
+
+func (p Progress) Percentage() float32 {
+	return 100.0 * float32(p.pos) / float32(p.size)
+}
+
+func (p Progress) Detail() string {
+	// Refer to the progress reader's bps field, so that this function always
+	// returns an up-to-date number.
+	//
+	// For example: if there hasn't been progress for the last 5 seconds, the
+	// most recent progress report should report "0B/s".
+	//
+	bps := atomic.LoadUint64(p.bps)
+
+	switch {
+	case bps >= GiB:
+		return fmt.Sprintf("%.1fGiB/s", float32(bps)/float32(GiB))
+	case bps >= MiB:
+		return fmt.Sprintf("%.1fMiB/s", float32(bps)/float32(MiB))
+	case bps >= KiB:
+		return fmt.Sprintf("%.1fKiB/s", float32(bps)/float32(KiB))
+	default:
+		return fmt.Sprintf("%dB/s", bps)
+	}
+}
+
+func (p Progress) Error() error {
+	return p.err
+}
+
+// progressReader wraps a io.Reader and sends a progress report over a channel
+// for every read it handles.
+type progressReader struct {
+	r io.Reader
+
+	pos  int64
+	size int64
+	bps  uint64
+
+	ch    chan<- vim25.Progress
+	bpsch chan<- Progress
+}
+
+// Read calls the Read function on the underlying io.Reader. Additionally,
+// every read causes a progress report to be sent to the progress reader's
+// underlying channel. This progress report is sent optimistically; it is
+// dropped if it cannot be received immediately.
+func (p *progressReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	if err != nil {
+		return n, err
+	}
+
+	p.pos += int64(n)
+	q := Progress{
+		t:    time.Now(),
+		pos:  p.pos,
+		size: p.size,
+		bps:  &p.bps,
+	}
+
+	// Start bps computation if not already running
+	if p.bpsch == nil {
+		ch := make(chan Progress)
+		p.bpsch = ch
+		go p.bpsLoop(ch)
+	}
+
+	// Don't care if this is dropped
+	select {
+	case p.ch <- q:
+	default:
+	}
+
+	// Don't care if this is dropped
+	select {
+	case p.bpsch <- q:
+	default:
+	}
+
+	return n, err
+}
+
+// Done marks the progress reader as done, optionally including an error in the
+// progress report. This final progress report is never dropped on the sending
+// side. After sending it, the underlying channel is closed.
+func (p *progressReader) Done(err error) {
+	q := Progress{
+		t:    time.Now(),
+		pos:  p.pos,
+		size: p.size,
+		err:  err,
+	}
+
+	// Last one must always be delivered
+	p.ch <- q
+	close(p.ch)
+
+	// Stop bps computation if running
+	if p.bpsch != nil {
+		close(p.bpsch)
+	}
+}
+
+// bpsLoop computes the reader's throughput.
+func (p *progressReader) bpsLoop(ch chan Progress) {
+	l := list.New()
+
+	for {
+		var tch <-chan time.Time
+
+		// Setup timer for front of list to become stale.
+		if e := l.Front(); e != nil {
+			dt := time.Second - time.Now().Sub(e.Value.(Progress).t)
+			tch = time.After(dt)
+		}
+
+		select {
+		case q, ok := <-ch:
+			if !ok {
+				return
+			}
+
+			l.PushBack(q)
+		case <-tch:
+			l.Remove(l.Front())
+		}
+
+		// Compute new bps
+		if l.Len() == 0 {
+			atomic.StoreUint64(&p.bps, 0)
+		} else {
+			f := l.Front().Value.(Progress)
+			b := l.Back().Value.(Progress)
+			atomic.StoreUint64(&p.bps, uint64(b.pos-f.pos))
+		}
+	}
+}


### PR DESCRIPTION
The progress reporter now consumes an interface so that the
computation of percentage and any progress details can be moved to the
implementation of the unit that is reporting progress.

This paves the way for reporting progress on tasks.
