### PR TITLE
Add device.usb.add command

### DIFF
--- a/govc/device/usb/add.go
+++ b/govc/device/usb/add.go
@@ -1,0 +1,105 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usb
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*flags.VirtualMachineFlag
+
+	controller  string
+	autoConnect bool
+	ehciEnabled bool
+}
+
+func init() {
+	cli.Register("device.usb.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	ctypes := []string{"usb", "xhci"}
+	f.StringVar(&cmd.controller, "type", ctypes[0],
+		fmt.Sprintf("USB controller type (%s)", strings.Join(ctypes, "|")))
+
+	f.BoolVar(&cmd.autoConnect, "auto", true, "Enable ability to hot plug devices")
+	f.BoolVar(&cmd.ehciEnabled, "ehci", true, "Enable enhanced host controller interface (USB 2.0)")
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	var d types.BaseVirtualDevice
+
+	switch cmd.controller {
+	case "usb":
+		c := new(types.VirtualUSBController)
+		c.AutoConnectDevices = &cmd.autoConnect
+		c.EhciEnabled = &cmd.ehciEnabled
+		d = c
+	case "xhci":
+		c := new(types.VirtualUSBXHCIController)
+		c.AutoConnectDevices = &cmd.autoConnect
+		d = c
+	default:
+		return flag.ErrHelp
+	}
+
+	err = vm.AddDevice(ctx, d)
+	if err != nil {
+		return err
+	}
+
+	// output name of device we just created
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	devices = devices.SelectByType(d)
+
+	name := devices.Name(devices[len(devices)-1])
+
+	fmt.Println(name)
+
+	return nil
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/device/floppy"
 	_ "github.com/vmware/govmomi/govc/device/scsi"
 	_ "github.com/vmware/govmomi/govc/device/serial"
+	_ "github.com/vmware/govmomi/govc/device/usb"
 	_ "github.com/vmware/govmomi/govc/dvs"
 	_ "github.com/vmware/govmomi/govc/dvs/portgroup"
 	_ "github.com/vmware/govmomi/govc/env"

--- a/govc/test/device.bats
+++ b/govc/test/device.bats
@@ -206,3 +206,33 @@ load test_helper
   result=$(govc device.ls -vm $vm | grep $id | wc -l)
   [ $result -eq 1 ]
 }
+
+@test "device.usb" {
+  vm=$(new_empty_vm)
+
+  result=$(govc device.ls -vm $vm | grep usb | wc -l)
+  [ $result -eq 0 ]
+
+  run govc device.usb.add -type enoent -vm $vm
+  assert_failure
+
+  run govc device.usb.add -vm $vm
+  assert_success
+  id=$output
+
+  result=$(govc device.ls -vm $vm | grep $id | wc -l)
+  [ $result -eq 1 ]
+
+  run govc device.usb.add -vm $vm
+  assert_failure # 1 per vm max
+
+  run govc device.usb.add -type xhci -vm $vm
+  assert_success
+  id=$output
+
+  result=$(govc device.ls -vm $vm | grep $id | wc -l)
+  [ $result -eq 1 ]
+
+  run govc device.usb.add -type xhci -vm $vm
+  assert_failure # 1 per vm max
+}


### PR DESCRIPTION
Supports adding USB controllers to VMs.

Fixes #569