### PR TITLE
Add service ticket thumbprint validation

### DIFF
--- a/govc/flags/host_connect.go
+++ b/govc/flags/host_connect.go
@@ -49,7 +49,7 @@ func (flag *HostConnectFlag) Register(ctx context.Context, f *flag.FlagSet) {
 		f.StringVar(&flag.HostName, "hostname", "", "Hostname or IP address of the host")
 		f.StringVar(&flag.UserName, "username", "", "Username of administration account on the host")
 		f.StringVar(&flag.Password, "password", "", "Password of administration account on the host")
-		f.StringVar(&flag.SslThumbprint, "fingerprint", "", "Fingerprint of the host's SSL certificate")
+		f.StringVar(&flag.SslThumbprint, "thumbprint", "", "SHA-1 thumbprint of the host's SSL certificate")
 		f.BoolVar(&flag.Force, "force", false, "Force when host is managed by another VC")
 
 		f.BoolVar(&flag.noverify, "noverify", false, "When true, ignore host SSL certificate verification error")
@@ -70,7 +70,7 @@ func (flag *HostConnectFlag) AcceptThumbprint(err error) error {
 				flag.SslThumbprint = fault.Thumbprint
 				return nil
 			}
-			return fmt.Errorf("%s Fingerprint is %s", err, fault.Thumbprint)
+			return fmt.Errorf("%s thumbprint=%s", err, fault.Thumbprint)
 		}
 	}
 

--- a/object/datastore.go
+++ b/object/datastore.go
@@ -226,6 +226,8 @@ func (d Datastore) ServiceTicket(ctx context.Context, path string, method string
 		u.Host = ticket.HostName
 	}
 
+	d.Client().SetThumbprint(u.Host, ticket.SslThumbprint)
+
 	return u, cookie, nil
 }
 


### PR DESCRIPTION
Generalize certificate thumbprint validation such that we can use it for
any number of user specified hosts and transparently for service
ticketed hosts.

- Rename host.add/cluster.add 'fingerprint' flag to 'thumbprint'

- Update use of http.DefaultTransport fields to 1.7

- Add -version flag to about.cert command