### PR TITLE
Handle the import.spec case where no spec file is provided

### DIFF
--- a/govc/importx/spec.go
+++ b/govc/importx/spec.go
@@ -60,14 +60,16 @@ func (cmd *spec) Run(f *flag.FlagSet) error {
 		fpath = f.Arg(0)
 	}
 
-	switch path.Ext(fpath) {
-	case ".ovf":
-		cmd.Archive = &FileArchive{fpath}
-	case "", ".ova":
-		cmd.Archive = &TapeArchive{fpath}
-		fpath = "*.ovf"
-	default:
-		return fmt.Errorf("invalid file extension %s", path.Ext(fpath))
+	if len(fpath) > 0 {
+		switch path.Ext(fpath) {
+		case ".ovf":
+			cmd.Archive = &FileArchive{fpath}
+		case "", ".ova":
+			cmd.Archive = &TapeArchive{fpath}
+			fpath = "*.ovf"
+		default:
+			return fmt.Errorf("invalid file extension %s", path.Ext(fpath))
+		}
 	}
 
 	return cmd.Spec(fpath)


### PR DESCRIPTION
* Originally this was handled implicitly via a blank extension. We now allow for a blank file extension, therefore the 'no file name provided' case needs to be explicit.