### PR TITLE
SOAP decoding fixes

### DIFF
--- a/vim25/mo/type_info.go
+++ b/vim25/mo/type_info.go
@@ -189,12 +189,20 @@ func assignValue(val reflect.Value, fi []int, pv reflect.Value) {
 				npv := reflect.New(pt)
 				npv.Elem().Set(pv)
 				pv = npv
+				pt = pv.Type()
 			} else {
 				panic(fmt.Sprintf("type %s doesn't implement %s", pt.Name(), rt.Name()))
 			}
 		}
 
-		rv.Set(pv)
+		if pt.AssignableTo(rt) {
+			rv.Set(pv)
+		} else if rt.ConvertibleTo(pt) {
+			rv.Set(pv.Convert(rt))
+		} else {
+			panic(fmt.Sprintf("cannot assign %s (%s) to %s (%s)", rt.Name(), rt.Kind(), pt.Name(), pt.Kind()))
+		}
+
 		return
 	}
 

--- a/vim25/xml/read.go
+++ b/vim25/xml/read.go
@@ -271,9 +271,19 @@ var (
 // Find reflect.Type for an element's type attribute.
 func (p *Decoder) typeForElement(val reflect.Value, start *StartElement) reflect.Type {
 	t := ""
-	for _, a := range start.Attr {
+	for i, a := range start.Attr {
 		if a.Name == xmlSchemaInstance {
 			t = a.Value
+			// HACK: ensure xsi:type is last in the list to avoid using that value for
+			// a "type" attribute, such as ManagedObjectReference.Type for example.
+			// Note that xsi:type is already the last attribute in VC/ESX responses.
+			// This is only an issue with govmomi simulator generated responses.
+			// Proper fix will require finding a few needles in this xml package haystack.
+			x := len(start.Attr) - 1
+			if i != x {
+				start.Attr[i] = start.Attr[x]
+				start.Attr[x] = a
+			}
 			break
 		}
 	}


### PR DESCRIPTION
These are for decoding responses from the in-progress govmomi simulator.  The proper fixes will be more involved, but these small changes have no impact on the non-simulator paths.