### PR TITLE
Use gvt to get dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: false
 language: go
-go: 1.4
+go: 1.5
 
 before_install:
   - go get golang.org/x/tools/cmd/vet
   - go get golang.org/x/tools/cmd/goimports
 
 script:
-  - make check test
+  - make check gvt dependencies test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: test
 
-all: check test
+$(shell export GO15VENDOREXPERIMENT=1)
+
+all: check gvt dependencies test
 
 check: goimports govet
 
@@ -12,8 +14,15 @@ govet:
 	@echo checking go vet...
 	@go tool vet -structtags=false -methods=false .
 
+gvt:
+	@echo getting gvt
+	go get -u github.com/FiloSottile/gvt
+
+dependencies:
+	@echo restoring dependencies
+	$(GOPATH)/bin/gvt restore
+
 test:
-	go get
 	go test -v $(TEST_OPTS) ./...
 
 install:

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -1,0 +1,12 @@
+{
+	"version": 0,
+	"dependencies": [
+		{
+			"importpath": "golang.org/x/net/context",
+			"repository": "https://go.googlesource.com/net",
+			"revision": "eb066e37c13279b9201bced453eb0e2f7ca69b18",
+			"branch": "master",
+			"path": "/context"
+		}
+	]
+}


### PR DESCRIPTION
The go vendor experiment (GO15VENDOREXPERIMENT) adds a vendor/ dir which out of tree imports can be added.  Gvt can be used to specify the import at a specific revision.  Use gvt to get the context package at the given release.  This will avoid build breakages if the context package changes underneath you.