### PR TITLE
Add ClusterComputeResource.Hosts() support

### DIFF
--- a/find/finder.go
+++ b/find/finder.go
@@ -393,19 +393,21 @@ func (f *Finder) HostSystemList(ctx context.Context, path string) ([]*object.Hos
 		switch o := e.Object.(type) {
 		case mo.HostSystem:
 			hs = object.NewHostSystem(f.client, o.Reference())
-		case mo.ComputeResource:
+
+			hs.InventoryPath = e.Path
+			hss = append(hss, hs)
+		case mo.ComputeResource, mo.ClusterComputeResource:
 			cr := object.NewComputeResource(f.client, o.Reference())
+
+			cr.InventoryPath = e.Path
+
 			hosts, err := cr.Hosts(ctx)
 			if err != nil {
 				return nil, err
 			}
-			hs = object.NewHostSystem(f.client, hosts[0])
-		default:
-			continue
-		}
 
-		hs.InventoryPath = e.Path
-		hss = append(hss, hs)
+			hss = append(hss, hosts...)
+		}
 	}
 
 	if len(hss) == 0 {

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -180,8 +180,17 @@ load test_helper
     run govc vm.create -on=false $id
     assert_success
 
-    local found=$(govc vm.info $id | grep Name: | wc -l)
+    local info=$(govc vm.info -r $id)
+    local found=$(grep Name: <<<"$info" | wc -l)
     [ "$found" -eq 1 ]
+
+    # test that mo names are printed
+    found=$(grep Host: <<<"$info" | awk '{print $2}')
+    [ -n "$found" ]
+    found=$(grep Storage: <<<"$info" | awk '{print $2}')
+    [ -n "$found" ]
+    found=$(grep Network: <<<"$info" | awk '{print $2}')
+    [ -n "$found" ]
   done
 
   # test find slice

--- a/object/compute_resource.go
+++ b/object/compute_resource.go
@@ -17,6 +17,9 @@ limitations under the License.
 package object
 
 import (
+	"path"
+
+	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -36,7 +39,7 @@ func NewComputeResource(c *vim25.Client, ref types.ManagedObjectReference) *Comp
 	}
 }
 
