### PR TITLE
Fix missing datastore name with vm.clone -force=false

### DIFF
--- a/govc/vm/clone.go
+++ b/govc/vm/clone.go
@@ -23,7 +23,9 @@ import (
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
 )
@@ -92,7 +94,7 @@ func (cmd *clone) Register(ctx context.Context, f *flag.FlagSet) {
 
 	f.IntVar(&cmd.memory, "m", 0, "Size in MB of memory")
 	f.IntVar(&cmd.cpus, "c", 0, "Number of CPUs")
-	f.BoolVar(&cmd.on, "on", true, "Power on VM. Default is true if -disk argument is given.")
+	f.BoolVar(&cmd.on, "on", true, "Power on VM")
 	f.BoolVar(&cmd.force, "force", false, "Create VM if vmx already exists")
 	f.BoolVar(&cmd.template, "template", false, "Create a Template")
 	f.StringVar(&cmd.customization, "customization", "", "Customization Specification Name")
@@ -347,7 +349,14 @@ func (cmd *clone) cloneVM(ctx context.Context) (*object.Task, error) {
 	if !cmd.force {
 		vmxPath := fmt.Sprintf("%s/%s.vmx", cmd.name, cmd.name)
 
+		var mds mo.Datastore
+		err = property.DefaultCollector(cmd.Client).RetrieveOne(ctx, datastoreref, []string{"name"}, &mds)
+		if err != nil {
+			return nil, err
+		}
+
 		datastore := object.NewDatastore(cmd.Client, datastoreref)
+		datastore.InventoryPath = mds.Name
 
 		_, err := datastore.Stat(ctx, vmxPath)
 		if err == nil {


### PR DESCRIPTION
This copies the same behaviour as vm.create and fetches the datastore name.

Otherwise, there's methods called on the datastore object (datastore.Stat) that panic due to the name not being available. Example:

```
$ govc vm.clone -vm=templates/template test_template
panic: expected non-empty name

goroutine 1 [running]:
panic(0xaceb40, 0xc4204361d0)
        /home/saracen/go/src/runtime/panic.go:500 +0x1a1
github.com/vmware/govmomi/object.Datastore.Path(0x0, 0x0, 0xc42007db80, 0xc420222d40, 0x9, 0xc420222d60, 0xe, 0xc420435900, 0xa, 0xc4203dca00, ...)
        /home/saracen/go_workspace/src/github.com/vmware/govmomi/object/datastore.go:72 +0x1ea
github.com/vmware/govmomi/object.Datastore.Stat(0x0, 0x0, 0xc42007db80, 0xc420222d40, 0x9, 0xc420222d60, 0xe, 0x7fbf3e63c028, 0xc4200122d8, 0xc420435900, ...)
        /home/saracen/go_workspace/src/github.com/vmware/govmomi/object/datastore.go:360 +0x2a9
github.com/vmware/govmomi/govc/vm.(*clone).cloneVM(0xc420019790, 0x7fbf3e63c028, 0xc4200122d8, 0x7fbf3e63c028, 0xc4200122d8, 0xc42018e040)
        /home/saracen/go_workspace/src/github.com/vmware/govmomi/govc/vm/clone.go:352 +0xef3
github.com/vmware/govmomi/govc/vm.(*clone).Run(0xc420019790, 0x7fbf3e63c028, 0xc4200122d0, 0xc420056840, 0x0, 0x0)
        /home/saracen/go_workspace/src/github.com/vmware/govmomi/govc/vm/clone.go:192 +0x3c0
github.com/vmware/govmomi/govc/cli.Run(0xc42000c1d0, 0x3, 0x3, 0xc4200001a0)
        /home/saracen/go_workspace/src/github.com/vmware/govmomi/govc/cli/command.go:139 +0x4c3
main.main()
        /home/saracen/go_workspace/src/github.com/vmware/govmomi/govc/main.go:67 +0x66
```