### PR TITLE
Default cli client url.User field

### DIFF
--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -73,6 +73,10 @@ func (flag *ClientFlag) Set(s string) error {
 		if flag.url.Path == "" {
 			flag.url.Path = "/sdk"
 		}
+
+		if flag.url.User == nil {
+			flag.url.User = url.UserPassword("", "")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
If credentials are not provided in the govc url, govc would panic.

Fixes github issue #141
