### PR TITLE
Disable datastore service ticket hostname usage

### DIFF
--- a/object/datastore.go
+++ b/object/datastore.go
@@ -131,14 +131,20 @@ func (d Datastore) useServiceTicketHostName(name string) bool {
 		return false
 	}
 
-	// An escape hatch, as it is still possible to have HostName that doesn't resolve via DNS,
-	// or resolves to an address that isn't reachable.
-	env := os.Getenv("GOVMOMI_USE_SERVICE_TICKET_HOSTNAME")
-	if env == "0" || env == "false" {
-		return false
+	// Still possible to have HostName that don't resolve via DNS,
+	// so we default to false.
+	key := "GOVMOMI_USE_SERVICE_TICKET_HOSTNAME"
+
+	val := d.c.URL().Query().Get(key)
+	if val == "" {
+		val = os.Getenv(key)
 	}
 
-	return true
+	if val == "1" || val == "true" {
+		return true
+	}
+
+	return false
 }
 
 // ServiceTicket obtains a ticket via AcquireGenericServiceTicket and returns it an http.Cookie with the url.URL


### PR DESCRIPTION
Main use case currently is the govcsim, so turn this option off by
default.  Can be enabled using env or url query string.

Related commits: ff7b5b0, c26c797