-func (c ComputeResource) Hosts(ctx context.Context) ([]types.ManagedObjectReference, error) {
+func (c ComputeResource) Hosts(ctx context.Context) ([]*HostSystem, error) {
 	var cr mo.ComputeResource
 
 	err := c.Properties(ctx, c.Reference(), []string{"host"}, &cr)
@@ -44,7 +47,26 @@ func (c ComputeResource) Hosts(ctx context.Context) ([]types.ManagedObjectRefere
 		return nil, err
 	}
 
-	return cr.Host, nil
+	if len(cr.Host) == 0 {
+		return nil, nil
+	}
+
+	var hs []mo.HostSystem
+	pc := property.DefaultCollector(c.Client())
+	err = pc.Retrieve(ctx, cr.Host, []string{"name"}, &hs)
+	if err != nil {
+		return nil, err
+	}
+
+	var hosts []*HostSystem
+
+	for _, h := range hs {
+		host := NewHostSystem(c.Client(), h.Reference())
+		host.InventoryPath = path.Join(c.InventoryPath, h.Name)
+		hosts = append(hosts, host)
+	}
+
+	return hosts, nil
 }
 
 func (c ComputeResource) Datastores(ctx context.Context) ([]*Datastore, error) {

--- a/vim25/mo/fixtures/cluster_host_property.xml
+++ b/vim25/mo/fixtures/cluster_host_property.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RetrievePropertiesResponse xmlns="urn:vim25" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+ <returnval>
+  <obj type="ClusterComputeResource">domain-c7</obj>
+  <propSet>
+   <name>host</name>
+   <val xsi:type="ArrayOfManagedObjectReference">
+    <ManagedObjectReference type="HostSystem" xsi:type="ManagedObjectReference">host-14</ManagedObjectReference>
+    <ManagedObjectReference type="HostSystem" xsi:type="ManagedObjectReference">host-17</ManagedObjectReference>
+    <ManagedObjectReference type="HostSystem" xsi:type="ManagedObjectReference">host-19</ManagedObjectReference>
+    <ManagedObjectReference type="HostSystem" xsi:type="ManagedObjectReference">host-52</ManagedObjectReference>
+   </val>
+  </propSet>
+ </returnval>
+</RetrievePropertiesResponse>

--- a/vim25/mo/fixtures/hostsystem_list_name_property.xml
+++ b/vim25/mo/fixtures/hostsystem_list_name_property.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RetrievePropertiesResponse xmlns="urn:vim25" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+ <returnval>
+  <obj type="HostSystem">host-10</obj>
+  <propSet>
+   <name>name</name>
+   <val xsi:type="xsd:string">host-01.example.com</val>
+  </propSet>
+ </returnval>
+ <returnval>
+  <obj type="HostSystem">host-30</obj>
+  <propSet>
+   <name>name</name>
+   <val xsi:type="xsd:string">host-02.example.com</val>
+  </propSet>
+ </returnval>
+</RetrievePropertiesResponse>

--- a/vim25/mo/retrieve.go
+++ b/vim25/mo/retrieve.go
@@ -90,6 +90,17 @@ func LoadRetrievePropertiesResponse(res *types.RetrievePropertiesResponse, dst i
 			if err != nil {
 				return err
 			}
+
+			vt := reflect.TypeOf(v)
+
+			if !rv.Type().AssignableTo(vt) {
+				// For example: dst is []ManagedEntity, res is []HostSystem
+				if field, ok := vt.FieldByName(rt.Elem().Elem().Name()); ok && field.Anonymous {
+					rv.Set(reflect.Append(rv, reflect.ValueOf(v).FieldByIndex(field.Index)))
+					continue
+				}
+			}
+
 			rv.Set(reflect.Append(rv, reflect.ValueOf(v)))
 		}
 	} else {
@@ -100,6 +111,17 @@ func LoadRetrievePropertiesResponse(res *types.RetrievePropertiesResponse, dst i
 			if err != nil {
 				return err
 			}
+
+			vt := reflect.TypeOf(v)
+
+			if !rv.Type().AssignableTo(vt) {
+				// For example: dst is ComputeResource, res is ClusterComputeResource
+				if field, ok := vt.FieldByName(rt.Elem().Name()); ok && field.Anonymous {
+					rv.Set(reflect.ValueOf(v).FieldByIndex(field.Index))
+					return nil
+				}
+			}
+
 			rv.Set(reflect.ValueOf(v))
 		default:
 			// If dst is not a slice, expect to receive 0 or 1 results

--- a/vim25/mo/retrieve_test.go
+++ b/vim25/mo/retrieve_test.go
@@ -104,3 +104,41 @@ func TestPointerProperty(t *testing.T) {
 		t.Fatalf("Expected vm.Config.BootOptions to be set")
 	}
 }
+
+func TestEmbeddedTypeProperty(t *testing.T) {
+	// Test that we avoid in this case:
+	// panic: reflect.Set: value of type mo.ClusterComputeResource is not assignable to type mo.ComputeResource
+	var cr ComputeResource
+
+	err := LoadRetrievePropertiesResponse(load("fixtures/cluster_host_property.xml"), &cr)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %s", err)
+	}
+
+	if len(cr.Host) != 4 {
+		t.Fatalf("Expected cr.Host to be set")
+	}
+}
+
+func TestEmbeddedTypePropertySlice(t *testing.T) {
+	var me []ManagedEntity
+
+	err := LoadRetrievePropertiesResponse(load("fixtures/hostsystem_list_name_property.xml"), &me)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %s", err)
+	}
+
+	if len(me) != 2 {
+		t.Fatalf("Expected 2 elements")
+	}
+
+	for _, m := range me {
+		if m.Name == "" {
+			t.Fatal("Expected Name field to be set")
+		}
+	}
+
+	if me[0].Name == me[1].Name {
+		t.Fatal("Name fields should not be the same")
+	}
+}


### PR DESCRIPTION
Prior to this change, the ClusterComputeResource.Hosts() method would panic.