### PR TITLE
Add VirtualMachine.Unregister func

### DIFF
--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -645,3 +645,12 @@ func (v VirtualMachine) MarkAsVirtualMachine(ctx context.Context, pool ResourceP
 
 	return nil
 }
+
+func (v VirtualMachine) Unregister(ctx context.Context) error {
+	req := types.UnregisterVM{
+		This: v.Reference(),
+	}
+
+	_, err := methods.UnregisterVM(ctx, v.Client(), &req)
+	return err
+}


### PR DESCRIPTION
This is a simple addition to object/virtual_machine.go to to allow for unregistering a VM.