### PR TITLE
Remove a bunch of context.TODO() calls

### DIFF
--- a/govc/datastore/cp.go
+++ b/govc/datastore/cp.go
@@ -90,10 +90,10 @@ func (cmd *cp) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	m := object.NewFileManager(c)
-	task, err := m.CopyDatastoreFile(context.TODO(), src, dc, dst, dc, cmd.force)
+	task, err := m.CopyDatastoreFile(ctx, src, dc, dst, dc, cmd.force)
 	if err != nil {
 		return err
 	}
 
-	return task.Wait(context.TODO())
+	return task.Wait(ctx)
 }

--- a/govc/datastore/ls.go
+++ b/govc/datastore/ls.go
@@ -77,7 +77,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	b, err := ds.Browser(context.TODO())
+	b, err := ds.Browser(ctx)
 	if err != nil {
 		return err
 	}
@@ -133,6 +133,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 func (cmd *ls) ListPath(b *object.HostDatastoreBrowser, path string, spec types.HostDatastoreBrowserSearchSpec) (types.HostDatastoreBrowserSearchResults, error) {
+	ctx := context.TODO()
 	var res types.HostDatastoreBrowserSearchResults
 
 	path, err := cmd.DatastorePath(path)
@@ -140,12 +141,12 @@ func (cmd *ls) ListPath(b *object.HostDatastoreBrowser, path string, spec types.
 		return res, err
 	}
 
-	task, err := b.SearchDatastore(context.TODO(), path, &spec)
+	task, err := b.SearchDatastore(ctx, path, &spec)
 	if err != nil {
 		return res, err
 	}
 
-	info, err := task.WaitForResult(context.TODO(), nil)
+	info, err := task.WaitForResult(ctx, nil)
 	if err != nil {
 		return res, err
 	}

--- a/govc/datastore/mv.go
+++ b/govc/datastore/mv.go
@@ -83,10 +83,10 @@ func (cmd *mv) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	m := object.NewFileManager(c)
-	task, err := m.MoveDatastoreFile(context.TODO(), src, dc, dst, dc, cmd.force)
+	task, err := m.MoveDatastoreFile(ctx, src, dc, dst, dc, cmd.force)
 	if err != nil {
 		return err
 	}
 
-	return task.Wait(context.TODO())
+	return task.Wait(ctx)
 }

--- a/govc/device/boot.go
+++ b/govc/device/boot.go
@@ -69,7 +69,7 @@ func (cmd *boot) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -79,5 +79,5 @@ func (cmd *boot) Run(ctx context.Context, f *flag.FlagSet) error {
 		cmd.BootOrder = devices.BootOrder(o)
 	}
 
-	return vm.SetBootOptions(context.TODO(), &cmd.VirtualMachineBootOptions)
+	return vm.SetBootOptions(ctx, &cmd.VirtualMachineBootOptions)
 }

--- a/govc/device/cdrom/add.go
+++ b/govc/device/cdrom/add.go
@@ -59,7 +59,7 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -74,13 +74,13 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	err = vm.AddDevice(context.TODO(), d)
+	err = vm.AddDevice(ctx, d)
 	if err != nil {
 		return err
 	}
 
 	// output name of device we just created
-	devices, err = vm.Device(context.TODO())
+	devices, err = vm.Device(ctx)
 	if err != nil {
 		return err
 	}

--- a/govc/device/cdrom/eject.go
+++ b/govc/device/cdrom/eject.go
@@ -64,7 +64,7 @@ func (cmd *eject) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -74,5 +74,5 @@ func (cmd *eject) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return vm.EditDevice(context.TODO(), devices.EjectIso(c))
+	return vm.EditDevice(ctx, devices.EjectIso(c))
 }

--- a/govc/device/cdrom/insert.go
+++ b/govc/device/cdrom/insert.go
@@ -74,7 +74,7 @@ func (cmd *insert) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -89,5 +89,5 @@ func (cmd *insert) Run(ctx context.Context, f *flag.FlagSet) error {
 		return nil
 	}
 
-	return vm.EditDevice(context.TODO(), devices.InsertIso(c, iso))
+	return vm.EditDevice(ctx, devices.InsertIso(c, iso))
 }

--- a/govc/device/connect.go
+++ b/govc/device/connect.go
@@ -59,7 +59,7 @@ func (cmd *connect) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (cmd *connect) Run(ctx context.Context, f *flag.FlagSet) error {
 			return err
 		}
 
-		if err = vm.EditDevice(context.TODO(), device); err != nil {
+		if err = vm.EditDevice(ctx, device); err != nil {
 			return err
 		}
 	}

--- a/govc/device/disconnect.go
+++ b/govc/device/disconnect.go
@@ -59,7 +59,7 @@ func (cmd *disconnect) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (cmd *disconnect) Run(ctx context.Context, f *flag.FlagSet) error {
 			return err
 		}
 
-		if err = vm.EditDevice(context.TODO(), device); err != nil {
+		if err = vm.EditDevice(ctx, device); err != nil {
 			return err
 		}
 	}

--- a/govc/device/floppy/add.go
+++ b/govc/device/floppy/add.go
@@ -55,7 +55,7 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -65,13 +65,13 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	err = vm.AddDevice(context.TODO(), d)
+	err = vm.AddDevice(ctx, d)
 	if err != nil {
 		return err
 	}
 
 	// output name of device we just created
-	devices, err = vm.Device(context.TODO())
+	devices, err = vm.Device(ctx)
 	if err != nil {
 		return err
 	}

--- a/govc/device/floppy/eject.go
+++ b/govc/device/floppy/eject.go
@@ -64,7 +64,7 @@ func (cmd *eject) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -74,5 +74,5 @@ func (cmd *eject) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return vm.EditDevice(context.TODO(), devices.EjectImg(c))
+	return vm.EditDevice(ctx, devices.EjectImg(c))
 }

--- a/govc/device/floppy/insert.go
+++ b/govc/device/floppy/insert.go
@@ -74,7 +74,7 @@ func (cmd *insert) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -89,5 +89,5 @@ func (cmd *insert) Run(ctx context.Context, f *flag.FlagSet) error {
 		return nil
 	}
 
-	return vm.EditDevice(context.TODO(), devices.InsertImg(c, img))
+	return vm.EditDevice(ctx, devices.InsertImg(c, img))
 }

--- a/govc/device/info.go
+++ b/govc/device/info.go
@@ -79,7 +79,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 			return err
 		}
 
-		backing, err := net.EthernetCardBackingInfo(context.TODO())
+		backing, err := net.EthernetCardBackingInfo(ctx)
 		if err != nil {
 			return err
 		}

--- a/govc/device/ls.go
+++ b/govc/device/ls.go
@@ -61,13 +61,13 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
 
 	if cmd.boot {
-		options, err := vm.BootOptions(context.TODO())
+		options, err := vm.BootOptions(ctx)
 		if err != nil {
 			return err
 		}

--- a/govc/device/remove.go
+++ b/govc/device/remove.go
@@ -61,7 +61,7 @@ func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
 			return fmt.Errorf("device '%s' not found", name)
 		}
 
-		if err = vm.RemoveDevice(context.TODO(), cmd.keepFiles, device); err != nil {
+		if err = vm.RemoveDevice(ctx, cmd.keepFiles, device); err != nil {
 			return err
 		}
 	}

--- a/govc/device/scsi/add.go
+++ b/govc/device/scsi/add.go
@@ -72,7 +72,7 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -86,13 +86,13 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 	c.HotAddRemove = &cmd.hotAddRemove
 	c.SharedBus = types.VirtualSCSISharing(cmd.sharedBus)
 
-	err = vm.AddDevice(context.TODO(), d)
+	err = vm.AddDevice(ctx, d)
 	if err != nil {
 		return err
 	}
 
 	// output name of device we just created
-	devices, err = vm.Device(context.TODO())
+	devices, err = vm.Device(ctx)
 	if err != nil {
 		return err
 	}

--- a/govc/device/serial/add.go
+++ b/govc/device/serial/add.go
@@ -55,7 +55,7 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -65,13 +65,13 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	err = vm.AddDevice(context.TODO(), d)
+	err = vm.AddDevice(ctx, d)
 	if err != nil {
 		return err
 	}
 
 	// output name of device we just created
