### PR TITLE
Remove host reference from HostFirewallSystem

### DIFF
--- a/govc/host/esxcli/firewall_info.go
+++ b/govc/host/esxcli/firewall_info.go
@@ -27,8 +27,8 @@ type FirewallInfo struct {
 // GetFirewallInfo via 'esxcli network firewall get'
 // The HostFirewallSystem type does not expose this data.
 // This helper can be useful in particular to determine if the firewall is enabled or disabled.
-func GetFirewallInfo(s *object.HostFirewallSystem) (*FirewallInfo, error) {
-	x, err := NewExecutor(s.Client(), s.Host)
+func GetFirewallInfo(s *object.HostSystem) (*FirewallInfo, error) {
+	x, err := NewExecutor(s.Client(), s)
 
 	res, err := x.Run([]string{"network", "firewall", "get"})
 	if err != nil {

--- a/govc/host/firewall/find.go
+++ b/govc/host/firewall/find.go
@@ -77,7 +77,7 @@ func (cmd *find) Run(f *flag.FlagSet) error {
 	}
 
 	if cmd.check {
-		esxfw, err := esxcli.GetFirewallInfo(fs)
+		esxfw, err := esxcli.GetFirewallInfo(host)
 		if err != nil {
 			return err
 		}

--- a/object/host_config_manager.go
+++ b/object/host_config_manager.go
@@ -63,7 +63,7 @@ func (m HostConfigManager) FirewallSystem(ctx context.Context) (*HostFirewallSys
 		return nil, err
 	}
 
-	return NewHostFirewallSystem(m.c, *h.ConfigManager.FirewallSystem, m.Reference()), nil
+	return NewHostFirewallSystem(m.c, *h.ConfigManager.FirewallSystem), nil
 }
 
 func (m HostConfigManager) VirtualNicManager(ctx context.Context) (*HostVirtualNicManager, error) {

--- a/object/host_firewall_system.go
+++ b/object/host_firewall_system.go
@@ -30,13 +30,11 @@ import (
 
 type HostFirewallSystem struct {
 	Common
-	Host *HostSystem
 }
 
-func NewHostFirewallSystem(c *vim25.Client, ref types.ManagedObjectReference, host types.ManagedObjectReference) *HostFirewallSystem {
+func NewHostFirewallSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostFirewallSystem {
 	return &HostFirewallSystem{
 		Common: NewCommon(c, ref),
-		Host:   NewHostSystem(c, host),
 	}
 }
 


### PR DESCRIPTION
iirc, started with a method attached to object.HostFirewallSystem to get the esxcli firewall info, that didn't work out due to cyclic import.