### PR TITLE
Change 'go install' to 'go get' if govmomi is not present

### DIFF
--- a/govc/README.md
+++ b/govc/README.md
@@ -9,7 +9,9 @@ exposed by the CLI is in flux and may be changed without prior notice.
 
 ## Installation
 
-Install govc with `go install github.com/vmware/govmomi/govc`.
+If you don't have govmomi package yet, install govc directly with `go get github.com/vmware/govmomi/govc`.
+
+If you already have govmomi package, install govc with `go install github.com/vmware/govmomi/govc`.
 
 ## Usage
 


### PR DESCRIPTION
If one doesn't have govmomi package installed, 'go install' will not work, and 'go get' should be used instead.