### PR TITLE
Rename persist flag to persist-session

### DIFF
--- a/govc/CHANGELOG.md
+++ b/govc/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * Add `host.autostart` commands to manage VM autostart.
 
-* Add `-persist` flag to control whether or not the session is persisted to
-  disk (defaults to true).
+* Add `-persist-session` flag to control whether or not the session is
+  persisted to disk (defaults to true).
 
 ### 0.1.0 (2015-03-17)
 

--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -132,7 +132,7 @@ func (flag *ClientFlag) Register(f *flag.FlagSet) {
 			}
 
 			usage := fmt.Sprintf("Persist session to disk [%s]", envPersist)
-			f.BoolVar(&flag.persist, "persist", persist, usage)
+			f.BoolVar(&flag.persist, "persist-session", persist, usage)
 		}
 
 		{


### PR DESCRIPTION
It conflicted with the "persist" flag for the vm.disk.attach command.

Should have been caught by tests. It's time to backfill on tests for vm.disk.*.