### PR TITLE
Update finder.go / func VirtualMachineList

### DIFF
--- a/find/finder.go
+++ b/find/finder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
 )
 
@@ -533,7 +534,28 @@ func (f *Finder) DefaultResourcePool(ctx context.Context) (*object.ResourcePool,
 
 	return rp, nil
 }
+//foreach all Folder
+func (f *Finder) findVirtualMachineListForFolder(ctx context.Context, fobj types.ManagedObjectReference, vms *[]*object.VirtualMachine) {
+	if fobj.Type != "Folder" {
+		return
+	}
+	folder := object.NewFolder(f.client, fobj)
+	childs, err := folder.Children(ctx)
+	if err != nil {
+		return
+	}
+	for _, chie := range childs {
+		switch chie.Reference().Type {
+		case "VirtualMachine":
+			vm := object.NewVirtualMachine(f.client, chie.Reference())
+			//vm.InventoryPath?
+			*vms = append(*vms, vm)
+		case "Folder":
+			f.findVirtualMachineListForFolder(ctx, chie.Reference(), vms)
+		}
 
+	}
+}
 func (f *Finder) VirtualMachineList(ctx context.Context, path string) ([]*object.VirtualMachine, error) {
 	es, err := f.find(ctx, f.vmFolder, false, path)
 	if err != nil {
@@ -547,9 +569,10 @@ func (f *Finder) VirtualMachineList(ctx context.Context, path string) ([]*object
 			vm := object.NewVirtualMachine(f.client, o.Reference())
 			vm.InventoryPath = e.Path
 			vms = append(vms, vm)
+		case mo.Folder:
+			f.findVirtualMachineListForFolder(ctx, e.Object.Reference(), &vms)
 		}
 	}
-
 	if len(vms) == 0 {
 		return nil, &NotFoundError{"vm", path}
 	}


### PR DESCRIPTION
In the functions of VirtualMachineList, e.Object.(type) may be mo.Folder, and exist VirtualMachine under the Folder.
Add function findVirtualMachineListForFolder, which is change to foreach all Folder. But I didn't get VirtualMachine.InventoryPath.
Sorry for my bad code, hope someone could help me to improve it.