### PR TITLE
Fix vm.change's ExtraConfig values being truncated at equal signs

### DIFF
--- a/govc/vm/change.go
+++ b/govc/vm/change.go
@@ -34,7 +34,7 @@ func (e *extraConfig) String() string {
 }
 
 func (e *extraConfig) Set(v string) error {
-	r := strings.Split(v, "=")
+	r := strings.SplitN(v, "=", 2)
 	if len(r) < 2 {
 		return fmt.Errorf("failed to parse extraConfig: %s", v)
 	} else if r[1] == "" {


### PR DESCRIPTION
`govc vm.change -vm=test -e "guestinfo.hello=world=foo"` would result in `guestinfo.hello` having the value **`world`**, rather than **`world=foo`**.


