### PR TITLE
Add switch to specify protocol version in SOAPAction header

### DIFF
--- a/govc/README.md
+++ b/govc/README.md
@@ -83,6 +83,10 @@ to set defaults:
 
 * `GOVC_GUEST_LOGIN`: Guest credentials for guest operations
 
+* `GOVC_VIM_NAMESPACE`: Vim namespace defaults to `urn:vim25`
+
+* `GOVC_VIM_VERSION`: Vim version defaults to `6.0`
+
 ## Examples
 
 * About

--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -43,6 +43,8 @@ const (
 	envInsecure      = "GOVC_INSECURE"
 	envPersist       = "GOVC_PERSIST_SESSION"
 	envMinAPIVersion = "GOVC_MIN_API_VERSION"
+	envVimNamespace  = "GOVC_VIM_NAMESPACE"
+	envVimVersion    = "GOVC_VIM_VERSION"
 )
 
 const cDescr = "ESX or vCenter URL"
@@ -60,6 +62,8 @@ type ClientFlag struct {
 	insecure      bool
 	persist       bool
 	minAPIVersion string
+	vimNamespace  string
+	vimVersion    string
 
 	client *vim25.Client
 }
@@ -160,6 +164,24 @@ func (flag *ClientFlag) Register(ctx context.Context, f *flag.FlagSet) {
 			}
 
 			flag.minAPIVersion = env
+		}
+
+		{
+			value := os.Getenv(envVimNamespace)
+			if value == "" {
+				value = soap.DefaultVimNamespace
+			}
+			usage := fmt.Sprintf("Vim namespace [%s]", envVimNamespace)
+			f.StringVar(&flag.vimNamespace, "vim-namespace", value, usage)
+		}
+
+		{
+			value := os.Getenv(envVimVersion)
+			if value == "" {
+				value = soap.DefaultVimVersion
+			}
+			usage := fmt.Sprintf("Vim version [%s]", envVimVersion)
+			f.StringVar(&flag.vimVersion, "vim-version", value, usage)
 		}
 	})
 }
@@ -312,6 +334,10 @@ func (flag *ClientFlag) newClient() (*vim25.Client, error) {
 
 		sc.SetCertificate(cert)
 	}
+
+	// Set namespace and version
+	sc.Namespace = flag.vimNamespace
+	sc.Version = flag.vimVersion
 
 	// Add retry functionality before making any calls
 	rt := attachRetries(sc)

--- a/govc/test/cli.bats
+++ b/govc/test/cli.bats
@@ -23,3 +23,8 @@ load test_helper
   run env GOVC_MIN_API_VERSION=24.4 govc about
   assert grep -q "^govc: Require API version 24.4," <<<${output}
 }
+
+@test "connect to an endpoint with user provided Vim namespace and Vim version" {
+  run govc about -vim-namespace urn:vim25 -vim-version 6.0
+  assert_success
+}

--- a/govc/test/images/update.sh
+++ b/govc/test/images/update.sh
@@ -9,7 +9,7 @@ ttylinux="ttylinux-pc_i486-16.1"
 files="${ttylinux}.iso ${ttylinux}-live.ova ${ttylinux}.ova"
 
 for name in $files ; do
-  wget -N $base_url/$name
+  wget -O $name $base_url/$name
 done
 
 wget -N https://github.com/icebreaker/floppybird/raw/master/build/floppybird.img


### PR DESCRIPTION
Added `-vim-namespace` and `-vim-version` flags to govc. Also set by corresponding env vars documented in README.md
```./govc -vim-namespace urn:vim25 -vim-version 6.0 -k -persist-session=false```

Also updated `govc/test/images/update.sh` since I was getting bad filenames from bintray due to akamai.

Addresses https://github.com/vmware/govmomi/issues/384