### PR TITLE
Leave AddressType empty in EthernetCardTypes

### DIFF
--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -63,7 +63,6 @@ func EthernetCardTypes() VirtualDeviceList {
 		&types.VirtualVmxnet3{},
 	}).Select(func(device types.BaseVirtualDevice) bool {
 		c := device.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-		c.AddressType = string(types.VirtualEthernetCardMacTypeGenerated)
 		c.GetVirtualDevice().Key = -1
 		return true
 	})


### PR DESCRIPTION
VirtualEthernetCard.AddressType is an optional field, no need to set it
to generated in this helper.

Fixes #492