### PR TITLE
added explicit cloning path to drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,6 @@
 clone:
   tags: true
+  path: github.com/vmware/govmomi
 build:
   image: golang:1.5
   pull: true


### PR DESCRIPTION
This fixes local `drone exec` execution.