### PR TITLE
Adding vSPC proxyURI to govc

### DIFF
--- a/govc/device/serial/connect.go
+++ b/govc/device/serial/connect.go
@@ -27,6 +27,7 @@ import (
 type connect struct {
 	*flags.VirtualMachineFlag
 
+	proxy  string
 	device string
 	client bool
 }
@@ -39,6 +40,7 @@ func (cmd *connect) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
 	cmd.VirtualMachineFlag.Register(ctx, f)
 
+	f.StringVar(&cmd.proxy, "vspc-proxy", "", "vSPC proxy URI")
 	f.StringVar(&cmd.device, "device", "", "serial port device name")
 	f.BoolVar(&cmd.client, "client", false, "Use client direction")
 }
@@ -70,5 +72,5 @@ func (cmd *connect) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return vm.EditDevice(ctx, devices.ConnectSerialPort(d, f.Arg(0), cmd.client))
+	return vm.EditDevice(ctx, devices.ConnectSerialPort(d, f.Arg(0), cmd.client, cmd.proxy))
 }

--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -610,7 +610,7 @@ func (l VirtualDeviceList) CreateSerialPort() (*types.VirtualSerialPort, error) 
 }
 
 // ConnectSerialPort connects a serial port to a server or client uri.
-func (l VirtualDeviceList) ConnectSerialPort(device *types.VirtualSerialPort, uri string, client bool) *types.VirtualSerialPort {
+func (l VirtualDeviceList) ConnectSerialPort(device *types.VirtualSerialPort, uri string, client bool, proxyuri string) *types.VirtualSerialPort {
 	direction := types.VirtualDeviceURIBackingOptionDirectionServer
 	if client {
 		direction = types.VirtualDeviceURIBackingOptionDirectionClient
@@ -620,6 +620,7 @@ func (l VirtualDeviceList) ConnectSerialPort(device *types.VirtualSerialPort, ur
 		VirtualDeviceURIBackingInfo: types.VirtualDeviceURIBackingInfo{
 			Direction:  string(direction),
 			ServiceURI: uri,
+			ProxyURI:   proxyuri,
 		},
 	}
 

--- a/object/virtual_device_list_test.go
+++ b/object/virtual_device_list_test.go
@@ -731,7 +731,7 @@ func TestSerialPort(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	devices.ConnectSerialPort(device, "telnet://:33233", false)
+	devices.ConnectSerialPort(device, "telnet://:33233", false, "")
 }
 
 func TestPrimaryMacAddress(t *testing.T) {


### PR DESCRIPTION
This PR adds functionality to device.serial.connect to specify a vSPC proxy URI