### PR TITLE
Only retrieve "currentSession" property

### DIFF
--- a/session/manager.go
+++ b/session/manager.go
@@ -19,6 +19,7 @@ package session
 import (
 	"net/url"
 
+	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -83,7 +84,8 @@ func (sm *Manager) Logout(ctx context.Context) error {
 func (sm *Manager) UserSession(ctx context.Context) (*types.UserSession, error) {
 	var mgr mo.SessionManager
 
-	err := mo.RetrieveProperties(ctx, sm.client, sm.client.ServiceContent.PropertyCollector, sm.Reference(), &mgr)
+	pc := property.DefaultCollector(sm.client)
+	err := pc.RetrieveOne(ctx, sm.Reference(), []string{"currentSession"}, &mgr)
 	if err != nil {
 		// It's OK if we can't retrieve properties because we're not authenticated
 		if f, ok := err.(types.HasFault); ok {


### PR DESCRIPTION
The previous implementation tried to retrieve all properties on the
session manager. The "sessionList" property requires the
"Sessions.TerminateSession" privilege. If the user didn't have this
privilege, this property would be missing from the response and the
response would include a "NoPermission" fault for this property. This
fault was then bubbled up to the user as if the session was invalid.

Change this to only retrieve the "currentSession" property.

Thanks to @skuzye for providing debugging information.

Fixes #251.