### PR TITLE
InjectOvfEnv() should work with VSphere

### DIFF
--- a/govc/importx/ovf.go
+++ b/govc/importx/ovf.go
@@ -349,7 +349,7 @@ func (cmd *ovfx) InjectOvfEnv(vm *object.VirtualMachine) error {
 	}
 
 	a := cmd.Client.ServiceContent.About
-	if strings.EqualFold(a.ProductLineId, "esx") || strings.EqualFold(a.ProductLineId, "embeddedEsx") {
+	if strings.EqualFold(a.ProductLineId, "esx") || strings.EqualFold(a.ProductLineId, "embeddedEsx") || strings.EqualFold(a.ProductLineId, "vpx") {
 		cmd.Log("Injecting OVF environment...\n")
 
 		// build up Environment in order to marshal to xml


### PR DESCRIPTION
In addition to working with ESX, `InjectOvfEnv()` should work with VSphere.

This change causes `govc` to show "Injecting OVF environment..." when using `import.ovf` with the `-options` flag.

However, it doesn't seem to actually *set* the environment variables... The VSphere web-ui still shows no properties being set. :-(