### PR TITLE
Get complete file details in Datastore.Stat

### DIFF
--- a/object/datastore.go
+++ b/object/datastore.go
@@ -314,8 +314,10 @@ func (d Datastore) Stat(ctx context.Context, file string) (types.BaseFileInfo, e
 
 	spec := types.HostDatastoreBrowserSearchSpec{
 		Details: &types.FileQueryFlags{
-			FileType:  true,
-			FileOwner: types.NewBool(true), // TODO: omitempty is generated, but seems to be required
+			FileType:     true,
+			FileSize:     true,
+			Modification: true,
+			FileOwner:    types.NewBool(true),
 		},
 		MatchPattern: []string{path.Base(file)},
 	}


### PR DESCRIPTION
This helper was originally optimized within govc to just check if a file
exists.  It isn't much more overhead to get the additional details for a
single file, add the full set for convenience.