### PR TITLE
Fix vm.create disk scsi controller lookup

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -148,6 +148,9 @@ load test_helper
 
   result=$(govc device.ls -vm $vm | grep lsilogic- | wc -l)
   [ $result -eq 0 ]
+
+  vm=$(new_id)
+  govc vm.create -on=false -disk.controller pvscsi -disk=1GB $vm
 }
 
 @test "vm.create in cluster" {

--- a/govc/vm/create.go
+++ b/govc/vm/create.go
@@ -336,6 +336,7 @@ func (cmd *create) addStorage(devices object.VirtualDeviceList) (object.VirtualD
 		}
 
 		devices = append(devices, scsi)
+		cmd.controller = devices.Name(scsi)
 	}
 
 	// If controller is specified to be IDE or if an ISO is specified, add IDE controller.


### PR DESCRIPTION
When -disk.controller and -disk flags are provided, the lookup of a scsi
controller needs to be by device name, not type name.

Fixes #515