### PR TITLE
Set insert_key = false

### DIFF
--- a/govc/test/esxbox/Vagrantfile
+++ b/govc/test/esxbox/Vagrantfile
@@ -2,6 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
+  config.ssh.insert_key = false
   config.ssh.default.username = "root"
   config.ssh.shell = "sh"
   config.vm.hostname = "esxbox"


### PR DESCRIPTION
Vagrant 1.7 expects to be able to replace the insecure key with a
freshly generated one. This doesn't work for an ESX guest yet.