-	devices, err = vm.Device(context.TODO())
+	devices, err = vm.Device(ctx)
 	if err != nil {
 		return err
 	}

--- a/govc/device/serial/connect.go
+++ b/govc/device/serial/connect.go
@@ -60,7 +60,7 @@ func (cmd *connect) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -70,5 +70,5 @@ func (cmd *connect) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return vm.EditDevice(context.TODO(), devices.ConnectSerialPort(d, f.Arg(0), cmd.client))
+	return vm.EditDevice(ctx, devices.ConnectSerialPort(d, f.Arg(0), cmd.client))
 }

--- a/govc/device/serial/disconnect.go
+++ b/govc/device/serial/disconnect.go
@@ -58,7 +58,7 @@ func (cmd *disconnect) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -68,5 +68,5 @@ func (cmd *disconnect) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return vm.EditDevice(context.TODO(), devices.DisconnectSerialPort(d))
+	return vm.EditDevice(ctx, devices.DisconnectSerialPort(d))
 }

--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -332,6 +332,7 @@ func (flag *ClientFlag) loadClient() (*vim25.Client, error) {
 }
 
 func (flag *ClientFlag) newClient() (*vim25.Client, error) {
+	ctx := context.TODO()
 	sc := soap.NewClient(flag.url, flag.insecure)
 	isTunnel := false
 
@@ -351,7 +352,7 @@ func (flag *ClientFlag) newClient() (*vim25.Client, error) {
 
 	// Add retry functionality before making any calls
 	rt := attachRetries(sc)
-	c, err := vim25.NewClient(context.TODO(), rt)
+	c, err := vim25.NewClient(ctx, rt)
 	if err != nil {
 		return nil, err
 	}
@@ -364,19 +365,19 @@ func (flag *ClientFlag) newClient() (*vim25.Client, error) {
 
 	if u.Username() == "" {
 		// Assume we are running on an ESX or Workstation host if no username is provided
-		u, err = flag.localTicket(context.TODO(), m)
+		u, err = flag.localTicket(ctx, m)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if isTunnel {
-		err = m.LoginExtensionByCertificate(context.TODO(), u.Username(), "")
+		err = m.LoginExtensionByCertificate(ctx, u.Username(), "")
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		err = m.Login(context.TODO(), u)
+		err = m.Login(ctx, u)
 		if err != nil {
 			return nil, err
 		}

--- a/govc/flags/datacenter.go
+++ b/govc/flags/datacenter.go
@@ -92,10 +92,11 @@ func (flag *DatacenterFlag) Finder() (*find.Finder, error) {
 	// Datacenter is not required (ls command for example).
 	// Set for relative func if dc flag is given or
 	// if there is a single (default) Datacenter
+	ctx := context.TODO()
 	if flag.path == "" {
-		flag.dc, flag.err = finder.DefaultDatacenter(context.TODO())
+		flag.dc, flag.err = finder.DefaultDatacenter(ctx)
 	} else {
-		if flag.dc, err = finder.Datacenter(context.TODO(), flag.path); err != nil {
+		if flag.dc, err = finder.Datacenter(ctx, flag.path); err != nil {
 			return nil, err
 		}
 	}

--- a/govc/flags/search.go
+++ b/govc/flags/search.go
@@ -150,20 +150,22 @@ func (flag *SearchFlag) searchIndex(c *vim25.Client) *object.SearchIndex {
 }
 
 func (flag *SearchFlag) searchByDatastorePath(c *vim25.Client, dc *object.Datacenter) (object.Reference, error) {
+	ctx := context.TODO()
 	switch flag.t {
 	case SearchVirtualMachines:
-		return flag.searchIndex(c).FindByDatastorePath(context.TODO(), dc, flag.byDatastorePath)
+		return flag.searchIndex(c).FindByDatastorePath(ctx, dc, flag.byDatastorePath)
 	default:
 		panic("unsupported type")
 	}
 }
 
 func (flag *SearchFlag) searchByDNSName(c *vim25.Client, dc *object.Datacenter) (object.Reference, error) {
+	ctx := context.TODO()
 	switch flag.t {
 	case SearchVirtualMachines:
-		return flag.searchIndex(c).FindByDnsName(context.TODO(), dc, flag.byDNSName, true)
+		return flag.searchIndex(c).FindByDnsName(ctx, dc, flag.byDNSName, true)
 	case SearchHosts:
-		return flag.searchIndex(c).FindByDnsName(context.TODO(), dc, flag.byDNSName, false)
+		return flag.searchIndex(c).FindByDnsName(ctx, dc, flag.byDNSName, false)
 	default:
 		panic("unsupported type")
 	}
@@ -171,21 +173,24 @@ func (flag *SearchFlag) searchByDNSName(c *vim25.Client, dc *object.Datacenter) 
 
 func (flag *SearchFlag) searchByInventoryPath(c *vim25.Client, dc *object.Datacenter) (object.Reference, error) {
 	// TODO(PN): The datacenter flag should not be set because it is ignored.
-	return flag.searchIndex(c).FindByInventoryPath(context.TODO(), flag.byInventoryPath)
+	ctx := context.TODO()
+	return flag.searchIndex(c).FindByInventoryPath(ctx, flag.byInventoryPath)
 }
 
 func (flag *SearchFlag) searchByIP(c *vim25.Client, dc *object.Datacenter) (object.Reference, error) {
+	ctx := context.TODO()
 	switch flag.t {
 	case SearchVirtualMachines:
-		return flag.searchIndex(c).FindByIp(context.TODO(), dc, flag.byIP, true)
+		return flag.searchIndex(c).FindByIp(ctx, dc, flag.byIP, true)
 	case SearchHosts:
-		return flag.searchIndex(c).FindByIp(context.TODO(), dc, flag.byIP, false)
+		return flag.searchIndex(c).FindByIp(ctx, dc, flag.byIP, false)
 	default:
 		panic("unsupported type")
 	}
 }
 
 func (flag *SearchFlag) searchByUUID(c *vim25.Client, dc *object.Datacenter) (object.Reference, error) {
+	ctx := context.TODO()
 	isVM := false
 	switch flag.t {
 	case SearchVirtualMachines:
@@ -199,7 +204,7 @@ func (flag *SearchFlag) searchByUUID(c *vim25.Client, dc *object.Datacenter) (ob
 	var err error
 
 	for _, iu := range []*bool{nil, types.NewBool(true)} {
-		ref, err = flag.searchIndex(c).FindByUuid(context.TODO(), dc, flag.byUUID, isVM, iu)
+		ref, err = flag.searchIndex(c).FindByUuid(ctx, dc, flag.byUUID, isVM, iu)
 		if err != nil {
 			if soap.IsSoapFault(err) {
 				fault := soap.ToSoapFault(err).VimFault()
@@ -218,6 +223,7 @@ func (flag *SearchFlag) searchByUUID(c *vim25.Client, dc *object.Datacenter) (ob
 }
 
 func (flag *SearchFlag) search() (object.Reference, error) {
+	ctx := context.TODO()
 	var ref object.Reference
 	var err error
 
@@ -259,7 +265,7 @@ func (flag *SearchFlag) search() (object.Reference, error) {
 	if err != nil {
 		return nil, err
 	}
-	ref, err = finder.ObjectReference(context.TODO(), ref.Reference())
+	ref, err = finder.ObjectReference(ctx, ref.Reference())
 	if err != nil {
 		return nil, err
 	}
@@ -282,6 +288,7 @@ func (flag *SearchFlag) VirtualMachine() (*object.VirtualMachine, error) {
 }
 
 func (flag *SearchFlag) VirtualMachines(args []string) ([]*object.VirtualMachine, error) {
+	ctx := context.TODO()
 	var out []*object.VirtualMachine
 
 	if flag.IsSet() {
@@ -308,7 +315,7 @@ func (flag *SearchFlag) VirtualMachines(args []string) ([]*object.VirtualMachine
 
 	// List virtual machines for every argument
 	for _, arg := range args {
-		vms, err := finder.VirtualMachineList(context.TODO(), arg)
+		vms, err := finder.VirtualMachineList(ctx, arg)
 		if err != nil {
 			if _, ok := err.(*find.NotFoundError); ok {
 				// Let caller decide how to handle NotFoundError
@@ -339,6 +346,7 @@ func (flag *SearchFlag) VirtualApp() (*object.VirtualApp, error) {
 }
 
 func (flag *SearchFlag) VirtualApps(args []string) ([]*object.VirtualApp, error) {
+	ctx := context.TODO()
 	var out []*object.VirtualApp
 
 	if flag.IsSet() {
@@ -363,7 +371,7 @@ func (flag *SearchFlag) VirtualApps(args []string) ([]*object.VirtualApp, error)
 
 	// List virtual apps for every argument
 	for _, arg := range args {
-		apps, err := finder.VirtualAppList(context.TODO(), arg)
+		apps, err := finder.VirtualAppList(ctx, arg)
 		if err != nil {
 			return nil, err
 		}
@@ -389,6 +397,7 @@ func (flag *SearchFlag) HostSystem() (*object.HostSystem, error) {
 }
 
 func (flag *SearchFlag) HostSystems(args []string) ([]*object.HostSystem, error) {
+	ctx := context.TODO()
 	var out []*object.HostSystem
 
 	if flag.IsSet() {
@@ -413,7 +422,7 @@ func (flag *SearchFlag) HostSystems(args []string) ([]*object.HostSystem, error)
 
 	// List host systems for every argument
 	for _, arg := range args {
-		vms, err := finder.HostSystemList(context.TODO(), arg)
+		vms, err := finder.HostSystemList(ctx, arg)
 		if err != nil {
 			return nil, err
 		}

--- a/govc/flags/storage_pod.go
+++ b/govc/flags/storage_pod.go
@@ -52,6 +52,7 @@ func (f *StoragePodFlag) Isset() bool {
 }
 
 func (f *StoragePodFlag) StoragePod() (*object.StoragePod, error) {
+	ctx := context.TODO()
 	if f.sp != nil {
 		return f.sp, nil
 	}
@@ -62,12 +63,12 @@ func (f *StoragePodFlag) StoragePod() (*object.StoragePod, error) {
 	}
 
 	if f.Isset() {
-		f.sp, err = finder.DatastoreCluster(context.TODO(), f.Name)
+		f.sp, err = finder.DatastoreCluster(ctx, f.Name)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		f.sp, err = finder.DefaultDatastoreCluster(context.TODO())
+		f.sp, err = finder.DefaultDatastoreCluster(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/govc/flags/virtual_app.go
+++ b/govc/flags/virtual_app.go
@@ -74,6 +74,8 @@ func (flag *VirtualAppFlag) Process(ctx context.Context) error {
 }
 
 func (flag *VirtualAppFlag) VirtualApp() (*object.VirtualApp, error) {
+	ctx := context.TODO()
+
 	if flag.app != nil {
 		return flag.app, nil
 	}
@@ -99,6 +101,6 @@ func (flag *VirtualAppFlag) VirtualApp() (*object.VirtualApp, error) {
 		return nil, err
 	}
 
-	flag.app, err = finder.VirtualApp(context.TODO(), flag.name)
+	flag.app, err = finder.VirtualApp(ctx, flag.name)
 	return flag.app, err
 }

--- a/govc/flags/virtual_machine.go
+++ b/govc/flags/virtual_machine.go
@@ -80,6 +80,8 @@ func (flag *VirtualMachineFlag) Process(ctx context.Context) error {
 }
 
 func (flag *VirtualMachineFlag) VirtualMachine() (*object.VirtualMachine, error) {
+	ctx := context.TODO()
+
 	if flag.vm != nil {
 		return flag.vm, nil
 	}
@@ -105,6 +107,6 @@ func (flag *VirtualMachineFlag) VirtualMachine() (*object.VirtualMachine, error)
 		return nil, err
 	}
 
-	flag.vm, err = finder.VirtualMachine(context.TODO(), flag.name)
+	flag.vm, err = finder.VirtualMachine(ctx, flag.name)
 	return flag.vm, err
 }

--- a/govc/host/autostart/autostart.go
+++ b/govc/host/autostart/autostart.go
@@ -66,6 +66,7 @@ func (f *AutostartFlag) Process(ctx context.Context) error {
 // flags.SearchFlag as well, but that pulls in other virtual machine flags that
 // are not relevant here.
 func (f *AutostartFlag) VirtualMachines(args []string) ([]*object.VirtualMachine, error) {
+	ctx := context.TODO()
 	if len(args) == 0 {
 		return nil, errors.New("no argument")
 	}
@@ -77,7 +78,7 @@ func (f *AutostartFlag) VirtualMachines(args []string) ([]*object.VirtualMachine
 
 	var out []*object.VirtualMachine
 	for _, arg := range args {
-		vms, err := finder.VirtualMachineList(context.TODO(), arg)
+		vms, err := finder.VirtualMachineList(ctx, arg)
 		if err != nil {
 			return nil, err
 		}
@@ -89,19 +90,20 @@ func (f *AutostartFlag) VirtualMachines(args []string) ([]*object.VirtualMachine
 }
 
 func (f *AutostartFlag) HostAutoStartManager() (*mo.HostAutoStartManager, error) {
+	ctx := context.TODO()
 	h, err := f.HostSystem()
 	if err != nil {
 		return nil, err
 	}
 
 	var mhs mo.HostSystem
-	err = h.Properties(context.TODO(), h.Reference(), []string{"configManager.autoStartManager"}, &mhs)
+	err = h.Properties(ctx, h.Reference(), []string{"configManager.autoStartManager"}, &mhs)
 	if err != nil {
 		return nil, err
 	}
 
 	var mhas mo.HostAutoStartManager
-	err = h.Properties(context.TODO(), *mhs.ConfigManager.AutoStartManager, nil, &mhas)
+	err = h.Properties(ctx, *mhs.ConfigManager.AutoStartManager, nil, &mhas)
 	if err != nil {
 		return nil, err
 	}
@@ -110,6 +112,7 @@ func (f *AutostartFlag) HostAutoStartManager() (*mo.HostAutoStartManager, error)
 }
 
 func (f *AutostartFlag) ReconfigureDefaults(template types.AutoStartDefaults) error {
+	ctx := context.TODO()
 	c, err := f.Client()
 	if err != nil {
 		return err
@@ -127,7 +130,7 @@ func (f *AutostartFlag) ReconfigureDefaults(template types.AutoStartDefaults) er
 		},
 	}
 
-	_, err = methods.ReconfigureAutostart(context.TODO(), c, &req)
+	_, err = methods.ReconfigureAutostart(ctx, c, &req)
 	if err != nil {
 		return err
 	}
@@ -136,6 +139,7 @@ func (f *AutostartFlag) ReconfigureDefaults(template types.AutoStartDefaults) er
 }
 
 func (f *AutostartFlag) ReconfigureVMs(args []string, template types.AutoStartPowerInfo) error {
+	ctx := context.TODO()
 	c, err := f.Client()
 	if err != nil {
 		return err
@@ -164,7 +168,7 @@ func (f *AutostartFlag) ReconfigureVMs(args []string, template types.AutoStartPo
 		req.Spec.PowerInfo = append(req.Spec.PowerInfo, pi)
 	}
 
-	_, err = methods.ReconfigureAutostart(context.TODO(), c, &req)
+	_, err = methods.ReconfigureAutostart(ctx, c, &req)
 	if err != nil {
 		return err
 	}

--- a/govc/host/autostart/info.go
+++ b/govc/host/autostart/info.go
@@ -88,9 +88,10 @@ func (r *infoResult) MarshalJSON() ([]byte, error) {
 
 // vmPaths resolves the paths for the VMs in the result.
 func (r *infoResult) vmPaths() (map[string]string, error) {
+	ctx := context.TODO()
 	paths := make(map[string]string)
 	for _, info := range r.mhas.Config.PowerInfo {
-		mes, err := mo.Ancestors(context.TODO(), r.client, r.client.ServiceContent.PropertyCollector, info.Key)
+		mes, err := mo.Ancestors(ctx, r.client, r.client.ServiceContent.PropertyCollector, info.Key)
 		if err != nil {
 			return nil, err
 		}

--- a/govc/host/esxcli/executor.go
+++ b/govc/host/esxcli/executor.go
@@ -37,6 +37,7 @@ type Executor struct {
 }
 
 func NewExecutor(c *vim25.Client, host *object.HostSystem) (*Executor, error) {
+	ctx := context.TODO()
 	e := &Executor{
 		c:    c,
 		host: host,
@@ -48,7 +49,7 @@ func NewExecutor(c *vim25.Client, host *object.HostSystem) (*Executor, error) {
 			This: host.Reference(),
 		}
 
-		res, err := methods.RetrieveManagedMethodExecuter(context.TODO(), c, &req)
+		res, err := methods.RetrieveManagedMethodExecuter(ctx, c, &req)
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +62,7 @@ func NewExecutor(c *vim25.Client, host *object.HostSystem) (*Executor, error) {
 			This: host.Reference(),
 		}
 
-		res, err := methods.RetrieveDynamicTypeManager(context.TODO(), c, &req)
+		res, err := methods.RetrieveDynamicTypeManager(ctx, c, &req)
 		if err != nil {
 			return nil, err
 		}
@@ -127,10 +128,11 @@ func (e *Executor) NewRequest(args []string) (*types.ExecuteSoap, *CommandInfoMe
 }
 
 func (e *Executor) Execute(req *types.ExecuteSoap, res interface{}) error {
+	ctx := context.TODO()
 	req.This = e.mme.ManagedObjectReference
 	req.Version = "urn:vim25/5.0"
 
-	x, err := methods.ExecuteSoap(context.TODO(), e.c, req)
+	x, err := methods.ExecuteSoap(ctx, e.c, req)
 	if err != nil {
 		return err
 	}

--- a/govc/host/esxcli/guest_info.go
+++ b/govc/host/esxcli/guest_info.go
@@ -83,11 +83,12 @@ func (g *GuestInfo) hostInfo(ref *types.ManagedObjectReference) (*hostInfo, erro
 // For example:
 // $ govc host.esxcli -- system settings advanced set -o /Net/GuestIPHack -i 1
 func (g *GuestInfo) IpAddress(vm *object.VirtualMachine) (string, error) {
+	ctx := context.TODO()
 	const any = "0.0.0.0"
 	var mvm mo.VirtualMachine
 
 	pc := property.DefaultCollector(g.c)
-	err := pc.RetrieveOne(context.TODO(), vm.Reference(), []string{"runtime.host", "config.uuid"}, &mvm)
+	err := pc.RetrieveOne(ctx, vm.Reference(), []string{"runtime.host", "config.uuid"}, &mvm)
 	if err != nil {
 		return "", err
 	}

--- a/govc/host/portgroup/add.go
+++ b/govc/host/portgroup/add.go
@@ -62,5 +62,5 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	cmd.spec.Name = f.Arg(0)
 
-	return ns.AddPortGroup(context.TODO(), cmd.spec)
+	return ns.AddPortGroup(ctx, cmd.spec)
 }

--- a/govc/host/portgroup/remove.go
+++ b/govc/host/portgroup/remove.go
@@ -54,5 +54,5 @@ func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return ns.RemovePortGroup(context.TODO(), f.Arg(0))
+	return ns.RemovePortGroup(ctx, f.Arg(0))
 }

--- a/govc/host/vswitch/add.go
+++ b/govc/host/vswitch/add.go
@@ -69,5 +69,5 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 	}
 
-	return ns.AddVirtualSwitch(context.TODO(), f.Arg(0), &cmd.spec)
+	return ns.AddVirtualSwitch(ctx, f.Arg(0), &cmd.spec)
 }

--- a/govc/host/vswitch/info.go
+++ b/govc/host/vswitch/info.go
@@ -77,7 +77,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 	var mns mo.HostNetworkSystem
 
 	pc := property.DefaultCollector(client)
-	err = pc.RetrieveOne(context.TODO(), ns.Reference(), []string{"networkInfo.vswitch"}, &mns)
+	err = pc.RetrieveOne(ctx, ns.Reference(), []string{"networkInfo.vswitch"}, &mns)
 	if err != nil {
 		return err
 	}

--- a/govc/host/vswitch/remove.go
+++ b/govc/host/vswitch/remove.go
@@ -54,5 +54,5 @@ func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return ns.RemoveVirtualSwitch(context.TODO(), f.Arg(0))
+	return ns.RemoveVirtualSwitch(ctx, f.Arg(0))
 }

--- a/govc/importx/folder.go
+++ b/govc/importx/folder.go
@@ -48,12 +48,13 @@ func (flag *FolderFlag) Process(ctx context.Context) error {
 }
 
 func (flag *FolderFlag) Folder() (*object.Folder, error) {
+	ctx := context.TODO()
 	if len(flag.folder) == 0 {
 		dc, err := flag.Datacenter()
 		if err != nil {
 			return nil, err
 		}
-		folders, err := dc.Folders(context.TODO())
+		folders, err := dc.Folders(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -65,7 +66,7 @@ func (flag *FolderFlag) Folder() (*object.Folder, error) {
 		return nil, err
 	}
 
-	mo, err := finder.ManagedObjectList(context.TODO(), flag.folder)
+	mo, err := finder.ManagedObjectList(ctx, flag.folder)
 	if err != nil {
 		return nil, err
 	}

--- a/govc/importx/ovf.go
+++ b/govc/importx/ovf.go
@@ -178,6 +178,7 @@ func (cmd *ovfx) Map(op []Property) (p []types.KeyValue) {
 }
 
 func (cmd *ovfx) NetworkMap(e *ovf.Envelope) (p []types.OvfNetworkMapping) {
+	ctx := context.TODO()
 	finder, err := cmd.DatastoreFlag.Finder()
 	if err != nil {
 		return
@@ -196,7 +197,7 @@ func (cmd *ovfx) NetworkMap(e *ovf.Envelope) (p []types.OvfNetworkMapping) {
 	}
 
 	for src, dst := range networks {
-		if net, err := finder.Network(context.TODO(), dst); err == nil {
+		if net, err := finder.Network(ctx, dst); err == nil {
 			p = append(p, types.OvfNetworkMapping{
 				Name:    src,
 				Network: net.Reference(),
@@ -207,6 +208,7 @@ func (cmd *ovfx) NetworkMap(e *ovf.Envelope) (p []types.OvfNetworkMapping) {
 }
 
 func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
+	ctx := context.TODO()
 	o, err := cmd.ReadOvf(fpath)
 	if err != nil {
 		return nil, err
@@ -248,7 +250,7 @@ func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 	}
 
 	m := object.NewOvfManager(cmd.Client)
-	spec, err := m.CreateImportSpec(context.TODO(), string(o), cmd.ResourcePool, cmd.Datastore, cisp)
+	spec, err := m.CreateImportSpec(ctx, string(o), cmd.ResourcePool, cmd.Datastore, cisp)
 	if err != nil {
 		return nil, err
 	}
@@ -282,12 +284,12 @@ func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 		return nil, err
 	}
 
-	lease, err := cmd.ResourcePool.ImportVApp(context.TODO(), spec.ImportSpec, folder, host)
+	lease, err := cmd.ResourcePool.ImportVApp(ctx, spec.ImportSpec, folder, host)
 	if err != nil {
 		return nil, err
 	}
 
-	info, err := lease.Wait(context.TODO())
+	info, err := lease.Wait(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +329,7 @@ func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 		}
 	}
 
-	return &info.Entity, lease.HttpNfcLeaseComplete(context.TODO())
+	return &info.Entity, lease.HttpNfcLeaseComplete(ctx)
 }
 
 func (cmd *ovfx) Upload(lease *object.HttpNfcLease, ofi ovfFileItem) error {
@@ -364,18 +366,19 @@ func (cmd *ovfx) Upload(lease *object.HttpNfcLease, ofi ovfFileItem) error {
 }
 
 func (cmd *ovfx) PowerOn(vm *object.VirtualMachine) error {
+	ctx := context.TODO()
 	if !cmd.Options.PowerOn {
 		return nil
 	}
 
 	cmd.Log("Powering on VM...\n")
 
-	task, err := vm.PowerOn(context.TODO())
+	task, err := vm.PowerOn(ctx)
 	if err != nil {
 		return err
 	}
 
-	if _, err = task.WaitForResult(context.TODO(), nil); err != nil {
+	if _, err = task.WaitForResult(ctx, nil); err != nil {
 		return err
 	}
 
@@ -383,6 +386,7 @@ func (cmd *ovfx) PowerOn(vm *object.VirtualMachine) error {
 }
 
 func (cmd *ovfx) InjectOvfEnv(vm *object.VirtualMachine) error {
+	ctx := context.TODO()
 	if !cmd.Options.PowerOn || !cmd.Options.InjectOvfEnv {
 		return nil
 	}
@@ -416,11 +420,11 @@ func (cmd *ovfx) InjectOvfEnv(vm *object.VirtualMachine) error {
 				Key:   "guestinfo.ovfEnv",
 				Value: xenv}}}
 
-		task, err := vm.Reconfigure(context.TODO(), vmConfigSpec)
+		task, err := vm.Reconfigure(ctx, vmConfigSpec)
 		if err != nil {
 			return err
 		}
-		if err := task.Wait(context.TODO()); err != nil {
+		if err := task.Wait(ctx); err != nil {
 			return err
 		}
 	}
@@ -429,12 +433,13 @@ func (cmd *ovfx) InjectOvfEnv(vm *object.VirtualMachine) error {
 }
 
 func (cmd *ovfx) WaitForIP(vm *object.VirtualMachine) error {
+	ctx := context.TODO()
 	if !cmd.Options.PowerOn || !cmd.Options.WaitForIP {
 		return nil
 	}
 
 	cmd.Log("Waiting for IP address...\n")
-	ip, err := vm.WaitForIP(context.TODO())
+	ip, err := vm.WaitForIP(ctx)
 	if err != nil {
 		return err
 	}

--- a/govc/license/add.go
+++ b/govc/license/add.go
@@ -84,7 +84,7 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	result := make(licenseOutput, 0)
 	for _, v := range f.Args() {
-		license, err := addFunc(context.TODO(), v, nil)
+		license, err := addFunc(ctx, v, nil)
 		if err != nil {
 			return err
 		}

--- a/govc/license/assigned.go
+++ b/govc/license/assigned.go
@@ -67,12 +67,12 @@ func (cmd *assigned) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	m, err := license.NewManager(client).AssignmentManager(context.TODO())
+	m, err := license.NewManager(client).AssignmentManager(ctx)
 	if err != nil {
 		return err
 	}
 
-	assigned, err := m.QueryAssigned(context.TODO(), cmd.id)
+	assigned, err := m.QueryAssigned(ctx, cmd.id)
 	if err != nil {
 		return err
 	}

--- a/govc/license/decode.go
+++ b/govc/license/decode.go
@@ -69,7 +69,7 @@ func (cmd *decode) Run(ctx context.Context, f *flag.FlagSet) error {
 	var result license.InfoList
 	m := license.NewManager(client)
 	for _, v := range f.Args() {
-		license, err := m.Decode(context.TODO(), v)
+		license, err := m.Decode(ctx, v)
 		if err != nil {
 			return err
 		}

--- a/govc/license/list.go
+++ b/govc/license/list.go
@@ -65,7 +65,7 @@ func (cmd *list) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	m := license.NewManager(client)
-	result, err := m.List(context.TODO())
+	result, err := m.List(ctx)
 	if err != nil {
 		return err
 	}

--- a/govc/license/remove.go
+++ b/govc/license/remove.go
@@ -64,7 +64,7 @@ func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	m := license.NewManager(client)
 	for _, v := range f.Args() {
-		err = m.Remove(context.TODO(), v)
+		err = m.Remove(ctx, v)
 		if err != nil {
 			return err
 		}

--- a/govc/logs/download.go
+++ b/govc/logs/download.go
@@ -76,15 +76,16 @@ func (cmd *download) DownloadFile(c *vim25.Client, b string) error {
 }
 
 func (cmd *download) GenerateLogBundles(m *object.DiagnosticManager, host []*object.HostSystem) ([]types.DiagnosticManagerBundleInfo, error) {
+	ctx := context.TODO()
 	logger := cmd.ProgressLogger("Generating log bundles... ")
 	defer logger.Wait()
 
-	task, err := m.GenerateLogBundles(context.TODO(), cmd.IncludeDefault, host)
+	task, err := m.GenerateLogBundles(ctx, cmd.IncludeDefault, host)
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := task.WaitForResult(context.TODO(), logger)
+	r, err := task.WaitForResult(ctx, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +102,7 @@ func (cmd *download) Run(ctx context.Context, f *flag.FlagSet) error {
 	var host []*object.HostSystem
 
 	for _, arg := range f.Args() {
-		hs, err := finder.HostSystemList(context.TODO(), arg)
+		hs, err := finder.HostSystemList(ctx, arg)
 		if err != nil {
 			return err
 		}

--- a/govc/ls/command.go
+++ b/govc/ls/command.go
@@ -101,7 +101,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 			}
 		}
 
-		es, err := finder.ManagedObjectListChildren(context.TODO(), arg)
+		es, err := finder.ManagedObjectListChildren(ctx, arg)
 		if err != nil {
 			return err
 		}

--- a/govc/pool/change.go
+++ b/govc/pool/change.go
@@ -81,13 +81,13 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
 	})
 
 	for _, arg := range f.Args() {
-		pools, err := finder.ResourcePoolList(context.TODO(), arg)
+		pools, err := finder.ResourcePoolList(ctx, arg)
 		if err != nil {
 			return err
 		}
 
 		for _, pool := range pools {
-			err := pool.UpdateConfig(context.TODO(), cmd.name, &cmd.ResourceConfigSpec)
+			err := pool.UpdateConfig(ctx, cmd.name, &cmd.ResourceConfigSpec)
 			if err != nil {
 				return err
 			}

--- a/govc/pool/create.go
+++ b/govc/pool/create.go
@@ -81,7 +81,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 	for _, arg := range f.Args() {
 		dir := path.Dir(arg)
 		base := path.Base(arg)
-		parents, err := finder.ResourcePoolList(context.TODO(), dir)
+		parents, err := finder.ResourcePoolList(ctx, dir)
 		if err != nil {
 			if _, ok := err.(*find.NotFoundError); ok {
 				return fmt.Errorf("cannot create resource pool '%s': parent not found", base)
@@ -90,7 +90,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		for _, parent := range parents {
-			_, err = parent.Create(context.TODO(), base, cmd.ResourceConfigSpec)
+			_, err = parent.Create(ctx, base, cmd.ResourceConfigSpec)
 			if err != nil {
 				return err
 			}

--- a/govc/pool/destroy.go
+++ b/govc/pool/destroy.go
@@ -68,7 +68,7 @@ func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	for _, arg := range f.Args() {
-		pools, err := finder.ResourcePoolList(context.TODO(), arg)
+		pools, err := finder.ResourcePoolList(ctx, arg)
 		if err != nil {
 			if _, ok := err.(*find.NotFoundError); ok {
 				// Ignore if pool cannot be found
@@ -80,16 +80,16 @@ func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
 
 		for _, pool := range pools {
 			if cmd.children {
-				err = pool.DestroyChildren(context.TODO())
+				err = pool.DestroyChildren(ctx)
 				if err != nil {
 					return err
 				}
 			} else {
-				task, err := pool.Destroy(context.TODO())
+				task, err := pool.Destroy(ctx)
 				if err != nil {
 					return err
 				}
-				err = task.Wait(context.TODO())
+				err = task.Wait(ctx)
 				if err != nil {
 					return err
 				}

--- a/govc/vapp/destroy.go
+++ b/govc/vapp/destroy.go
@@ -61,7 +61,7 @@ func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	for _, arg := range f.Args() {
-		vapps, err := finder.VirtualAppList(context.TODO(), arg)
+		vapps, err := finder.VirtualAppList(ctx, arg)
 		if err != nil {
 			if _, ok := err.(*find.NotFoundError); ok {
 				// Ignore if vapp cannot be found
@@ -73,11 +73,11 @@ func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
 
 		for _, vapp := range vapps {
 			powerOff := func() error {
-				task, err := vapp.PowerOffVApp_Task(context.TODO(), false)
+				task, err := vapp.PowerOffVApp_Task(ctx, false)
 				if err != nil {
 					return err
 				}
-				err = task.Wait(context.TODO())
+				err = task.Wait(ctx)
 				if err != nil {
 					// it's safe to ignore if the vapp is already powered off
 					if f, ok := err.(types.HasFault); ok {
@@ -95,11 +95,11 @@ func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
 			}
 
 			destroy := func() error {
-				task, err := vapp.Destroy(context.TODO())
+				task, err := vapp.Destroy(ctx)
 				if err != nil {
 					return err
 				}
-				err = task.Wait(context.TODO())
+				err = task.Wait(ctx)
 				if err != nil {
 					return err
 				}

--- a/govc/vapp/power.go
+++ b/govc/vapp/power.go
@@ -84,13 +84,13 @@ func (cmd *power) Run(ctx context.Context, f *flag.FlagSet) error {
 		switch {
 		case cmd.On:
 			fmt.Fprintf(cmd, "Powering on %s... ", vapp.Reference())
-			task, err = vapp.PowerOnVApp_Task(context.TODO())
+			task, err = vapp.PowerOnVApp_Task(ctx)
 		case cmd.Off:
 			fmt.Fprintf(cmd, "Powering off %s... ", vapp.Reference())
-			task, err = vapp.PowerOffVApp_Task(context.TODO(), cmd.Force)
+			task, err = vapp.PowerOffVApp_Task(ctx, cmd.Force)
 		case cmd.Suspend:
 			fmt.Fprintf(cmd, "Suspend %s... ", vapp.Reference())
-			task, err = vapp.SuspendVApp_Task(context.TODO())
+			task, err = vapp.SuspendVApp_Task(ctx)
 		}
 
 		if err != nil {
@@ -98,7 +98,7 @@ func (cmd *power) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		if task != nil {
-			err = task.Wait(context.TODO())
+			err = task.Wait(ctx)
 		}
 		if err == nil {
 			fmt.Fprintf(cmd, "OK\n")

--- a/govc/vm/change.go
+++ b/govc/vm/change.go
@@ -89,10 +89,10 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
 		cmd.VirtualMachineConfigSpec.ExtraConfig = cmd.extraConfig
 	}
 
-	task, err := vm.Reconfigure(context.TODO(), cmd.VirtualMachineConfigSpec)
+	task, err := vm.Reconfigure(ctx, cmd.VirtualMachineConfigSpec)
 	if err != nil {
 		return err
 	}
 
-	return task.Wait(context.TODO())
+	return task.Wait(ctx)
 }

--- a/govc/vm/clone.go
+++ b/govc/vm/clone.go
@@ -173,7 +173,7 @@ func (cmd *clone) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	if cmd.HostSystem != nil {
-		if cmd.ResourcePool, err = cmd.HostSystem.ResourcePool(context.TODO()); err != nil {
+		if cmd.ResourcePool, err = cmd.HostSystem.ResourcePool(ctx); err != nil {
 			return err
 		}
 	} else {
@@ -191,12 +191,12 @@ func (cmd *clone) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	task, err := cmd.cloneVM(context.TODO())
+	task, err := cmd.cloneVM(ctx)
 	if err != nil {
 		return err
 	}
 
-	info, err := task.WaitForResult(context.TODO(), nil)
+	info, err := task.WaitForResult(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -211,23 +211,23 @@ func (cmd *clone) Run(ctx context.Context, f *flag.FlagSet) error {
 		if cmd.memory > 0 {
 			vmConfigSpec.MemoryMB = int64(cmd.memory)
 		}
-		task, err := vm.Reconfigure(context.TODO(), vmConfigSpec)
+		task, err := vm.Reconfigure(ctx, vmConfigSpec)
 		if err != nil {
 			return err
 		}
-		_, err = task.WaitForResult(context.TODO(), nil)
+		_, err = task.WaitForResult(ctx, nil)
 		if err != nil {
 			return err
 		}
 	}
 
 	if cmd.on {
-		task, err := vm.PowerOn(context.TODO())
+		task, err := vm.PowerOn(ctx)
 		if err != nil {
 			return err
 		}
 
-		_, err = task.WaitForResult(context.TODO(), nil)
+		_, err = task.WaitForResult(ctx, nil)
 		if err != nil {
 			return err
 		}

--- a/govc/vm/create.go
+++ b/govc/vm/create.go
@@ -194,7 +194,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	if cmd.HostSystem != nil {
-		if cmd.ResourcePool, err = cmd.HostSystem.ResourcePool(context.TODO()); err != nil {
+		if cmd.ResourcePool, err = cmd.HostSystem.ResourcePool(ctx); err != nil {
 			return err
 		}
 	} else {
@@ -210,7 +210,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	// Verify ISO exists
 	if cmd.iso != "" {
-		_, err = cmd.isoDatastoreFlag.Stat(context.TODO(), cmd.iso)
+		_, err = cmd.isoDatastoreFlag.Stat(ctx, cmd.iso)
 		if err != nil {
 			return err
 		}
@@ -230,7 +230,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		if err == nil {
 			cmd.diskByteSize = int64(b)
 		} else {
-			_, err = cmd.diskDatastoreFlag.Stat(context.TODO(), cmd.disk)
+			_, err = cmd.diskDatastoreFlag.Stat(ctx, cmd.disk)
 			if err != nil {
 				return err
 			}
@@ -242,12 +242,12 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 	}
 
-	task, err := cmd.createVM(context.TODO())
+	task, err := cmd.createVM(ctx)
 	if err != nil {
 		return err
 	}
 
-	info, err := task.WaitForResult(context.TODO(), nil)
+	info, err := task.WaitForResult(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -255,12 +255,12 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 	vm := object.NewVirtualMachine(cmd.Client, info.Result.(types.ManagedObjectReference))
 
 	if cmd.on {
-		task, err := vm.PowerOn(context.TODO())
+		task, err := vm.PowerOn(ctx)
 		if err != nil {
 			return err
 		}
 
-		_, err = task.WaitForResult(context.TODO(), nil)
+		_, err = task.WaitForResult(ctx, nil)
 		if err != nil {
 			return err
 		}

--- a/govc/vm/destroy.go
+++ b/govc/vm/destroy.go
@@ -58,21 +58,21 @@ func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	for _, vm := range vms {
-		task, err := vm.PowerOff(context.TODO())
+		task, err := vm.PowerOff(ctx)
 		if err != nil {
 			return err
 		}
 
 		// Ignore error since the VM may already been in powered off state.
 		// vm.Destroy will fail if the VM is still powered on.
-		_ = task.Wait(context.TODO())
+		_ = task.Wait(ctx)
 
-		task, err = vm.Destroy(context.TODO())
+		task, err = vm.Destroy(ctx)
 		if err != nil {
 			return err
 		}
 
-		err = task.Wait(context.TODO())
+		err = task.Wait(ctx)
 		if err != nil {
 			return err
 		}

--- a/govc/vm/disk/attach.go
+++ b/govc/vm/disk/attach.go
@@ -76,7 +76,7 @@ func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		disk = devices.ChildDisk(disk)
-		return vm.AddDevice(context.TODO(), disk)
+		return vm.AddDevice(ctx, disk)
 	}
 
 	if cmd.persist {
@@ -106,5 +106,5 @@ func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
 		backing.DiskMode = string(types.VirtualDiskModeNonpersistent)
 	}
 
-	return vm.AddDevice(context.TODO(), disk)
+	return vm.AddDevice(ctx, disk)
 }

--- a/govc/vm/disk/create.go
+++ b/govc/vm/disk/create.go
@@ -107,7 +107,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -148,5 +148,5 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	cmd.Log("Creating disk\n")
 	disk.CapacityInKB = int64(cmd.Bytes) / 1024
-	return vm.AddDevice(context.TODO(), disk)
+	return vm.AddDevice(ctx, disk)
 }

--- a/govc/vm/guest/chmod.go
+++ b/govc/vm/guest/chmod.go
@@ -55,5 +55,5 @@ func (cmd *chmod) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return m.ChangeFileAttributes(context.TODO(), cmd.Auth(), f.Arg(0), cmd.Attr())
+	return m.ChangeFileAttributes(ctx, cmd.Auth(), f.Arg(0), cmd.Attr())
 }

--- a/govc/vm/guest/download.go
+++ b/govc/vm/guest/download.go
@@ -63,7 +63,7 @@ func (cmd *download) Run(ctx context.Context, f *flag.FlagSet) error {
 		return os.ErrExist
 	}
 
-	info, err := m.InitiateFileTransferFromGuest(context.TODO(), cmd.Auth(), src)
+	info, err := m.InitiateFileTransferFromGuest(ctx, cmd.Auth(), src)
 	if err != nil {
 		return err
 	}

--- a/govc/vm/guest/getenv.go
+++ b/govc/vm/guest/getenv.go
@@ -50,7 +50,7 @@ func (cmd *getenv) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	vars, err := m.ReadEnvironmentVariable(context.TODO(), cmd.Auth(), f.Args())
+	vars, err := m.ReadEnvironmentVariable(ctx, cmd.Auth(), f.Args())
 	if err != nil {
 		return err
 	}

--- a/govc/vm/guest/guest.go
+++ b/govc/vm/guest/guest.go
@@ -63,6 +63,7 @@ func (flag *GuestFlag) Process(ctx context.Context) error {
 }
 
 func (flag *GuestFlag) FileManager() (*guest.FileManager, error) {
+	ctx := context.TODO()
 	c, err := flag.Client()
 	if err != nil {
 		return nil, err
@@ -74,10 +75,11 @@ func (flag *GuestFlag) FileManager() (*guest.FileManager, error) {
 	}
 
 	o := guest.NewOperationsManager(c, vm.Reference())
-	return o.FileManager(context.TODO())
+	return o.FileManager(ctx)
 }
 
 func (flag *GuestFlag) ProcessManager() (*guest.ProcessManager, error) {
+	ctx := context.TODO()
 	c, err := flag.Client()
 	if err != nil {
 		return nil, err
@@ -89,7 +91,7 @@ func (flag *GuestFlag) ProcessManager() (*guest.ProcessManager, error) {
 	}
 
 	o := guest.NewOperationsManager(c, vm.Reference())
-	return o.ProcessManager(context.TODO())
+	return o.ProcessManager(ctx)
 }
 
 func (flag *GuestFlag) ParseURL(urlStr string) (*url.URL, error) {

--- a/govc/vm/guest/kill.go
+++ b/govc/vm/guest/kill.go
@@ -54,7 +54,7 @@ func (cmd *kill) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	for _, pid := range cmd.pids {
-		if err := m.TerminateProcess(context.TODO(), cmd.Auth(), pid); err != nil {
+		if err := m.TerminateProcess(ctx, cmd.Auth(), pid); err != nil {
 			return err
 		}
 	}

--- a/govc/vm/guest/ls.go
+++ b/govc/vm/guest/ls.go
@@ -56,7 +56,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 	tw := tabwriter.NewWriter(os.Stdout, 3, 0, 2, ' ', 0)
 
 	for {
-		info, err := m.ListFiles(context.TODO(), cmd.Auth(), f.Arg(0), offset, 0, f.Arg(1))
+		info, err := m.ListFiles(ctx, cmd.Auth(), f.Arg(0), offset, 0, f.Arg(1))
 		if err != nil {
 			return err
 		}

--- a/govc/vm/guest/mkdir.go
+++ b/govc/vm/guest/mkdir.go
@@ -55,7 +55,7 @@ func (cmd *mkdir) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	err = m.MakeDirectory(context.TODO(), cmd.Auth(), f.Arg(0), cmd.createParents)
+	err = m.MakeDirectory(ctx, cmd.Auth(), f.Arg(0), cmd.createParents)
 
 	// ignore EEXIST if -p flag is given
 	if err != nil && cmd.createParents {

--- a/govc/vm/guest/mktemp.go
+++ b/govc/vm/guest/mktemp.go
@@ -63,7 +63,7 @@ func (cmd *mktemp) Run(ctx context.Context, f *flag.FlagSet) error {
 		mk = m.CreateTemporaryDirectory
 	}
 
-	name, err := mk(context.TODO(), cmd.Auth(), cmd.prefix, cmd.suffix)
+	name, err := mk(ctx, cmd.Auth(), cmd.prefix, cmd.suffix)
 	if err != nil {
 		return err
 	}

--- a/govc/vm/guest/ps.go
+++ b/govc/vm/guest/ps.go
@@ -93,7 +93,7 @@ func (cmd *ps) Run(ctx context.Context, f *flag.FlagSet) error {
 		cmd.uids[cmd.auth.Username] = true
 	}
 
-	procs, err := m.ListProcesses(context.TODO(), cmd.Auth(), cmd.pids)
+	procs, err := m.ListProcesses(ctx, cmd.Auth(), cmd.pids)
 	if err != nil {
 		return err
 	}

--- a/govc/vm/guest/rm.go
+++ b/govc/vm/guest/rm.go
@@ -49,5 +49,5 @@ func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return m.DeleteFile(context.TODO(), cmd.Auth(), f.Arg(0))
+	return m.DeleteFile(ctx, cmd.Auth(), f.Arg(0))
 }

--- a/govc/vm/guest/rmdir.go
+++ b/govc/vm/guest/rmdir.go
@@ -53,5 +53,5 @@ func (cmd *rmdir) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return m.DeleteDirectory(context.TODO(), cmd.Auth(), f.Arg(0), cmd.recursive)
+	return m.DeleteDirectory(ctx, cmd.Auth(), f.Arg(0), cmd.recursive)
 }

--- a/govc/vm/guest/start.go
+++ b/govc/vm/guest/start.go
@@ -76,7 +76,7 @@ func (cmd *start) Run(ctx context.Context, f *flag.FlagSet) error {
 		EnvVariables:     cmd.vars,
 	}
 
-	pid, err := m.StartProgram(context.TODO(), cmd.Auth(), &spec)
+	pid, err := m.StartProgram(ctx, cmd.Auth(), &spec)
 	if err != nil {
 		return err
 	}

--- a/govc/vm/guest/upload.go
+++ b/govc/vm/guest/upload.go
@@ -68,7 +68,7 @@ func (cmd *upload) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	url, err := m.InitiateFileTransferToGuest(context.TODO(), cmd.Auth(), dst, cmd.Attr(), s.Size(), cmd.overwrite)
+	url, err := m.InitiateFileTransferToGuest(ctx, cmd.Auth(), dst, cmd.Attr(), s.Size(), cmd.overwrite)
 	if err != nil {
 		return err
 	}

--- a/govc/vm/ip.go
+++ b/govc/vm/ip.go
@@ -101,7 +101,7 @@ func (cmd *ip) Run(ctx context.Context, f *flag.FlagSet) error {
 	} else {
 		get = func(vm *object.VirtualMachine) (string, error) {
 			if cmd.all {
-				macs, err := vm.WaitForNetIP(context.TODO(), cmd.v4)
+				macs, err := vm.WaitForNetIP(ctx, cmd.v4)
 				if err != nil {
 					return "", err
 				}
@@ -114,7 +114,7 @@ func (cmd *ip) Run(ctx context.Context, f *flag.FlagSet) error {
 				}
 				return strings.Join(ips, ","), nil
 			}
-			return vm.WaitForIP(context.TODO())
+			return vm.WaitForIP(ctx)
 		}
 	}
 

--- a/govc/vm/markastemplate.go
+++ b/govc/vm/markastemplate.go
@@ -58,7 +58,7 @@ func (cmd *markastemplate) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	for _, vm := range vms {
-		err := vm.MarkAsTemplate(context.TODO())
+		err := vm.MarkAsTemplate(ctx)
 		if err != nil {
 			return err
 		}

--- a/govc/vm/markasvm.go
+++ b/govc/vm/markasvm.go
@@ -69,12 +69,12 @@ func (cmd *markasvm) Run(ctx context.Context, f *flag.FlagSet) error {
 	if err != nil {
 		return err
 	}
-	cmd.ResourcePool, err = cmd.HostSystem.ResourcePool(context.TODO())
+	cmd.ResourcePool, err = cmd.HostSystem.ResourcePool(ctx)
 	if err != nil {
 		return err
 	}
 	for _, vm := range vms {
-		err := vm.MarkAsVirtualMachine(context.TODO(), *cmd.ResourcePool, cmd.HostSystem)
+		err := vm.MarkAsVirtualMachine(ctx, *cmd.ResourcePool, cmd.HostSystem)
 		if err != nil {
 			return err
 		}

--- a/govc/vm/network/add.go
+++ b/govc/vm/network/add.go
@@ -71,5 +71,5 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return vm.AddDevice(context.TODO(), net)
+	return vm.AddDevice(ctx, net)
 }

--- a/govc/vm/network/change.go
+++ b/govc/vm/network/change.go
@@ -74,7 +74,7 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
 		_ = cmd.NetworkFlag.Set(f.Arg(1))
 	}
 
-	devices, err := vm.Device(context.TODO())
+	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
 	}
@@ -103,5 +103,5 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
 		current.AddressType = changed.AddressType
 	}
 
-	return vm.EditDevice(context.TODO(), net)
+	return vm.EditDevice(ctx, net)
 }

--- a/govc/vm/power.go
+++ b/govc/vm/power.go
@@ -110,29 +110,29 @@ func (cmd *power) Run(ctx context.Context, f *flag.FlagSet) error {
 		switch {
 		case cmd.On:
 			fmt.Fprintf(cmd, "Powering on %s... ", vm.Reference())
-			task, err = vm.PowerOn(context.TODO())
+			task, err = vm.PowerOn(ctx)
 		case cmd.Off:
 			fmt.Fprintf(cmd, "Powering off %s... ", vm.Reference())
-			task, err = vm.PowerOff(context.TODO())
+			task, err = vm.PowerOff(ctx)
 		case cmd.Reset:
 			fmt.Fprintf(cmd, "Reset %s... ", vm.Reference())
-			task, err = vm.Reset(context.TODO())
+			task, err = vm.Reset(ctx)
 		case cmd.Suspend:
 			fmt.Fprintf(cmd, "Suspend %s... ", vm.Reference())
-			task, err = vm.Suspend(context.TODO())
+			task, err = vm.Suspend(ctx)
 		case cmd.Reboot:
 			fmt.Fprintf(cmd, "Reboot guest %s... ", vm.Reference())
-			err = vm.RebootGuest(context.TODO())
+			err = vm.RebootGuest(ctx)
 
 			if err != nil && cmd.Force && isToolsUnavailable(err) {
-				task, err = vm.Reset(context.TODO())
+				task, err = vm.Reset(ctx)
 			}
 		case cmd.Shutdown:
 			fmt.Fprintf(cmd, "Shutdown guest %s... ", vm.Reference())
-			err = vm.ShutdownGuest(context.TODO())
+			err = vm.ShutdownGuest(ctx)
 
 			if err != nil && cmd.Force && isToolsUnavailable(err) {
-				task, err = vm.PowerOff(context.TODO())
+				task, err = vm.PowerOff(ctx)
 			}
 		}
 
@@ -141,7 +141,7 @@ func (cmd *power) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		if task != nil {
-			err = task.Wait(context.TODO())
+			err = task.Wait(ctx)
 		}
 		if err == nil {
 			fmt.Fprintf(cmd, "OK\n")

--- a/govc/vm/question.go
+++ b/govc/vm/question.go
@@ -71,7 +71,7 @@ func (cmd *question) Run(ctx context.Context, f *flag.FlagSet) error {
 	var mvm mo.VirtualMachine
 
 	pc := property.DefaultCollector(c)
-	err = pc.RetrieveOne(context.TODO(), vm.Reference(), []string{"runtime.question"}, &mvm)
+	err = pc.RetrieveOne(ctx, vm.Reference(), []string{"runtime.question"}, &mvm)
 	if err != nil {
 		return err
 	}
@@ -94,5 +94,5 @@ func (cmd *question) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	// Answer question
-	return vm.Answer(context.TODO(), q.Id, cmd.answer)
+	return vm.Answer(ctx, q.Id, cmd.answer)
 }

--- a/govc/vm/vnc.go
+++ b/govc/vm/vnc.go
@@ -205,7 +205,8 @@ func newVNCVM(c *vim25.Client, vm *object.VirtualMachine) (*vncVM, error) {
 	}
 
 	pc := property.DefaultCollector(c)
-	err := pc.RetrieveOne(context.TODO(), vm.Reference(), virtualMachineProperties, &v.mvm)
+	ctx := context.TODO()
+	err := pc.RetrieveOne(ctx, vm.Reference(), virtualMachineProperties, &v.mvm)
 	if err != nil {
 		return nil, err
 	}
@@ -259,12 +260,13 @@ func (v *vncVM) reconfigure() error {
 		ExtraConfig: v.newOptions.ToExtraConfig(),
 	}
 
-	task, err := v.vm.Reconfigure(context.TODO(), spec)
+	ctx := context.TODO()
+	task, err := v.vm.Reconfigure(ctx, spec)
 	if err != nil {
 		return err
 	}
 
-	return task.Wait(context.TODO())
+	return task.Wait(ctx)
 }
 
 func (v *vncVM) uri() (string, error) {
@@ -327,6 +329,7 @@ func newVNCHost(c *vim25.Client, host *object.HostSystem, low, high int) (*vncHo
 }
 
 func loadUsedPorts(c *vim25.Client, host types.ManagedObjectReference) ([]int, error) {
+	ctx := context.TODO()
 	ospec := types.ObjectSpec{
 		Obj: host,
 		SelectSet: []types.BaseSelectionSpec{
@@ -355,7 +358,7 @@ func loadUsedPorts(c *vim25.Client, host types.ManagedObjectReference) ([]int, e
 	}
 
 	var vms []mo.VirtualMachine
-	err := mo.RetrievePropertiesForRequest(context.TODO(), c, req, &vms)
+	err := mo.RetrievePropertiesForRequest(ctx, c, req, &vms)
 	if err != nil {
 		return nil, err
 	}
@@ -393,11 +396,12 @@ func (h *vncHost) popUnusedPort() (int, error) {
 }
 
 func (h *vncHost) managementIP() (string, error) {
+	ctx := context.TODO()
 	if h.ip != "" {
 		return h.ip, nil
 	}
 
-	ips, err := h.host.ManagementIPs(context.TODO())
+	ips, err := h.host.ManagementIPs(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/object/datastore.go
+++ b/object/datastore.go
@@ -358,12 +358,12 @@ func (d Datastore) Stat(ctx context.Context, file string) (types.BaseFileInfo, e
 	}
 
 	dsPath := d.Path(path.Dir(file))
-	task, err := b.SearchDatastore(context.TODO(), dsPath, &spec)
+	task, err := b.SearchDatastore(ctx, dsPath, &spec)
 	if err != nil {
 		return nil, err
 	}
 
-	info, err := task.WaitForResult(context.TODO(), nil)
+	info, err := task.WaitForResult(ctx, nil)
 	if err != nil {
 		if info == nil || info.Error != nil {
 			_, ok := info.Error.Fault.(*types.FileNotFound)

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -212,7 +212,7 @@ func (c *Client) UnmarshalJSON(b []byte) error {
 }
 
 func (c *Client) do(ctx context.Context, req *http.Request) (*http.Response, error) {
-	if nil == ctx || nil == ctx.Done() { // ctx.Done() is for context.TODO()
+	if nil == ctx || nil == ctx.Done() { // ctx.Done() is for ctx
 		return c.Client.Do(req)
 	}
 


### PR DESCRIPTION
Either replace with ctx when a Context is already in scope, or assign
context.TODO() to ctx at the top of the function, for functions which
look like they'll later need to take a context anyway.