### PR TITLE
Add net.address flag

### DIFF
--- a/govc/device/info.go
+++ b/govc/device/info.go
@@ -100,6 +100,7 @@ func (cmd *info) Run(f *flag.FlagSet) error {
 		switch md := device.(type) {
 		case types.BaseVirtualEthernetCard:
 			fmt.Fprintf(tw, "  MAC Address:\t%s\n", md.GetVirtualEthernetCard().MacAddress)
+			fmt.Fprintf(tw, "  Address type:\t%s\n", md.GetVirtualEthernetCard().AddressType)
 		case *types.VirtualDisk:
 			if b, ok := md.Backing.(types.BaseVirtualDeviceFileBackingInfo); ok {
 				fmt.Fprintf(tw, "  File:\t%s\n", b.GetVirtualDeviceFileBackingInfo().FileName)

--- a/govc/flags/network.go
+++ b/govc/flags/network.go
@@ -34,6 +34,7 @@ type NetworkFlag struct {
 	name     string
 	net      object.NetworkReference
 	adapter  string
+	address  string
 }
 
 func NewNetworkFlag() *NetworkFlag {
@@ -48,6 +49,7 @@ func (flag *NetworkFlag) Register(f *flag.FlagSet) {
 		usage := fmt.Sprintf("Network [%s]", env)
 		f.Var(flag, "net", usage)
 		f.StringVar(&flag.adapter, "net.adapter", "e1000", "Network adapter type")
+		f.StringVar(&flag.address, "net.address", "", "Network hardware address")
 	})
 }
 
@@ -97,6 +99,12 @@ func (flag *NetworkFlag) Device() (types.BaseVirtualDevice, error) {
 	device, err := object.EthernetCardTypes().CreateEthernetCard(flag.adapter, backing)
 	if err != nil {
 		return nil, err
+	}
+
+	if flag.address != "" {
+		card := device.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+		card.AddressType = string(types.VirtualEthernetCardMacTypeManual)
+		card.MacAddress = flag.address
 	}
 
 	return device, nil

--- a/govc/test/test_helper.bash
+++ b/govc/test/test_helper.bash
@@ -75,6 +75,10 @@ vm_power_state() {
   govc vm.info "$1" | grep "Power state:" | awk -F: '{print $2}' | collapse_ws
 }
 
+vm_mac() {
+  govc device.info -vm "$1" ethernet-0 | grep "MAC Address" | awk '{print $NF}'
+}
+
 # exports an enviroment for using vcsim if running, otherwise skips the calling test.
 vcsim_env() {
   if [ "$(uname)" == "Darwin" ]

--- a/govc/vm/network/change.go
+++ b/govc/vm/network/change.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
 )
 
@@ -71,12 +72,23 @@ func (cmd *change) Run(f *flag.FlagSet) error {
 		return fmt.Errorf("device '%s' not found", name)
 	}
 
-	backing, err := cmd.NetworkFlag.Device()
+	dev, err := cmd.NetworkFlag.Device()
 	if err != nil {
 		return err
 	}
 
-	net.GetVirtualDevice().Backing = backing.GetVirtualDevice().Backing
+	current := net.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+	changed := dev.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+
+	current.Backing = changed.Backing
+
+	if changed.MacAddress != "" {
+		current.MacAddress = changed.MacAddress
+	}
+
+	if changed.AddressType != "" {
+		current.AddressType = changed.AddressType
+	}
 
 	return vm.EditDevice(context.TODO(), net)
 }


### PR DESCRIPTION
This makes it possible to specify the network hardware address when
creating a vm or change it for an existing vm.

Closes issue #228