### PR TITLE
Misc govc changes

### DIFF
--- a/govc/host/esxcli/esxcli.go
+++ b/govc/host/esxcli/esxcli.go
@@ -30,6 +30,8 @@ import (
 
 type esxcli struct {
 	*flags.HostSystemFlag
+
+	hints bool
 }
 
 func init() {
@@ -40,7 +42,9 @@ func (cmd *esxcli) Usage() string {
 	return "COMMAND [ARG]..."
 }
 
-func (cmd *esxcli) Register(f *flag.FlagSet) {}
+func (cmd *esxcli) Register(f *flag.FlagSet) {
+	f.BoolVar(&cmd.hints, "hints", true, "Use command info hints when formatting output")
+}
 
 func (cmd *esxcli) Process() error { return nil }
 
@@ -69,8 +73,13 @@ func (cmd *esxcli) Run(f *flag.FlagSet) error {
 		return nil
 	}
 
+	var formatType string
+	if cmd.hints {
+		formatType = res.Info.Hints.Formatter()
+	}
+
 	// TODO: OutputFlag / format options
-	switch res.Info.Hints.Formatter() {
+	switch formatType {
 	case "table":
 		cmd.formatTable(res)
 	default:

--- a/govc/test/fields.bats
+++ b/govc/test/fields.bats
@@ -25,7 +25,7 @@ load test_helper
   run govc fields.set $field $val vm/$vm_id
   assert_success
 
-  info=$(govc vm.info -json $vm_id | jq .VmInfos[0].CustomValue[0])
+  info=$(govc vm.info -json $vm_id | jq .VirtualMachines[0].CustomValue[0])
 
   ikey=$(jq -r .Key <<<"$info")
   assert_equal $key $ikey

--- a/govc/vm/info.go
+++ b/govc/vm/info.go
@@ -26,7 +26,6 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
 	"golang.org/x/net/context"
@@ -81,20 +80,18 @@ func (cmd *info) Run(f *flag.FlagSet) error {
 		}
 	}
 
-	ctx := context.TODO()
-
 	for _, vm := range vms {
 		for {
 			var mvm mo.VirtualMachine
 
 			pc := property.DefaultCollector(c)
-			err = pc.RetrieveOne(ctx, vm.Reference(), props, &mvm)
+			err = pc.RetrieveOne(context.TODO(), vm.Reference(), props, &mvm)
 			if err != nil {
 				return err
 			}
 
 			if cmd.WaitForIP && mvm.Guest.IpAddress == "" {
-				_, err = vm.WaitForIP(ctx)
+				_, err = vm.WaitForIP(context.TODO())
 				if err != nil {
 					return err
 				}
@@ -103,19 +100,7 @@ func (cmd *info) Run(f *flag.FlagSet) error {
 				continue
 			}
 
-			var hostName string
-			hostRef := mvm.Summary.Runtime.Host
-			if hostRef == nil {
-				hostName = "<unavailable>"
-			} else {
-				host := object.NewHostSystem(c, *hostRef)
-				hostName, err = host.Name(ctx)
-				if err != nil {
-					return err
-				}
-			}
-
-			res.VmInfos = append(res.VmInfos, vmInfo{mvm, hostName})
+			res.VirtualMachines = append(res.VirtualMachines, mvm)
 			break
 		}
 	}
@@ -123,20 +108,14 @@ func (cmd *info) Run(f *flag.FlagSet) error {
 	return cmd.WriteResult(&res)
 }
 
-type vmInfo struct {
-	mo.VirtualMachine
-	hostName string
-}
-
 type infoResult struct {
-	VmInfos []vmInfo
+	VirtualMachines []mo.VirtualMachine
 }
 
 func (r *infoResult) Write(w io.Writer) error {
 	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 
-	for _, vmInfo := range r.VmInfos {
-		vm := vmInfo.VirtualMachine
+	for _, vm := range r.VirtualMachines {
 		s := vm.Summary
 
 		fmt.Fprintf(tw, "Name:\t%s\n", s.Config.Name)
@@ -147,7 +126,6 @@ func (r *infoResult) Write(w io.Writer) error {
 		fmt.Fprintf(tw, "  Power state:\t%s\n", s.Runtime.PowerState)
 		fmt.Fprintf(tw, "  Boot time:\t%s\n", s.Runtime.BootTime)
 		fmt.Fprintf(tw, "  IP address:\t%s\n", s.Guest.IpAddress)
-		fmt.Fprintf(tw, "  Host:\t%s\n", vmInfo.hostName)
 		if vm.Config != nil && vm.Config.ExtraConfig != nil {
 			fmt.Fprintf(tw, "  ExtraConfig:\n")
 			for _, v := range vm.Config.ExtraConfig {


### PR DESCRIPTION
Add -hints option to host.esxcli, enables other frontends to parse the simple output format and render table data in their own way

Reduce number of round trips for vm.info property collection