### PR TITLE
Add code to ignore environmentBrowser value in MissingSet method

### DIFF
--- a/vim25/mo/retrieve.go
+++ b/vim25/mo/retrieve.go
@@ -33,7 +33,11 @@ import (
 func objectContentToType(o types.ObjectContent) (*reflect.Value, error) {
 	// Expect no properties in the missing set
 	for _, p := range o.MissingSet {
-		return nil, soap.WrapVimFault(p.Fault.Fault)
+		if p.Path == "environmentBrowser" {
+			continue
+		} else {
+			return nil, soap.WrapVimFault(p.Fault.Fault)
+		}
 	}
 
 	ti := typeInfoForType(o.Obj.Type)


### PR DESCRIPTION
`environmentBrowser` value is unset in VirtualMachine Object of VM templates. This means that `objectContentToType` always returns error as following xml data, when I try to find target VM template with `finder.VirtualMachine`. This fixes #242.

```
...
<missingSet>
  <path>environmentBrowser</path>
  <fault>
    <fault xsi:type="SystemError">
      <reason>unexpected error reading property</reason>
    </fault>
    <localizedMessage/>
  </fault>
</missingSet>
...
```