### PR TITLE
Added new -dump output flag for pretty printing underlying objects using davecgh/go-spew

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,7 @@ build:
   commands:
     - go get golang.org/x/tools/cmd/vet
     - go get golang.org/x/tools/cmd/goimports
+    - go get github.com/davecgh/go-spew/spew
     - go get
     - make all
     - govc/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go: 1.4
 before_install:
   - go get golang.org/x/tools/cmd/vet
   - go get golang.org/x/tools/cmd/goimports
+  - go get github.com/davecgh/go-spew/spew
 
 script:
   - make check test

--- a/govc/flags/datacenter.go
+++ b/govc/flags/datacenter.go
@@ -87,7 +87,7 @@ func (flag *DatacenterFlag) Finder() (*find.Finder, error) {
 		return nil, err
 	}
 
-	finder := find.NewFinder(c, flag.JSON)
+	finder := find.NewFinder(c, flag.JSON || flag.Dump)
 
 	// Datacenter is not required (ls command for example).
 	// Set for relative func if dc flag is given or

--- a/govc/flags/output.go
+++ b/govc/flags/output.go
@@ -28,6 +28,8 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/vmware/govmomi/vim25/progress"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 type OutputWriter interface {
@@ -39,6 +41,7 @@ type OutputFlag struct {
 
 	JSON bool
 	TTY  bool
+	Dump bool
 }
 
 var outputFlagKey = flagKey("output")
@@ -56,6 +59,7 @@ func NewOutputFlag(ctx context.Context) (*OutputFlag, context.Context) {
 func (flag *OutputFlag) Register(ctx context.Context, f *flag.FlagSet) {
 	flag.RegisterOnce(func() {
 		f.BoolVar(&flag.JSON, "json", false, "Enable JSON output")
+		f.BoolVar(&flag.Dump, "dump", false, "Enable output dump")
 	})
 }
 
@@ -102,6 +106,9 @@ func (flag *OutputFlag) WriteResult(result OutputWriter) error {
 
 	if flag.JSON {
 		err = json.NewEncoder(out).Encode(result)
+	} else if flag.Dump {
+		scs := spew.ConfigState{Indent: "    "}
+		scs.Fdump(out, result)
 	} else {
 		err = result.Write(out)
 	}


### PR DESCRIPTION
I have found this pretty-printing library (davecgh/go-spew) very useful for discovering underlying data structures when working on new features in govc, and present this new output -dump flag code if there is any interest in inclusion.

Since it's an external library and not included with Go, I suspect there may be a policy on what is allowed to be included in govc. If there is a document on such a policy then I would be interested in reading it for future reference.

Please feel free to close this pull request if there is no interest, or this cannot be merged.

