### PR TITLE
Use service ticket for datastore file access

### DIFF
--- a/govc/datastore/download.go
+++ b/govc/datastore/download.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"flag"
 
+	"golang.org/x/net/context"
+
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -47,12 +49,7 @@ func (cmd *download) Run(f *flag.FlagSet) error {
 		return errors.New("invalid arguments")
 	}
 
-	c, err := cmd.Client()
-	if err != nil {
-		return err
-	}
-
-	u, err := cmd.DatastoreURL(args[0])
+	ds, err := cmd.Datastore()
 	if err != nil {
 		return err
 	}
@@ -64,5 +61,5 @@ func (cmd *download) Run(f *flag.FlagSet) error {
 		defer logger.Wait()
 	}
 
-	return c.Client.DownloadFile(args[1], u, &p)
+	return ds.DownloadFile(context.TODO(), args[0], args[1], &p)
 }

--- a/govc/datastore/upload.go
+++ b/govc/datastore/upload.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"flag"
 
+	"golang.org/x/net/context"
+
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -48,12 +50,7 @@ func (cmd *upload) Run(f *flag.FlagSet) error {
 		return errors.New("invalid arguments")
 	}
 
-	c, err := cmd.Client()
-	if err != nil {
-		return err
-	}
-
-	u, err := cmd.DatastoreURL(args[1])
+	ds, err := cmd.Datastore()
 	if err != nil {
 		return err
 	}
@@ -65,5 +62,5 @@ func (cmd *upload) Run(f *flag.FlagSet) error {
 		defer logger.Wait()
 	}
 
-	return c.Client.UploadFile(args[0], u, &p)
+	return ds.UploadFile(context.TODO(), args[0], args[1], &p)
 }

--- a/govc/importx/vmdk.go
+++ b/govc/importx/vmdk.go
@@ -170,11 +170,6 @@ func (cmd *vmdk) PrepareDestination(i importable) error {
 }
 
 func (cmd *vmdk) Upload(i importable) error {
-	u, err := cmd.Datastore.URL(context.TODO(), cmd.Datacenter, i.RemoteSrcVMDK())
-	if err != nil {
-		return err
-	}
-
 	p := soap.DefaultUpload
 	if cmd.OutputFlag.TTY {
 		logger := cmd.ProgressLogger("Uploading... ")
@@ -182,7 +177,7 @@ func (cmd *vmdk) Upload(i importable) error {
 		defer logger.Wait()
 	}
 
-	return cmd.Client.Client.UploadFile(i.localPath, u, &p)
+	return cmd.Datastore.UploadFile(context.TODO(), i.localPath, i.RemoteSrcVMDK(), &p)
 }
 
 func (cmd *vmdk) Import(i importable) error {

--- a/session/manager.go
+++ b/session/manager.go
@@ -137,3 +137,17 @@ func (sm *Manager) SessionIsActive(ctx context.Context) (bool, error) {
 
 	return active.Returnval, err
 }
+
+func (sm *Manager) AcquireGenericServiceTicket(ctx context.Context, spec types.BaseSessionManagerServiceRequestSpec) (*types.SessionManagerGenericServiceTicket, error) {
+	req := types.AcquireGenericServiceTicket{
+		This: sm.Reference(),
+		Spec: spec,
+	}
+
+	res, err := methods.AcquireGenericServiceTicket(ctx, sm.client, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}


### PR DESCRIPTION
- Add object.Datastore methods to upload/download datastore files using
  a service ticket rather than user/pass authentication

- Required for http datastore access when authenticating with client
  certificate

- Faster for upload/download of large files to talk to an ESX box
  directly than via vCenter