### PR TITLE
Add -require flag to govc version command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,8 @@ Change _$USER_ below to your github username if they are not the same.
 
 ``` shell
 export GOPATH=$HOME/govmomi
-mkdir -p $GOPATH/src/github.com/vmware
-cd $GOPATH/src/github.com/vmware
-git clone git@github.com:vmware/govmomi.git
-cd govmomi
+go get github.com/vmware/govmomi
+cd $GOPATH/src/github.com/vmware/govmomi
 git config push.default nothing # anything to avoid pushing to vmware/govmomi by default
 git remote rename origin vmware
 git remote add $USER git@github.com:$USER/govmomi.git
@@ -26,6 +24,7 @@ This is a rough outline of what a contributor's workflow looks like:
 - Create a topic branch from where you want to base your work.
 - Make commits of logical units.
 - Make sure your commit messages are in the proper format (see below).
+- Update CHANGELOG.md and/or govc/CHANGELOG.md when appropriate.
 - Push your changes to a topic branch in your fork of the repository.
 - Submit a pull request to vmware/govmomi.
 

--- a/govc/CHANGELOG.md
+++ b/govc/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### unreleased
 
+* Add `-require` flag to version command
+
 * Add support for local type in the datastore.create command
 
 * Add `-namespace` option to datastore.mkdir and datastore.rm to create/remove namespaces on VSANs

--- a/govc/README.md
+++ b/govc/README.md
@@ -111,6 +111,19 @@ to set defaults:
 
 * [Create and configure a vCenter VM](examples/vcsa.sh)
 
+## Status
+
+Changes to the cli are subject to [semantic versioning](http://semver.org).
+
+Refer to the [CHANGELOG](CHANGELOG.md) for version to version changes.
+
+When new govc commands or flags are added, the PATCH version will be incremented.  This enables you to require a minimum
+version from within a script, for example:
+
+```
+govc version -require 0.7.1
+```
+
 ## Projects using govc
 
 * [Kubernetes vSphere Provider](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/cluster/vsphere)

--- a/govc/test/cli.bats
+++ b/govc/test/cli.bats
@@ -14,6 +14,21 @@ load test_helper
   assert_success
 }
 
+@test "version" {
+    run govc version
+    assert_success
+
+    v=$(govc version | awk '{print $NF}')
+    run govc version -require "$v"
+    assert_success
+
+    run govc version -require "not-a-version-string"
+    assert_failure
+
+    run govc version -require 100.0.0
+    assert_failure
+}
+
 @test "login attempt without credentials" {
   run govc about -u $(echo $GOVC_URL | awk -F@ '{print $2}')
   assert_failure "govc: ServerFaultCode: Cannot complete login due to an incorrect user name or password."


### PR DESCRIPTION
The version is now hardcoded, rather than injected by the linker.