### PR TITLE
Make govet stop complaining

### DIFF
--- a/govc/host/esxcli/esxcli.go
+++ b/govc/host/esxcli/esxcli.go
@@ -37,7 +37,7 @@ func init() {
 }
 
 func (cmd *esxcli) Usage() string {
-  return "COMMAND [ARG]..."
+	return "COMMAND [ARG]..."
 }
 
 func (cmd *esxcli) Register(f *flag.FlagSet) {}

--- a/govc/importx/archive.go
+++ b/govc/importx/archive.go
@@ -20,8 +20,8 @@ import (
 	"archive/tar"
 	"io"
 	"os"
-	"path/filepath"
 	"path"
+	"path/filepath"
 )
 
 type Archive interface {


### PR DESCRIPTION
The govet Makefile target was complaining about the indentation and import order in the following files.  This change is to make it stop complaining.