### PR TITLE
Add support for reading and changing SyncTimeWithHost option

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -68,6 +68,20 @@ load test_helper
   assert_line "guestinfo.a: 1"
   assert_line "guestinfo.b: 2"
 
+  run govc vm.change -sync-time-with-host-enabled=false -vm $id
+  assert_success
+
+  run govc vm.info -t $id
+  assert_success
+  assert_line "SyncTimeWithHost: false"
+
+  run govc vm.change -sync-time-with-host-enabled=true -vm $id
+  assert_success
+
+  run govc vm.info -t $id
+  assert_success
+  assert_line "SyncTimeWithHost: true"
+
   nid=$(new_id)
   run govc vm.change -name $nid -vm $id
   assert_success

--- a/govc/vm/change.go
+++ b/govc/vm/change.go
@@ -66,6 +66,8 @@ func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
 	f.Var(&cmd.extraConfig, "e", "ExtraConfig. <key>=<value>")
 
 	f.Var(flags.NewOptionalBool(&cmd.NestedHVEnabled), "nested-hv-enabled", "Enable nested hardware-assisted virtualization")
+	cmd.Tools = &types.ToolsConfigInfo{}
+	f.Var(flags.NewOptionalBool(&cmd.Tools.SyncTimeWithHost), "sync-time-with-host-enabled", "Enable SyncTimeWithHost")
 }
 
 func (cmd *change) Process(ctx context.Context) error {

--- a/govc/vm/info.go
+++ b/govc/vm/info.go
@@ -41,10 +41,11 @@ type info struct {
 	*flags.OutputFlag
 	*flags.SearchFlag
 
-	WaitForIP   bool
-	General     bool
-	ExtraConfig bool
-	Resources   bool
+	WaitForIP       bool
+	General         bool
+	ExtraConfig     bool
+	Resources       bool
+	ToolsConfigInfo bool
 }
 
 func init() {
@@ -65,6 +66,7 @@ func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
 	f.BoolVar(&cmd.General, "g", true, "Show general summary")
 	f.BoolVar(&cmd.ExtraConfig, "e", false, "Show ExtraConfig")
 	f.BoolVar(&cmd.Resources, "r", false, "Show resource summary")
+	f.BoolVar(&cmd.ToolsConfigInfo, "t", false, "Show ToolsConfigInfo")
 }
 
 func (cmd *info) Process(ctx context.Context) error {
@@ -115,6 +117,9 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 		if cmd.Resources {
 			props = append(props, "datastore", "network")
+		}
+		if cmd.ToolsConfigInfo {
+			props = append(props, "config.tools")
 		}
 	}
 
@@ -310,6 +315,20 @@ func (r *infoResult) Write(w io.Writer) error {
 			for _, v := range vm.Config.ExtraConfig {
 				fmt.Fprintf(tw, "    %s:\t%s\n", v.GetOptionValue().Key, v.GetOptionValue().Value)
 			}
+		}
+
+		if r.cmd.ToolsConfigInfo {
+			t := vm.Config.Tools
+			fmt.Fprintf(tw, "  ToolsConfigInfo:\n")
+			fmt.Fprintf(tw, "    ToolsVersion:\t%d\n", t.ToolsVersion)
+			fmt.Fprintf(tw, "    AfterPowerOn:\t%s\n", flags.NewOptionalBool(&t.AfterPowerOn).String())
+			fmt.Fprintf(tw, "    AfterResume:\t%s\n", flags.NewOptionalBool(&t.AfterResume).String())
+			fmt.Fprintf(tw, "    BeforeGuestStandby:\t%s\n", flags.NewOptionalBool(&t.BeforeGuestStandby).String())
+			fmt.Fprintf(tw, "    BeforeGuestShutdown:\t%s\n", flags.NewOptionalBool(&t.BeforeGuestShutdown).String())
+			fmt.Fprintf(tw, "    BeforeGuestReboot:\t%s\n", flags.NewOptionalBool(&t.BeforeGuestReboot).String())
+			fmt.Fprintf(tw, "    ToolsUpgradePolicy:\t%s\n", t.ToolsUpgradePolicy)
+			fmt.Fprintf(tw, "    PendingCustomization:\t%s\n", t.PendingCustomization)
+			fmt.Fprintf(tw, "    SyncTimeWithHost:\t%s\n", flags.NewOptionalBool(&t.SyncTimeWithHost).String())
 		}
 	}
 


