### PR TITLE
Specify the new entity's name upon import

### DIFF
--- a/govc/importx/options.go
+++ b/govc/importx/options.go
@@ -50,6 +50,7 @@ type Options struct {
 	PowerOn      bool
 	InjectOvfEnv bool
 	WaitForIP    bool
+	Name         *string
 }
 
 type OptionsFlag struct {

--- a/govc/importx/ova.go
+++ b/govc/importx/ova.go
@@ -52,7 +52,6 @@ func (cmd *ova) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	vm := object.NewVirtualMachine(cmd.Client, *moref)
-
 	return cmd.Deploy(vm)
 }
 

--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -34,3 +34,27 @@ load test_helper
   run govc vm.destroy ${TTYLINUX_NAME}
   assert_success
 }
+
+@test "import.ovf with name in options" {
+  name=$(new_id)
+  file=$($mktemp --tmpdir govc-test-XXXXX)
+  echo "{ \"Name\": \"${name}\"}" > ${file}
+
+  run govc import.ovf -options="${file}" $GOVC_IMAGES/${TTYLINUX_NAME}.ovf
+  assert_success
+
+  run govc vm.destroy "${name}"
+  assert_success
+
+  rm -f ${file}
+}
+
+@test "import.ovf with name as argument" {
+  name=$(new_id)
+
+  run govc import.ova -name="${name}" $GOVC_IMAGES/${TTYLINUX_NAME}.ova
+  assert_success
+
+  run govc vm.destroy "${name}"
+  assert_success
+}


### PR DESCRIPTION
Can be specified by setting it as a property in the options file, or by passing it as a command line argument.