### PR TITLE
Add host storage commands

### DIFF
--- a/govc/host/storage/info.go
+++ b/govc/host/storage/info.go
@@ -1,0 +1,179 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+)
+
+var infoTypes = []string{"hba", "lun"}
+
+type infoType string
+
+func (t *infoType) Set(s string) error {
+	s = strings.ToLower(s)
+
+	for _, e := range infoTypes {
+		if s == e {
+			*t = infoType(s)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid type")
+}
+
+func (t *infoType) String() string {
+	return string(*t)
+}
+
+func (t *infoType) Result(hss mo.HostStorageSystem) flags.OutputWriter {
+	switch string(*t) {
+	case "hba":
+		return hbaResult(hss)
+	case "lun":
+		return lunResult(hss)
+	default:
+		panic("unsupported")
+	}
+}
+
+type info struct {
+	*flags.HostSystemFlag
+	*flags.OutputFlag
+
+	typ infoType
+}
+
+func init() {
+	cli.Register("host.storage.info", &info{})
+}
+
+func (cmd *info) Register(f *flag.FlagSet) {
+	err := cmd.typ.Set("lun")
+	if err != nil {
+		panic(err)
+	}
+
+	f.Var(&cmd.typ, "t", fmt.Sprintf("Type (%s)", strings.Join(infoTypes, ",")))
+}
+
+func (cmd *info) Process() error {
+	return nil
+}
+
+func (cmd *info) Usage() string {
+	return "[-t TYPE]"
+}
+
+func (cmd *info) Description() string {
+	return `Show information about a host's storage system.`
+}
+
+func (cmd *info) Run(f *flag.FlagSet) error {
+	ctx := context.TODO()
+
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	ss, err := host.ConfigManager().StorageSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	var hss mo.HostStorageSystem
+	err = ss.Properties(ctx, ss.Reference(), nil, &hss)
+	if err != nil {
+		return nil
+	}
+
+	return cmd.WriteResult(cmd.typ.Result(hss))
+}
+
+type hbaResult mo.HostStorageSystem
+
+func (r hbaResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "Device\t")
+	fmt.Fprintf(tw, "PCI\t")
+	fmt.Fprintf(tw, "Driver\t")
+	fmt.Fprintf(tw, "Status\t")
+	fmt.Fprintf(tw, "Model\t")
+	fmt.Fprintf(tw, "\n")
+
+	for _, e := range r.StorageDeviceInfo.HostBusAdapter {
+		hba := e.GetHostHostBusAdapter()
+
+		fmt.Fprintf(tw, "%s\t", hba.Device)
+		fmt.Fprintf(tw, "%s\t", hba.Pci)
+		fmt.Fprintf(tw, "%s\t", hba.Driver)
+		fmt.Fprintf(tw, "%s\t", hba.Status)
+		fmt.Fprintf(tw, "%s\t", hba.Model)
+		fmt.Fprintf(tw, "\n")
+	}
+
+	return tw.Flush()
+}
+
+type lunResult mo.HostStorageSystem
+
+func (r lunResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "Name\t")
+	fmt.Fprintf(tw, "Type\t")
+	fmt.Fprintf(tw, "Capacity\t")
+	fmt.Fprintf(tw, "Model\t")
+	fmt.Fprintf(tw, "\n")
+
+	for _, e := range r.StorageDeviceInfo.ScsiLun {
+		var capacity int64
+
+		lun := e.GetScsiLun()
+		if disk, ok := e.(*types.HostScsiDisk); ok {
+			capacity = int64(disk.Capacity.Block) * int64(disk.Capacity.BlockSize)
+		}
+
+		fmt.Fprintf(tw, "%s\t", lun.DeviceName)
+		fmt.Fprintf(tw, "%s\t", lun.DeviceType)
+
+		if capacity == 0 {
+			fmt.Fprintf(tw, "-\t")
+		} else {
+			fmt.Fprintf(tw, "%s\t", units.ByteSize(capacity))
+		}
+
+		fmt.Fprintf(tw, "%s\t", lun.Model)
+		fmt.Fprintf(tw, "\n")
+	}
+
+	return tw.Flush()
+}

