### PR TITLE
Update missing property whitelist

### DIFF
--- a/vim25/mo/retrieve.go
+++ b/vim25/mo/retrieve.go
@@ -32,6 +32,9 @@ func ignoreMissingProperty(ref types.ManagedObjectReference, p types.MissingProp
 		case "environmentBrowser":
 			// See https://github.com/vmware/govmomi/pull/242
 			return true
+		case "alarmActionsEnabled":
+			// Seen with vApp child VM
+			return true
 		}
 	}
 


### PR DESCRIPTION
Ignore missing alarmActionsEnabled missing property, possible with a
vApp child VM.