### PR TITLE
fix a issue of ignored https_proxy environment variable with https scheme

### DIFF
--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -70,7 +70,12 @@ func NewClient(u url.URL, insecure bool) *Client {
 	}
 
 	if c.u.Scheme == "https" {
-		c.Client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: c.insecure}}
+		c.Client.Transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: c.insecure,
+			},
+		}
 	}
 
 	c.Jar, _ = cookiejar.New(nil)


### PR DESCRIPTION
`govmomi.NewClient` doesn't work when it access to vCenter via https proxy. It seems that `https_proxy` environment variable is ignored with RoundTripper.