### PR TITLE
Types: use explicitly sized type for properties

### DIFF
--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -44626,9 +44626,9 @@ func init() {
 type VirtualHardware struct {
 	DynamicData
 
-	NumCPU              int                 `xml:"numCPU"`
-	NumCoresPerSocket   int                 `xml:"numCoresPerSocket,omitempty"`
-	MemoryMB            int                 `xml:"memoryMB"`
+	NumCPU              int32               `xml:"numCPU"`
+	NumCoresPerSocket   int32               `xml:"numCoresPerSocket,omitempty"`
+	MemoryMB            int32               `xml:"memoryMB"`
 	VirtualICH7MPresent *bool               `xml:"virtualICH7MPresent"`
 	VirtualSMCPresent   *bool               `xml:"virtualSMCPresent"`
 	Device              []BaseVirtualDevice `xml:"device,omitempty,typeattr"`


### PR DESCRIPTION
When retrieving CPU/Memory values on our system, we encountered a panic
caused in assignValue() by trying to assigning between int32 and int:

	panic: reflect.Set: value of type int32 is not assignable to type int

	goroutine 14 [running]:
	reflect.Value.assignTo(0xbc74c0, 0xc82021f5c0, 0x45, 0x10a1d70, 0xb, 0xbc73c0, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/reflect/value.go:2158 +0x3be
	reflect.Value.Set(0xbc73c0, 0xc820165d98, 0xc2, 0xbc74c0, 0xc82021f5c0, 0x45)
	/usr/local/go/src/reflect/value.go:1327 +0x95
	github.com/vmware/govmomi/vim25/mo.assignValue(0x10218a0, 0xc820165d88, 0xd9, 0xc820234bb0, 0x0, 0x0, 0xbc74c0, 0xc82021f5c0, 0x45)
	/root/sh-safehaven3/integration/src/github.com/vmware/govmomi/vim25/mo/type_info.go:197 +0x5e8
	github.com/vmware/govmomi/vim25/mo.assignValue(0x1080840, 0xc820165b00, 0xd9, 0xc820234bb0, 0x1, 0x1, 0xbc74c0, 0xc82021f5c0, 0x45)
	/root/sh-safehaven3/integration/src/github.com/vmware/govmomi/vim25/mo/type_info.go:201 +0x882
	github.com/vmware/govmomi/vim25/mo.assignValue(0x10617a0, 0xc820095800, 0xd9, 0xc820234ba8, 0x2, 0x2, 0xbc74c0, 0xc82021f5c0, 0x45)
	/root/sh-safehaven3/integration/src/github.com/vmware/govmomi/vim25/mo/type_info.go:201 +0x882
	github.com/vmware/govmomi/vim25/mo.(*typeInfo).LoadFromObjectContent(0xc8201a1170, 0xc8201debe0, 0xe, 0xc8201dec10, 0x6, 0xc82008eb00, 0x5, 0x8, 0x0, 0x0, ...)
	/root/sh-safehaven3/integration/src/github.com/vmware/govmomi/vim25/mo/type_info.go:235 +0x368
	github.com/vmware/govmomi/vim25/mo.ObjectContentToType(0xc8201debe0, 0xe, 0xc8201dec10, 0x6, 0xc82008eb00, 0x5, 0x8, 0x0, 0x0, 0x0, ...)
	/root/sh-safehaven3/integration/src/github.com/vmware/govmomi/vim25/mo/retrieve.go:60 +0x1ce
	github.com/vmware/govmomi/vim25/mo.LoadRetrievePropertiesResponse(0xc8201d8ee0, 0xe6c8e0, 0xc820095000, 0x0, 0x0)
	/root/sh-safehaven3/integration/src/github.com/vmware/govmomi/vim25/mo/retrieve.go:113 +0xa37
	github.com/vmware/govmomi/property.(*Collector).Retrieve(0xc8202075d0, 0x7f62e1d43da8, 0xc82000f350, 0xc8201d8980, 0x1, 0x1, 0xc82000b360, 0x5, 0x5, 0xe6c8e0, ...)
	/root/sh-safehaven3/integration/src/github.com/vmware/govmomi/property/collector.go:167 +0x52f
	github.com/vmware/govmomi.(*Client).Retrieve(0xc8201bf3b0, 0x7f62e1d43da8, 0xc82000f350, 0xc8201d8980, 0x1, 0x1, 0xc82000b360, 0x5, 0x5, 0xe6c8e0, ...)
	/root/sh-safehaven3/integration/src/github.com/vmware/govmomi/client.go:156 +0x192
	vcenter_proxy/handlers.(VCenterCommandHandler).handleVMGetConfiguration(0xc8201bfe30, 0xc820011890, 0x0, 0x0, 0x0, 0x0)
	/root/sh-safehaven3/integration/src/vcenter_proxy/handlers/vm_config.go:35 +0x410

Since int is a distinct type (https://golang.org/pkg/builtin/#int),
fixed problem by using the explicitly-sized int32 type.