--- a/govc/host/storage/partition.go
+++ b/govc/host/storage/partition.go
@@ -1,0 +1,120 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"golang.org/x/net/context"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type partition struct {
+	*flags.HostSystemFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("host.storage.partition", &partition{})
+}
+
+func (cmd *partition) Register(f *flag.FlagSet) {
+	return
+}
+
+func (cmd *partition) Process() error {
+	return nil
+}
+
+func (cmd *partition) Usage() string {
+	return "DEVICE_PATH"
+}
+
+func (cmd *partition) Description() string {
+	return `Show partition table for device at DEVICE_PATH.`
+}
+
+func (cmd *partition) Run(f *flag.FlagSet) error {
+	ctx := context.TODO()
+
+	if f.NArg() != 1 {
+		return fmt.Errorf("specify device path")
+	}
+
+	path := f.Args()[0]
+
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	ss, err := host.ConfigManager().StorageSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	var hss mo.HostStorageSystem
+	err = ss.Properties(ctx, ss.Reference(), nil, &hss)
+	if err != nil {
+		return nil
+	}
+
+	info, err := ss.RetrieveDiskPartitionInfo(ctx, path)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(partitionInfo(*info))
+}
+
+type partitionInfo types.HostDiskPartitionInfo
+
+func (p partitionInfo) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "Table format: %s\n", p.Spec.PartitionFormat)
+	fmt.Fprintf(tw, "Number of sectors: %d\n", p.Spec.TotalSectors)
+	fmt.Fprintf(tw, "\n")
+
+	fmt.Fprintf(tw, "Number\t")
+	fmt.Fprintf(tw, "Start\t")
+	fmt.Fprintf(tw, "End\t")
+	fmt.Fprintf(tw, "Size\t")
+	fmt.Fprintf(tw, "Type\t")
+	fmt.Fprintf(tw, "\n")
+
+	for _, e := range p.Spec.Partition {
+		sectors := e.EndSector - e.StartSector
+
+		fmt.Fprintf(tw, "%d\t", e.Partition)
+		fmt.Fprintf(tw, "%d\t", e.StartSector)
+		fmt.Fprintf(tw, "%d\t", e.EndSector)
+		fmt.Fprintf(tw, "%s\t", units.ByteSize(sectors*512))
+		fmt.Fprintf(tw, "%s\t", e.Type)
+		fmt.Fprintf(tw, "\n")
+	}
+
+	return tw.Flush()
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -42,6 +42,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/host/firewall"
 	_ "github.com/vmware/govmomi/govc/host/maintenance"
 	_ "github.com/vmware/govmomi/govc/host/portgroup"
+	_ "github.com/vmware/govmomi/govc/host/storage"
 	_ "github.com/vmware/govmomi/govc/host/vnic"
 	_ "github.com/vmware/govmomi/govc/host/vswitch"
 	_ "github.com/vmware/govmomi/govc/importx"

--- a/object/host_config_manager.go
+++ b/object/host_config_manager.go
@@ -66,6 +66,17 @@ func (m HostConfigManager) FirewallSystem(ctx context.Context) (*HostFirewallSys
 	return NewHostFirewallSystem(m.c, *h.ConfigManager.FirewallSystem, m.Reference()), nil
 }
 
+func (m HostConfigManager) StorageSystem(ctx context.Context) (*HostStorageSystem, error) {
+	var h mo.HostSystem
+
+	err := m.Properties(ctx, m.Reference(), []string{"configManager.storageSystem"}, &h)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewHostStorageSystem(m.c, *h.ConfigManager.StorageSystem), nil
+}
+
 func (m HostConfigManager) VirtualNicManager(ctx context.Context) (*HostVirtualNicManager, error) {
 	var h mo.HostSystem
 

--- a/object/host_storage_system.go
+++ b/object/host_storage_system.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"errors"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+)
+
+type HostStorageSystem struct {
+	Common
+}
+
+func NewHostStorageSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostStorageSystem {
+	return &HostStorageSystem{
+		Common: NewCommon(c, ref),
+	}
+}
+
+func (s HostStorageSystem) RetrieveDiskPartitionInfo(ctx context.Context, devicePath string) (*types.HostDiskPartitionInfo, error) {
+	req := types.RetrieveDiskPartitionInfo{
+		This:       s.Reference(),
+		DevicePath: []string{devicePath},
+	}
+
+	res, err := methods.RetrieveDiskPartitionInfo(ctx, s.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.Returnval == nil || len(res.Returnval) == 0 {
+		return nil, errors.New("no partition info")
+	}
+
+	return &res.Returnval[0], nil
+}
+
+func (s HostStorageSystem) ComputeDiskPartitionInfo(ctx context.Context, devicePath string, layout types.HostDiskPartitionLayout) (*types.HostDiskPartitionInfo, error) {
+	req := types.ComputeDiskPartitionInfo{
+		This:       s.Reference(),
+		DevicePath: devicePath,
+		Layout:     layout,
+	}
+
+	res, err := methods.ComputeDiskPartitionInfo(ctx, s.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (s HostStorageSystem) UpdateDiskPartitionInfo(ctx context.Context, devicePath string, spec types.HostDiskPartitionSpec) error {
+	req := types.UpdateDiskPartitions{
+		This:       s.Reference(),
+		DevicePath: devicePath,
+		Spec:       spec,
+	}
+
+	_, err := methods.UpdateDiskPartitions(ctx, s.c, &req)
+	return err
+}


### PR DESCRIPTION
These commands cannot yet change the host's devices in
any way, only show HBAs, LUNs, and partition tables.