### PR TITLE
govc - popualte 'Path' fiels in xxx.info output

### DIFF
--- a/govc/flags/search.go
+++ b/govc/flags/search.go
@@ -231,6 +231,16 @@ func (flag *SearchFlag) search() (object.Reference, error) {
 		return nil, fmt.Errorf("no such %s", flag.entity)
 	}
 
+	// set the InventoryPath field
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+	ref, err = finder.ObjectReference(context.TODO(), ref.Reference())
+	if err != nil {
+		return nil, err
+	}
+
 	return ref, nil
 }
 


### PR DESCRIPTION
Common InventoryPath field is not initialized in the new objects
returned by SearchIndex - for now do it in the SearchFlag