### PR TITLE
Add some useful methods to VirtualMachine and some information to govc output

### DIFF
--- a/govc/vm/info.go
+++ b/govc/vm/info.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
 	"golang.org/x/net/context"
@@ -102,13 +103,16 @@ func (cmd *info) Run(f *flag.FlagSet) error {
 				continue
 			}
 
-			host, err := vm.HostSystem(ctx)
-			if err != nil {
-				return err
-			}
-			hostName, err := host.Name(ctx)
-			if err != nil {
-				return err
+			var hostName string
+			hostRef := mvm.Summary.Runtime.Host
+			if hostRef == nil {
+				hostName = "<unavailable>"
+			} else {
+				host := object.NewHostSystem(c, *hostRef)
+				hostName, err = host.Name(ctx)
+				if err != nil {
+					return err
+				}
 			}
 
 			res.VmInfos = append(res.VmInfos, vmInfo{mvm, hostName})

--- a/object/common.go
+++ b/object/common.go
@@ -17,6 +17,8 @@ limitations under the License.
 package object
 
 import (
+	"fmt"
+
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
@@ -27,6 +29,10 @@ import (
 type Common struct {
 	c *vim25.Client
 	r types.ManagedObjectReference
+}
+
+func (c Common) String() string {
+	return fmt.Sprintf("%v", c.Reference())
 }
 
 func NewCommon(c *vim25.Client, r types.ManagedObjectReference) Common {

--- a/object/host_system.go
+++ b/object/host_system.go
@@ -33,11 +33,10 @@ type HostSystem struct {
 }
 
 func (h HostSystem) String() string {
-	name, err := h.Name(context.TODO())
-	if err != nil {
-		return "<" + err.Error() + ">"
+	if h.InventoryPath == "" {
+		return h.Common.String()
 	}
-	return name
+	return fmt.Sprintf("%v @ %v", h.Common, h.InventoryPath)
 }
 
 func NewHostSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostSystem {

--- a/object/host_system.go
+++ b/object/host_system.go
@@ -32,10 +32,29 @@ type HostSystem struct {
 	InventoryPath string
 }
 
+func (h HostSystem) String() string {
+	name, err := h.Name(context.TODO())
+	if err != nil {
+		return "<" + err.Error() + ">"
+	}
+	return name
+}
+
 func NewHostSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostSystem {
 	return &HostSystem{
 		Common: NewCommon(c, ref),
 	}
+}
+
+func (h HostSystem) Name(ctx context.Context) (string, error) {
+	var mh mo.HostSystem
+
+	err := h.Properties(ctx, h.Reference(), []string{"name"}, &mh)
+	if err != nil {
+		return "", err
+	}
+
+	return mh.Name, nil
 }
 
 func (h HostSystem) ConfigManager() *HostConfigManager {

--- a/object/resource_pool.go
+++ b/object/resource_pool.go
@@ -17,6 +17,8 @@ limitations under the License.
 package object
 
 import (
+	"fmt"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -31,11 +33,10 @@ type ResourcePool struct {
 }
 
 func (p ResourcePool) String() string {
-	name, err := p.Name(context.TODO())
-	if err != nil {
-		return "<" + err.Error() + ">"
+	if p.InventoryPath == "" {
+		return p.Common.String()
 	}
-	return name
+	return fmt.Sprintf("%v @ %v", p.Common, p.InventoryPath)
 }
 
 func NewResourcePool(c *vim25.Client, ref types.ManagedObjectReference) *ResourcePool {

--- a/object/resource_pool.go
+++ b/object/resource_pool.go
@@ -19,6 +19,7 @@ package object
 import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
 )
@@ -29,10 +30,29 @@ type ResourcePool struct {
 	InventoryPath string
 }
 
+func (p ResourcePool) String() string {
+	name, err := p.Name(context.TODO())
+	if err != nil {
+		return "<" + err.Error() + ">"
+	}
+	return name
+}
+
 func NewResourcePool(c *vim25.Client, ref types.ManagedObjectReference) *ResourcePool {
 	return &ResourcePool{
 		Common: NewCommon(c, ref),
 	}
+}
+
+func (p ResourcePool) Name(ctx context.Context) (string, error) {
+	var o mo.ResourcePool
+
+	err := p.Properties(ctx, p.Reference(), []string{"name"}, &o)
+	if err != nil {
+		return "", err
+	}
+
+	return o.Name, nil
 }
 
 func (p ResourcePool) ImportVApp(ctx context.Context, spec types.BaseImportSpec, folder *Folder, host *HostSystem) (*HttpNfcLease, error) {

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -18,6 +18,7 @@ package object
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
@@ -34,11 +35,10 @@ type VirtualMachine struct {
 }
 
 func (v VirtualMachine) String() string {
-	name, err := v.Name(context.TODO())
-	if err != nil {
-		return "<" + err.Error() + ">"
+	if v.InventoryPath == "" {
+		return v.Common.String()
 	}
-	return name
+	return fmt.Sprintf("%v @ %v", v.Common, v.InventoryPath)
 }
 
 func NewVirtualMachine(c *vim25.Client, ref types.ManagedObjectReference) *VirtualMachine {

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -31,10 +31,29 @@ type VirtualMachine struct {
 	InventoryPath string
 }
 
+func (v VirtualMachine) String() string {
+	name, err := v.Name(context.TODO())
+	if err != nil {
+		return "<" + err.Error() + ">"
+	}
+	return name
+}
+
 func NewVirtualMachine(c *vim25.Client, ref types.ManagedObjectReference) *VirtualMachine {
 	return &VirtualMachine{
 		Common: NewCommon(c, ref),
 	}
+}
+
+func (v VirtualMachine) Name(ctx context.Context) (string, error) {
+	var o mo.VirtualMachine
+
+	err := v.Properties(ctx, v.Reference(), []string{"name"}, &o)
+	if err != nil {
+		return "", err
+	}
+
+	return o.Name, nil
 }
 
 func (v VirtualMachine) PowerOn(ctx context.Context) (*Task, error) {

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -155,6 +155,21 @@ func (v VirtualMachine) Clone(ctx context.Context, folder *Folder, name string, 
 	return NewTask(v.c, res.Returnval), nil
 }
 
+func (v VirtualMachine) Relocate(ctx context.Context, config types.VirtualMachineRelocateSpec, priority types.VirtualMachineMovePriority) (*Task, error) {
+	req := types.RelocateVM_Task{
+		This:     v.Reference(),
+		Spec:     config,
+		Priority: priority,
+	}
+
+	res, err := methods.RelocateVM_Task(ctx, v.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(v.c, res.Returnval), nil
+}
+
 func (v VirtualMachine) Reconfigure(ctx context.Context, config types.VirtualMachineConfigSpec) (*Task, error) {
 	req := types.ReconfigVM_Task{
 		This: v.Reference(),


### PR DESCRIPTION
The attached commits add a few useful methods to the VirtualMachine object:
- `String()` methods for pretty printing
- `Relocate` a VM to another host
- Retrieve the current host and resource pools for a VM

In addition, the `govc vm.info` output now shows the current host that a VM is running on.