### PR TITLE
Version prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# changelog
+
+### (unreleased)
+
+...
+
+### 0.1.0 (2015-03-17)
+
+Prior to this version the API of this library was in flux.
+
+Notable changes w.r.t. the state of this library before March 2015 are:
+
+* All functions that may execute a request take a `context.Context` parameter.
+* The `vim25` package contains a minimal client implementation.
+* The property collector and its convenience functions live in the `property` package.

--- a/README.md
+++ b/README.md
@@ -27,12 +27,9 @@ See [godoc.org][godoc] for documentation.
 
 ## Status
 
-The API is a work in progress. Because the code in the `vim25` package is
-generated from the vSphere API description, you can safely use all types and
-functions in those packages without worrying about deprecation. The code in the
-the root `govmomi` package is what is a work in progress.
+Changes to the API are subject to [semantic versioning](http://semver.org).
 
-After the library reaches v1.0, changes to the API will be subject to [semantic versioning](http://semver.org).
+Refer to the [CHANGELOG](CHANGELOG.md) for version to version changes.
 
 ## License
 

--- a/client.go
+++ b/client.go
@@ -14,6 +14,46 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+This package is the root package of the govmomi library.
+
+The library is structured as follows:
+
+Package vim25
+
+The minimal usable functionality is available through the vim25 package.
+It contains subpackages that contain generated types, managed objects, and all
+available methods. The vim25 package is entirely independent of the other
+packages in the govmomi tree -- it has no dependencies on its peers.
+
+The vim25 package itself contains a client structure that is
+passed around throughout the entire library. It abstracts a session and its
+immutable state. See the vim25 package for more information.
+
+Package session
+
+The session package contains an abstraction for the session manager that allows
+a user to login and logout. It also provides access to the current session
+(i.e. to determine if the user is in fact logged in)
+
+Package object
+
+The object package contains wrappers for a selection of managed objects. The
+constructors of these objects all take a *vim25.Client, which they pass along
+to derived objects, if applicable.
+
+Package govc
+
+The govc package contains the govc CLI. The code in this tree is not intended
+to be used as a library. Any functionality that govc contains that _could_ be
+used as a library function but isn't, _should_ live in a root level package.
+
+Other packages
+
+Other packages, such as "event", "guest", or "license", provide wrappers for
+the respective subsystems. They are typically not needed in normal workflows so
+are kept outside the object package.
+*/
 package govmomi
 
 import (

--- a/govc/.gitignore
+++ b/govc/.gitignore
@@ -1,1 +1,1 @@
-/govc
+/govc*

--- a/govc/build.sh
+++ b/govc/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+if ! which gox > /dev/null; then
+  echo "gox is not installed..."
+  exit 1
+fi
+
+git_version=$(git describe --tags)
+if git_status=$(git status --porcelain 2>/dev/null) && [ -n "${git_status}" ]; then
+  git_version="${git_version}-dirty"
+fi
+
+ldflags="-X github.com/vmware/govmomi/govc/version.gitVersion ${git_version}"
+os="darwin linux windows freebsd"
+arch="386 amd64"
+
+gox \
+  -parallel=1 \
+  -ldflags="${ldflags}" \
+  -os="${os}" \
+  -arch="${arch}" \
+  github.com/vmware/govmomi/govc

--- a/govc/version/command.go
+++ b/govc/version/command.go
@@ -24,15 +24,21 @@ import (
 	"github.com/vmware/govmomi/govc/flags"
 )
 
+var gitVersion string
+
 type version struct {
 	*flags.EmptyFlag
 }
 
 func init() {
+	if gitVersion == "" {
+		gitVersion = "unknown"
+	}
+
 	cli.Register("version", &version{})
 }
 
 func (c *version) Run(f *flag.FlagSet) error {
-	fmt.Println("govc version 0.0.1-dev")
+	fmt.Printf("govc %s\n", gitVersion)
 	return nil
 }


### PR DESCRIPTION
This marks 0.1.0.

The build script produces a number of govc binaries.

Once this is merged I'm putting those up for download on the release page.