### PR TITLE
Update travis.yml for new infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: go
 go: 1.4
 


### PR DESCRIPTION
See: http://docs.travis-ci.com/user/migrating-from-legacy

Looks like our travis build hasn't run for ~2 months, not sure if this is why, but we should make this change in any case.