### PR TITLE
Move govc url.Parse wrapper to soap.ParseURL

### DIFF
--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/vmware/govmomi/session"
@@ -97,33 +96,12 @@ func (flag *ClientFlag) String() string {
 	return url.String()
 }
 
-var schemeMatch = regexp.MustCompile(`^\w+://`)
-
 func (flag *ClientFlag) Set(s string) error {
 	var err error
 
-	if s != "" {
-		// Default the scheme to https
-		if !schemeMatch.MatchString(s) {
-			s = "https://" + s
-		}
+	flag.url, err = soap.ParseURL(s)
 
-		flag.url, err = url.Parse(s)
-		if err != nil {
-			return err
-		}
-
-		// Default the path to /sdk
-		if flag.url.Path == "" {
-			flag.url.Path = "/sdk"
-		}
-
-		if flag.url.User == nil {
-			flag.url.User = url.UserPassword("", "")
-		}
-	}
-
-	return nil
+	return err
 }
 
 func (flag *ClientFlag) Register(ctx context.Context, f *flag.FlagSet) {

--- a/govc/test/test_helper.bash
+++ b/govc/test/test_helper.bash
@@ -3,6 +3,7 @@ export GOVC_URL=$GOVC_TEST_URL
 export GOVC_DATASTORE=datastore1
 export GOVC_NETWORK="VM Network"
 export GOVC_INSECURE=true
+unset GOVC_DATACENTER
 unset GOVC_USERNAME
 unset GOVC_PASSWORD
 

--- a/test/helper.go
+++ b/test/helper.go
@@ -34,7 +34,7 @@ func URL() *url.URL {
 	if s == "" {
 		return nil
 	}
-	u, err := url.Parse(s)
+	u, err := soap.ParseURL(s)
 	if err != nil {
 		panic(err)
 	}

--- a/vim25/client_test.go
+++ b/vim25/client_test.go
@@ -35,7 +35,7 @@ func testURL(t *testing.T) *url.URL {
 	if s == "" {
 		t.SkipNow()
 	}
-	u, err := url.Parse(s)
+	u, err := soap.ParseURL(s)
 	if err != nil {
 		panic(err)
 	}

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -27,6 +27,7 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -52,6 +53,37 @@ type Client struct {
 	d *debugContainer
 	t *http.Transport
 	p *url.URL
+}
+
+var schemeMatch = regexp.MustCompile(`^\w+://`)
+
+// ParseURL is wrapper around url.Parse, where Scheme defaults to "https" and Path defaults to "/sdk"
+func ParseURL(s string) (*url.URL, error) {
+	var err error
+	var u *url.URL
+
+	if s != "" {
+		// Default the scheme to https
+		if !schemeMatch.MatchString(s) {
+			s = "https://" + s
+		}
+
+		u, err = url.Parse(s)
+		if err != nil {
+			return nil, err
+		}
+
+		// Default the path to /sdk
+		if u.Path == "" {
+			u.Path = "/sdk"
+		}
+
+		if u.User == nil {
+			u.User = url.UserPassword("", "")
+		}
+	}
+
+	return u, nil
 }
 
 func NewClient(u *url.URL, insecure bool) *Client {


### PR DESCRIPTION
By exposing this wrapper, programs other than govc can easily use the
same url defaults as govc (scheme, path).