### PR TITLE
Add support for custom session keep alive handler

### DIFF
--- a/session/keep_alive.go
+++ b/session/keep_alive.go
@@ -36,11 +36,12 @@ type keepAlive struct {
 
 	// keepAlive executes a request in the background with the purpose of
 	// keeping the session active. The response for this request is discarded.
-	keepAlive func(soap.RoundTripper)
+	keepAlive func(soap.RoundTripper) error
 }
 
-func defaultKeepAlive(roundTripper soap.RoundTripper) {
-	methods.GetServiceContent(context.Background(), roundTripper)
+func defaultKeepAlive(roundTripper soap.RoundTripper) error {
+	_, _ = methods.GetCurrentTime(context.Background(), roundTripper)
+	return nil
 }
 
 // KeepAlive wraps the specified soap.RoundTripper and executes a meaningless
@@ -48,13 +49,20 @@ func defaultKeepAlive(roundTripper soap.RoundTripper) {
 // specified amount of idle time. The keep alive process only starts once a
 // user logs in and runs until the user logs out again.
 func KeepAlive(roundTripper soap.RoundTripper, idleTime time.Duration) soap.RoundTripper {
+	return KeepAliveHandler(roundTripper, idleTime, defaultKeepAlive)
+}
+
+// KeepAliveHandler works as KeepAlive() does, but the handler param can decide how to handle errors.
+// For example, if connectivity to ESX/VC is down long enough for a session to expire, a handler can choose to
+// Login() on a types.NotAuthenticated error.  If handler returns non-nil, the keep alive go routine will be stopped.
+func KeepAliveHandler(roundTripper soap.RoundTripper, idleTime time.Duration, handler func(soap.RoundTripper) error) soap.RoundTripper {
 	k := &keepAlive{
 		roundTripper:  roundTripper,
 		idleTime:      idleTime,
 		notifyRequest: make(chan struct{}),
 	}
 
-	k.keepAlive = defaultKeepAlive
+	k.keepAlive = handler
 
 	return k
 }
@@ -81,7 +89,9 @@ func (k *keepAlive) start() {
 			case <-k.notifyRequest:
 				t.Reset(k.idleTime)
 			case <-t.C:
-				k.keepAlive(k.roundTripper)
+				if err := k.keepAlive(k.roundTripper); err != nil {
+					k.stop()
+				}
 				t = time.NewTimer(k.idleTime)
 			}
 		}

--- a/session/manager.go
+++ b/session/manager.go
@@ -117,6 +117,16 @@ func (sm *Manager) UserSession(ctx context.Context) (*types.UserSession, error) 
 	return mgr.CurrentSession, nil
 }
 
+func (sm *Manager) TerminateSession(ctx context.Context, sessionId []string) error {
+	req := types.TerminateSession{
+		This:      sm.Reference(),
+		SessionId: sessionId,
+	}
+
+	_, err := methods.TerminateSession(ctx, sm.client, &req)
+	return err
+}
+
 // SessionIsActive checks whether the session that was created at login is
 // still valid. This function only works against vCenter.
 func (sm *Manager) SessionIsActive(ctx context.Context) (bool, error) {

--- a/vim25/methods/service_content.go
+++ b/vim25/methods/service_content.go
@@ -17,6 +17,8 @@ limitations under the License.
 package methods
 
 import (
+	"time"
+
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
@@ -38,4 +40,17 @@ func GetServiceContent(ctx context.Context, r soap.RoundTripper) (types.ServiceC
 	}
 
 	return res.Returnval, nil
+}
+
+func GetCurrentTime(ctx context.Context, r soap.RoundTripper) (*time.Time, error) {
+	req := types.CurrentTime{
+		This: serviceInstance,
+	}
+
+	res, err := CurrentTime(ctx, r, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
 }


### PR DESCRIPTION
- Switch to CurrentTime in the default handler (smaller payload)
  And useful for custom handlers as it requires authentication, whereas
  ServiceContent does not

- Add session.Manager TerminateSession method