### PR TITLE
Add OVF unmarshalling

### DIFF
--- a/ovf/cim.go
+++ b/ovf/cim.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovf
+
+/*
+Source: http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.24.0/CIM_VirtualSystemSettingData.xsd
+*/
+
+type CIMVirtualSystemSettingData struct {
+	ElementName string `xml:"ElementName"`
+	InstanceID  string `xml:"InstanceID"`
+
+	AutomaticRecoveryAction              *uint8   `xml:"AutomaticRecoveryAction"`
+	AutomaticShutdownAction              *uint8   `xml:"AutomaticShutdownAction"`
+	AutomaticStartupAction               *uint8   `xml:"AutomaticStartupAction"`
+	AutomaticStartupActionDelay          *string  `xml:"AutomaticStartupActionDelay>Interval"`
+	AutomaticStartupActionSequenceNumber *uint16  `xml:"AutomaticStartupActionSequenceNumber"`
+	Caption                              *string  `xml:"Caption"`
+	ConfigurationDataRoot                *string  `xml:"ConfigurationDataRoot"`
+	ConfigurationFile                    *string  `xml:"ConfigurationFile"`
+	ConfigurationID                      *string  `xml:"ConfigurationID"`
+	CreationTime                         *string  `xml:"CreationTime"`
+	Description                          *string  `xml:"Description"`
+	LogDataRoot                          *string  `xml:"LogDataRoot"`
+	Notes                                []string `xml:"Notes"`
+	RecoveryFile                         *string  `xml:"RecoveryFile"`
+	SnapshotDataRoot                     *string  `xml:"SnapshotDataRoot"`
+	SuspendDataRoot                      *string  `xml:"SuspendDataRoot"`
+	SwapFileDataRoot                     *string  `xml:"SwapFileDataRoot"`
+	VirtualSystemIdentifier              *string  `xml:"VirtualSystemIdentifier"`
+	VirtualSystemType                    *string  `xml:"VirtualSystemType"`
+}
+
+/*
+Source: http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.24.0/CIM_ResourceAllocationSettingData.xsd
+*/
+
+type CIMResourceAllocationSettingData struct {
+	ElementName string `xml:"ElementName"`
+	InstanceID  string `xml:"InstanceID"`
+
+	ResourceType      *uint16 `xml:"ResourceType"`
+	OtherResourceType *string `xml:"OtherResourceType"`
+	ResourceSubType   *string `xml:"ResourceSubType"`
+
+	AddressOnParent       *string  `xml:"AddressOnParent"`
+	Address               *string  `xml:"Address"`
+	AllocationUnits       *string  `xml:"AllocationUnits"`
+	AutomaticAllocation   *bool    `xml:"AutomaticAllocation"`
+	AutomaticDeallocation *bool    `xml:"AutomaticDeallocation"`
+	Caption               *string  `xml:"Caption"`
+	Connection            []string `xml:"Connection"`
+	ConsumerVisibility    *uint16  `xml:"ConsumerVisibility"`
+	Description           *string  `xml:"Description"`
+	HostResource          []string `xml:"HostResource"`
+	Limit                 *uint64  `xml:"Limit"`
+	MappingBehavior       *uint    `xml:"MappingBehavior"`
+	Parent                *string  `xml:"Parent"`
+	PoolID                *string  `xml:"PoolID"`
+	Reservation           *uint64  `xml:"Reservation"`
+	VirtualQuantity       *uint    `xml:"VirtualQuantity"`
+	VirtualQuantityUnits  *string  `xml:"VirtualQuantityUnits"`
+	Weight                *uint    `xml:"Weight"`
+}

