### PR TITLE
Set default ScsiCtlrUnitNumber

### DIFF
--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -245,6 +245,7 @@ func (l VirtualDeviceList) CreateSCSIController(name string) (types.BaseVirtualD
 	scsi := c.GetVirtualSCSIController()
 	scsi.BusNumber = l.newSCSIBusNumber()
 	scsi.Key = l.NewKey()
+	scsi.ScsiCtlrUnitNumber = 7
 	return c.(types.BaseVirtualDevice), nil
 }
 


### PR DESCRIPTION
CreateSCSIController needs to set the default ScsiCtlrUnitNumber,
otherwise newUnitNumber considers UnitNumber 0 in use.

See PR #588