### PR TITLE
Fix issue with optional UnitNumber

### DIFF
--- a/govc/device/info.go
+++ b/govc/device/info.go
@@ -125,7 +125,11 @@ func (r *infoResult) Write(w io.Writer) error {
 		} else {
 			if c := r.list.FindByKey(d.ControllerKey); c != nil {
 				fmt.Fprintf(tw, "  Controller:\t%s\n", r.Devices.Name(c))
-				fmt.Fprintf(tw, "  Unit number:\t%d\n", d.UnitNumber)
+				if d.UnitNumber != nil {
+					fmt.Fprintf(tw, "  Unit number:\t%d\n", *d.UnitNumber)
+				} else {
+					fmt.Fprintf(tw, "  Unit number:\t<nil>\n")
+				}
 			}
 		}
 

--- a/govc/importx/ovf.go
+++ b/govc/importx/ovf.go
@@ -231,16 +231,6 @@ func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 		}
 	}
 
-	// TODO: ImportSpec may have unitNumber==0, but this field is optional in the wsdl
-	// and hence omitempty in the struct tag; but unitNumber is required for certain devices.
-	s := &spec.ImportSpec.(*types.VirtualMachineImportSpec).ConfigSpec
-	for _, d := range s.DeviceChange {
-		n := &d.GetVirtualDeviceConfigSpec().Device.GetVirtualDevice().UnitNumber
-		if *n == 0 {
-			*n = -1
-		}
-	}
-
 	var host *object.HostSystem
 	if cmd.SearchFlag.IsSet() {
 		if host, err = cmd.HostSystem(); err != nil {

--- a/govc/importx/vmdk.go
+++ b/govc/importx/vmdk.go
@@ -451,7 +451,6 @@ func (c *configSpec) AddDisk(ds *object.Datastore, path string) {
 		VirtualDevice: types.VirtualDevice{
 			Key:           -1,
 			ControllerKey: -1,
-			UnitNumber:    -1,
 			Backing: &types.VirtualDiskFlatVer2BackingInfo{
 				VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
 					FileName: ds.Path(path),

--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -317,8 +317,8 @@ func (l VirtualDeviceList) newUnitNumber(c types.BaseVirtualController) int {
 		d := device.GetVirtualDevice()
 
 		if d.ControllerKey == key {
-			if d.UnitNumber > max {
-				max = d.UnitNumber
+			if d.UnitNumber != nil && *d.UnitNumber > max {
+				max = *d.UnitNumber
 			}
 		}
 	}
@@ -348,9 +348,10 @@ func (l VirtualDeviceList) NewKey() int {
 func (l VirtualDeviceList) AssignController(device types.BaseVirtualDevice, c types.BaseVirtualController) {
 	d := device.GetVirtualDevice()
 	d.ControllerKey = c.GetVirtualController().Key
-	d.UnitNumber = l.newUnitNumber(c)
-	if d.UnitNumber == 0 {
-		d.UnitNumber = -1 // TODO: this field is annotated as omitempty
+	d.UnitNumber = new(int)
+	*d.UnitNumber = l.newUnitNumber(c)
+	if *d.UnitNumber == 0 {
+		*d.UnitNumber = -1
 	}
 	if d.Key == 0 {
 		d.Key = -1
@@ -764,14 +765,18 @@ func (l VirtualDeviceList) Type(device types.BaseVirtualDevice) string {
 // Name returns a stable, human-readable name for the given device
 func (l VirtualDeviceList) Name(device types.BaseVirtualDevice) string {
 	var key string
+	var UnitNumber int
 	d := device.GetVirtualDevice()
-	dtype := l.Type(device)
+	if d.UnitNumber != nil {
+		UnitNumber = *d.UnitNumber
+	}
 
+	dtype := l.Type(device)
 	switch dtype {
 	case DeviceTypeEthernet:
-		key = fmt.Sprintf("%d", d.UnitNumber-7)
+		key = fmt.Sprintf("%d", UnitNumber-7)
 	case DeviceTypeDisk:
-		key = fmt.Sprintf("%d-%d", d.ControllerKey, d.UnitNumber)
+		key = fmt.Sprintf("%d-%d", d.ControllerKey, UnitNumber)
 	default:
 		key = fmt.Sprintf("%d", d.Key)
 	}

--- a/object/virtual_device_list_test.go
+++ b/object/virtual_device_list_test.go
@@ -24,6 +24,10 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+func intPtrValue(val int) *int {
+	return &val
+}
+
 var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 	&types.VirtualIDEController{
 		VirtualController: types.VirtualController{
@@ -39,7 +43,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 				SlotInfo:      nil,
 				ControllerKey: 0,
-				UnitNumber:    0,
+				UnitNumber:    intPtrValue(0),
 			},
 			BusNumber: 0,
 			Device:    []int{3001, 3000},
@@ -59,7 +63,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 				SlotInfo:      nil,
 				ControllerKey: 0,
-				UnitNumber:    0,
+				UnitNumber:    intPtrValue(0),
 			},
 			BusNumber: 1,
 			Device:    []int{3002},
@@ -79,7 +83,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 				SlotInfo:      nil,
 				ControllerKey: 0,
-				UnitNumber:    0,
+				UnitNumber:    intPtrValue(0),
 			},
 			BusNumber: 0,
 			Device:    []int{600, 700},
@@ -99,7 +103,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 				SlotInfo:      nil,
 				ControllerKey: 0,
-				UnitNumber:    0,
+				UnitNumber:    intPtrValue(0),
 			},
 			BusNumber: 0,
 			Device:    []int{500, 12000, 1000, 4000},
@@ -119,7 +123,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 				SlotInfo:      nil,
 				ControllerKey: 0,
-				UnitNumber:    0,
+				UnitNumber:    intPtrValue(0),
 			},
 			BusNumber: 0,
 			Device:    []int{9000},
@@ -138,7 +142,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 			SlotInfo:      nil,
 			ControllerKey: 300,
-			UnitNumber:    0,
+			UnitNumber:    intPtrValue(0),
 		},
 	},
 	&types.VirtualPointingDevice{
@@ -157,7 +161,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 			SlotInfo:      nil,
 			ControllerKey: 300,
-			UnitNumber:    1,
+			UnitNumber:    intPtrValue(1),
 		},
 	},
 	&types.VirtualMachineVideoCard{
@@ -173,7 +177,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 			SlotInfo:      nil,
 			ControllerKey: 100,
-			UnitNumber:    0,
+			UnitNumber:    intPtrValue(0),
 		},
 		VideoRamSizeInKB: 4096,
 		NumDisplays:      1,
@@ -197,7 +201,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 				PciSlotNumber:            33,
 			},
 			ControllerKey: 100,
-			UnitNumber:    17,
+			UnitNumber:    intPtrValue(17),
 		},
 		Id: 1754519335,
 		AllowUnrestrictedCommunication: types.NewBool(false),
@@ -217,7 +221,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 					Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 					SlotInfo:      nil,
 					ControllerKey: 100,
-					UnitNumber:    3,
+					UnitNumber:    intPtrValue(3),
 				},
 				BusNumber: 0,
 				Device:    nil,
@@ -253,7 +257,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			},
 			SlotInfo:      nil,
 			ControllerKey: 200,
-			UnitNumber:    1,
+			UnitNumber:    intPtrValue(1),
 		},
 	},
 	&types.VirtualDisk{
@@ -307,7 +311,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 			SlotInfo:      nil,
 			ControllerKey: 200,
-			UnitNumber:    0,
+			UnitNumber:    intPtrValue(0),
 		},
 		CapacityInKB:    30720,
 		CapacityInBytes: 31457280,
