### PR TITLE
Populate network mapping from ovf envelope

### DIFF
--- a/govc/importx/ovf.go
+++ b/govc/importx/ovf.go
@@ -217,6 +217,22 @@ func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 		PropertyMapping: cmd.Map(cmd.Options.PropertyMapping),
 	}
 
+	if e.Network != nil {
+		finder, err := cmd.DatastoreFlag.Finder()
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range e.Network.Networks {
+			if net, err := finder.Network(context.TODO(), n.Name); err == nil {
+				cisp.NetworkMapping = append(cisp.NetworkMapping,
+					types.OvfNetworkMapping{
+						Name:    n.Name,
+						Network: net.Reference(),
+					})
+			}
+		}
+	}
+
 	m := object.NewOvfManager(cmd.Client)
 	spec, err := m.CreateImportSpec(context.TODO(), string(o), cmd.ResourcePool, cmd.Datastore, cisp)
 	if err != nil {


### PR DESCRIPTION
On OVF import bind network adapters to the networks specified in the
OVF envelope if they exist on the target.