--- a/ovf/envelope.go
+++ b/ovf/envelope.go
@@ -1,0 +1,195 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovf
+
+type Envelope struct {
+	References []File `xml:"References>File"`
+
+	// Package level meta-data
+	Annotation         *AnnotationSection         `xml:"AnnotationSection"`
+	Product            *ProductSection            `xml:"ProductSection"`
+	Network            *NetworkSection            `xml:"NetworkSection"`
+	Disk               *DiskSection               `xml:"DiskSection"`
+	OperatingSystem    *OperatingSystemSection    `xml:"OperatingSystemSection"`
+	Eula               *EulaSection               `xml:"EulaSection"`
+	VirtualHardware    *VirtualHardwareSection    `xml:"VirtualHardwareSection"`
+	ResourceAllocation *ResourceAllocationSection `xml:"ResourceAllocationSection"`
+	DeploymentOption   *DeploymentOptionSection   `xml:"DeploymentOptionSection"`
+
+	// Content: A VirtualSystem or a VirtualSystemCollection
+	VirtualSystem *VirtualSystem `xml:"VirtualSystem"`
+}
+
+type VirtualSystem struct {
+	Content
+
+	Annotation         *AnnotationSection         `xml:"AnnotationSection"`
+	Product            *ProductSection            `xml:"ProductSection"`
+	Network            *NetworkSection            `xml:"NetworkSection"`
+	Disk               *DiskSection               `xml:"DiskSection"`
+	OperatingSystem    *OperatingSystemSection    `xml:"OperatingSystemSection"`
+	Eula               *EulaSection               `xml:"EulaSection"`
+	VirtualHardware    *VirtualHardwareSection    `xml:"VirtualHardwareSection"`
+	ResourceAllocation *ResourceAllocationSection `xml:"ResourceAllocationSection"`
+	DeploymentOption   *DeploymentOptionSection   `xml:"DeploymentOptionSection"`
+}
+
+type File struct {
+	ID          string  `xml:"id,attr"`
+	Href        string  `xml:"href,attr"`
+	Size        uint    `xml:"size,attr"`
+	Compression *string `xml:"compression,attr"`
+	ChunkSize   *int    `xml:"chunkSize,attr"`
+}
+
+type Content struct {
+	ID   string  `xml:"id,attr"`
+	Info string  `xml:"Info"`
+	Name *string `xml:"Name"`
+}
+
+type Section struct {
+	Required *bool  `xml:"required,attr"`
+	Info     string `xml:"Info"`
+}
+
+type AnnotationSection struct {
+	Section
+
+	Annotation string `xml:"Annotation"`
+}
+
+type ProductSection struct {
+	Section
+
+	Class    *string `xml:"class,attr"`
+	Instance *string `xml:"instance,attr"`
+
+	Product     string     `xml:"Product"`
+	Vendor      string     `xml:"Vendor"`
+	Version     string     `xml:"Version"`
+	FullVersion string     `xml:"FullVersion"`
+	ProductURL  string     `xml:"ProductUrl"`
+	VendorURL   string     `xml:"VendorUrl"`
+	AppURL      string     `xml:"AppUrl"`
+	Property    []Property `xml:"Property"`
+}
+
+type Property struct {
+	Key              string  `xml:"key,attr"`
+	Type             string  `xml:"type,attr"`
+	Qualifiers       *string `xml:"qualifiers,attr"`
+	UserConfigurable *bool   `xml:"userConfigurable,attr"`
+	Default          *string `xml:"value,attr"`
+	Password         *bool   `xml:"password,attr"`
+
+	Label       *string `xml:"Label"`
+	Description *string `xml:"Description"`
+
+	Values []PropertyConfigurationValue `xml:"Value"`
+}
+
+type PropertyConfigurationValue struct {
+	Value         string  `xml:"value,attr"`
+	Configuration *string `xml:"configuration,attr"`
+}
+
+type NetworkSection struct {
+	Section
+
+	Networks []Network `xml:"Network"`
+}
+
+type Network struct {
+	Name string `xml:"name,attr"`
+
+	Description string `xml:"Description"`
+}
+
+type DiskSection struct {
+	Section
+
+	Disks []VirtualDiskDesc `xml:"Disk"`
+}
+
+type VirtualDiskDesc struct {
+	DiskID                  string  `xml:"diskId,attr"`
+	FileRef                 *string `xml:"fileRef,attr"`
+	Capacity                string  `xml:"capacity,attr"`
+	CapacityAllocationUnits *string `xml:"capacityAllocationUnits,attr"`
+	Format                  *string `xml:"format,attr"`
+	PopulatedSize           *int    `xml:"populatedSize,attr"`
+	ParentRef               *string `xml:"parentRef,attr"`
+}
+
+type OperatingSystemSection struct {
+	Section
+
+	ID      uint16  `xml:"id,attr"`
+	Version *string `xml:"version,attr"`
+	OSType  *string `xml:"osType,attr"`
+
+	Description *string `xml:"Description"`
+}
+
+type EulaSection struct {
+	Section
+
+	License string `xml:"License"`
+}
+
+type VirtualHardwareSection struct {
+	Section
+
+	ID        *string `xml:"id,attr"`
+	Transport *string `xml:"transport,attr"`
+
+	System *VirtualSystemSettingData       `xml:"System"`
+	Item   []ResourceAllocationSettingData `xml:"Item"`
+}
+
+type VirtualSystemSettingData struct {
+	CIMVirtualSystemSettingData
+}
+
+type ResourceAllocationSettingData struct {
+	CIMResourceAllocationSettingData
+
+	Required      *bool   `xml:"required,attr"`
+	Configuration *string `xml:"configuration,attr"`
+	Bound         *string `xml:"bound,attr"`
+}
+
+type ResourceAllocationSection struct {
+	Section
+
+	Item []ResourceAllocationSettingData `xml:"Item"`
+}
+
+type DeploymentOptionSection struct {
+	Section
+
+	Configuration []DeploymentOptionConfiguration `xml:"Configuration"`
+}
+
+type DeploymentOptionConfiguration struct {
+	ID      string `xml:"id,attr"`
+	Default *bool  `xml:"default,attr"`
+
+	Label       string `xml:"Label"`
+	Description string `xml:"Description"`
+}

