### PR TITLE
KeepAlive support with certificate based login

### DIFF
--- a/session/keep_alive.go
+++ b/session/keep_alive.go
@@ -108,6 +108,7 @@ func (k *keepAlive) RoundTrip(ctx context.Context, req, res soap.HasFault) error
 	// Start ticker on login, stop ticker on logout.
 	switch req.(type) {
 	case *methods.LoginBody:
+	case *methods.LoginExtensionByCertificateBody:
 		k.start()
 	case *methods.LogoutBody:
 		k.stop()


### PR DESCRIPTION
Seeing NotAuthenticated errors again when using certificate based auth