### PR TITLE
Add govc vm.info resources option

### DIFF
--- a/govc/vm/info.go
+++ b/govc/vm/info.go
@@ -21,12 +21,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/units"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
@@ -38,7 +40,9 @@ type info struct {
 	*flags.SearchFlag
 
 	WaitForIP   bool
+	General     bool
 	ExtraConfig bool
+	Resources   bool
 }
 
 func init() {
@@ -49,7 +53,9 @@ func (cmd *info) Register(f *flag.FlagSet) {
 	cmd.SearchFlag = flags.NewSearchFlag(flags.SearchVirtualMachines)
 
 	f.BoolVar(&cmd.WaitForIP, "waitip", false, "Wait for VM to acquire IP address")
+	f.BoolVar(&cmd.General, "g", true, "Show general summary")
 	f.BoolVar(&cmd.ExtraConfig, "e", false, "Show ExtraConfig")
+	f.BoolVar(&cmd.Resources, "r", false, "Show resource summary")
 }
 
 func (cmd *info) Process() error { return nil }
@@ -80,17 +86,25 @@ func (cmd *info) Run(f *flag.FlagSet) error {
 	if cmd.OutputFlag.JSON {
 		props = nil // Load everything
 	} else {
-		props = []string{"summary", "guest.ipAddress"} // Load summary
+		props = []string{"summary"} // Load summary
+		if cmd.General {
+			props = append(props, "guest.ipAddress")
+		}
 		if cmd.ExtraConfig {
 			props = append(props, "config.extraConfig")
+		}
+		if cmd.Resources {
+			props = append(props, "datastore", "network")
 		}
 	}
 
 	ctx := context.TODO()
 	pc := property.DefaultCollector(c)
-	err = pc.Retrieve(ctx, refs, props, &res.VirtualMachines)
-	if err != nil {
-		return err
+	if len(refs) != 0 {
+		err = pc.Retrieve(ctx, refs, props, &res.VirtualMachines)
+		if err != nil {
+			return err
+		}
 	}
 
 	if cmd.WaitForIP {
@@ -109,32 +123,11 @@ func (cmd *info) Run(f *flag.FlagSet) error {
 		}
 	}
 
-	// Build a list of host system references and fetch host properties for all hosts in one call
-	xrefs := make(map[string]bool)
-	refs = nil
-	var hosts []mo.HostSystem
-
-	for _, vm := range res.VirtualMachines {
-		href := vm.Summary.Runtime.Host
-		if href == nil {
-			continue
+	if !cmd.OutputFlag.JSON {
+		res.cmd = cmd
+		if err = res.collectReferences(pc, ctx); err != nil {
+			return err
 		}
-		if _, exists := xrefs[href.Value]; exists {
-			continue
-		}
-		xrefs[href.Value] = true
-		refs = append(refs, *href)
-	}
-
-	err = pc.Retrieve(ctx, refs, []string{"name"}, &hosts)
-	if err != nil {
-		return err
-	}
-
-	res.hostSystems = make(map[string]*mo.HostSystem)
-
-	for i, ref := range refs {
-		res.hostSystems[ref.Value] = &hosts[i]
 	}
 
 	return cmd.WriteResult(&res)
@@ -142,7 +135,94 @@ func (cmd *info) Run(f *flag.FlagSet) error {
 
 type infoResult struct {
 	VirtualMachines []mo.VirtualMachine
-	hostSystems     map[string]*mo.HostSystem
+	entities        map[types.ManagedObjectReference]string
+	cmd             *info
+}
+
+// collectReferences builds a unique set of MORs to the set of VirtualMachines,
+// so we can collect properties in a single call for each reference type {host,datastore,network}.
+func (r *infoResult) collectReferences(pc *property.Collector, ctx context.Context) error {
+	r.entities = make(map[types.ManagedObjectReference]string) // MOR -> Name map
+
+	var host []mo.HostSystem
+	var network []mo.Network
+	var datastore []mo.Datastore
+	// Table to drive inflating refs to their mo.* counterparts (dest)
+	// and save() the Name to r.entities w/o using reflection here.
+	vrefs := map[string]*struct {
+		dest interface{}
+		refs []types.ManagedObjectReference
+		save func()
+	}{
+		"host": {
+			&host, nil, func() {
+				for _, e := range host {
+					r.entities[e.Reference()] = e.Name
+				}
+			},
+		},
+		"network": {
+			&network, nil, func() {
+				for _, e := range network {
+					r.entities[e.Reference()] = e.Name
+				}
+			},
+		},
+		"datastore": {
+			&datastore, nil, func() {
+				for _, e := range datastore {
+					r.entities[e.Reference()] = e.Name
+				}
+			},
+		},
+	}
+
+	xrefs := make(map[types.ManagedObjectReference]bool)
+	// Add MOR to vrefs[kind].refs avoiding any duplicates.
+	addRef := func(kind string, refs ...types.ManagedObjectReference) {
+		for _, ref := range refs {
+			if _, exists := xrefs[ref]; exists {
+				return
+			}
+			xrefs[ref] = true
+			vref := vrefs[kind]
+			vref.refs = append(vref.refs, ref)
+		}
+	}
+
+	for _, vm := range r.VirtualMachines {
+		if r.cmd.General {
+			if ref := vm.Summary.Runtime.Host; ref != nil {
+				addRef("host", *ref)
+			}
+		}
+
+		if r.cmd.Resources {
+			addRef("datastore", vm.Datastore...)
+			addRef("network", vm.Network...)
+		}
+	}
+
+	for _, vref := range vrefs {
+		if vref.refs == nil {
+			continue
+		}
+		err := pc.Retrieve(ctx, vref.refs, []string{"name"}, vref.dest)
+		if err != nil {
+			return err
+		}
+		vref.save()
+	}
+
+	return nil
+}
+
+func (r *infoResult) entityNames(refs []types.ManagedObjectReference) string {
+	var names []string
+	for _, ref := range refs {
+		names = append(names, r.entities[ref])
+	}
+	return strings.Join(names, ", ")
 }
 
 func (r *infoResult) Write(w io.Writer) error {
@@ -150,25 +230,40 @@ func (r *infoResult) Write(w io.Writer) error {
 
 	for _, vm := range r.VirtualMachines {
 		s := vm.Summary
-		hostName := "<unavailable>"
-
-		if href := vm.Summary.Runtime.Host; href != nil {
-			if h, ok := r.hostSystems[href.Value]; ok {
-				hostName = h.Name
-			}
-		}
 
 		fmt.Fprintf(tw, "Name:\t%s\n", s.Config.Name)
-		fmt.Fprintf(tw, "  UUID:\t%s\n", s.Config.Uuid)
-		fmt.Fprintf(tw, "  Guest name:\t%s\n", s.Config.GuestFullName)
-		fmt.Fprintf(tw, "  Memory:\t%dMB\n", s.Config.MemorySizeMB)
-		fmt.Fprintf(tw, "  CPU:\t%d vCPU(s)\n", s.Config.NumCpu)
-		fmt.Fprintf(tw, "  Power state:\t%s\n", s.Runtime.PowerState)
-		fmt.Fprintf(tw, "  Boot time:\t%s\n", s.Runtime.BootTime)
-		fmt.Fprintf(tw, "  IP address:\t%s\n", s.Guest.IpAddress)
-		fmt.Fprintf(tw, "  Host:\t%s\n", hostName)
 
-		if vm.Config != nil && vm.Config.ExtraConfig != nil {
+		if r.cmd.General {
+			hostName := "<unavailable>"
+
+			if href := vm.Summary.Runtime.Host; href != nil {
+				if name, ok := r.entities[*href]; ok {
+					hostName = name
+				}
+			}
+
+			fmt.Fprintf(tw, "  UUID:\t%s\n", s.Config.Uuid)
+			fmt.Fprintf(tw, "  Guest name:\t%s\n", s.Config.GuestFullName)
+			fmt.Fprintf(tw, "  Memory:\t%dMB\n", s.Config.MemorySizeMB)
+			fmt.Fprintf(tw, "  CPU:\t%d vCPU(s)\n", s.Config.NumCpu)
+			fmt.Fprintf(tw, "  Power state:\t%s\n", s.Runtime.PowerState)
+			fmt.Fprintf(tw, "  Boot time:\t%s\n", s.Runtime.BootTime)
+			fmt.Fprintf(tw, "  IP address:\t%s\n", s.Guest.IpAddress)
+			fmt.Fprintf(tw, "  Host:\t%s\n", hostName)
+		}
+
+		if r.cmd.Resources {
+			fmt.Fprintf(tw, "  CPU usage:\t%dMHz\n", s.QuickStats.OverallCpuUsage)
+			fmt.Fprintf(tw, "  Host memory usage:\t%dMB\n", s.QuickStats.HostMemoryUsage)
+			fmt.Fprintf(tw, "  Guest memory usage:\t%dMB\n", s.QuickStats.GuestMemoryUsage)
+			fmt.Fprintf(tw, "  Storage uncommitted:\t%s\n", units.ByteSize(s.Storage.Uncommitted))
+			fmt.Fprintf(tw, "  Storage committed:\t%s\n", units.ByteSize(s.Storage.Committed))
+			fmt.Fprintf(tw, "  Storage unshared:\t%s\n", units.ByteSize(s.Storage.Unshared))
+			fmt.Fprintf(tw, "  Storage:\t%s\n", r.entityNames(vm.Datastore))
+			fmt.Fprintf(tw, "  Network:\t%s\n", r.entityNames(vm.Network))
+		}
+
+		if r.cmd.ExtraConfig {
 			fmt.Fprintf(tw, "  ExtraConfig:\n")
 			for _, v := range vm.Config.ExtraConfig {
 				fmt.Fprintf(tw, "    %s:\t%s\n", v.GetOptionValue().Key, v.GetOptionValue().Value)


### PR DESCRIPTION
New '-r' option outputs the same data as the vSphere Client's
"Resources" section.

Make the "General" data optional via '-g' option, but enabled by
default.