### PR TITLE
Loosen .ovf match in ova.import

### DIFF
--- a/govc/importx/archive.go
+++ b/govc/importx/archive.go
@@ -55,7 +55,12 @@ func (t *TapeArchive) Open(name string) (io.ReadCloser, int64, error) {
 			break
 		}
 
-		if h.Name == name {
+		matched, err := filepath.Match(name, h.Name)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if matched {
 			return &TapeArchiveEntry{r, f}, h.Size, nil
 		}
 	}

--- a/govc/importx/ova.go
+++ b/govc/importx/ova.go
@@ -49,8 +49,8 @@ func (cmd *ova) Run(f *flag.FlagSet) error {
 }
 
 func (cmd *ova) Import(fpath string) error {
-	// basename i | sed -e s/\.ova$/.ovf/
-	ovf := strings.TrimSuffix(path.Base(fpath), path.Ext(fpath)) + ".ovf"
+	// basename i | sed -e s/\.ova$/*.ovf/
+	ovf := strings.TrimSuffix(path.Base(fpath), path.Ext(fpath)) + "*.ovf"
 
 	return cmd.ovf.Import(ovf)
 }


### PR DESCRIPTION
The .ovf file within a .ova archive may not have the same name.

For example:
ova: VMware-vRealize-Log-Insight-2.5.0-2475126.ova
ovf: VMware-vRealize-Log-Insight-2.5.0-2475126_OVF10.ovf