### PR TITLE
Pool destroy children

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,7 +10,7 @@ Arran Walker <arran.walker@zopa.com>
 Bob Killen <killen.bob@gmail.com>
 Bruce Downs <bdowns@vmware.com>
 Clint Greenwood <cgreenwood@vmware.com> <clint.greenwood@gmail.com>
-cedric <cblomart@gmail.com>
+Cédric Blomart <cblomart@gmail.com>
 Danny Lockard <danny.lockard@banno.com>
 Doug MacEachern <dougm@vmware.com>
 Eloy Coto <eloy.coto@gmail.com>

--- a/govc/pool/destroy.go
+++ b/govc/pool/destroy.go
@@ -28,7 +28,7 @@ import (
 type destroy struct {
 	*flags.DatacenterFlag
 
-	recursive bool
+	children bool
 }
 
 func init() {
@@ -39,7 +39,7 @@ func (cmd *destroy) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
 	cmd.DatacenterFlag.Register(ctx, f)
 
-	f.BoolVar(&cmd.recursive, "r", false, "Remove all child resource pools recursively")
+	f.BoolVar(&cmd.children, "children", false, "Remove all children pools")
 }
 
 func (cmd *destroy) Process(ctx context.Context) error {
@@ -79,20 +79,20 @@ func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		for _, pool := range pools {
-			if cmd.recursive {
+			if cmd.children {
 				err = pool.DestroyChildren(context.TODO())
 				if err != nil {
 					return err
 				}
-			}
-
-			task, err := pool.Destroy(context.TODO())
-			if err != nil {
-				return err
-			}
-			err = task.Wait(context.TODO())
-			if err != nil {
-				return err
+			} else {
+				task, err := pool.Destroy(context.TODO())
+				if err != nil {
+					return err
+				}
+				err = task.Wait(context.TODO())
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/govc/test/pool.bats
+++ b/govc/test/pool.bats
@@ -154,6 +154,49 @@ load test_helper
   [ $result -eq 0 ]
 }
 
+@test "pool.destroy children" {
+  id=$(new_id)
+
+  # parent pool
+  path="*/Resources/$id"
+  run govc pool.create $path
+  assert_success
+
+  result=$(govc ls "host/$path/*" | wc -l)
+  [ $result -eq 0 ]
+
+  # child pools
+  run govc pool.create $path/$(new_id)
+  assert_success
+
+  run govc pool.create $path/$(new_id)
+  assert_success
+
+  # 2 child pools
+  result=$(govc ls "host/$path/*" | wc -l)
+  [ $result -eq 2 ]
+
+  # 1 parent pool
+  result=$(govc ls "host/*/Resources/govc-test-*" | wc -l)
+  [ $result -eq 1 ]
+
+  # delete childs
+  run govc pool.destroy -children $path
+  assert_success
+
+  # no more child pools
+  result=$(govc ls "host/$path/*" | wc -l)
+  [ $result -eq 0 ]
+  
+  # cleanup 
+  run govc pool.destroy $path
+  assert_success
+  
+  # cleanup check
+  result=$(govc ls "host/$path" | wc -l)
+  [ $result -eq 0 ]  
+}
+
 @test "pool.destroy multiple" {
   id=$(new_id)
   path="*/Resources/$id"


### PR DESCRIPTION
Adaptations to pool.destroy following issue #479 

Ignore the "-r" switch
Add the "-children" switch to only remove childs

What could also be changed, but i'd like to be sure it is ok:
- remove the "-r" switch completely (i feel it could cause problem to existing script using the switch)
- simplify the pool.destroy test to just create and destroy a pool (not play with child pools)