### PR TITLE
Localization : Set default locale to en_US

### DIFF
--- a/session/manager.go
+++ b/session/manager.go
@@ -46,7 +46,8 @@ func (sm Manager) Reference() types.ManagedObjectReference {
 
 func (sm *Manager) Login(ctx context.Context, u *url.Userinfo) error {
 	req := types.Login{
-		This: sm.Reference(),
+		This:   sm.Reference(),
+		Locale: "en_US",
 	}
 
 	if u != nil {


### PR DESCRIPTION
We use to vcenter. If we display performance metrics using the default *NewClient* method, we retrieve metrics in French in one vcenter and in English on the second.
We use : 
```go
govmomi.NewClient(ctx, url, insecureFlag)
``` 

and:

```go
for _, vcenter := range VCenters {
		fmt.Printf("== vCenter: %s ==\n", vcenter.Host)
		for _, perfCounterInfo := range vcenter.PerfManager.PerfCounter {
			groupInfo := perfCounterInfo.GroupInfo.GetElementDescription()
			nameInfo := perfCounterInfo.NameInfo.GetElementDescription()
			metricName := fmt.Sprintf("%s_%s_%s", namespace, snaker.CamelToSnake(groupInfo.Key), strings.Join(strings.Split(snaker.CamelToSnake(nameInfo.Key), "."), "_"))
			fmt.Printf("%s: %s\n", metricName, nameInfo.Summary)
		}
	}
}
```

Without patch : 

```bash
vsphere_sys_uptime: Total time elapsed, in seconds, since last system startup
vsphere_sys_uptime: Temps total, en secondes, depuis le dernier démarrage du système  
```

With patch :

```bash
vsphere_sys_uptime: Total time elapsed, in seconds, since last system startup                            
vsphere_sys_uptime: Total time elapsed, in seconds, since last system startup  
```

Signed-off-by: Nicolas Lamirault <nicolas.lamirault@gmail.com>