@@ -361,7 +365,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 			SlotInfo:      nil,
 			ControllerKey: 201,
-			UnitNumber:    0,
+			UnitNumber:    intPtrValue(0),
 		},
 		CapacityInKB:    10000000,
 		CapacityInBytes: 10240000000,
@@ -414,7 +418,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 					PciSlotNumber:            32,
 				},
 				ControllerKey: 100,
-				UnitNumber:    7,
+				UnitNumber:    intPtrValue(7),
 			},
 			AddressType:      "generated",
 			MacAddress:       "00:0c:29:93:d7:27",
@@ -447,7 +451,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			},
 			SlotInfo:      nil,
 			ControllerKey: 400,
-			UnitNumber:    0,
+			UnitNumber:    intPtrValue(0),
 		},
 		YieldOnPoll: true,
 	},
@@ -643,9 +647,10 @@ func TestPickController(t *testing.T) {
 
 		dev := &types.VirtualDevice{
 			Key:           rand.Int(),
-			UnitNumber:    unit,
+			UnitNumber:    new(int),
 			ControllerKey: key,
 		}
+		*dev.UnitNumber = unit
 
 		list = append(list, dev)
 		c.Device = append(c.Device, dev.Key)
@@ -831,7 +836,7 @@ func TestName(t *testing.T) {
 			&types.VirtualE1000{
 				VirtualEthernetCard: types.VirtualEthernetCard{
 					VirtualDevice: types.VirtualDevice{
-						UnitNumber: 7,
+						UnitNumber: intPtrValue(7),
 					},
 				},
 			},

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -43796,7 +43796,7 @@ type VirtualDevice struct {
 	Connectable   *VirtualDeviceConnectInfo    `xml:"connectable,omitempty"`
 	SlotInfo      BaseVirtualDeviceBusSlotInfo `xml:"slotInfo,omitempty,typeattr"`
 	ControllerKey int                          `xml:"controllerKey,omitempty"`
-	UnitNumber    int                          `xml:"unitNumber,omitempty"`
+	UnitNumber    *int                         `xml:"unitNumber"`
 }
 
 func init() {

--- a/vim25/types/types_test.go
+++ b/vim25/types/types_test.go
@@ -49,7 +49,7 @@ func TestVirtualMachineConfigSpec(t *testing.T) {
 					VirtualDevice: VirtualDevice{
 						Key:           0,
 						ControllerKey: 1000,
-						UnitNumber:    0,
+						UnitNumber:    new(int), // zero default value
 						Backing: &VirtualDiskFlatVer2BackingInfo{
 							DiskMode:        string(VirtualDiskModePersistent),
 							ThinProvisioned: NewBool(true),


### PR DESCRIPTION
The UnitNumber is optional in the wsdl, hence the 'omitempty' directive
causes issues, as evidenced by 2 FIXMEs in the code. This addresses
those FIXMEs, being able to properly distinguish between absent optional
UnitNumber and a properly present zero-valued UnitNumber.