### PR TITLE
Fix Datastore upload/download against VC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+### 0.7.1 (2016-06-03)
+
+* Fix object.ObjectName method
+
 ### 0.7.0 (2016-06-02)
 
 * Move InventoryPath field to object.Common

--- a/govc/CHANGELOG.md
+++ b/govc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+### 0.7.1 (2016-06-03)
+
+* Fix datastore.{upload,download} against VirtualCenter
+
 ### 0.7.0 (2016-06-02)
 
 * Add `-require` flag to version command

--- a/govc/version/command.go
+++ b/govc/version/command.go
@@ -27,7 +27,7 @@ import (
 	"github.com/vmware/govmomi/govc/flags"
 )
 
-const Version = "0.7.0"
+const Version = "0.7.1"
 
 var gitVersion string
 

--- a/object/common.go
+++ b/object/common.go
@@ -65,6 +65,9 @@ func (c Common) Client() *vim25.Client {
 
 // Name returns the base name of the InventoryPath field
 func (c Common) Name() string {
+	if c.InventoryPath == "" {
+		return ""
+	}
 	return path.Base(c.InventoryPath)
 }
 

--- a/object/common_test.go
+++ b/object/common_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import "testing"
+
+func TestCommonName(t *testing.T) {
+	c := &Common{}
+
+	name := c.Name()
+	if name != "" {
+		t.Errorf("Name=%s", name)
+	}
+
+	c.InventoryPath = "/foo/bar"
+	name = c.Name()
+	if name != "bar" {
+		t.Errorf("Name=%s", name)
+	}
+}


### PR DESCRIPTION
These methods need a service ticket, which when run against VC uses the
ObjectName of the selected HostSystem as the URL host.  The Name()
method was returning path.Base(InventoryPath), which defaults to ".",
when we should return an empty string in that case.

Caused by commit 558321d