### PR TITLE
Add -net flag to device.info command

### DIFF
--- a/govc/device/info.go
+++ b/govc/device/info.go
@@ -34,6 +34,7 @@ import (
 type info struct {
 	*flags.VirtualMachineFlag
 	*flags.OutputFlag
+	*flags.NetworkFlag
 }
 
 func init() {
@@ -46,6 +47,9 @@ func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
 
 	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
 	cmd.OutputFlag.Register(ctx, f)
+
+	cmd.NetworkFlag, ctx = flags.NewNetworkFlag(ctx)
+	cmd.NetworkFlag.Register(ctx, f)
 }
 
 func (cmd *info) Process(ctx context.Context) error {
@@ -53,6 +57,9 @@ func (cmd *info) Process(ctx context.Context) error {
 		return err
 	}
 	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.NetworkFlag.Process(ctx); err != nil {
 		return err
 	}
 	return nil
@@ -79,6 +86,20 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	res := infoResult{
 		list: devices,
+	}
+
+	if cmd.NetworkFlag.IsSet() {
+		net, err := cmd.Network()
+		if err != nil {
+			return err
+		}
+
+		backing, err := net.EthernetCardBackingInfo(context.TODO())
+		if err != nil {
+			return err
+		}
+
+		devices = devices.SelectByBackingInfo(backing)
 	}
 
 	if f.NArg() == 0 {

--- a/govc/flags/network.go
+++ b/govc/flags/network.go
@@ -35,6 +35,7 @@ type NetworkFlag struct {
 	net     object.NetworkReference
 	adapter string
 	address string
+	isset   bool
 }
 
 var networkFlagKey = flagKey("network")
@@ -56,7 +57,7 @@ func (flag *NetworkFlag) Register(ctx context.Context, f *flag.FlagSet) {
 
 		env := "GOVC_NETWORK"
 		value := os.Getenv(env)
-		flag.Set(value)
+		flag.name = value
 		usage := fmt.Sprintf("Network [%s]", env)
 		f.Var(flag, "net", usage)
 		f.StringVar(&flag.adapter, "net.adapter", "e1000", "Network adapter type")
@@ -79,7 +80,12 @@ func (flag *NetworkFlag) String() string {
 
 func (flag *NetworkFlag) Set(name string) error {
 	flag.name = name
+	flag.isset = true
 	return nil
+}
+
+func (flag *NetworkFlag) IsSet() bool {
+	return flag.isset
 }
 
 func (flag *NetworkFlag) Network() (object.NetworkReference, error) {

--- a/govc/test/device.bats
+++ b/govc/test/device.bats
@@ -17,6 +17,15 @@ load test_helper
 
   run govc device.info -vm $vm ide-20000
   assert_failure
+
+  run govc device.info -vm $vm -net enoent
+  assert_failure
+
+  run govc device.info -vm $vm -net "VM Network" ide-200
+  assert_failure
+
+  result=$(govc device.info -vm $vm -net "VM Network" | grep "MAC Address" | wc -l)
+  [ $result -eq 1 ]
 }
 
 @test "device.boot" {

--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -126,7 +126,8 @@ func (l VirtualDeviceList) SelectByBackingInfo(backing types.BaseVirtualDeviceBa
 			return a.DeviceName == b.DeviceName
 		case *types.VirtualEthernetCardDistributedVirtualPortBackingInfo:
 			b := backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo)
-			return a.Port.SwitchUuid == b.Port.SwitchUuid
+			return a.Port.SwitchUuid == b.Port.SwitchUuid &&
+				a.Port.PortgroupKey == b.Port.PortgroupKey
 		case *types.VirtualDiskFlatVer2BackingInfo:
 			b := backing.(*types.VirtualDiskFlatVer2BackingInfo)
 			if a.Parent != nil && b.Parent != nil {


### PR DESCRIPTION
Filters device.info to devices backed by the given network.

Example use ( cc @hickeng ):
```
% govc device.info -vm /clovervm/vm/bon-368/bon-368 -net Bonneville
Name:               ethernet-1
  Type:             VirtualVmxnet3
  Label:            Network adapter 2
  Summary:          DVSwitch: 36 97 19 50 36 3e fe 71-62 eb 8b f7 43 b1 d9 03
  Key:              4001
  Controller:       pci-100
  Unit number:      8
  Connected:        true
  Start connected:  true
  Guest control:    true
  Status:           ok
  MAC Address:      00:50:56:99:a7:69
  Address type:     assigned

% govc device.info -vm /clovervm/vm/bon-368/bon-368 -net DPortGroup
Name:               ethernet-0
  Type:             VirtualVmxnet3
  Label:            Network adapter 1
  Summary:          DVSwitch: 36 97 19 50 36 3e fe 71-62 eb 8b f7 43 b1 d9 03
  Key:              4000
  Controller:       pci-100
  Unit number:      7
  Connected:        true
  Start connected:  true
  Guest control:    true
  Status:           ok
  MAC Address:      00:50:56:99:fd:d6
  Address type:     assigned
```