### PR DESCRIPTION
This PR adds support for reading and changing SyncTimeWithHost option of ToolsConfigInfo with govc. The example is as follows.

```
$ govc vm.change -h
Usage: govc vm.change [OPTIONS]

Options:
  -c=0                                      Number of CPUs
  -cert=                                    Certificate [GOVC_CERTIFICATE]
  -dc=                                      Datacenter [GOVC_DATACENTER]
  -debug=false                              Store debug logs [GOVC_DEBUG]
  -dump=false                               Enable output dump
  -e=[]                                     ExtraConfig. <key>=<value>
  -g=                                       Guest OS
  -json=false                               Enable JSON output
  -k=true                                   Skip verification of server certificate [GOVC_INSECURE]
  -key=                                     Private key [GOVC_PRIVATE_KEY]
  -m=0                                      Size in MB of memory
  -name=                                    Display name
  -nested-hv-enabled=<nil>                  Enable nested hardware-assisted virtualization
  -persist-session=true                     Persist session to disk [GOVC_PERSIST_SESSION]
  -sync-time-with-host-enabled=<nil>        Enable SyncTimeWithHost
  -u=https://@avcenter501z.ms.jp.local/sdk  ESX or vCenter URL [GOVC_URL]
  -vim-namespace=urn:vim25                  Vim namespace [GOVC_VIM_NAMESPACE]
  -vim-version=6.0                          Vim version [GOVC_VIM_VERSION]
  -vm=                                      Virtual machine [GOVC_VM]
  -vm.dns=                                  Find VM by FQDN
  -vm.ip=                                   Find VM by IP address
  -vm.ipath=                                Find VM by inventory path
  -vm.path=                                 Find VM by path to .vmx file
  -vm.uuid=                                 Find VM by instance UUID
$ govc vm.change -sync-time-with-host-enabled=false -vm=/DC-1/vm/test-1

$ govc vm.info -h
Usage: govc vm.info [OPTIONS]

Options:
  -cert=                                    Certificate [GOVC_CERTIFICATE]
  -dc=                                      Datacenter [GOVC_DATACENTER]
  -debug=false                              Store debug logs [GOVC_DEBUG]
  -dump=false                               Enable output dump
  -e=false                                  Show ExtraConfig
  -g=true                                   Show general summary
  -json=false                               Enable JSON output
  -k=true                                   Skip verification of server certificate [GOVC_INSECURE]
  -key=                                     Private key [GOVC_PRIVATE_KEY]
  -persist-session=true                     Persist session to disk [GOVC_PERSIST_SESSION]
  -r=false                                  Show resource summary
  -t=false                                  Show ToolsConfig
  -u=https://@avcenter501z.ms.jp.local/sdk  ESX or vCenter URL [GOVC_URL]
  -vim-namespace=urn:vim25                  Vim namespace [GOVC_VIM_NAMESPACE]
  -vim-version=6.0                          Vim version [GOVC_VIM_VERSION]
  -vm.dns=                                  Find VM by FQDN
  -vm.ip=                                   Find VM by IP address
  -vm.ipath=                                Find VM by inventory path
  -vm.path=                                 Find VM by path to .vmx file
  -vm.uuid=                                 Find VM by instance UUID
  -waitip=false                             Wait for VM to acquire IP address
$ govc vm.info -t /DC-1/vm/test-1
Name:           test-1
  Path:         /DC-1/vm/test-1
  UUID:         4206ca82-2a01-9c81-3422-94e6956c6e3e
  Guest name:   CentOS 4/5/6/7 (64-bit)
  Memory:       2048MB
  CPU:          2 vCPU(s)
  Power state:  poweredOff
  Boot time:    <nil>
  IP address:
  Host:         xxx
  ToolsConfigInfo:
    ToolsVersion:          9355
    AfterPowerOn:          true
    AfterResume:           true
    BeforeGuestStandby:    true
    BeforeGuestShutdown:   true
    BeforeGuestReboot:     <nil>
    ToolsUpgradePolicy:    upgradeAtPowerCycle
    PendingCustomization:
    SyncTimeWithHost:      false
```

References:
- https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.ToolsConfigInfo.html
