### PR TITLE
Use ticket HostName for Datastore http access

### DIFF
--- a/object/datastore.go
+++ b/object/datastore.go
@@ -161,6 +161,10 @@ func (d Datastore) ServiceTicket(ctx context.Context, path string, method string
 		Value: ticket.Id,
 	}
 
+	if d.c.IsVC() && ticket.HostName != "" {
+		u.Host = ticket.HostName
+	}
+
 	return u, cookie, nil
 }
 


### PR DESCRIPTION
The service ticket HostName to use for http access might be different
than the HostSystem.Name used to request the ticket.