### PR TITLE
Change finder functions to no longer take varargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ...
 
+* Change finder functions to no longer take varargs
+
+    The `find` package had functions to return a list of objects, given a
+    variable number of patterns. This makes it impossible to distinguish which
+    patterns produced results and which ones didn't.
+
+    In particular for govc, where multiple arguments can be passed from the
+    command line, it is useful to let the user know which ones produce results
+    and which ones don't.
+
+    To evaluate multiple patterns, the user should call the find functions
+    multiple times (either serially or in parallel).
+
 * Make optional boolean fields pointers (`vim25/types`).
 
     False is the zero value of a boolean field, which means they are not serialized

--- a/govc/datacenter/create.go
+++ b/govc/datacenter/create.go
@@ -56,16 +56,20 @@ func (cmd *create) Run(f *flag.FlagSet) error {
 	finder := find.NewFinder(client, false)
 	rootFolder := object.NewRootFolder(client)
 	for _, datacenterToCreate := range datacenters {
-		foundDatacenters, err := finder.DatacenterList(context.TODO(), datacenterToCreate)
-		if err != nil {
-			return err
+		_, err := finder.Datacenter(context.TODO(), datacenterToCreate)
+		if err == nil {
+			// The datacenter was found, no need to create it
+			continue
 		}
 
-		if foundDatacenters == nil {
+		switch err.(type) {
+		case *find.NotFoundError:
 			_, err = rootFolder.CreateDatacenter(context.TODO(), datacenterToCreate)
 			if err != nil {
 				return err
 			}
+		default:
+			return err
 		}
 	}
 

--- a/govc/flags/search.go
+++ b/govc/flags/search.go
@@ -241,7 +241,17 @@ func (flag *SearchFlag) VirtualMachines(args []string) ([]*object.VirtualMachine
 		return nil, err
 	}
 
-	return finder.VirtualMachineList(context.TODO(), args...)
+	// List virtual machines for every argument
+	for _, arg := range args {
+		vms, err := finder.VirtualMachineList(context.TODO(), arg)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, vms...)
+	}
+
+	return out, nil
 }
 
 func (flag *SearchFlag) HostSystem() (*object.HostSystem, error) {
@@ -281,5 +291,15 @@ func (flag *SearchFlag) HostSystems(args []string) ([]*object.HostSystem, error)
 		return nil, err
 	}
 
-	return finder.HostSystemList(context.TODO(), args...)
+	// List host systems for every argument
+	for _, arg := range args {
+		vms, err := finder.HostSystemList(context.TODO(), arg)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, vms...)
+	}
+
+	return out, nil
 }

--- a/govc/host/autostart/autostart.go
+++ b/govc/host/autostart/autostart.go
@@ -52,7 +52,17 @@ func (f *AutostartFlag) VirtualMachines(args []string) ([]*object.VirtualMachine
 		return nil, err
 	}
 
-	return finder.VirtualMachineList(context.TODO(), args...)
+	var out []*object.VirtualMachine
+	for _, arg := range args {
+		vms, err := finder.VirtualMachineList(context.TODO(), arg)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, vms...)
+	}
+
+	return out, nil
 }
 
 func (f *AutostartFlag) HostAutoStartManager() (*mo.HostAutoStartManager, error) {

--- a/govc/ls/command.go
+++ b/govc/ls/command.go
@@ -54,14 +54,23 @@ func (cmd *ls) Run(f *flag.FlagSet) error {
 		return err
 	}
 
-	es, err := finder.ManagedObjectList(context.TODO(), f.Args()...)
-	if err != nil {
-		return err
+	lr := listResult{
+		Elements: nil,
+		Long:     cmd.Long,
 	}
 
-	lr := listResult{
-		Elements: es,
-		Long:     cmd.Long,
+	args := f.Args()
+	if len(args) == 0 {
+		args = []string{"."}
+	}
+
+	for _, arg := range args {
+		es, err := finder.ManagedObjectList(context.TODO(), arg)
+		if err != nil {
+			return err
+		}
+
+		lr.Elements = append(lr.Elements, es...)
 	}
 
 	return cmd.WriteResult(lr)

--- a/govc/pool/change.go
+++ b/govc/pool/change.go
@@ -66,15 +66,17 @@ func (cmd *change) Run(f *flag.FlagSet) error {
 		}
 	})
 
-	pools, err := finder.ResourcePoolList(context.TODO(), f.Args()...)
-	if err != nil {
-		return err
-	}
-
-	for _, pool := range pools {
-		err := pool.UpdateConfig(context.TODO(), cmd.name, &cmd.ResourceConfigSpec)
+	for _, arg := range f.Args() {
+		pools, err := finder.ResourcePoolList(context.TODO(), arg)
 		if err != nil {
 			return err
+		}
+
+		for _, pool := range pools {
+			err := pool.UpdateConfig(context.TODO(), cmd.name, &cmd.ResourceConfigSpec)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/govc/pool/create.go
+++ b/govc/pool/create.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vim25/types"
@@ -69,11 +70,10 @@ func (cmd *create) Run(f *flag.FlagSet) error {
 		base := path.Base(arg)
 		parents, err := finder.ResourcePoolList(context.TODO(), dir)
 		if err != nil {
+			if _, ok := err.(*find.NotFoundError); ok {
+				return fmt.Errorf("cannot create resource pool '%s': parent not found", base)
+			}
 			return err
-		}
-
-		if len(parents) == 0 {
-			return fmt.Errorf("cannot create resource pool '%s': parent not found", base)
 		}
 
 		for _, parent := range parents {

--- a/govc/pool/info.go
+++ b/govc/pool/info.go
@@ -66,11 +66,6 @@ func (cmd *info) Run(f *flag.FlagSet) error {
 		return err
 	}
 
-	pools, err := finder.ResourcePoolList(context.TODO(), f.Args()...)
-	if err != nil {
-		return err
-	}
-
 	var res infoResult
 	var props []string
 
@@ -86,16 +81,23 @@ func (cmd *info) Run(f *flag.FlagSet) error {
 		}
 	}
 
-	for _, pool := range pools {
-		var p mo.ResourcePool
-
-		pc := property.DefaultCollector(c)
-		err = pc.RetrieveOne(context.TODO(), pool.Reference(), props, &p)
+	for _, arg := range f.Args() {
+		pools, err := finder.ResourcePoolList(context.TODO(), arg)
 		if err != nil {
 			return err
 		}
 
-		res.ResourcePools = append(res.ResourcePools, p)
+		for _, pool := range pools {
+			var p mo.ResourcePool
+
+			pc := property.DefaultCollector(c)
+			err = pc.RetrieveOne(context.TODO(), pool.Reference(), props, &p)
+			if err != nil {
+				return err
+			}
+
+			res.ResourcePools = append(res.ResourcePools, p)
+		}
 	}
 
 	return cmd.WriteResult(&res)

--- a/govc/vm/info.go
+++ b/govc/vm/info.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/property"
@@ -58,7 +59,11 @@ func (cmd *info) Run(f *flag.FlagSet) error {
 
 	vms, err := cmd.VirtualMachines(f.Args())
 	if err != nil {
-		return err
+		if _, ok := err.(*find.NotFoundError); ok {
+			// Continue with empty VM slice
+		} else {
+			return err
+		}
 	}
 
 	var res infoResult


### PR DESCRIPTION
This means that these functions can safely return a not found error for patterns that didn't match any object. It is up to the caller to figure out what to do in case of such an error.

For the govc commands, many will continue executing for the remaining arguments, but exit with a non-zero status to indicate failure for one of the arguments. This is not the case right now, but with this change becomes easier to do so.