### PR TITLE
Change destination path for import.vmdk command

### DIFF
--- a/govc/importx/importable.go
+++ b/govc/importx/importable.go
@@ -42,12 +42,12 @@ func (i importable) BaseClean() string {
 	return b[:len(b)-len(e)]
 }
 
-func (i importable) RemoteVMDK() string {
+func (i importable) RemoteSrcVMDK() string {
 	bc := i.BaseClean()
-	return fmt.Sprintf("%s-vmdk/%s.vmdk", bc, bc)
+	return fmt.Sprintf("%s-src.vmdk", bc)
 }
 
-func (i importable) RemoteDst() string {
+func (i importable) RemoteDstVMDK() string {
 	bc := i.BaseClean()
-	return fmt.Sprintf("%s/%s.vmdk", bc, bc)
+	return fmt.Sprintf("%s.vmdk", bc)
 }

--- a/virtual_disk_manager.go
+++ b/virtual_disk_manager.go
@@ -57,6 +57,36 @@ func (m VirtualDiskManager) CopyVirtualDisk(
 	return NewTask(m.c, res.Returnval), nil
 }
 
+// MoveVirtualDisk moves a virtual disk.
+func (m VirtualDiskManager) MoveVirtualDisk(
+	sourceName string, sourceDatacenter *Datacenter,
+	destName string, destDatacenter *Datacenter,
+	force bool) (*Task, error) {
+	req := types.MoveVirtualDisk_Task{
+		This:       *m.c.ServiceContent.VirtualDiskManager,
+		SourceName: sourceName,
+		DestName:   destName,
+		Force:      force,
+	}
+
+	if sourceDatacenter != nil {
+		ref := sourceDatacenter.Reference()
+		req.SourceDatacenter = &ref
+	}
+
+	if destDatacenter != nil {
+		ref := destDatacenter.Reference()
+		req.DestDatacenter = &ref
+	}
+
+	res, err := methods.MoveVirtualDisk_Task(m.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(m.c, res.Returnval), nil
+}
+
 // DeleteVirtualDisk deletes a virtual disk.
 func (m VirtualDiskManager) DeleteVirtualDisk(name string, dc *Datacenter) (*Task, error) {
 	req := types.DeleteVirtualDisk_Task{


### PR DESCRIPTION
The imported VMDK always lives in the datastore root.

This fixes #91.
