### PR TITLE
Credentials via environment variables

### DIFF
--- a/govc/test/cli.bats
+++ b/govc/test/cli.bats
@@ -13,6 +13,19 @@ load test_helper
   assert_failure "Error: ServerFaultCode: Cannot complete login due to an incorrect user name or password."
 }
 
+@test "login attempt with GOVC_URL, GOVC_USERNAME, and GOVC_PASSWORD" {
+  local url
+  local username
+  local password
+
+  url=$(echo $GOVC_URL | awk -F@ '{print $2}')
+  username=$(echo $GOVC_URL | awk -F@ '{print $1}' | awk -F: '{print $1}')
+  password=$(echo $GOVC_URL | awk -F@ '{print $1}' | awk -F: '{print $2}')
+
+  run env GOVC_URL="${url}" GOVC_USERNAME="${username}" GOVC_PASSWORD="${password}" govc about
+  assert_success
+}
+
 @test "connect to an endpoint with a non-supported API version" {
   run env GOVC_MIN_API_VERSION=24.4 govc about
   assert grep -q "^Error: Require API version 24.4," <<<${output}

--- a/govc/test/license.bats
+++ b/govc/test/license.bats
@@ -2,6 +2,13 @@
 
 load test_helper
 
+# These tests should only run against a server running an evaluation license.
+verify_evaluation() {
+  if [ "$(govc license.list -json | jq -r .[0].EditionKey)" != "eval" ]; then
+    skip "requires evaluation license"
+  fi
+}
+
 get_key() {
   jq ".[] | select(.LicenseKey == \"$1\")"
 }
@@ -11,6 +18,8 @@ get_property() {
 }
 
 @test "license.add" {
+  verify_evaluation
+
   run govc license.add -json 00000-00000-00000-00000-00001 00000-00000-00000-00000-00002
   assert_success
 
@@ -20,11 +29,15 @@ get_property() {
 }
 
 @test "license.remove" {
+  verify_evaluation
+
   run govc license.remove -json 00000-00000-00000-00000-00001
   assert_success
 }
 
 @test "license.list" {
+  verify_evaluation
+
   run govc license.list -json
   assert_success
 


### PR DESCRIPTION
Support the `GOVC_USERNAME` and `GOVC_PASSWORD` environment variables.

This enables users to specify usernames and passwords with special characters that prohibit them from being specified as part of the `GOVC_URL` variable.

Fixes #273.