### PR TITLE
clear golint warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 all: check test
 
-check: goimports govet
+check: goimports govet golint
 
 goimports:
 	@echo checking go imports...
@@ -11,6 +11,17 @@ goimports:
 govet:
 	@echo checking go vet...
 	@go tool vet -structtags=false -methods=false .
+
+golint:
+	@echo checking go lint ...
+	@go get -v github.com/golang/lint/golint
+	@for file in $$(find . -name '*.go' | grep -v 'vendor\|govc\|vim25\|test\|authorization_manager.go\|customization_spec_manager.go\|datacenter.go\|host_network_system.go\|http_nfc_lease.go\|search_index.go\|virtual_app.go'); do \
+		golint $${file}; \
+		if [ -n "$$(golint $${file})" ]; then \
+			exit 1; \
+		fi; \
+	done
+
 
 test:
 	go get

--- a/client.go
+++ b/client.go
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-This package is the root package of the govmomi library.
+/*Package govmomi implements the vmware monitoring interface.
 
 The library is structured as follows:
 
@@ -68,6 +67,7 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Client represents a govmomi client
 type Client struct {
 	*vim25.Client
 
@@ -129,7 +129,7 @@ func (c *Client) Login(ctx context.Context, u *url.Userinfo) error {
 	return c.SessionManager.Login(ctx, u)
 }
 
-// Login dispatches to the SessionManager.
+// LoginExtensionByCertificate dispatches to the SessionManager.
 func (c *Client) LoginExtensionByCertificate(ctx context.Context, key string, locale string) error {
 	return c.SessionManager.LoginExtensionByCertificate(ctx, key, locale)
 }

--- a/event/history_collector.go
+++ b/event/history_collector.go
@@ -25,16 +25,19 @@ import (
 	"golang.org/x/net/context"
 )
 
+// HistoryCollector collects event history
 type HistoryCollector struct {
 	*object.HistoryCollector
 }
 
+// NewHistoryCollector creates a new event history collector
 func NewHistoryCollector(c *vim25.Client, ref types.ManagedObjectReference) *HistoryCollector {
 	return &HistoryCollector{
 		HistoryCollector: object.NewHistoryCollector(c, ref),
 	}
 }
 
+// LatestPage gets the latest history page
 func (h HistoryCollector) LatestPage(ctx context.Context) ([]types.BaseEvent, error) {
 	var o mo.EventHistoryCollector
 
@@ -46,6 +49,7 @@ func (h HistoryCollector) LatestPage(ctx context.Context) ([]types.BaseEvent, er
 	return o.LatestPage, nil
 }
 
+// ReadNextEvents reads the next events
 func (h HistoryCollector) ReadNextEvents(ctx context.Context, maxCount int) ([]types.BaseEvent, error) {
 	req := types.ReadNextEvents{
 		This:     h.Reference(),
@@ -60,6 +64,7 @@ func (h HistoryCollector) ReadNextEvents(ctx context.Context, maxCount int) ([]t
 	return res.Returnval, nil
 }
 
+// ReadPreviousEvents reads the previous event up to maxCount
 func (h HistoryCollector) ReadPreviousEvents(ctx context.Context, maxCount int) ([]types.BaseEvent, error) {
 	req := types.ReadPreviousEvents{
 		This:     h.Reference(),

--- a/event/manager.go
+++ b/event/manager.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Manager is an event manager
 type Manager struct {
 	reference types.ManagedObjectReference
 
@@ -37,6 +38,7 @@ type Manager struct {
 	eventCategoryMu *sync.Mutex
 }
 
+// NewManager creates a new event manager
 func NewManager(c *vim25.Client) *Manager {
 	m := Manager{
 		reference: *c.ServiceContent.EventManager,
@@ -50,6 +52,7 @@ func NewManager(c *vim25.Client) *Manager {
 	return &m
 }
 
+// CreateCollectorForEvents creates a collector for an event filter
 func (m Manager) CreateCollectorForEvents(ctx context.Context, filter types.EventFilterSpec) (*HistoryCollector, error) {
 	req := types.CreateCollectorForEvents{
 		This:   m.reference,
@@ -64,6 +67,7 @@ func (m Manager) CreateCollectorForEvents(ctx context.Context, filter types.Even
 	return NewHistoryCollector(m.c, res.Returnval), nil
 }
 
+// LogUserEvent logs a user event
 func (m Manager) LogUserEvent(ctx context.Context, entity types.ManagedObjectReference, msg string) error {
 	req := types.LogUserEvent{
 		This:   m.reference,
@@ -79,6 +83,7 @@ func (m Manager) LogUserEvent(ctx context.Context, entity types.ManagedObjectRef
 	return nil
 }
 
+// PostEvent posts an event to vsphere
 func (m Manager) PostEvent(ctx context.Context, eventToPost types.BaseEvent, taskInfo types.TaskInfo) error {
 	req := types.PostEvent{
 		This:        m.reference,
@@ -94,6 +99,7 @@ func (m Manager) PostEvent(ctx context.Context, eventToPost types.BaseEvent, tas
 	return nil
 }
 
+// QueryEvents queries the events in vsphere with a filter
 func (m Manager) QueryEvents(ctx context.Context, filter types.EventFilterSpec) ([]types.BaseEvent, error) {
 	req := types.QueryEvents{
 		This:   m.reference,
@@ -108,6 +114,7 @@ func (m Manager) QueryEvents(ctx context.Context, filter types.EventFilterSpec) 
 	return res.Returnval, nil
 }
 
+// RetrieveArgumentDescription retrieves an argument description
 func (m Manager) RetrieveArgumentDescription(ctx context.Context, eventTypeID string) ([]types.EventArgDesc, error) {
 	req := types.RetrieveArgumentDescription{
 		This:        m.reference,

--- a/find/error.go
+++ b/find/error.go
@@ -18,36 +18,44 @@ package find
 
 import "fmt"
 
+// NotFoundError is returned when something can't be found
 type NotFoundError struct {
 	kind string
 	path string
 }
 
+// Error returns the formatted error string
 func (e *NotFoundError) Error() string {
 	return fmt.Sprintf("%s '%s' not found", e.kind, e.path)
 }
 
+// MultipleFoundError is returned when there are multiple results found
 type MultipleFoundError struct {
 	kind string
 	path string
 }
 
+// Error returns the formatted error string
 func (e *MultipleFoundError) Error() string {
 	return fmt.Sprintf("path '%s' resolves to multiple %ss", e.path, e.kind)
 }
 
+// DefaultNotFoundError the default not found error
 type DefaultNotFoundError struct {
 	kind string
 }
 
+// Error returns the formatted error string
 func (e *DefaultNotFoundError) Error() string {
 	return fmt.Sprintf("no default %s found", e.kind)
 }
 
+// DefaultMultipleFoundError the default multiple not found error
 type DefaultMultipleFoundError struct {
 	kind string
 }
 
+// Error returns the formatted error string
 func (e DefaultMultipleFoundError) Error() string {
 	return fmt.Sprintf("default %s resolves to multiple instances, please specify", e.kind)
 }

--- a/find/finder.go
+++ b/find/finder.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Finder finds things in vspeher
 type Finder struct {
 	client   *vim25.Client
 	recurser list.Recurser
@@ -36,6 +37,7 @@ type Finder struct {
 	folders *object.DatacenterFolders
 }
 
+// NewFinder creates a new finder
 func NewFinder(client *vim25.Client, all bool) *Finder {
 	f := &Finder{
 		client: client,
@@ -48,6 +50,7 @@ func NewFinder(client *vim25.Client, all bool) *Finder {
 	return f
 }
 
+// SetDatacenter sets the datacenter
 func (f *Finder) SetDatacenter(dc *object.Datacenter) *Finder {
 	f.dc = dc
 	f.folders = nil
@@ -192,14 +195,17 @@ func (f *Finder) managedObjectList(ctx context.Context, path string, tl bool) ([
 	return f.find(ctx, fn, tl, path)
 }
 
+// ManagedObjectList a managed object list
 func (f *Finder) ManagedObjectList(ctx context.Context, path string) ([]list.Element, error) {
 	return f.managedObjectList(ctx, path, false)
 }
 
+// ManagedObjectListChildren the children of a managed object list
 func (f *Finder) ManagedObjectListChildren(ctx context.Context, path string) ([]list.Element, error) {
 	return f.managedObjectList(ctx, path, true)
 }
 
+// DatacenterList list the datacenters
 func (f *Finder) DatacenterList(ctx context.Context, path string) ([]*object.Datacenter, error) {
 	es, err := f.find(ctx, f.rootFolder, false, path)
 	if err != nil {
@@ -221,6 +227,7 @@ func (f *Finder) DatacenterList(ctx context.Context, path string) ([]*object.Dat
 	return dcs, nil
 }
 
+// Datacenter finds a datacenter
 func (f *Finder) Datacenter(ctx context.Context, path string) (*object.Datacenter, error) {
 	dcs, err := f.DatacenterList(ctx, path)
 	if err != nil {
@@ -234,6 +241,7 @@ func (f *Finder) Datacenter(ctx context.Context, path string) (*object.Datacente
 	return dcs[0], nil
 }
 
+// DefaultDatacenter finds the default data center
 func (f *Finder) DefaultDatacenter(ctx context.Context) (*object.Datacenter, error) {
 	dc, err := f.Datacenter(ctx, "*")
 	if err != nil {
@@ -243,6 +251,7 @@ func (f *Finder) DefaultDatacenter(ctx context.Context) (*object.Datacenter, err
 	return dc, nil
 }
 
+// DatastoreList lists the datastores
 func (f *Finder) DatastoreList(ctx context.Context, path string) ([]*object.Datastore, error) {
 	es, err := f.find(ctx, f.datastoreFolder, false, path)
 	if err != nil {
@@ -267,6 +276,7 @@ func (f *Finder) DatastoreList(ctx context.Context, path string) ([]*object.Data
 	return dss, nil
 }
 
+// Datastore finds a data store
 func (f *Finder) Datastore(ctx context.Context, path string) (*object.Datastore, error) {
 	dss, err := f.DatastoreList(ctx, path)
 	if err != nil {
@@ -280,6 +290,7 @@ func (f *Finder) Datastore(ctx context.Context, path string) (*object.Datastore,
 	return dss[0], nil
 }
 
+// DefaultDatastore finds the default datastore
 func (f *Finder) DefaultDatastore(ctx context.Context) (*object.Datastore, error) {
 	ds, err := f.Datastore(ctx, "*")
 	if err != nil {
@@ -289,6 +300,7 @@ func (f *Finder) DefaultDatastore(ctx context.Context) (*object.Datastore, error
 	return ds, nil
 }
 
+// ComputeResourceList finds the computer resources
 func (f *Finder) ComputeResourceList(ctx context.Context, path string) ([]*object.ComputeResource, error) {
 	es, err := f.find(ctx, f.hostFolder, false, path)
 	if err != nil {
@@ -317,6 +329,7 @@ func (f *Finder) ComputeResourceList(ctx context.Context, path string) ([]*objec
 	return crs, nil
 }
 
+// ComputeResource represents a compute resource
 func (f *Finder) ComputeResource(ctx context.Context, path string) (*object.ComputeResource, error) {
 	crs, err := f.ComputeResourceList(ctx, path)
 	if err != nil {
@@ -330,6 +343,7 @@ func (f *Finder) ComputeResource(ctx context.Context, path string) (*object.Comp
 	return crs[0], nil
 }
 
+// DefaultComputeResource finds the default compute resource
 func (f *Finder) DefaultComputeResource(ctx context.Context) (*object.ComputeResource, error) {
 	cr, err := f.ComputeResource(ctx, "*")
 	if err != nil {
@@ -339,6 +353,7 @@ func (f *Finder) DefaultComputeResource(ctx context.Context) (*object.ComputeRes
 	return cr, nil
 }
 
+// ClusterComputeResourceList finds the compute resource list for a cluster
 func (f *Finder) ClusterComputeResourceList(ctx context.Context, path string) ([]*object.ClusterComputeResource, error) {
 	es, err := f.find(ctx, f.hostFolder, false, path)
 	if err != nil {
@@ -367,6 +382,7 @@ func (f *Finder) ClusterComputeResourceList(ctx context.Context, path string) ([
 	return ccrs, nil
 }
 
+// ClusterComputeResource finds a compute resource in a cluster
 func (f *Finder) ClusterComputeResource(ctx context.Context, path string) (*object.ClusterComputeResource, error) {
 	ccrs, err := f.ClusterComputeResourceList(ctx, path)
 	if err != nil {
@@ -380,6 +396,7 @@ func (f *Finder) ClusterComputeResource(ctx context.Context, path string) (*obje
 	return ccrs[0], nil
 }
 
+// HostSystemList represents a host system list
 func (f *Finder) HostSystemList(ctx context.Context, path string) ([]*object.HostSystem, error) {
 	es, err := f.find(ctx, f.hostFolder, false, path)
 	if err != nil {
@@ -417,6 +434,7 @@ func (f *Finder) HostSystemList(ctx context.Context, path string) ([]*object.Hos
 	return hss, nil
 }
 
+// HostSystem represents a host system
 func (f *Finder) HostSystem(ctx context.Context, path string) (*object.HostSystem, error) {
 	hss, err := f.HostSystemList(ctx, path)
 	if err != nil {
@@ -430,6 +448,7 @@ func (f *Finder) HostSystem(ctx context.Context, path string) (*object.HostSyste
 	return hss[0], nil
 }
 
+// DefaultHostSystem finds the default host system
 func (f *Finder) DefaultHostSystem(ctx context.Context) (*object.HostSystem, error) {
 	hs, err := f.HostSystem(ctx, "*/*")
 	if err != nil {
@@ -439,6 +458,7 @@ func (f *Finder) DefaultHostSystem(ctx context.Context) (*object.HostSystem, err
 	return hs, nil
 }
 
+// NetworkList returns the network list
 func (f *Finder) NetworkList(ctx context.Context, path string) ([]object.NetworkReference, error) {
 	es, err := f.find(ctx, f.networkFolder, false, path)
 	if err != nil {
@@ -471,6 +491,7 @@ func (f *Finder) NetworkList(ctx context.Context, path string) ([]object.Network
 	return ns, nil
 }
 
+// Network finds a network
 func (f *Finder) Network(ctx context.Context, path string) (object.NetworkReference, error) {
 	networks, err := f.NetworkList(ctx, path)
 	if err != nil {
@@ -484,6 +505,7 @@ func (f *Finder) Network(ctx context.Context, path string) (object.NetworkRefere
 	return networks[0], nil
 }
 
+// DefaultNetwork finds the default network
 func (f *Finder) DefaultNetwork(ctx context.Context) (object.NetworkReference, error) {
 	network, err := f.Network(ctx, "*")
 	if err != nil {
@@ -493,6 +515,7 @@ func (f *Finder) DefaultNetwork(ctx context.Context) (object.NetworkReference, e
 	return network, nil
 }
 
+// ResourcePoolList returns the resource pools
 func (f *Finder) ResourcePoolList(ctx context.Context, path string) ([]*object.ResourcePool, error) {
 	es, err := f.find(ctx, f.hostFolder, true, path)
 	if err != nil {
@@ -518,6 +541,7 @@ func (f *Finder) ResourcePoolList(ctx context.Context, path string) ([]*object.R
 	return rps, nil
 }
 
+// ResourcePool finds a resource pool for the given path
 func (f *Finder) ResourcePool(ctx context.Context, path string) (*object.ResourcePool, error) {
 	rps, err := f.ResourcePoolList(ctx, path)
 	if err != nil {
@@ -531,6 +555,7 @@ func (f *Finder) ResourcePool(ctx context.Context, path string) (*object.Resourc
 	return rps[0], nil
 }
 
+// DefaultResourcePool finds the default resource pool
 func (f *Finder) DefaultResourcePool(ctx context.Context) (*object.ResourcePool, error) {
 	rp, err := f.ResourcePool(ctx, "*/Resources")
 	if err != nil {
@@ -540,6 +565,7 @@ func (f *Finder) DefaultResourcePool(ctx context.Context) (*object.ResourcePool,
 	return rp, nil
 }
 
+// VirtualMachineList returns the list of virtual machines
 func (f *Finder) VirtualMachineList(ctx context.Context, path string) ([]*object.VirtualMachine, error) {
 	es, err := f.find(ctx, f.vmFolder, false, path)
 	if err != nil {
@@ -563,6 +589,7 @@ func (f *Finder) VirtualMachineList(ctx context.Context, path string) ([]*object
 	return vms, nil
 }
 
+// VirtualMachine finds a virtual machine for a given path
 func (f *Finder) VirtualMachine(ctx context.Context, path string) (*object.VirtualMachine, error) {
 	vms, err := f.VirtualMachineList(ctx, path)
 	if err != nil {
@@ -576,6 +603,7 @@ func (f *Finder) VirtualMachine(ctx context.Context, path string) (*object.Virtu
 	return vms[0], nil
 }
 
+// VirtualAppList lists the virtual applications
 func (f *Finder) VirtualAppList(ctx context.Context, path string) ([]*object.VirtualApp, error) {
 	es, err := f.find(ctx, f.vmFolder, false, path)
 	if err != nil {
@@ -599,6 +627,7 @@ func (f *Finder) VirtualAppList(ctx context.Context, path string) ([]*object.Vir
 	return apps, nil
 }
 
+// VirtualApp creates a virtual application
 func (f *Finder) VirtualApp(ctx context.Context, path string) (*object.VirtualApp, error) {
 	apps, err := f.VirtualAppList(ctx, path)
 	if err != nil {
@@ -612,6 +641,7 @@ func (f *Finder) VirtualApp(ctx context.Context, path string) (*object.VirtualAp
 	return apps[0], nil
 }
 
+// Folder finds a folder
 func (f *Finder) Folder(ctx context.Context, path string) (*object.Folder, error) {
 	mo, err := f.ManagedObjectList(ctx, path)
 	if err != nil {

--- a/guest/auth_manager.go
+++ b/guest/auth_manager.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/context"
 )
 
+// AuthManager is a manager for authentication
 type AuthManager struct {
 	types.ManagedObjectReference
 
@@ -31,10 +32,12 @@ type AuthManager struct {
 	c *vim25.Client
 }
 
+// Reference returns the managed object reference
 func (m AuthManager) Reference() types.ManagedObjectReference {
 	return m.ManagedObjectReference
 }
 
+// AcquireCredentials acquires the credentisls for this session
 func (m AuthManager) AcquireCredentials(ctx context.Context, requestedAuth types.BaseGuestAuthentication, sessionID int64) (types.BaseGuestAuthentication, error) {
 	req := types.AcquireCredentialsInGuest{
 		This:          m.Reference(),
@@ -51,6 +54,7 @@ func (m AuthManager) AcquireCredentials(ctx context.Context, requestedAuth types
 	return res.Returnval, nil
 }
 
+// ReleaseCredentials release the credentials in the guest
 func (m AuthManager) ReleaseCredentials(ctx context.Context, auth types.BaseGuestAuthentication) error {
 	req := types.ReleaseCredentialsInGuest{
 		This: m.Reference(),
@@ -63,6 +67,7 @@ func (m AuthManager) ReleaseCredentials(ctx context.Context, auth types.BaseGues
 	return err
 }
 
+// ValidateCredentials validates the basic auth credentials
 func (m AuthManager) ValidateCredentials(ctx context.Context, auth types.BaseGuestAuthentication) error {
 	req := types.ValidateCredentialsInGuest{
 		This: m.Reference(),

--- a/guest/file_manager.go
+++ b/guest/file_manager.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/context"
 )
 
+// FileManager managed files in a guest
 type FileManager struct {
 	types.ManagedObjectReference
 
@@ -31,10 +32,12 @@ type FileManager struct {
 	c *vim25.Client
 }
 
+// Reference implements a referencable interface
 func (m FileManager) Reference() types.ManagedObjectReference {
 	return m.ManagedObjectReference
 }
 
+// ChangeFileAttributes changes the attributes on a file
 func (m FileManager) ChangeFileAttributes(ctx context.Context, auth types.BaseGuestAuthentication, guestFilePath string, fileAttributes types.BaseGuestFileAttributes) error {
 	req := types.ChangeFileAttributesInGuest{
 		This:           m.Reference(),
@@ -48,6 +51,7 @@ func (m FileManager) ChangeFileAttributes(ctx context.Context, auth types.BaseGu
 	return err
 }
 
+// CreateTemporaryDirectory creates a temporary directory
 func (m FileManager) CreateTemporaryDirectory(ctx context.Context, auth types.BaseGuestAuthentication, prefix, suffix string) (string, error) {
 	req := types.CreateTemporaryDirectoryInGuest{
 		This:   m.Reference(),
@@ -65,6 +69,7 @@ func (m FileManager) CreateTemporaryDirectory(ctx context.Context, auth types.Ba
 	return res.Returnval, nil
 }
 
+// CreateTemporaryFile creates a temporary file
 func (m FileManager) CreateTemporaryFile(ctx context.Context, auth types.BaseGuestAuthentication, prefix, suffix string) (string, error) {
 	req := types.CreateTemporaryFileInGuest{
 		This:   m.Reference(),
@@ -82,6 +87,7 @@ func (m FileManager) CreateTemporaryFile(ctx context.Context, auth types.BaseGue
 	return res.Returnval, nil
 }
 
+// DeleteDirectory deletes a directory, this can be a recursive delete
 func (m FileManager) DeleteDirectory(ctx context.Context, auth types.BaseGuestAuthentication, directoryPath string, recursive bool) error {
 	req := types.DeleteDirectoryInGuest{
 		This:          m.Reference(),
@@ -95,6 +101,7 @@ func (m FileManager) DeleteDirectory(ctx context.Context, auth types.BaseGuestAu
 	return err
 }
 
+// DeleteFile deletes a file
 func (m FileManager) DeleteFile(ctx context.Context, auth types.BaseGuestAuthentication, filePath string) error {
 	req := types.DeleteFileInGuest{
 		This:     m.Reference(),
@@ -107,6 +114,7 @@ func (m FileManager) DeleteFile(ctx context.Context, auth types.BaseGuestAuthent
 	return err
 }
 
+// InitiateFileTransferFromGuest initiates a file transfer from guest
 func (m FileManager) InitiateFileTransferFromGuest(ctx context.Context, auth types.BaseGuestAuthentication, guestFilePath string) (*types.FileTransferInformation, error) {
 	req := types.InitiateFileTransferFromGuest{
 		This:          m.Reference(),
@@ -123,6 +131,7 @@ func (m FileManager) InitiateFileTransferFromGuest(ctx context.Context, auth typ
 	return &res.Returnval, nil
 }
 
+// InitiateFileTransferToGuest iniates a file tranfer to a guest
 func (m FileManager) InitiateFileTransferToGuest(ctx context.Context, auth types.BaseGuestAuthentication, guestFilePath string, fileAttributes types.BaseGuestFileAttributes, fileSize int64, overwrite bool) (string, error) {
 	req := types.InitiateFileTransferToGuest{
 		This:           m.Reference(),
@@ -142,6 +151,7 @@ func (m FileManager) InitiateFileTransferToGuest(ctx context.Context, auth types
 	return res.Returnval, nil
 }
 
+// ListFiles lists filtered files in a guest
 func (m FileManager) ListFiles(ctx context.Context, auth types.BaseGuestAuthentication, filePath string, index int, maxResults int, matchPattern string) (*types.GuestListFileInfo, error) {
 	req := types.ListFilesInGuest{
 		This:         m.Reference(),
@@ -161,6 +171,7 @@ func (m FileManager) ListFiles(ctx context.Context, auth types.BaseGuestAuthenti
 	return &res.Returnval, nil
 }
 
+// MakeDirectory makes a directory
 func (m FileManager) MakeDirectory(ctx context.Context, auth types.BaseGuestAuthentication, directoryPath string, createParentDirectories bool) error {
 	req := types.MakeDirectoryInGuest{
 		This:                    m.Reference(),
@@ -174,6 +185,7 @@ func (m FileManager) MakeDirectory(ctx context.Context, auth types.BaseGuestAuth
 	return err
 }
 
+// MoveDirectory a moves a directory in guest
 func (m FileManager) MoveDirectory(ctx context.Context, auth types.BaseGuestAuthentication, srcDirectoryPath string, dstDirectoryPath string) error {
 	req := types.MoveDirectoryInGuest{
 		This:             m.Reference(),
@@ -187,6 +199,7 @@ func (m FileManager) MoveDirectory(ctx context.Context, auth types.BaseGuestAuth
 	return err
 }
 
+// MoveFile files a file in a guest
 func (m FileManager) MoveFile(ctx context.Context, auth types.BaseGuestAuthentication, srcFilePath string, dstFilePath string, overwrite bool) error {
 	req := types.MoveFileInGuest{
 		This:        m.Reference(),

--- a/guest/operations_manager.go
+++ b/guest/operations_manager.go
@@ -24,11 +24,13 @@ import (
 	"golang.org/x/net/context"
 )
 
+// OperationsManager is a facade for guest operations
 type OperationsManager struct {
 	c  *vim25.Client
 	vm types.ManagedObjectReference
 }
 
+// NewOperationsManager creates a new operations manager
 func NewOperationsManager(c *vim25.Client, vm types.ManagedObjectReference) *OperationsManager {
 	return &OperationsManager{c, vm}
 }
@@ -38,6 +40,7 @@ func (m OperationsManager) retrieveOne(ctx context.Context, p string, dst *mo.Gu
 	return pc.RetrieveOne(ctx, *m.c.ServiceContent.GuestOperationsManager, []string{p}, dst)
 }
 
+// AuthManager returns the auth manager
 func (m OperationsManager) AuthManager(ctx context.Context) (*AuthManager, error) {
 	var g mo.GuestOperationsManager
 
@@ -49,6 +52,7 @@ func (m OperationsManager) AuthManager(ctx context.Context) (*AuthManager, error
 	return &AuthManager{*g.AuthManager, m.vm, m.c}, nil
 }
 
+// FileManager returns the file manager
 func (m OperationsManager) FileManager(ctx context.Context) (*FileManager, error) {
 	var g mo.GuestOperationsManager
 
@@ -60,6 +64,7 @@ func (m OperationsManager) FileManager(ctx context.Context) (*FileManager, error
 	return &FileManager{*g.FileManager, m.vm, m.c}, nil
 }
 
+// ProcessManager manages the processes for the given context
 func (m OperationsManager) ProcessManager(ctx context.Context) (*ProcessManager, error) {
 	var g mo.GuestOperationsManager
 

--- a/guest/process_manager.go
+++ b/guest/process_manager.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/context"
 )
 
+// ProcessManager a guest process manager
 type ProcessManager struct {
 	types.ManagedObjectReference
 
@@ -31,10 +32,12 @@ type ProcessManager struct {
 	c *vim25.Client
 }
 
+// Reference returns the managed object reference
 func (m ProcessManager) Reference() types.ManagedObjectReference {
 	return m.ManagedObjectReference
 }
 
+// ListProcesses lists the processes in the guest
 func (m ProcessManager) ListProcesses(ctx context.Context, auth types.BaseGuestAuthentication, pids []int64) ([]types.GuestProcessInfo, error) {
 	req := types.ListProcessesInGuest{
 		This: m.Reference(),
@@ -51,6 +54,7 @@ func (m ProcessManager) ListProcesses(ctx context.Context, auth types.BaseGuestA
 	return res.Returnval, err
 }
 
+// ReadEnvironmentVariable reads a guest environment variable
 func (m ProcessManager) ReadEnvironmentVariable(ctx context.Context, auth types.BaseGuestAuthentication, names []string) ([]string, error) {
 	req := types.ReadEnvironmentVariableInGuest{
 		This:  m.Reference(),
@@ -67,6 +71,7 @@ func (m ProcessManager) ReadEnvironmentVariable(ctx context.Context, auth types.
 	return res.Returnval, err
 }
 
+// StartProgram starts a program in the guest
 func (m ProcessManager) StartProgram(ctx context.Context, auth types.BaseGuestAuthentication, spec types.BaseGuestProgramSpec) (int64, error) {
 	req := types.StartProgramInGuest{
 		This: m.Reference(),
@@ -83,6 +88,7 @@ func (m ProcessManager) StartProgram(ctx context.Context, auth types.BaseGuestAu
 	return res.Returnval, err
 }
 
+// TerminateProcess terminates a process in a guest
 func (m ProcessManager) TerminateProcess(ctx context.Context, auth types.BaseGuestAuthentication, pid int64) error {
 	req := types.TerminateProcessInGuest{
 		This: m.Reference(),

--- a/license/assignment_manager.go
+++ b/license/assignment_manager.go
@@ -23,10 +23,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// AssignmentManager manages assignments
 type AssignmentManager struct {
 	object.Common
 }
 
+// QueryAssigned queries the assigned licenses
 func (m AssignmentManager) QueryAssigned(ctx context.Context, id string) ([]types.LicenseAssignmentManagerLicenseAssignment, error) {
 	req := types.QueryAssignedLicenses{
 		This:     m.Reference(),
@@ -41,6 +43,7 @@ func (m AssignmentManager) QueryAssigned(ctx context.Context, id string) ([]type
 	return res.Returnval, nil
 }
 
+// Remove removes a license assignment
 func (m AssignmentManager) Remove(ctx context.Context, id string) error {
 	req := types.RemoveAssignedLicense{
 		This:     m.Reference(),
@@ -52,6 +55,7 @@ func (m AssignmentManager) Remove(ctx context.Context, id string) error {
 	return err
 }
 
+// Update updates a license assignment
 func (m AssignmentManager) Update(ctx context.Context, id string, key string, name string) (*types.LicenseManagerLicenseInfo, error) {
 	req := types.UpdateAssignedLicense{
 		This:              m.Reference(),

--- a/license/manager.go
+++ b/license/manager.go
@@ -28,10 +28,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Manager represents a license manager
 type Manager struct {
 	object.Common
 }
 
+// NewManager creates a new manager
 func NewManager(c *vim25.Client) *Manager {
 	m := Manager{
 		object.NewCommon(c, *c.ServiceContent.LicenseManager),
@@ -48,6 +50,7 @@ func mapToKeyValueSlice(m map[string]string) []types.KeyValue {
 	return r
 }
 
+// Add a license
 func (m Manager) Add(ctx context.Context, key string, labels map[string]string) (types.LicenseManagerLicenseInfo, error) {
 	req := types.AddLicense{
 		This:       m.Reference(),
@@ -63,6 +66,7 @@ func (m Manager) Add(ctx context.Context, key string, labels map[string]string) 
 	return res.Returnval, nil
 }
 
+// Decode decode a license
 func (m Manager) Decode(ctx context.Context, key string) (types.LicenseManagerLicenseInfo, error) {
 	req := types.DecodeLicense{
 		This:       m.Reference(),
@@ -77,6 +81,7 @@ func (m Manager) Decode(ctx context.Context, key string) (types.LicenseManagerLi
 	return res.Returnval, nil
 }
 
+// Remove removes a license
 func (m Manager) Remove(ctx context.Context, key string) error {
 	req := types.RemoveLicense{
 		This:       m.Reference(),
@@ -87,6 +92,7 @@ func (m Manager) Remove(ctx context.Context, key string) error {
 	return err
 }
 
+// Update updates a license
 func (m Manager) Update(ctx context.Context, key string, labels map[string]string) (types.LicenseManagerLicenseInfo, error) {
 	req := types.UpdateLicense{
 		This:       m.Reference(),
@@ -102,6 +108,7 @@ func (m Manager) Update(ctx context.Context, key string, labels map[string]strin
 	return res.Returnval, nil
 }
 
+// List the license infos
 func (m Manager) List(ctx context.Context) (InfoList, error) {
 	var mlm mo.LicenseManager
 
@@ -113,6 +120,7 @@ func (m Manager) List(ctx context.Context) (InfoList, error) {
 	return InfoList(mlm.Licenses), nil
 }
 
+// AssignmentManager create an assignment manager for the given context
 func (m Manager) AssignmentManager(ctx context.Context) (*AssignmentManager, error) {
 	var mlm mo.LicenseManager
 
@@ -155,6 +163,7 @@ func parseLicenseFeature(feature string) *licenseFeature {
 	return lf
 }
 
+// HasFeature checks if a license has a given feature
 func HasFeature(license types.LicenseManagerLicenseInfo, key string) bool {
 	feature := parseLicenseFeature(key)
 
@@ -182,6 +191,7 @@ func HasFeature(license types.LicenseManagerLicenseInfo, key string) bool {
 // InfoList provides helper methods for []types.LicenseManagerLicenseInfo
 type InfoList []types.LicenseManagerLicenseInfo
 
+// WithFeature filters a list of licenses for a particular feature
 func (l InfoList) WithFeature(key string) InfoList {
 	var result InfoList
 

--- a/list/lister.go
+++ b/list/lister.go
@@ -28,11 +28,13 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Element represents an element at a path
 type Element struct {
 	Path   string
 	Object mo.Reference
 }
 
+// ToElement converts a reference to an element
 func ToElement(r mo.Reference, prefix string) Element {
 	var name string
 
@@ -103,6 +105,7 @@ func ToElement(r mo.Reference, prefix string) Element {
 	return e
 }
 
+// Lister lists references
 type Lister struct {
 	Collector *property.Collector
 	Reference types.ManagedObjectReference
@@ -159,6 +162,7 @@ func (l Lister) retrieveProperties(ctx context.Context, req types.RetrieveProper
 	return nil
 }
 
+// List sub paths for the reference type
 func (l Lister) List(ctx context.Context) ([]Element, error) {
 	switch l.Reference.Type {
 	case "Folder", "StoragePod":
@@ -180,6 +184,7 @@ func (l Lister) List(ctx context.Context) ([]Element, error) {
 	}
 }
 
+// ListFolder lists the folder paths
 func (l Lister) ListFolder(ctx context.Context) ([]Element, error) {
 	spec := types.PropertyFilterSpec{
 		ObjectSet: []types.ObjectSpec{
@@ -252,6 +257,7 @@ func (l Lister) ListFolder(ctx context.Context) ([]Element, error) {
 	return es, nil
 }
 
+// ListDatacenter lists the datacenter paths
 func (l Lister) ListDatacenter(ctx context.Context) ([]Element, error) {
 	ospec := types.ObjectSpec{
 		Obj:  l.Reference,
@@ -310,6 +316,7 @@ func (l Lister) ListDatacenter(ctx context.Context) ([]Element, error) {
 	return es, nil
 }
 
+// ListComputeResource lists the compute resource paths
 func (l Lister) ListComputeResource(ctx context.Context) ([]Element, error) {
 	ospec := types.ObjectSpec{
 		Obj:  l.Reference,
@@ -375,6 +382,7 @@ func (l Lister) ListComputeResource(ctx context.Context) ([]Element, error) {
 	return es, nil
 }
 
+// ListResourcePool lists the resource pool paths
 func (l Lister) ListResourcePool(ctx context.Context) ([]Element, error) {
 	ospec := types.ObjectSpec{
 		Obj:  l.Reference,
@@ -438,6 +446,7 @@ func (l Lister) ListResourcePool(ctx context.Context) ([]Element, error) {
 	return es, nil
 }
 
+// ListHostSystem lists the host sytem paths
 func (l Lister) ListHostSystem(ctx context.Context) ([]Element, error) {
 	ospec := types.ObjectSpec{
 		Obj:  l.Reference,
@@ -505,6 +514,7 @@ func (l Lister) ListHostSystem(ctx context.Context) ([]Element, error) {
 	return es, nil
 }
 
+// ListVirtualApp lists the vapp paths
 func (l Lister) ListVirtualApp(ctx context.Context) ([]Element, error) {
 	ospec := types.ObjectSpec{
 		Obj:  l.Reference,

--- a/list/path.go
+++ b/list/path.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 )
 
+// ToParts splits a path into parts
 func ToParts(p string) []string {
 	p = path.Clean(p)
 	if p == "/" {

--- a/list/recurser.go
+++ b/list/recurser.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Recurser recurses a graph
 type Recurser struct {
 	Collector *property.Collector
 
@@ -37,6 +38,7 @@ type Recurser struct {
 	TraverseLeafs bool
 }
 
+// Recurse a given root for the given parts
 func (r Recurser) Recurse(ctx context.Context, root Element, parts []string) ([]Element, error) {
 	if len(parts) == 0 {
 		// Include non-traversable leaf elements in result. For example, consider

--- a/object/authorization_manager.go
+++ b/object/authorization_manager.go
@@ -24,10 +24,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// AuthorizationManager represents an authorization manager
 type AuthorizationManager struct {
 	Common
 }
 
+// NewAuthorizationManager creates an authorization manager
 func NewAuthorizationManager(c *vim25.Client) *AuthorizationManager {
 	m := AuthorizationManager{
 		Common: NewCommon(c, *c.ServiceContent.AuthorizationManager),
@@ -36,8 +38,10 @@ func NewAuthorizationManager(c *vim25.Client) *AuthorizationManager {
 	return &m
 }
 
+// AuthorizationRoleList respresents a list of authorization roles
 type AuthorizationRoleList []types.AuthorizationRole
 
+// ById finds the role by id
 func (l AuthorizationRoleList) ById(id int) *types.AuthorizationRole {
 	for _, role := range l {
 		if role.RoleId == id {
@@ -48,6 +52,7 @@ func (l AuthorizationRoleList) ById(id int) *types.AuthorizationRole {
 	return nil
 }
 
+// ByName finds the role by name
 func (l AuthorizationRoleList) ByName(name string) *types.AuthorizationRole {
 	for _, role := range l {
 		if role.Name == name {
@@ -58,6 +63,7 @@ func (l AuthorizationRoleList) ByName(name string) *types.AuthorizationRole {
 	return nil
 }
 
+// RoleList lists the known roles
 func (m AuthorizationManager) RoleList(ctx context.Context) (AuthorizationRoleList, error) {
 	var am mo.AuthorizationManager
 
@@ -69,6 +75,7 @@ func (m AuthorizationManager) RoleList(ctx context.Context) (AuthorizationRoleLi
 	return AuthorizationRoleList(am.RoleList), nil
 }
 
+// RetrieveEntityPermissions retrieves entity permissions
 func (m AuthorizationManager) RetrieveEntityPermissions(ctx context.Context, entity types.ManagedObjectReference, inherited bool) ([]types.Permission, error) {
 	req := types.RetrieveEntityPermissions{
 		This:      m.Reference(),
@@ -84,6 +91,7 @@ func (m AuthorizationManager) RetrieveEntityPermissions(ctx context.Context, ent
 	return res.Returnval, nil
 }
 
+// RemoveEntityPermission removes an entity permission
 func (m AuthorizationManager) RemoveEntityPermission(ctx context.Context, entity types.ManagedObjectReference, user string, isGroup bool) error {
 	req := types.RemoveEntityPermission{
 		This:    m.Reference(),
@@ -96,6 +104,7 @@ func (m AuthorizationManager) RemoveEntityPermission(ctx context.Context, entity
 	return err
 }
 
+// SetEntityPermissions set entity permissions
 func (m AuthorizationManager) SetEntityPermissions(ctx context.Context, entity types.ManagedObjectReference, permission []types.Permission) error {
 	req := types.SetEntityPermissions{
 		This:       m.Reference(),

--- a/object/cluster_compute_resource.go
+++ b/object/cluster_compute_resource.go
@@ -23,18 +23,21 @@ import (
 	"golang.org/x/net/context"
 )
 
+// ClusterComputeResource represents a compute resource in a cluster
 type ClusterComputeResource struct {
 	ComputeResource
 
 	InventoryPath string
 }
 
+// NewClusterComputeResource creates a new instance of a cluster compute resource
 func NewClusterComputeResource(c *vim25.Client, ref types.ManagedObjectReference) *ClusterComputeResource {
 	return &ClusterComputeResource{
 		ComputeResource: *NewComputeResource(c, ref),
 	}
 }
 
+// ReconfigureCluster reconfigures a cluster with the given spec
 func (c ClusterComputeResource) ReconfigureCluster(ctx context.Context, spec types.ClusterConfigSpec) (*Task, error) {
 	req := types.ReconfigureCluster_Task{
 		This:   c.Reference(),
@@ -50,6 +53,7 @@ func (c ClusterComputeResource) ReconfigureCluster(ctx context.Context, spec typ
 	return NewTask(c.c, res.Returnval), nil
 }
 
+// AddHost adds a host to this cluster compute resource
 func (c ClusterComputeResource) AddHost(ctx context.Context, spec types.HostConnectSpec, asConnected bool, license *string, resourcePool *types.ManagedObjectReference) (*Task, error) {
 	req := types.AddHost_Task{
 		This:        c.Reference(),
@@ -73,6 +77,7 @@ func (c ClusterComputeResource) AddHost(ctx context.Context, spec types.HostConn
 	return NewTask(c.c, res.Returnval), nil
 }
 
+// Destroy a cluster compute resource
 func (c ClusterComputeResource) Destroy(ctx context.Context) (*Task, error) {
 	req := types.Destroy_Task{
 		This: c.Reference(),

--- a/object/common.go
+++ b/object/common.go
@@ -28,6 +28,7 @@ import (
 )
 
 var (
+	// ErrNotSupported returned when something isn't supported by esx
 	ErrNotSupported = errors.New("not supported (vCenter only)")
 )
 
@@ -37,26 +38,32 @@ type Common struct {
 	r types.ManagedObjectReference
 }
 
+// String returns a string version of the reference
 func (c Common) String() string {
 	return fmt.Sprintf("%v", c.Reference())
 }
 
+// NewCommon returns a new instance of common
 func NewCommon(c *vim25.Client, r types.ManagedObjectReference) Common {
 	return Common{c: c, r: r}
 }
 
+// Reference returns the managed object reference
 func (c Common) Reference() types.ManagedObjectReference {
 	return c.r
 }
 
+// Client returns the client for this object
 func (c Common) Client() *vim25.Client {
 	return c.c
 }
 
+// Properties retrieves the properties for a given reference
 func (c Common) Properties(ctx context.Context, r types.ManagedObjectReference, ps []string, dst interface{}) error {
 	return property.DefaultCollector(c.c).RetrieveOne(ctx, r, ps, dst)
 }
 
+// Destroy the referenced object
 func (c Common) Destroy(ctx context.Context) (*Task, error) {
 	req := types.Destroy_Task{
 		This: c.Reference(),

--- a/object/compute_resource.go
+++ b/object/compute_resource.go
@@ -27,18 +27,21 @@ import (
 	"golang.org/x/net/context"
 )
 
+// ComputeResource represents a compute resource client
 type ComputeResource struct {
 	Common
 
 	InventoryPath string
 }
 
+// NewComputeResource creates a new compute resource client
 func NewComputeResource(c *vim25.Client, ref types.ManagedObjectReference) *ComputeResource {
 	return &ComputeResource{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// Hosts lists the hosts in this compute resource
 func (c ComputeResource) Hosts(ctx context.Context) ([]*HostSystem, error) {
 	var cr mo.ComputeResource
 
@@ -69,6 +72,7 @@ func (c ComputeResource) Hosts(ctx context.Context) ([]*HostSystem, error) {
 	return hosts, nil
 }
 
+// Datastores lists the datastores for this compute resource
 func (c ComputeResource) Datastores(ctx context.Context) ([]*Datastore, error) {
 	var cr mo.ComputeResource
 
@@ -86,6 +90,7 @@ func (c ComputeResource) Datastores(ctx context.Context) ([]*Datastore, error) {
 	return dss, nil
 }
 
+// ResourcePool gets the resource pool for this compute resource
 func (c ComputeResource) ResourcePool(ctx context.Context) (*ResourcePool, error) {
 	var cr mo.ComputeResource
 
@@ -97,6 +102,7 @@ func (c ComputeResource) ResourcePool(ctx context.Context) (*ResourcePool, error
 	return NewResourcePool(c.c, *cr.ResourcePool), nil
 }
 
+// Reconfigure this compute resource
 func (c ComputeResource) Reconfigure(ctx context.Context, spec types.BaseComputeResourceConfigSpec, modify bool) (*Task, error) {
 	req := types.ReconfigureComputeResource_Task{
 		This:   c.Reference(),
@@ -112,6 +118,7 @@ func (c ComputeResource) Reconfigure(ctx context.Context, spec types.BaseCompute
 	return NewTask(c.c, res.Returnval), nil
 }
 
+// Destroy the compute resource
 func (c ComputeResource) Destroy(ctx context.Context) (*Task, error) {
 	req := types.Destroy_Task{
 		This: c.Reference(),

--- a/object/custom_fields_manager.go
+++ b/object/custom_fields_manager.go
@@ -28,9 +28,11 @@ import (
 )
 
 var (
+	// ErrKeyNameNotFound returned when a key by the specified name can't be found
 	ErrKeyNameNotFound = errors.New("key name not found")
 )
 
+// CustomFieldsManager represents a client for custom fields
 type CustomFieldsManager struct {
 	Common
 }
@@ -44,6 +46,7 @@ func GetCustomFieldsManager(c *vim25.Client) (*CustomFieldsManager, error) {
 	return NewCustomFieldsManager(c), nil
 }
 
+// NewCustomFieldsManager creates a new custom fields client
 func NewCustomFieldsManager(c *vim25.Client) *CustomFieldsManager {
 	m := CustomFieldsManager{
 		Common: NewCommon(c, *c.ServiceContent.CustomFieldsManager),
@@ -52,6 +55,7 @@ func NewCustomFieldsManager(c *vim25.Client) *CustomFieldsManager {
 	return &m
 }
 
+// Add a custom field
 func (m CustomFieldsManager) Add(ctx context.Context, name string, moType string, fieldDefPolicy *types.PrivilegePolicyDef, fieldPolicy *types.PrivilegePolicyDef) (*types.CustomFieldDef, error) {
 	req := types.AddCustomFieldDef{
 		This:           m.Reference(),
@@ -69,6 +73,7 @@ func (m CustomFieldsManager) Add(ctx context.Context, name string, moType string
 	return &res.Returnval, nil
 }
 
+// Remove a custom field
 func (m CustomFieldsManager) Remove(ctx context.Context, key int) error {
 	req := types.RemoveCustomFieldDef{
 		This: m.Reference(),
@@ -79,6 +84,7 @@ func (m CustomFieldsManager) Remove(ctx context.Context, key int) error {
 	return err
 }
 
+// Rename a custom field
 func (m CustomFieldsManager) Rename(ctx context.Context, key int, name string) error {
 	req := types.RenameCustomFieldDef{
 		This: m.Reference(),
@@ -90,6 +96,7 @@ func (m CustomFieldsManager) Rename(ctx context.Context, key int, name string) e
 	return err
 }
 
+// Set a custom field value
 func (m CustomFieldsManager) Set(ctx context.Context, entity types.ManagedObjectReference, key int, value string) error {
 	req := types.SetField{
 		This:   m.Reference(),
@@ -102,6 +109,7 @@ func (m CustomFieldsManager) Set(ctx context.Context, entity types.ManagedObject
 	return err
 }
 
+// Field gets a custom field definition
 func (m CustomFieldsManager) Field(ctx context.Context) ([]types.CustomFieldDef, error) {
 	var fm mo.CustomFieldsManager
 
@@ -113,6 +121,7 @@ func (m CustomFieldsManager) Field(ctx context.Context) ([]types.CustomFieldDef,
 	return fm.Field, nil
 }
 
+// FindKey finds a key id by key name
 func (m CustomFieldsManager) FindKey(ctx context.Context, key string) (int, error) {
 	field, err := m.Field(ctx)
 	if err != nil {

--- a/object/customization_spec_manager.go
+++ b/object/customization_spec_manager.go
@@ -23,10 +23,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// CustomizationSpecManager a customization spec client
 type CustomizationSpecManager struct {
 	Common
 }
 
+// NewCustomizationSpecManager creates a new customization spec client
 func NewCustomizationSpecManager(c *vim25.Client) *CustomizationSpecManager {
 	cs := CustomizationSpecManager{
 		Common: NewCommon(c, *c.ServiceContent.CustomizationSpecManager),
@@ -35,6 +37,7 @@ func NewCustomizationSpecManager(c *vim25.Client) *CustomizationSpecManager {
 	return &cs
 }
 
+// DoesCustomizationSpecExist returns true when the customization spec exists
 func (cs CustomizationSpecManager) DoesCustomizationSpecExist(ctx context.Context, name string) (bool, error) {
 	req := types.DoesCustomizationSpecExist{
 		This: cs.Reference(),
@@ -50,6 +53,7 @@ func (cs CustomizationSpecManager) DoesCustomizationSpecExist(ctx context.Contex
 	return res.Returnval, nil
 }
 
+// GetCustomizationSpec gets a customization spec by name
 func (cs CustomizationSpecManager) GetCustomizationSpec(ctx context.Context, name string) (*types.CustomizationSpecItem, error) {
 	req := types.GetCustomizationSpec{
 		This: cs.Reference(),
@@ -65,6 +69,7 @@ func (cs CustomizationSpecManager) GetCustomizationSpec(ctx context.Context, nam
 	return &res.Returnval, nil
 }
 
+// CreateCustomizationSpec creates a customization spec
 func (cs CustomizationSpecManager) CreateCustomizationSpec(ctx context.Context, item types.CustomizationSpecItem) error {
 	req := types.CreateCustomizationSpec{
 		This: cs.Reference(),
@@ -79,6 +84,7 @@ func (cs CustomizationSpecManager) CreateCustomizationSpec(ctx context.Context, 
 	return nil
 }
 
+// OverwriteCustomizationSpec overwrites a customization spec
 func (cs CustomizationSpecManager) OverwriteCustomizationSpec(ctx context.Context, item types.CustomizationSpecItem) error {
 	req := types.OverwriteCustomizationSpec{
 		This: cs.Reference(),
@@ -93,6 +99,7 @@ func (cs CustomizationSpecManager) OverwriteCustomizationSpec(ctx context.Contex
 	return nil
 }
 
+// DeleteCustomizationSpec deletes a customization spec
 func (cs CustomizationSpecManager) DeleteCustomizationSpec(ctx context.Context, name string) error {
 	req := types.DeleteCustomizationSpec{
 		This: cs.Reference(),
@@ -107,6 +114,7 @@ func (cs CustomizationSpecManager) DeleteCustomizationSpec(ctx context.Context, 
 	return nil
 }
 
+// DuplicateCustomizationSpec duplicates a customization spec
 func (cs CustomizationSpecManager) DuplicateCustomizationSpec(ctx context.Context, name string, newName string) error {
 	req := types.DuplicateCustomizationSpec{
 		This:    cs.Reference(),
@@ -122,6 +130,7 @@ func (cs CustomizationSpecManager) DuplicateCustomizationSpec(ctx context.Contex
 	return nil
 }
 
+// RenameCustomizationSpec renames a customization spec
 func (cs CustomizationSpecManager) RenameCustomizationSpec(ctx context.Context, name string, newName string) error {
 	req := types.RenameCustomizationSpec{
 		This:    cs.Reference(),
@@ -137,6 +146,7 @@ func (cs CustomizationSpecManager) RenameCustomizationSpec(ctx context.Context, 
 	return nil
 }
 
+// CustomizationSpecItemToXml converts the given spec to xml
 func (cs CustomizationSpecManager) CustomizationSpecItemToXml(ctx context.Context, item types.CustomizationSpecItem) (string, error) {
 	req := types.CustomizationSpecItemToXml{
 		This: cs.Reference(),
@@ -151,6 +161,7 @@ func (cs CustomizationSpecManager) CustomizationSpecItemToXml(ctx context.Contex
 	return res.Returnval, nil
 }
 
+// XmlToCustomizationSpecItem converts xml to a customization spec item
 func (cs CustomizationSpecManager) XmlToCustomizationSpecItem(ctx context.Context, xml string) (*types.CustomizationSpecItem, error) {
 	req := types.XmlToCustomizationSpecItem{
 		This:        cs.Reference(),

--- a/object/datacenter.go
+++ b/object/datacenter.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/net/context"
 )
 
+// DatacenterFolders represents the datacenter folder paths
 type DatacenterFolders struct {
 	VmFolder        *Folder
 	HostFolder      *Folder
@@ -33,16 +34,19 @@ type DatacenterFolders struct {
 	NetworkFolder   *Folder
 }
 
+// Datacenter a datacenter client
 type Datacenter struct {
 	Common
 }
 
+// NewDatacenter creates a new datacenter client
 func NewDatacenter(c *vim25.Client, ref types.ManagedObjectReference) *Datacenter {
 	return &Datacenter{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// Folders gets the folders for the datacenter
 func (d *Datacenter) Folders(ctx context.Context) (*DatacenterFolders, error) {
 	var md mo.Datacenter
 
@@ -76,6 +80,7 @@ func (d *Datacenter) Folders(ctx context.Context) (*DatacenterFolders, error) {
 	return df, nil
 }
 
+// Destroy the datacenter
 func (d Datacenter) Destroy(ctx context.Context) (*Task, error) {
 	req := types.Destroy_Task{
 		This: d.Reference(),

--- a/object/datastore.go
+++ b/object/datastore.go
@@ -55,22 +55,26 @@ func (e DatastoreNoSuchFileError) Error() string {
 	return fmt.Sprintf("cannot %s '%s': No such file", e.verb, e.subject)
 }
 
+// Datastore a datastore client
 type Datastore struct {
 	Common
 
 	InventoryPath string
 }
 
+// NewDatastore creates a new datastore client
 func NewDatastore(c *vim25.Client, ref types.ManagedObjectReference) *Datastore {
 	return &Datastore{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// Name returns the name of the datastore
 func (d Datastore) Name() string {
 	return path.Base(d.InventoryPath)
 }
 
+// Path for the datestore
 func (d Datastore) Path(path string) string {
 	name := d.Name()
 	if name == "" {
@@ -105,6 +109,7 @@ func (d Datastore) URL(ctx context.Context, dc *Datacenter, path string) (*url.U
 	}, nil
 }
 
+// Browser gets a browser for the datastore
 func (d Datastore) Browser(ctx context.Context) (*HostDatastoreBrowser, error) {
 	var do mo.Datastore
 
@@ -269,6 +274,7 @@ func (d Datastore) AttachedHosts(ctx context.Context) ([]*HostSystem, error) {
 	return hosts, nil
 }
 
+// Stat gets the file base info
 func (d Datastore) Stat(ctx context.Context, file string) (types.BaseFileInfo, error) {
 	b, err := d.Browser(ctx)
 	if err != nil {

--- a/object/diagnostic_manager.go
+++ b/object/diagnostic_manager.go
@@ -23,10 +23,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// DiagnosticManager represents a client for diagnostic information
 type DiagnosticManager struct {
 	Common
 }
 
+// NewDiagnosticManager creates a new diagnostic information client
 func NewDiagnosticManager(c *vim25.Client) *DiagnosticManager {
 	m := DiagnosticManager{
 		Common: NewCommon(c, *c.ServiceContent.DiagnosticManager),
@@ -35,6 +37,7 @@ func NewDiagnosticManager(c *vim25.Client) *DiagnosticManager {
 	return &m
 }
 
+// BrowseLog browse the log
 func (m DiagnosticManager) BrowseLog(ctx context.Context, host *HostSystem, key string, start, lines int) (*types.DiagnosticManagerLogHeader, error) {
 	req := types.BrowseDiagnosticLog{
 		This:  m.Reference(),
@@ -56,6 +59,7 @@ func (m DiagnosticManager) BrowseLog(ctx context.Context, host *HostSystem, key 
 	return &res.Returnval, nil
 }
 
+// GenerateLogBundles generates log bundles
 func (m DiagnosticManager) GenerateLogBundles(ctx context.Context, includeDefault bool, host []*HostSystem) (*Task, error) {
 	req := types.GenerateLogBundles_Task{
 		This:           m.Reference(),
@@ -76,6 +80,7 @@ func (m DiagnosticManager) GenerateLogBundles(ctx context.Context, includeDefaul
 	return NewTask(m.c, res.Returnval), nil
 }
 
+// QueryDescriptions queries the descriptions
 func (m DiagnosticManager) QueryDescriptions(ctx context.Context, host *HostSystem) ([]types.DiagnosticManagerLogDescriptor, error) {
 	req := types.QueryDescriptions{
 		This: m.Reference(),

--- a/object/distributed_virtual_portgroup.go
+++ b/object/distributed_virtual_portgroup.go
@@ -25,17 +25,21 @@ import (
 	"golang.org/x/net/context"
 )
 
+// DistributedVirtualPortgroup represents a distributed virtual port group client
 type DistributedVirtualPortgroup struct {
 	Common
 
 	InventoryPath string
 }
 
+// NewDistributedVirtualPortgroup creates a new distributed virtual port group client
 func NewDistributedVirtualPortgroup(c *vim25.Client, ref types.ManagedObjectReference) *DistributedVirtualPortgroup {
 	return &DistributedVirtualPortgroup{
 		Common: NewCommon(c, ref),
 	}
 }
+
+// Name of the distributed virtual port group
 func (p DistributedVirtualPortgroup) Name() string {
 	return path.Base(p.InventoryPath)
 }

--- a/object/distributed_virtual_switch.go
+++ b/object/distributed_virtual_switch.go
@@ -23,22 +23,26 @@ import (
 	"golang.org/x/net/context"
 )
 
+// DistributedVirtualSwitch represents a distributed virtual switch client
 type DistributedVirtualSwitch struct {
 	Common
 
 	InventoryPath string
 }
 
+// NewDistributedVirtualSwitch creates a distributed virtual switch
 func NewDistributedVirtualSwitch(c *vim25.Client, ref types.ManagedObjectReference) *DistributedVirtualSwitch {
 	return &DistributedVirtualSwitch{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// EthernetCardBackingInfo satisfies the network reference interface for the finder
 func (s DistributedVirtualSwitch) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
 	return nil, ErrNotSupported // TODO: just to satisfy NetworkReference interface for the finder
 }
 
+// Reconfigure a distributed virtual switch
 func (s DistributedVirtualSwitch) Reconfigure(ctx context.Context, spec types.BaseDVSConfigSpec) (*Task, error) {
 	req := types.ReconfigureDvs_Task{
 		This: s.Reference(),
@@ -53,6 +57,7 @@ func (s DistributedVirtualSwitch) Reconfigure(ctx context.Context, spec types.Ba
 	return NewTask(s.Client(), res.Returnval), nil
 }
 
+// AddPortgroup to this distributed vswitch
 func (s DistributedVirtualSwitch) AddPortgroup(ctx context.Context, spec []types.DVPortgroupConfigSpec) (*Task, error) {
 	req := types.AddDVPortgroup_Task{
 		This: s.Reference(),

--- a/object/extension_manager.go
+++ b/object/extension_manager.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/net/context"
 )
 
+// ExtensionManager represents an extension manager client
 type ExtensionManager struct {
 	Common
 }
@@ -37,6 +38,7 @@ func GetExtensionManager(c *vim25.Client) (*ExtensionManager, error) {
 	return NewExtensionManager(c), nil
 }
 
+// NewExtensionManager creates a new extension manager client
 func NewExtensionManager(c *vim25.Client) *ExtensionManager {
 	o := ExtensionManager{
 		Common: NewCommon(c, *c.ServiceContent.ExtensionManager),
@@ -45,6 +47,7 @@ func NewExtensionManager(c *vim25.Client) *ExtensionManager {
 	return &o
 }
 
+// List the known extensions
 func (m ExtensionManager) List(ctx context.Context) ([]types.Extension, error) {
 	var em mo.ExtensionManager
 
@@ -56,6 +59,7 @@ func (m ExtensionManager) List(ctx context.Context) ([]types.Extension, error) {
 	return em.ExtensionList, nil
 }
 
+// Find the extension by key
 func (m ExtensionManager) Find(ctx context.Context, key string) (*types.Extension, error) {
 	req := types.FindExtension{
 		This:         m.Reference(),
@@ -70,6 +74,7 @@ func (m ExtensionManager) Find(ctx context.Context, key string) (*types.Extensio
 	return res.Returnval, nil
 }
 
+// Register the extension
 func (m ExtensionManager) Register(ctx context.Context, extension types.Extension) error {
 	req := types.RegisterExtension{
 		This:      m.Reference(),
@@ -80,6 +85,7 @@ func (m ExtensionManager) Register(ctx context.Context, extension types.Extensio
 	return err
 }
 
+// SetCertificate for the extension
 func (m ExtensionManager) SetCertificate(ctx context.Context, key string, certificatePem string) error {
 	req := types.SetExtensionCertificate{
 		This:           m.Reference(),
@@ -91,6 +97,7 @@ func (m ExtensionManager) SetCertificate(ctx context.Context, key string, certif
 	return err
 }
 
+// Unregister the extension by name
 func (m ExtensionManager) Unregister(ctx context.Context, key string) error {
 	req := types.UnregisterExtension{
 		This:         m.Reference(),
@@ -101,6 +108,7 @@ func (m ExtensionManager) Unregister(ctx context.Context, key string) error {
 	return err
 }
 
+// Update the extension
 func (m ExtensionManager) Update(ctx context.Context, extension types.Extension) error {
 	req := types.UpdateExtension{
 		This:      m.Reference(),

--- a/object/file_manager.go
+++ b/object/file_manager.go
@@ -23,10 +23,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// FileManager client
 type FileManager struct {
 	Common
 }
 
+// NewFileManager client instance
 func NewFileManager(c *vim25.Client) *FileManager {
 	f := FileManager{
 		Common: NewCommon(c, *c.ServiceContent.FileManager),
@@ -35,6 +37,7 @@ func NewFileManager(c *vim25.Client) *FileManager {
 	return &f
 }
 
+// CopyDatastoreFile copies a file in a datastore
 func (f FileManager) CopyDatastoreFile(ctx context.Context, sourceName string, sourceDatacenter *Datacenter, destinationName string, destinationDatacenter *Datacenter, force bool) (*Task, error) {
 	req := types.CopyDatastoreFile_Task{
 		This:            f.Reference(),
@@ -98,6 +101,7 @@ func (f FileManager) MakeDirectory(ctx context.Context, name string, dc *Datacen
 	return err
 }
 
+// MoveDatastoreFile moves a file in a datastore
 func (f FileManager) MoveDatastoreFile(ctx context.Context, sourceName string, sourceDatacenter *Datacenter, destinationName string, destinationDatacenter *Datacenter, force bool) (*Task, error) {
 	req := types.MoveDatastoreFile_Task{
 		This:            f.Reference(),

--- a/object/folder.go
+++ b/object/folder.go
@@ -24,22 +24,26 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Folder represents a folder client
 type Folder struct {
 	Common
 
 	InventoryPath string
 }
 
+// NewFolder creates a new folder client
 func NewFolder(c *vim25.Client, ref types.ManagedObjectReference) *Folder {
 	return &Folder{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// NewRootFolder creates a new root folder client
 func NewRootFolder(c *vim25.Client) *Folder {
 	return NewFolder(c, c.ServiceContent.RootFolder)
 }
 
+// Children lists the immediate children of the root
 func (f Folder) Children(ctx context.Context) ([]Reference, error) {
 	var mf mo.Folder
 
@@ -58,6 +62,7 @@ func (f Folder) Children(ctx context.Context) ([]Reference, error) {
 	return rs, nil
 }
 
+// CreateDatacenter creates a datacenter
 func (f Folder) CreateDatacenter(ctx context.Context, datacenter string) (*Datacenter, error) {
 	req := types.CreateDatacenter{
 		This: f.Reference(),
@@ -77,6 +82,7 @@ func (f Folder) CreateDatacenter(ctx context.Context, datacenter string) (*Datac
 	return NewDatacenter(f.c, res.Returnval), nil
 }
 
+// CreateCluster for the given cluster config spec
 func (f Folder) CreateCluster(ctx context.Context, cluster string, spec types.ClusterConfigSpecEx) (*ClusterComputeResource, error) {
 	req := types.CreateClusterEx{
 		This: f.Reference(),
@@ -97,6 +103,7 @@ func (f Folder) CreateCluster(ctx context.Context, cluster string, spec types.Cl
 	return NewClusterComputeResource(f.c, res.Returnval), nil
 }
 
+// CreateFolder creates a folder under the root
 func (f Folder) CreateFolder(ctx context.Context, name string) (*Folder, error) {
 	req := types.CreateFolder{
 		This: f.Reference(),
@@ -111,6 +118,7 @@ func (f Folder) CreateFolder(ctx context.Context, name string) (*Folder, error) 
 	return NewFolder(f.c, res.Returnval), err
 }
 
+// AddStandaloneHost adds a standalone host
 func (f Folder) AddStandaloneHost(ctx context.Context, spec types.HostConnectSpec, addConnected bool, license *string, compResSpec *types.BaseComputeResourceConfigSpec) (*Task, error) {
 	req := types.AddStandaloneHost_Task{
 		This:         f.Reference(),
@@ -134,6 +142,7 @@ func (f Folder) AddStandaloneHost(ctx context.Context, spec types.HostConnectSpe
 	return NewTask(f.c, res.Returnval), nil
 }
 
+// CreateVM creates a vm for the given spec in the given pool on the specified host
 func (f Folder) CreateVM(ctx context.Context, config types.VirtualMachineConfigSpec, pool *ResourcePool, host *HostSystem) (*Task, error) {
 	req := types.CreateVM_Task{
 		This:   f.Reference(),
@@ -154,6 +163,7 @@ func (f Folder) CreateVM(ctx context.Context, config types.VirtualMachineConfigS
 	return NewTask(f.c, res.Returnval), nil
 }
 
+// RegisterVM registers a vm for the given path by the given name
 func (f Folder) RegisterVM(ctx context.Context, path string, name string, asTemplate bool, pool *ResourcePool, host *HostSystem) (*Task, error) {
 	req := types.RegisterVM_Task{
 		This:       f.Reference(),
@@ -183,6 +193,7 @@ func (f Folder) RegisterVM(ctx context.Context, path string, name string, asTemp
 	return NewTask(f.c, res.Returnval), nil
 }
 
+// CreateDVS creates a distributed virtual switch
 func (f Folder) CreateDVS(ctx context.Context, spec types.DVSCreateSpec) (*Task, error) {
 	req := types.CreateDVS_Task{
 		This: f.Reference(),

--- a/object/history_collector.go
+++ b/object/history_collector.go
@@ -23,16 +23,19 @@ import (
 	"golang.org/x/net/context"
 )
 
+// HistoryCollector represents a history collector client
 type HistoryCollector struct {
 	Common
 }
 
+// NewHistoryCollector creates a new history collector client instance
 func NewHistoryCollector(c *vim25.Client, ref types.ManagedObjectReference) *HistoryCollector {
 	return &HistoryCollector{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// Destroy this history collector
 func (h HistoryCollector) Destroy(ctx context.Context) error {
 	req := types.DestroyCollector{
 		This: h.Reference(),
@@ -42,6 +45,7 @@ func (h HistoryCollector) Destroy(ctx context.Context) error {
 	return err
 }
 
+// Reset this history collector
 func (h HistoryCollector) Reset(ctx context.Context) error {
 	req := types.ResetCollector{
 		This: h.Reference(),
@@ -51,6 +55,7 @@ func (h HistoryCollector) Reset(ctx context.Context) error {
 	return err
 }
 
+// Rewind this history collector
 func (h HistoryCollector) Rewind(ctx context.Context) error {
 	req := types.RewindCollector{
 		This: h.Reference(),
@@ -60,6 +65,7 @@ func (h HistoryCollector) Rewind(ctx context.Context) error {
 	return err
 }
 
+// SetPageSize for this history collector
 func (h HistoryCollector) SetPageSize(ctx context.Context, maxCount int) error {
 	req := types.SetCollectorPageSize{
 		This:     h.Reference(),

--- a/object/host_config_manager.go
+++ b/object/host_config_manager.go
@@ -23,16 +23,19 @@ import (
 	"golang.org/x/net/context"
 )
 
+// HostConfigManager represents a client for a host config
 type HostConfigManager struct {
 	Common
 }
 
+// NewHostConfigManager creates a new host config client
 func NewHostConfigManager(c *vim25.Client, ref types.ManagedObjectReference) *HostConfigManager {
 	return &HostConfigManager{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// DatastoreSystem gets the datastore system
 func (m HostConfigManager) DatastoreSystem(ctx context.Context) (*HostDatastoreSystem, error) {
 	var h mo.HostSystem
 
@@ -44,6 +47,7 @@ func (m HostConfigManager) DatastoreSystem(ctx context.Context) (*HostDatastoreS
 	return NewHostDatastoreSystem(m.c, *h.ConfigManager.DatastoreSystem), nil
 }
 
+// NetworkSystem gets the config manager network system
 func (m HostConfigManager) NetworkSystem(ctx context.Context) (*HostNetworkSystem, error) {
 	var h mo.HostSystem
 
@@ -55,6 +59,7 @@ func (m HostConfigManager) NetworkSystem(ctx context.Context) (*HostNetworkSyste
 	return NewHostNetworkSystem(m.c, *h.ConfigManager.NetworkSystem), nil
 }
 
+// FirewallSystem gets the firewall system config manager
 func (m HostConfigManager) FirewallSystem(ctx context.Context) (*HostFirewallSystem, error) {
 	var h mo.HostSystem
 
@@ -66,6 +71,7 @@ func (m HostConfigManager) FirewallSystem(ctx context.Context) (*HostFirewallSys
 	return NewHostFirewallSystem(m.c, *h.ConfigManager.FirewallSystem), nil
 }
 
+// StorageSystem gets a storage system config manager
 func (m HostConfigManager) StorageSystem(ctx context.Context) (*HostStorageSystem, error) {
 	var h mo.HostSystem
 
@@ -77,6 +83,7 @@ func (m HostConfigManager) StorageSystem(ctx context.Context) (*HostStorageSyste
 	return NewHostStorageSystem(m.c, *h.ConfigManager.StorageSystem), nil
 }
 
+// VirtualNicManager gets a virtual nic config manager
 func (m HostConfigManager) VirtualNicManager(ctx context.Context) (*HostVirtualNicManager, error) {
 	var h mo.HostSystem
 
@@ -88,6 +95,7 @@ func (m HostConfigManager) VirtualNicManager(ctx context.Context) (*HostVirtualN
 	return NewHostVirtualNicManager(m.c, *h.ConfigManager.VirtualNicManager, m.Reference()), nil
 }
 
+// VsanSystem gets the VSAN config manager
 func (m HostConfigManager) VsanSystem(ctx context.Context) (*HostVsanSystem, error) {
 	var h mo.HostSystem
 

--- a/object/host_datastore_browser.go
+++ b/object/host_datastore_browser.go
@@ -23,16 +23,19 @@ import (
 	"golang.org/x/net/context"
 )
 
+// HostDatastoreBrowser represents a host datastore browser
 type HostDatastoreBrowser struct {
 	Common
 }
 
+// NewHostDatastoreBrowser creates a new host datastore browser client
 func NewHostDatastoreBrowser(c *vim25.Client, ref types.ManagedObjectReference) *HostDatastoreBrowser {
 	return &HostDatastoreBrowser{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// SearchDatastore searches a datastore
 func (b HostDatastoreBrowser) SearchDatastore(ctx context.Context, datastorePath string, searchSpec *types.HostDatastoreBrowserSearchSpec) (*Task, error) {
 	req := types.SearchDatastore_Task{
 		This:          b.Reference(),
@@ -48,6 +51,7 @@ func (b HostDatastoreBrowser) SearchDatastore(ctx context.Context, datastorePath
 	return NewTask(b.c, res.Returnval), nil
 }
 
+// SearchDatastoreSubFolders search the datastore subfolders
 func (b HostDatastoreBrowser) SearchDatastoreSubFolders(ctx context.Context, datastorePath string, searchSpec *types.HostDatastoreBrowserSearchSpec) (*Task, error) {
 	req := types.SearchDatastoreSubFolders_Task{
 		This:          b.Reference(),

--- a/object/host_datastore_system.go
+++ b/object/host_datastore_system.go
@@ -23,16 +23,19 @@ import (
 	"golang.org/x/net/context"
 )
 
+// HostDatastoreSystem creates a host datastore config client
 type HostDatastoreSystem struct {
 	Common
 }
 
+// NewHostDatastoreSystem creates a new host datastore config client instance
 func NewHostDatastoreSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostDatastoreSystem {
 	return &HostDatastoreSystem{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// CreateNasDatastore creates a nas datastore client
 func (s HostDatastoreSystem) CreateNasDatastore(ctx context.Context, spec types.HostNasVolumeSpec) (*Datastore, error) {
 	req := types.CreateNasDatastore{
 		This: s.Reference(),
@@ -47,6 +50,7 @@ func (s HostDatastoreSystem) CreateNasDatastore(ctx context.Context, spec types.
 	return NewDatastore(s.Client(), res.Returnval), nil
 }
 
+// CreateVmfsDatastore creates a VMFS datastore
 func (s HostDatastoreSystem) CreateVmfsDatastore(ctx context.Context, spec types.VmfsDatastoreCreateSpec) (*Datastore, error) {
 	req := types.CreateVmfsDatastore{
 		This: s.Reference(),
@@ -61,6 +65,7 @@ func (s HostDatastoreSystem) CreateVmfsDatastore(ctx context.Context, spec types
 	return NewDatastore(s.Client(), res.Returnval), nil
 }
 
+// Remove a host datastore system
 func (s HostDatastoreSystem) Remove(ctx context.Context, ds *Datastore) error {
 	req := types.RemoveDatastore{
 		This:      s.Reference(),
@@ -75,6 +80,7 @@ func (s HostDatastoreSystem) Remove(ctx context.Context, ds *Datastore) error {
 	return nil
 }
 
+// QueryAvailableDisksForVmfs query the available disks for vmfs
 func (s HostDatastoreSystem) QueryAvailableDisksForVmfs(ctx context.Context) ([]types.HostScsiDisk, error) {
 	req := types.QueryAvailableDisksForVmfs{
 		This: s.Reference(),
@@ -88,6 +94,7 @@ func (s HostDatastoreSystem) QueryAvailableDisksForVmfs(ctx context.Context) ([]
 	return res.Returnval, nil
 }
 
+// QueryVmfsDatastoreCreateOptions query the vmfs datastore creation options for the specified device
 func (s HostDatastoreSystem) QueryVmfsDatastoreCreateOptions(ctx context.Context, devicePath string) ([]types.VmfsDatastoreOption, error) {
 	req := types.QueryVmfsDatastoreCreateOptions{
 		This:       s.Reference(),

--- a/object/host_firewall_system.go
+++ b/object/host_firewall_system.go
@@ -28,16 +28,19 @@ import (
 	"golang.org/x/net/context"
 )
 
+// HostFirewallSystem represents the host firewall system config client
 type HostFirewallSystem struct {
 	Common
 }
 
+// NewHostFirewallSystem creates a new host firewall config client
 func NewHostFirewallSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostFirewallSystem {
 	return &HostFirewallSystem{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// DisableRuleset disables the specified ruleset
 func (s HostFirewallSystem) DisableRuleset(ctx context.Context, id string) error {
 	req := types.DisableRuleset{
 		This: s.Reference(),
@@ -48,6 +51,7 @@ func (s HostFirewallSystem) DisableRuleset(ctx context.Context, id string) error
 	return err
 }
 
+// EnableRuleset enables the specified ruleset
 func (s HostFirewallSystem) EnableRuleset(ctx context.Context, id string) error {
 	req := types.EnableRuleset{
 		This: s.Reference(),
@@ -58,6 +62,7 @@ func (s HostFirewallSystem) EnableRuleset(ctx context.Context, id string) error 
 	return err
 }
 
+// Refresh this firewall system config
 func (s HostFirewallSystem) Refresh(ctx context.Context) error {
 	req := types.RefreshFirewall{
 		This: s.Reference(),
@@ -67,6 +72,7 @@ func (s HostFirewallSystem) Refresh(ctx context.Context) error {
 	return err
 }
 
+// Info for this host firewall system
 func (s HostFirewallSystem) Info(ctx context.Context) (*types.HostFirewallInfo, error) {
 	var fs mo.HostFirewallSystem
 

--- a/object/host_network_system.go
+++ b/object/host_network_system.go
@@ -23,10 +23,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// HostNetworkSystem represents a host network system client
 type HostNetworkSystem struct {
 	Common
 }
 
+// NewHostNetworkSystem creates a new host network system client
 func NewHostNetworkSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostNetworkSystem {
 	return &HostNetworkSystem{
 		Common: NewCommon(c, ref),

--- a/object/host_storage_system.go
+++ b/object/host_storage_system.go
@@ -25,16 +25,19 @@ import (
 	"golang.org/x/net/context"
 )
 
+// HostStorageSystem client
 type HostStorageSystem struct {
 	Common
 }
 
+// NewHostStorageSystem creates a new host storage system client
 func NewHostStorageSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostStorageSystem {
 	return &HostStorageSystem{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// RetrieveDiskPartitionInfo for this host storage system
 func (s HostStorageSystem) RetrieveDiskPartitionInfo(ctx context.Context, devicePath string) (*types.HostDiskPartitionInfo, error) {
 	req := types.RetrieveDiskPartitionInfo{
 		This:       s.Reference(),
@@ -53,6 +56,7 @@ func (s HostStorageSystem) RetrieveDiskPartitionInfo(ctx context.Context, device
 	return &res.Returnval[0], nil
 }
 
+// ComputeDiskPartitionInfo for this host storage system
 func (s HostStorageSystem) ComputeDiskPartitionInfo(ctx context.Context, devicePath string, layout types.HostDiskPartitionLayout) (*types.HostDiskPartitionInfo, error) {
 	req := types.ComputeDiskPartitionInfo{
 		This:       s.Reference(),
@@ -68,6 +72,7 @@ func (s HostStorageSystem) ComputeDiskPartitionInfo(ctx context.Context, deviceP
 	return &res.Returnval, nil
 }
 
+// UpdateDiskPartitionInfo on this host storage system
 func (s HostStorageSystem) UpdateDiskPartitionInfo(ctx context.Context, devicePath string, spec types.HostDiskPartitionSpec) error {
 	req := types.UpdateDiskPartitions{
 		This:       s.Reference(),

--- a/object/host_system.go
+++ b/object/host_system.go
@@ -27,12 +27,14 @@ import (
 	"golang.org/x/net/context"
 )
 
+// HostSystem represents a host system config client
 type HostSystem struct {
 	Common
 
 	InventoryPath string
 }
 
+// String a string representation for this host system
 func (h HostSystem) String() string {
 	if h.InventoryPath == "" {
 		return h.Common.String()
@@ -40,12 +42,14 @@ func (h HostSystem) String() string {
 	return fmt.Sprintf("%v @ %v", h.Common, h.InventoryPath)
 }
 
+// NewHostSystem creates a new host system config client
 func NewHostSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostSystem {
 	return &HostSystem{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// Name for this host system
 func (h HostSystem) Name(ctx context.Context) (string, error) {
 	var mh mo.HostSystem
 
@@ -57,10 +61,12 @@ func (h HostSystem) Name(ctx context.Context) (string, error) {
 	return mh.Name, nil
 }
 
+// ConfigManager for this host system
 func (h HostSystem) ConfigManager() *HostConfigManager {
 	return NewHostConfigManager(h.c, h.Reference())
 }
 
+// ResourcePool for this host system
 func (h HostSystem) ResourcePool(ctx context.Context) (*ResourcePool, error) {
 	var mh mo.HostSystem
 
@@ -93,6 +99,7 @@ func (h HostSystem) ResourcePool(ctx context.Context) (*ResourcePool, error) {
 	return pool, nil
 }
 
+// ManagementIPs for this host system
 func (h HostSystem) ManagementIPs(ctx context.Context) ([]net.IP, error) {
 	var mh mo.HostSystem
 
@@ -114,6 +121,7 @@ func (h HostSystem) ManagementIPs(ctx context.Context) ([]net.IP, error) {
 	return ips, nil
 }
 
+// Disconnect this host system
 func (h HostSystem) Disconnect(ctx context.Context) (*Task, error) {
 	req := types.DisconnectHost_Task{
 		This: h.Reference(),
@@ -127,6 +135,7 @@ func (h HostSystem) Disconnect(ctx context.Context) (*Task, error) {
 	return NewTask(h.c, res.Returnval), nil
 }
 
+// Reconnect this host system
 func (h HostSystem) Reconnect(ctx context.Context, cnxSpec *types.HostConnectSpec, reconnectSpec *types.HostSystemReconnectSpec) (*Task, error) {
 	req := types.ReconnectHost_Task{
 		This:          h.Reference(),
@@ -142,6 +151,7 @@ func (h HostSystem) Reconnect(ctx context.Context, cnxSpec *types.HostConnectSpe
 	return NewTask(h.c, res.Returnval), nil
 }
 
+// EnterMaintenanceMode for this host system
 func (h HostSystem) EnterMaintenanceMode(ctx context.Context, timeout int, evacuate bool, spec *types.HostMaintenanceSpec) (*Task, error) {
 	req := types.EnterMaintenanceMode_Task{
 		This:                  h.Reference(),
@@ -158,6 +168,7 @@ func (h HostSystem) EnterMaintenanceMode(ctx context.Context, timeout int, evacu
 	return NewTask(h.c, res.Returnval), nil
 }
 
+// ExitMaintenanceMode for this host system
 func (h HostSystem) ExitMaintenanceMode(ctx context.Context, timeout int) (*Task, error) {
 	req := types.ExitMaintenanceMode_Task{
 		This:    h.Reference(),

--- a/object/host_virtual_nic_manager.go
+++ b/object/host_virtual_nic_manager.go
@@ -24,11 +24,13 @@ import (
 	"golang.org/x/net/context"
 )
 
+// HostVirtualNicManager represents a virtual NIC manager client
 type HostVirtualNicManager struct {
 	Common
 	Host *HostSystem
 }
 
+// NewHostVirtualNicManager creates a new virtual NIC manager client
 func NewHostVirtualNicManager(c *vim25.Client, ref types.ManagedObjectReference, host types.ManagedObjectReference) *HostVirtualNicManager {
 	return &HostVirtualNicManager{
 		Common: NewCommon(c, ref),
@@ -36,6 +38,7 @@ func NewHostVirtualNicManager(c *vim25.Client, ref types.ManagedObjectReference,
 	}
 }
 
+// Info about the virtual NICs on a host
 func (m HostVirtualNicManager) Info(ctx context.Context) (*types.HostVirtualNicManagerInfo, error) {
 	var vnm mo.HostVirtualNicManager
 
@@ -47,6 +50,7 @@ func (m HostVirtualNicManager) Info(ctx context.Context) (*types.HostVirtualNicM
 	return &vnm.Info, nil
 }
 
+// DeselectVnic on the host
 func (m HostVirtualNicManager) DeselectVnic(ctx context.Context, nicType string, device string) error {
 	if nicType == string(types.HostVirtualNicManagerNicTypeVsan) {
 		// Avoid fault.NotSupported:
@@ -69,6 +73,7 @@ func (m HostVirtualNicManager) DeselectVnic(ctx context.Context, nicType string,
 	return err
 }
 
+// SelectVnic selects a vNIC
 func (m HostVirtualNicManager) SelectVnic(ctx context.Context, nicType string, device string) error {
 	if nicType == string(types.HostVirtualNicManagerNicTypeVsan) {
 		// Avoid fault.NotSupported:

--- a/object/host_vsan_system.go
+++ b/object/host_vsan_system.go
@@ -24,16 +24,19 @@ import (
 	"golang.org/x/net/context"
 )
 
+// HostVsanSystem represents a client to manage VSAN on a host system
 type HostVsanSystem struct {
 	Common
 }
 
+// NewHostVsanSystem creates a new VSAN manager client
 func NewHostVsanSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostVsanSystem {
 	return &HostVsanSystem{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// Update the VSAN configuration on a host system
 func (s HostVsanSystem) Update(ctx context.Context, config types.VsanHostConfigInfo) (*Task, error) {
 	req := types.UpdateVsan_Task{
 		This:   s.Reference(),

--- a/object/http_nfc_lease.go
+++ b/object/http_nfc_lease.go
@@ -28,10 +28,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// HttpNfcLease is a client to manage http nfc leases
 type HttpNfcLease struct {
 	Common
 }
 
+// NewHttpNfcLease creates a new client o manage http nfc leases
 func NewHttpNfcLease(c *vim25.Client, ref types.ManagedObjectReference) *HttpNfcLease {
 	return &HttpNfcLease{
 		Common: NewCommon(c, ref),
@@ -96,6 +98,7 @@ func (o HttpNfcLease) HttpNfcLeaseProgress(ctx context.Context, percent int) err
 	return nil
 }
 
+// Wait for the http nfc lease info to be collected
 func (o HttpNfcLease) Wait(ctx context.Context) (*types.HttpNfcLeaseInfo, error) {
 	var lease mo.HttpNfcLease
 

--- a/object/network.go
+++ b/object/network.go
@@ -24,18 +24,21 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Network represents a network management client
 type Network struct {
 	Common
 
 	InventoryPath string
 }
 
+// NewNetwork creates a new network management client
 func NewNetwork(c *vim25.Client, ref types.ManagedObjectReference) *Network {
 	return &Network{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// Name returns the name of this network client
 func (n Network) Name() string {
 	return path.Base(n.InventoryPath)
 }

--- a/object/ovf_manager.go
+++ b/object/ovf_manager.go
@@ -23,10 +23,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// OvfManager represents an ovf manager client
 type OvfManager struct {
 	Common
 }
 
+// NewOvfManager creates a new ovf manager client
 func NewOvfManager(c *vim25.Client) *OvfManager {
 	o := OvfManager{
 		Common: NewCommon(c, *c.ServiceContent.OvfManager),

--- a/object/resource_pool.go
+++ b/object/resource_pool.go
@@ -26,12 +26,14 @@ import (
 	"golang.org/x/net/context"
 )
 
+// ResourcePool represents a client to manage a resource pool
 type ResourcePool struct {
 	Common
 
 	InventoryPath string
 }
 
+// String has a string representation of the resource pool
 func (p ResourcePool) String() string {
 	if p.InventoryPath == "" {
 		return p.Common.String()
@@ -39,12 +41,14 @@ func (p ResourcePool) String() string {
 	return fmt.Sprintf("%v @ %v", p.Common, p.InventoryPath)
 }
 
+// NewResourcePool creates a new resource pool client
 func NewResourcePool(c *vim25.Client, ref types.ManagedObjectReference) *ResourcePool {
 	return &ResourcePool{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// Name returns the name of the resource poool
 func (p ResourcePool) Name(ctx context.Context) (string, error) {
 	var o mo.ResourcePool
 
@@ -56,6 +60,7 @@ func (p ResourcePool) Name(ctx context.Context) (string, error) {
 	return o.Name, nil
 }
 
+// ImportVApp imports a vApp into the resource pool
 func (p ResourcePool) ImportVApp(ctx context.Context, spec types.BaseImportSpec, folder *Folder, host *HostSystem) (*HttpNfcLease, error) {
 	req := types.ImportVApp{
 		This: p.Reference(),
@@ -80,6 +85,7 @@ func (p ResourcePool) ImportVApp(ctx context.Context, spec types.BaseImportSpec,
 	return NewHttpNfcLease(p.c, res.Returnval), nil
 }
 
+// Create a resource pool
 func (p ResourcePool) Create(ctx context.Context, name string, spec types.ResourceConfigSpec) (*ResourcePool, error) {
 	req := types.CreateResourcePool{
 		This: p.Reference(),
@@ -95,6 +101,7 @@ func (p ResourcePool) Create(ctx context.Context, name string, spec types.Resour
 	return NewResourcePool(p.c, res.Returnval), nil
 }
 
+// CreateVApp in this resource pool
 func (p ResourcePool) CreateVApp(ctx context.Context, name string, resSpec types.ResourceConfigSpec, configSpec types.VAppConfigSpec, folder *Folder) (*VirtualApp, error) {
 	req := types.CreateVApp{
 		This:       p.Reference(),
@@ -116,6 +123,7 @@ func (p ResourcePool) CreateVApp(ctx context.Context, name string, resSpec types
 	return NewVirtualApp(p.c, res.Returnval), nil
 }
 
+// UpdateConfig updates the config for this resource pool
 func (p ResourcePool) UpdateConfig(ctx context.Context, name string, config *types.ResourceConfigSpec) error {
 	req := types.UpdateConfig{
 		This:   p.Reference(),
@@ -136,6 +144,7 @@ func (p ResourcePool) UpdateConfig(ctx context.Context, name string, config *typ
 	return err
 }
 
+// DestroyChildren destroys the children for this resource pool
 func (p ResourcePool) DestroyChildren(ctx context.Context) error {
 	req := types.DestroyChildren{
 		This: p.Reference(),
@@ -145,6 +154,7 @@ func (p ResourcePool) DestroyChildren(ctx context.Context) error {
 	return err
 }
 
+// Destroy this resource pool
 func (p ResourcePool) Destroy(ctx context.Context) (*Task, error) {
 	req := types.Destroy_Task{
 		This: p.Reference(),

--- a/object/search_index.go
+++ b/object/search_index.go
@@ -23,10 +23,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// SearchIndex represents a search index client
 type SearchIndex struct {
 	Common
 }
 
+// NewSearchIndex creates a new search index client
 func NewSearchIndex(c *vim25.Client) *SearchIndex {
 	s := SearchIndex{
 		Common: NewCommon(c, *c.ServiceContent.SearchIndex),

--- a/object/storage_pod.go
+++ b/object/storage_pod.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package object
 
+// StoragePod represents a storage pod
 type StoragePod struct {
 	*Folder
 }

--- a/object/storage_resource_manager.go
+++ b/object/storage_resource_manager.go
@@ -23,10 +23,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// StorageResourceManager represents a storage resource manager client
 type StorageResourceManager struct {
 	Common
 }
 
+// NewStorageResourceManager creates a new storage resource manager client
 func NewStorageResourceManager(c *vim25.Client) *StorageResourceManager {
 	sr := StorageResourceManager{
 		Common: NewCommon(c, *c.ServiceContent.StorageResourceManager),
@@ -35,6 +37,7 @@ func NewStorageResourceManager(c *vim25.Client) *StorageResourceManager {
 	return &sr
 }
 
+// ApplyStorageDrsRecommendation applies the storage drs recommendation
 func (sr StorageResourceManager) ApplyStorageDrsRecommendation(ctx context.Context, key []string) (*Task, error) {
 	req := types.ApplyStorageDrsRecommendation_Task{
 		This: sr.Reference(),
@@ -49,6 +52,7 @@ func (sr StorageResourceManager) ApplyStorageDrsRecommendation(ctx context.Conte
 	return NewTask(sr.c, res.Returnval), nil
 }
 
+// ApplyStorageDrsRecommendationToPod for storage pod specific recommendations
 func (sr StorageResourceManager) ApplyStorageDrsRecommendationToPod(ctx context.Context, pod *StoragePod, key string) (*Task, error) {
 	req := types.ApplyStorageDrsRecommendationToPod_Task{
 		This: sr.Reference(),
@@ -67,6 +71,7 @@ func (sr StorageResourceManager) ApplyStorageDrsRecommendationToPod(ctx context.
 	return NewTask(sr.c, res.Returnval), nil
 }
 
+// CancelStorageDrsRecommendation cancels a recommendation application
 func (sr StorageResourceManager) CancelStorageDrsRecommendation(ctx context.Context, key []string) error {
 	req := types.CancelStorageDrsRecommendation{
 		This: sr.Reference(),
@@ -78,6 +83,7 @@ func (sr StorageResourceManager) CancelStorageDrsRecommendation(ctx context.Cont
 	return err
 }
 
+// ConfigureDatastoreIORM configure datastore for IORM
 func (sr StorageResourceManager) ConfigureDatastoreIORM(ctx context.Context, datastore *Datastore, spec types.StorageIORMConfigSpec, key string) (*Task, error) {
 	req := types.ConfigureDatastoreIORM_Task{
 		This: sr.Reference(),
@@ -96,6 +102,7 @@ func (sr StorageResourceManager) ConfigureDatastoreIORM(ctx context.Context, dat
 	return NewTask(sr.c, res.Returnval), nil
 }
 
+// ConfigureStorageDrsForPod configure the storage drs for a storage pod
 func (sr StorageResourceManager) ConfigureStorageDrsForPod(ctx context.Context, pod *StoragePod, spec types.StorageDrsConfigSpec, modify bool) (*Task, error) {
 	req := types.ConfigureStorageDrsForPod_Task{
 		This:   sr.Reference(),
@@ -115,6 +122,7 @@ func (sr StorageResourceManager) ConfigureStorageDrsForPod(ctx context.Context, 
 	return NewTask(sr.c, res.Returnval), nil
 }
 
+// QueryDatastorePerformanceSummary queries the datastore performance summary
 func (sr StorageResourceManager) QueryDatastorePerformanceSummary(ctx context.Context, datastore *Datastore) ([]types.StoragePerformanceSummary, error) {
 	req := types.QueryDatastorePerformanceSummary{
 		This: sr.Reference(),
@@ -132,6 +140,7 @@ func (sr StorageResourceManager) QueryDatastorePerformanceSummary(ctx context.Co
 	return res.Returnval, nil
 }
 
+// QueryIORMConfigOption queries the IORM config options
 func (sr StorageResourceManager) QueryIORMConfigOption(ctx context.Context, host *HostSystem) (*types.StorageIORMConfigOption, error) {
 	req := types.QueryIORMConfigOption{
 		This: sr.Reference(),
@@ -149,6 +158,7 @@ func (sr StorageResourceManager) QueryIORMConfigOption(ctx context.Context, host
 	return &res.Returnval, nil
 }
 
+// RecommendDatastores for this storage resource manager
 func (sr StorageResourceManager) RecommendDatastores(ctx context.Context, storageSpec types.StoragePlacementSpec) (*types.StoragePlacementResult, error) {
 	req := types.RecommendDatastores{
 		This:        sr.Reference(),
@@ -163,6 +173,7 @@ func (sr StorageResourceManager) RecommendDatastores(ctx context.Context, storag
 	return &res.Returnval, nil
 }
 
+// RefreshStorageDrsRecommendation refresh the storage DRS recommencation
 func (sr StorageResourceManager) RefreshStorageDrsRecommendation(ctx context.Context, pod *StoragePod) error {
 	req := types.RefreshStorageDrsRecommendation{
 		This: sr.Reference(),

--- a/object/task.go
+++ b/object/task.go
@@ -33,6 +33,7 @@ type Task struct {
 	Common
 }
 
+// NewTask creates a new task wrapper
 func NewTask(c *vim25.Client, ref types.ManagedObjectReference) *Task {
 	t := Task{
 		Common: NewCommon(c, ref),
@@ -41,11 +42,13 @@ func NewTask(c *vim25.Client, ref types.ManagedObjectReference) *Task {
 	return &t
 }
 
+// Wait for the result of a task, only error is returned
 func (t *Task) Wait(ctx context.Context) error {
 	_, err := t.WaitForResult(ctx, nil)
 	return err
 }
 
+// WaitForResult of a task, returns the task info or an error
 func (t *Task) WaitForResult(ctx context.Context, s progress.Sinker) (*types.TaskInfo, error) {
 	p := property.DefaultCollector(t.c)
 	return task.Wait(ctx, t.Reference(), p, s)

--- a/object/types.go
+++ b/object/types.go
@@ -21,10 +21,12 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+// Reference wraps a managed object reference
 type Reference interface {
 	Reference() types.ManagedObjectReference
 }
 
+// NewReference wraps the given managed object reference in the appropriate client
 func NewReference(c *vim25.Client, e types.ManagedObjectReference) Reference {
 	switch e.Type {
 	case "Folder":

--- a/object/virtual_app.go
+++ b/object/virtual_app.go
@@ -27,10 +27,12 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+// VirtualApp represents a virtual app
 type VirtualApp struct {
 	*ResourcePool
 }
 
+// NewVirtualApp creates a new virtual app client
 func NewVirtualApp(c *vim25.Client, ref types.ManagedObjectReference) *VirtualApp {
 	return &VirtualApp{
 		ResourcePool: NewResourcePool(c, ref),
@@ -44,6 +46,7 @@ func (p VirtualApp) String() string {
 	return fmt.Sprintf("%v @ %v", p.Common, p.InventoryPath)
 }
 
+// Name returns the name of this virtual app
 func (p VirtualApp) Name(ctx context.Context) (string, error) {
 	var o mo.VirtualApp
 
@@ -55,6 +58,7 @@ func (p VirtualApp) Name(ctx context.Context) (string, error) {
 	return o.Name, nil
 }
 
+// CreateChildVM_Task creates a child vm task
 func (p VirtualApp) CreateChildVM_Task(ctx context.Context, config types.VirtualMachineConfigSpec, host *HostSystem) (*Task, error) {
 	req := types.CreateChildVM_Task{
 		This:   p.Reference(),
@@ -74,6 +78,7 @@ func (p VirtualApp) CreateChildVM_Task(ctx context.Context, config types.Virtual
 	return NewTask(p.c, res.Returnval), nil
 }
 
+// UpdateVAppConfig updates the vapp config
 func (p VirtualApp) UpdateVAppConfig(ctx context.Context, spec types.VAppConfigSpec) error {
 	req := types.UpdateVAppConfig{
 		This: p.Reference(),
@@ -84,6 +89,7 @@ func (p VirtualApp) UpdateVAppConfig(ctx context.Context, spec types.VAppConfigS
 	return err
 }
 
+// PowerOnVApp_Task power this vApp on
 func (p VirtualApp) PowerOnVApp_Task(ctx context.Context) (*Task, error) {
 	req := types.PowerOnVApp_Task{
 		This: p.Reference(),
@@ -97,6 +103,7 @@ func (p VirtualApp) PowerOnVApp_Task(ctx context.Context) (*Task, error) {
 	return NewTask(p.c, res.Returnval), nil
 }
 
+// PowerOffVApp_Task power this vApp off
 func (p VirtualApp) PowerOffVApp_Task(ctx context.Context, force bool) (*Task, error) {
 	req := types.PowerOffVApp_Task{
 		This:  p.Reference(),
@@ -112,6 +119,7 @@ func (p VirtualApp) PowerOffVApp_Task(ctx context.Context, force bool) (*Task, e
 
 }
 
+// SuspendVApp_Task suspends a VApp task
 func (p VirtualApp) SuspendVApp_Task(ctx context.Context) (*Task, error) {
 	req := types.SuspendVApp_Task{
 		This: p.Reference(),

--- a/object/virtual_disk_manager.go
+++ b/object/virtual_disk_manager.go
@@ -23,10 +23,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// A VirtualDiskManager client
 type VirtualDiskManager struct {
 	Common
 }
 
+// NewVirtualDiskManager creates a new virtual disk manager
 func NewVirtualDiskManager(c *vim25.Client) *VirtualDiskManager {
 	m := VirtualDiskManager{
 		Common: NewCommon(c, *c.ServiceContent.VirtualDiskManager),

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -29,9 +29,11 @@ import (
 )
 
 const (
+	// PropRuntimePowerState constant
 	PropRuntimePowerState = "summary.runtime.powerState"
 )
 
+// A VirtualMachine client
 type VirtualMachine struct {
 	Common
 
@@ -45,12 +47,14 @@ func (v VirtualMachine) String() string {
 	return fmt.Sprintf("%v @ %v", v.Common, v.InventoryPath)
 }
 
+// NewVirtualMachine creates a new virtual machine client
 func NewVirtualMachine(c *vim25.Client, ref types.ManagedObjectReference) *VirtualMachine {
 	return &VirtualMachine{
 		Common: NewCommon(c, ref),
 	}
 }
 
+// Name for this virtual machine
 func (v VirtualMachine) Name(ctx context.Context) (string, error) {
 	var o mo.VirtualMachine
 
@@ -62,6 +66,7 @@ func (v VirtualMachine) Name(ctx context.Context) (string, error) {
 	return o.Name, nil
 }
 
+// PowerState the powerstate for this virtual machine
 func (v VirtualMachine) PowerState(ctx context.Context) (types.VirtualMachinePowerState, error) {
 	var o mo.VirtualMachine
 
@@ -73,6 +78,7 @@ func (v VirtualMachine) PowerState(ctx context.Context) (types.VirtualMachinePow
 	return o.Summary.Runtime.PowerState, nil
 }
 
+// PowerOn powers this virtual machine on
 func (v VirtualMachine) PowerOn(ctx context.Context) (*Task, error) {
 	req := types.PowerOnVM_Task{
 		This: v.Reference(),
@@ -86,6 +92,7 @@ func (v VirtualMachine) PowerOn(ctx context.Context) (*Task, error) {
 	return NewTask(v.c, res.Returnval), nil
 }
 
+// PowerOff powers this virtual machine off
 func (v VirtualMachine) PowerOff(ctx context.Context) (*Task, error) {
 	req := types.PowerOffVM_Task{
 		This: v.Reference(),
@@ -99,6 +106,7 @@ func (v VirtualMachine) PowerOff(ctx context.Context) (*Task, error) {
 	return NewTask(v.c, res.Returnval), nil
 }
 
+// Reset the virtual machine
 func (v VirtualMachine) Reset(ctx context.Context) (*Task, error) {
 	req := types.ResetVM_Task{
 		This: v.Reference(),
@@ -112,6 +120,7 @@ func (v VirtualMachine) Reset(ctx context.Context) (*Task, error) {
 	return NewTask(v.c, res.Returnval), nil
 }
 
+// Suspend this virtual machine
 func (v VirtualMachine) Suspend(ctx context.Context) (*Task, error) {
 	req := types.SuspendVM_Task{
 		This: v.Reference(),
@@ -125,6 +134,7 @@ func (v VirtualMachine) Suspend(ctx context.Context) (*Task, error) {
 	return NewTask(v.c, res.Returnval), nil
 }
 
+// ShutdownGuest for this virtual machine
 func (v VirtualMachine) ShutdownGuest(ctx context.Context) error {
 	req := types.ShutdownGuest{
 		This: v.Reference(),
@@ -134,6 +144,7 @@ func (v VirtualMachine) ShutdownGuest(ctx context.Context) error {
 	return err
 }
 
+// RebootGuest for this virtual machine
 func (v VirtualMachine) RebootGuest(ctx context.Context) error {
 	req := types.RebootGuest{
 		This: v.Reference(),
@@ -143,6 +154,7 @@ func (v VirtualMachine) RebootGuest(ctx context.Context) error {
 	return err
 }
 
+// Destroy this virtual machine
 func (v VirtualMachine) Destroy(ctx context.Context) (*Task, error) {
 	req := types.Destroy_Task{
 		This: v.Reference(),
@@ -156,6 +168,7 @@ func (v VirtualMachine) Destroy(ctx context.Context) (*Task, error) {
 	return NewTask(v.c, res.Returnval), nil
 }
 
+// Clone this virtual machine to the specified folder
 func (v VirtualMachine) Clone(ctx context.Context, folder *Folder, name string, config types.VirtualMachineCloneSpec) (*Task, error) {
 	req := types.CloneVM_Task{
 		This:   v.Reference(),
@@ -172,6 +185,7 @@ func (v VirtualMachine) Clone(ctx context.Context, folder *Folder, name string, 
 	return NewTask(v.c, res.Returnval), nil
 }
 
+// Customize this virtual machine with the specified spec
 func (v VirtualMachine) Customize(ctx context.Context, spec types.CustomizationSpec) (*Task, error) {
 	req := types.CustomizeVM_Task{
 		This: v.Reference(),
@@ -186,6 +200,7 @@ func (v VirtualMachine) Customize(ctx context.Context, spec types.CustomizationS
 	return NewTask(v.c, res.Returnval), nil
 }
 
+// Relocate this virtual machine
 func (v VirtualMachine) Relocate(ctx context.Context, config types.VirtualMachineRelocateSpec, priority types.VirtualMachineMovePriority) (*Task, error) {
 	req := types.RelocateVM_Task{
 		This:     v.Reference(),
@@ -201,6 +216,7 @@ func (v VirtualMachine) Relocate(ctx context.Context, config types.VirtualMachin
 	return NewTask(v.c, res.Returnval), nil
 }
 
+// Reconfigure this virtual machine
 func (v VirtualMachine) Reconfigure(ctx context.Context, config types.VirtualMachineConfigSpec) (*Task, error) {
 	req := types.ReconfigVM_Task{
 		This: v.Reference(),
@@ -215,6 +231,7 @@ func (v VirtualMachine) Reconfigure(ctx context.Context, config types.VirtualMac
 	return NewTask(v.c, res.Returnval), nil
 }
 
+// WaitForIP with this virtual machine
 func (v VirtualMachine) WaitForIP(ctx context.Context) (string, error) {
 	var ip string
 
@@ -257,6 +274,7 @@ func (v VirtualMachine) Device(ctx context.Context) (VirtualDeviceList, error) {
 	return VirtualDeviceList(o.Config.Hardware.Device), nil
 }
 
+// HostSystem gets the host system client for this virtual machine
 func (v VirtualMachine) HostSystem(ctx context.Context) (*HostSystem, error) {
 	var o mo.VirtualMachine
 
@@ -273,6 +291,7 @@ func (v VirtualMachine) HostSystem(ctx context.Context) (*HostSystem, error) {
 	return NewHostSystem(v.c, *host), nil
 }
 
+// ResourcePool creates the resource pool client for this virtual machine
 func (v VirtualMachine) ResourcePool(ctx context.Context) (*ResourcePool, error) {
 	var o mo.VirtualMachine
 
@@ -412,7 +431,7 @@ func (v VirtualMachine) IsToolsRunning(ctx context.Context) (bool, error) {
 	return o.Guest.ToolsRunningStatus == string(types.VirtualMachineToolsRunningStatusGuestToolsRunning), nil
 }
 
-// Wait for the VirtualMachine to change to the desired power state.
+// WaitForPowerState of the VirtualMachine to change to the desired power state.
 func (v VirtualMachine) WaitForPowerState(ctx context.Context, state types.VirtualMachinePowerState) error {
 	p := property.DefaultCollector(v.c)
 	err := property.Wait(ctx, p, v.Reference(), []string{PropRuntimePowerState}, func(pc []types.PropertyChange) bool {
@@ -435,6 +454,7 @@ func (v VirtualMachine) WaitForPowerState(ctx context.Context, state types.Virtu
 	return err
 }
 
+// MarkAsTemplate marks this virtual machine as a template
 func (v VirtualMachine) MarkAsTemplate(ctx context.Context) error {
 	req := types.MarkAsTemplate{
 		This: v.Reference(),
@@ -448,6 +468,7 @@ func (v VirtualMachine) MarkAsTemplate(ctx context.Context) error {
 	return nil
 }
 
+// MarkAsVirtualMachine marks this virtual machine as a virtual machine
 func (v VirtualMachine) MarkAsVirtualMachine(ctx context.Context, pool ResourcePool, host *HostSystem) error {
 	req := types.MarkAsVirtualMachine{
 		This: v.Reference(),

--- a/object/vmware_distributed_virtual_switch.go
+++ b/object/vmware_distributed_virtual_switch.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package object
 
+// A VmwareDistributedVirtualSwitch client
 type VmwareDistributedVirtualSwitch struct {
 	DistributedVirtualSwitch
 }

--- a/ovf/cim.go
+++ b/ovf/cim.go
@@ -16,10 +16,7 @@ limitations under the License.
 
 package ovf
 
-/*
-Source: http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.24.0/CIM_VirtualSystemSettingData.xsd
-*/
-
+// CIMVirtualSystemSettingData Source: http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.24.0/CIM_VirtualSystemSettingData.xsd
 type CIMVirtualSystemSettingData struct {
 	ElementName string `xml:"ElementName"`
 	InstanceID  string `xml:"InstanceID"`
@@ -45,10 +42,7 @@ type CIMVirtualSystemSettingData struct {
 	VirtualSystemType                    *string  `xml:"VirtualSystemType"`
 }
 
-/*
-Source: http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.24.0/CIM_ResourceAllocationSettingData.xsd
-*/
-
+// CIMResourceAllocationSettingData Source: http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.24.0/CIM_ResourceAllocationSettingData.xsd
 type CIMResourceAllocationSettingData struct {
 	ElementName string `xml:"ElementName"`
 	InstanceID  string `xml:"InstanceID"`

--- a/ovf/env.go
+++ b/ovf/env.go
@@ -42,6 +42,7 @@ const (
 	ovfEnvFooter         = `</Environment>`
 )
 
+// Env represents the environment settings
 type Env struct {
 	XMLName xml.Name `xml:"http://schemas.dmtf.org/ovf/environment/1 Environment"`
 	ID      string   `xml:"id,attr"`
@@ -51,6 +52,7 @@ type Env struct {
 	Property *PropertySection `xml:"PropertySection"`
 }
 
+// PlatformSection represents the platform section
 type PlatformSection struct {
 	Kind    string `xml:"Kind"`
 	Version string `xml:"Version"`
@@ -58,10 +60,12 @@ type PlatformSection struct {
 	Locale  string `xml:"Locale"`
 }
 
+// PropertySection represents the env property section
 type PropertySection struct {
 	Properties []EnvProperty `xml:"Property"`
 }
 
+// EnvProperty represents an EnvProperty
 type EnvProperty struct {
 	Key   string `xml:"key,attr"`
 	Value string `xml:"value,attr"`

--- a/ovf/envelope.go
+++ b/ovf/envelope.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package ovf
 
+// Envelope represents and OVF envelope
 type Envelope struct {
 	References []File `xml:"References>File"`
 
@@ -34,6 +35,7 @@ type Envelope struct {
 	VirtualSystem *VirtualSystem `xml:"VirtualSystem"`
 }
 
+// VirtualSystem represents a virtual system
 type VirtualSystem struct {
 	Content
 
@@ -44,6 +46,7 @@ type VirtualSystem struct {
 	VirtualHardware []VirtualHardwareSection `xml:"VirtualHardwareSection"`
 }
 
+// File represents a file
 type File struct {
 	ID          string  `xml:"id,attr"`
 	Href        string  `xml:"href,attr"`
@@ -52,23 +55,27 @@ type File struct {
 	ChunkSize   *int    `xml:"chunkSize,attr"`
 }
 
+// Content represents content
 type Content struct {
 	ID   string  `xml:"id,attr"`
 	Info string  `xml:"Info"`
 	Name *string `xml:"Name"`
 }
 
+// Section represents a section
 type Section struct {
 	Required *bool  `xml:"required,attr"`
 	Info     string `xml:"Info"`
 }
 
+// AnnotationSection represents an annotation section
 type AnnotationSection struct {
 	Section
 
 	Annotation string `xml:"Annotation"`
 }
 
+// ProductSection represents a product section
 type ProductSection struct {
 	Section
 
@@ -85,6 +92,7 @@ type ProductSection struct {
 	Property    []Property `xml:"Property"`
 }
 
+// Property represents a property
 type Property struct {
 	Key              string  `xml:"key,attr"`
 	Type             string  `xml:"type,attr"`
@@ -99,29 +107,34 @@ type Property struct {
 	Values []PropertyConfigurationValue `xml:"Value"`
 }
 
+// PropertyConfigurationValue represetns a property configuration value
 type PropertyConfigurationValue struct {
 	Value         string  `xml:"value,attr"`
 	Configuration *string `xml:"configuration,attr"`
 }
 
+// NetworkSection describes the network configuration
 type NetworkSection struct {
 	Section
 
 	Networks []Network `xml:"Network"`
 }
 
+// Network represents a network definition in an OVF
 type Network struct {
 	Name string `xml:"name,attr"`
 
 	Description string `xml:"Description"`
 }
 
+// DiskSection represents the disk definition in an OVF
 type DiskSection struct {
 	Section
 
 	Disks []VirtualDiskDesc `xml:"Disk"`
 }
 
+// VirtualDiskDesc describes an individual virtual disk configuration
 type VirtualDiskDesc struct {
 	DiskID                  string  `xml:"diskId,attr"`
 	FileRef                 *string `xml:"fileRef,attr"`
@@ -132,6 +145,7 @@ type VirtualDiskDesc struct {
 	ParentRef               *string `xml:"parentRef,attr"`
 }
 
+// OperatingSystemSection descritbes the operation system in an OVF
 type OperatingSystemSection struct {
 	Section
 
@@ -142,12 +156,14 @@ type OperatingSystemSection struct {
 	Description *string `xml:"Description"`
 }
 
+// EulaSection describes the License for an OVF
 type EulaSection struct {
 	Section
 
 	License string `xml:"License"`
 }
 
+// VirtualHardwareSection describes the virtual hardware in an OVF
 type VirtualHardwareSection struct {
 	Section
 
@@ -158,10 +174,12 @@ type VirtualHardwareSection struct {
 	Item   []ResourceAllocationSettingData `xml:"Item"`
 }
 
+// VirtualSystemSettingData describes the virtual system settings
 type VirtualSystemSettingData struct {
 	CIMVirtualSystemSettingData
 }
 
+// ResourceAllocationSettingData describes the resource allocation settings
 type ResourceAllocationSettingData struct {
 	CIMResourceAllocationSettingData
 
@@ -170,18 +188,21 @@ type ResourceAllocationSettingData struct {
 	Bound         *string `xml:"bound,attr"`
 }
 
+// ResourceAllocationSection describes the resource allocation section in an OVF
 type ResourceAllocationSection struct {
 	Section
 
 	Item []ResourceAllocationSettingData `xml:"Item"`
 }
 
+// DeploymentOptionSection describes the deployment options
 type DeploymentOptionSection struct {
 	Section
 
 	Configuration []DeploymentOptionConfiguration `xml:"Configuration"`
 }
 
+// DeploymentOptionConfiguration describes a deployment option
 type DeploymentOptionConfiguration struct {
 	ID      string `xml:"id,attr"`
 	Default *bool  `xml:"default,attr"`

--- a/ovf/ovf.go
+++ b/ovf/ovf.go
@@ -21,6 +21,7 @@ import (
 	"io"
 )
 
+// Unmarshal unmarshals an envelope from a reader
 func Unmarshal(r io.Reader) (*Envelope, error) {
 	var e Envelope
 

--- a/property/collector.go
+++ b/property/collector.go
@@ -47,6 +47,7 @@ func DefaultCollector(c *vim25.Client) *Collector {
 	return &p
 }
 
+// Reference returns the managed reference
 func (p Collector) Reference() types.ManagedObjectReference {
 	return p.reference
 }
@@ -86,6 +87,7 @@ func (p *Collector) Destroy(ctx context.Context) error {
 	return nil
 }
 
+// CreateFilter creates a filter
 func (p *Collector) CreateFilter(ctx context.Context, req types.CreateFilter) error {
 	req.This = p.Reference()
 
@@ -97,6 +99,7 @@ func (p *Collector) CreateFilter(ctx context.Context, req types.CreateFilter) er
 	return nil
 }
 
+// WaitForUpdates waits for updates
 func (p *Collector) WaitForUpdates(ctx context.Context, v string) (*types.UpdateSet, error) {
 	req := types.WaitForUpdatesEx{
 		This:    p.Reference(),
@@ -111,6 +114,7 @@ func (p *Collector) WaitForUpdates(ctx context.Context, v string) (*types.Update
 	return res.Returnval, nil
 }
 
+// RetrieveProperties retrieves the properties
 func (p *Collector) RetrieveProperties(ctx context.Context, req types.RetrieveProperties) (*types.RetrievePropertiesResponse, error) {
 	req.This = p.Reference()
 	return methods.RetrieveProperties(ctx, p.roundTripper, &req)

--- a/session/manager.go
+++ b/session/manager.go
@@ -27,11 +27,13 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Manager manages sessions
 type Manager struct {
 	client      *vim25.Client
 	userSession *types.UserSession
 }
 
+// NewManager creates a new manager
 func NewManager(client *vim25.Client) *Manager {
 	m := Manager{
 		client: client,
@@ -40,10 +42,12 @@ func NewManager(client *vim25.Client) *Manager {
 	return &m
 }
 
+// Reference returns the managed object reference
 func (sm Manager) Reference() types.ManagedObjectReference {
 	return *sm.client.ServiceContent.SessionManager
 }
 
+// Login logs in
 func (sm *Manager) Login(ctx context.Context, u *url.Userinfo) error {
 	req := types.Login{
 		This: sm.Reference(),
@@ -65,6 +69,7 @@ func (sm *Manager) Login(ctx context.Context, u *url.Userinfo) error {
 	return nil
 }
 
+// LoginExtensionByCertificate log in with a certificate
 func (sm *Manager) LoginExtensionByCertificate(ctx context.Context, key string, locale string) error {
 	req := types.LoginExtensionByCertificate{
 		This:         sm.Reference(),
@@ -81,6 +86,7 @@ func (sm *Manager) LoginExtensionByCertificate(ctx context.Context, key string, 
 	return nil
 }
 
+// Logout logs a session out
 func (sm *Manager) Logout(ctx context.Context) error {
 	req := types.Logout{
 		This: sm.Reference(),
@@ -117,10 +123,11 @@ func (sm *Manager) UserSession(ctx context.Context) (*types.UserSession, error) 
 	return mgr.CurrentSession, nil
 }
 
-func (sm *Manager) TerminateSession(ctx context.Context, sessionId []string) error {
+// TerminateSession terminates a session
+func (sm *Manager) TerminateSession(ctx context.Context, sessionID []string) error {
 	req := types.TerminateSession{
 		This:      sm.Reference(),
-		SessionId: sessionId,
+		SessionId: sessionID,
 	}
 
 	_, err := methods.TerminateSession(ctx, sm.client, &req)
@@ -148,6 +155,7 @@ func (sm *Manager) SessionIsActive(ctx context.Context) (bool, error) {
 	return active.Returnval, err
 }
 
+// AcquireGenericServiceTicket acquires a generic service ticket
 func (sm *Manager) AcquireGenericServiceTicket(ctx context.Context, spec types.BaseSessionManagerServiceRequestSpec) (*types.SessionManagerGenericServiceTicket, error) {
 	req := types.AcquireGenericServiceTicket{
 		This: sm.Reference(),

--- a/task/error.go
+++ b/task/error.go
@@ -18,6 +18,7 @@ package task
 
 import "github.com/vmware/govmomi/vim25/types"
 
+// Error reprents a task error
 type Error struct {
 	*types.LocalizedMethodFault
 }
@@ -27,6 +28,7 @@ func (e Error) Error() string {
 	return e.LocalizedMethodFault.LocalizedMessage
 }
 
+// Fault returns the tasks's base method fault
 func (e Error) Fault() types.BaseMethodFault {
 	return e.LocalizedMethodFault.Fault
 }

--- a/units/size.go
+++ b/units/size.go
@@ -23,15 +23,22 @@ import (
 	"strconv"
 )
 
+// ByteSize represents a byte size
 type ByteSize int64
 
 const (
-	_  = iota
+	_ = iota
+	// KB KiloByte
 	KB = 1 << (10 * iota)
+	// MB MegaByte
 	MB
+	// GB GigaByte
 	GB
+	// TB TerraByte
 	TB
+	// PB PetaByte
 	PB
+	// EB ExaByte
 	EB
 )
 
@@ -55,6 +62,7 @@ func (b ByteSize) String() string {
 
 var bytesRegexp = regexp.MustCompile(`^(?i)(\d+)([BKMGTPE]?)(ib|b)?$`)
 
+// Set the bytesize from a string
 func (b *ByteSize) Set(s string) error {
 	m := bytesRegexp.FindStringSubmatch(s)
 	if len(m) == 0 {


### PR DESCRIPTION
Clears a bunch of golint warnings

This also adds a golint make task. You can check that one to find out where we're violating the naming conventions on our exported interface. 