### PR TITLE
Add ManagedObject wrappers

### DIFF
--- a/cluster_compute_resource.go
+++ b/cluster_compute_resource.go
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package govmomi
+
+type ClusterComputeResource struct {
+	ComputeResource
+}

--- a/distributed_virtual_switch.go
+++ b/distributed_virtual_switch.go
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package govmomi
+
+import "github.com/vmware/govmomi/vim25/types"
+
+type DistributedVirtualSwitch struct {
+	types.ManagedObjectReference
+}
+
+func (s DistributedVirtualSwitch) Reference() types.ManagedObjectReference {
+	return s.ManagedObjectReference
+}

--- a/storage_pod.go
+++ b/storage_pod.go
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package govmomi
+
+type StoragePod struct {
+	Folder
+}

--- a/types.go
+++ b/types.go
@@ -26,24 +26,38 @@ func newReference(e types.ManagedObjectReference) Reference {
 	switch e.Type {
 	case "Folder":
 		return &Folder{ManagedObjectReference: e}
+	case "StoragePod":
+		return &StoragePod{
+			Folder{ManagedObjectReference: e},
+		}
 	case "Datacenter":
 		return &Datacenter{ManagedObjectReference: e}
 	case "VirtualMachine":
 		return &VirtualMachine{ManagedObjectReference: e}
-	case "VirtualApp": // Skip
-		return nil
+	case "VirtualApp":
+		return &VirtualApp{
+			ResourcePool{ManagedObjectReference: e},
+		}
 	case "ComputeResource":
 		return &ComputeResource{ManagedObjectReference: e}
+	case "ClusterComputeResource":
+		return &ClusterComputeResource{
+			ComputeResource{ManagedObjectReference: e},
+		}
 	case "HostSystem":
 		return &HostSystem{ManagedObjectReference: e}
 	case "Network":
 		return &Network{ManagedObjectReference: e}
 	case "ResourcePool":
 		return &ResourcePool{ManagedObjectReference: e}
-	case "DistributedVirtualSwitch": // Skip
-		return nil
-	case "DistributedVirtualPortgroup": // Skip
-		return nil
+	case "DistributedVirtualSwitch":
+		return &DistributedVirtualSwitch{ManagedObjectReference: e}
+	case "VmwareDistributedVirtualSwitch":
+		return &VmwareDistributedVirtualSwitch{
+			DistributedVirtualSwitch{ManagedObjectReference: e},
+		}
+	case "DistributedVirtualPortgroup":
+		return &DistributedVirtualPortgroup{ManagedObjectReference: e}
 	case "Datastore":
 		return &Datastore{ManagedObjectReference: e}
 	default:

--- a/virtual_app.go
+++ b/virtual_app.go
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package govmomi
+
+type VirtualApp struct {
+	ResourcePool
+}

--- a/vmware_distributed_virtual_switch.go
+++ b/vmware_distributed_virtual_switch.go
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package govmomi
+
+type VmwareDistributedVirtualSwitch struct {
+	DistributedVirtualSwitch
+}


### PR DESCRIPTION
Folder.Children and SearchIndex.Find methods convert
types.ManagedObjectReference to govmomi package types via the
newReference method.  Adding support other types such as:
StoragePod, ClusterComputeResource, VmwareDistributedVirtualSwitch

Fixes github issue #119