--- a/ovf/ovf.go
+++ b/ovf/ovf.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovf
+
+import (
+	"encoding/xml"
+	"io"
+)
+
+func Unmarshal(r io.Reader) (*Envelope, error) {
+	var e Envelope
+
+	dec := xml.NewDecoder(r)
+	err := dec.Decode(&e)
+	if err != nil {
+		return nil, err
+	}
+
+	return &e, nil
+}

--- a/ovf/ovf_test.go
+++ b/ovf/ovf_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovf
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+	"text/tabwriter"
+)
+
+func testFile(t *testing.T) *os.File {
+	n := os.Getenv("OVF_TEST_FILE")
+	if n == "" {
+		t.Skip("Please specify OVF_TEST_FILE")
+	}
+
+	f, err := os.Open(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return f
+}
+
+func testEnvelope(t *testing.T) *Envelope {
+	f := testFile(t)
+	defer f.Close()
+
+	e, err := Unmarshal(f)
+	if err != nil {
+		t.Fatal(f)
+	}
+
+	if e == nil {
+		t.Fatal("Empty envelope")
+	}
+
+	return e
+}
+
+func TestUnmarshal(t *testing.T) {
+	testEnvelope(t)
+}
+
+func TestDeploymentOptions(t *testing.T) {
+	e := testEnvelope(t)
+
+	if e.DeploymentOption == nil {
+		t.Fatal("Missing DeploymentOptionSection")
+	}
+
+	var b bytes.Buffer
+	tw := tabwriter.NewWriter(&b, 2, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "\n")
+	for _, c := range e.DeploymentOption.Configuration {
+		fmt.Fprintf(tw, "id=%s\t", c.ID)
+		fmt.Fprintf(tw, "label=%s\t", c.Label)
+
+		d := false
+		if c.Default != nil {
+			d = *c.Default
+		}
+
+		fmt.Fprintf(tw, "default=%t\t", d)
+		fmt.Fprintf(tw, "\n")
+	}
+	tw.Flush()
+	t.Log(b.String())
+}


### PR DESCRIPTION
This models the properties we would need to extract from an OVF to parameterize OVF deployment.

Not yet hooked up to the import functions in govc.