### PR TITLE
Move progress reader to vim25/progress

### DIFF
--- a/vim25/progress/reader_test.go
+++ b/vim25/progress/reader_test.go
@@ -14,27 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package soap
+package progress
 
 import (
 	"io"
 	"strings"
 	"testing"
-
-	"github.com/vmware/govmomi/vim25/progress"
 )
 
-func TestProgressReader(t *testing.T) {
+func TestReader(t *testing.T) {
 	s := "helloworld"
-	ch := make(chan progress.Report, 1)
-	pr := &progressReader{
-		r:    strings.NewReader(s),
-		size: int64(len(s)),
-		ch:   ch,
-	}
+	ch := make(chan Report, 1)
+	pr := NewReader(&dummySinker{ch}, strings.NewReader(s), int64(len(s)))
 
 	var buf [10]byte
-	var q progress.Report
+	var q Report
 	var n int
 	var err error
 


### PR DESCRIPTION
Refactored the progress reader a little bit to make use of Tee to
forward reports to both a downstream sink and a sink that computes the
reader's throughput.
