### PR TITLE
Double quote network name to prevent space in name from failing

### DIFF
--- a/govc/test/ls.bats
+++ b/govc/test/ls.bats
@@ -39,15 +39,15 @@ load test_helper
   [ ${#lines[@]} -ge 1 ]
 
   local path=${lines[0]}
-  run govc ls $path
+  run govc ls "$path"
   assert_success
   [ ${#lines[@]} -eq 1 ]
 
-  run govc ls network/$(basename $path)
+  run govc ls "network/$(basename "$path")"
   assert_success
   [ ${#lines[@]} -eq 1 ]
 
-  run govc ls /*/network/$(basename $path)
+  run govc ls "/*/network/$(basename "$path")"
   assert_success
   [ ${#lines[@]} -eq 1 ]
 }


### PR DESCRIPTION
Added double quotes to networking tests -- if there's a more precise way to do this please share.

Fixes 465