### PR TITLE
Add support for Finder lookup via moref

### DIFF
--- a/govc/test/ls.bats
+++ b/govc/test/ls.bats
@@ -91,3 +91,26 @@ load test_helper
   assert_success
   [ ${#lines[@]} -gt 0 ]
 }
+
+@test "ls moref" {
+    # ensure the vm folder isn't empty
+    run govc vm.create -on=false "$(new_id)"
+    assert_success
+
+    # list dc folder paths
+    folders1=$(govc ls)
+    # list dc folder refs | govc ls -L ; should output the same paths
+    folders2=$(govc ls -i | xargs govc ls -L)
+
+    assert_equal "$folders1" "$folders2"
+
+    for folder in $folders1
+    do
+        # list paths in $folder
+        items1=$(govc ls "$folder")
+        # list refs in $folder | govc ls -L ; should output the same paths
+        items2=$(govc ls -i "$folder" | xargs -d '\n' govc ls -L)
+
+        assert_equal "$items1" "$items2"
+    done
+}

--- a/object/common.go
+++ b/object/common.go
@@ -71,6 +71,10 @@ func (c Common) Name() string {
 	return path.Base(c.InventoryPath)
 }
 
+func (c *Common) SetInventoryPath(p string) {
+	c.InventoryPath = p
+}
+
 // ObjectName returns the base name of the InventoryPath field if set,
 // otherwise fetches the mo.ManagedEntity.Name field via the property collector.
 func (c Common) ObjectName(ctx context.Context) (string, error) {

--- a/vim25/mo/extra.go
+++ b/vim25/mo/extra.go
@@ -36,6 +36,10 @@ func (m DistributedVirtualSwitch) GetManagedEntity() ManagedEntity {
 	return m.ManagedEntity
 }
 
+func (m DistributedVirtualPortgroup) GetManagedEntity() ManagedEntity {
+	return m.ManagedEntity
+}
+
 func (m Folder) GetManagedEntity() ManagedEntity {
 	return m.ManagedEntity
 }

--- a/vim25/types/helpers.go
+++ b/vim25/types/helpers.go
@@ -16,10 +16,33 @@ limitations under the License.
 
 package types
 
+import "strings"
+
 func NewBool(v bool) *bool {
 	return &v
 }
 
 func NewReference(r ManagedObjectReference) *ManagedObjectReference {
 	return &r
+}
+
+func (r ManagedObjectReference) Reference() ManagedObjectReference {
+	return r
+}
+
+func (r ManagedObjectReference) String() string {
+	return strings.Join([]string{r.Type, r.Value}, ":")
+}
+
+func (r *ManagedObjectReference) FromString(o string) bool {
+	s := strings.SplitN(o, ":", 2)
+
+	if len(s) < 2 {
+		return false
+	}
+
+	r.Type = s[0]
+	r.Value = s[1]
+
+	return true
 }


### PR DESCRIPTION
In most cases, Finder is used to find a ManagedObjectReference via
InventoryPath.  This change makes the inverse possible, to find the
InventoryPath via a ManagedObjectReference.