### PR TITLE
Improve cluster/host add thumbprint support

### DIFF
--- a/govc/cluster/add.go
+++ b/govc/cluster/add.go
@@ -86,7 +86,7 @@ func (cmd *add) Add(ctx context.Context, cluster *object.ClusterComputeResource)
 		license = &cmd.license
 	}
 
-	task, err := cluster.AddHost(ctx, spec, cmd.connect, license, nil)
+	task, err := cluster.AddHost(ctx, cmd.Spec(cluster.Client()), cmd.connect, license, nil)
 	if err != nil {
 		return err
 	}
@@ -113,17 +113,5 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		return nil
 	}
 
-	err = cmd.Add(ctx, cluster)
-
-	if err == nil {
-		return nil
-	}
-
-	// Check if we failed due to SSLVerifyFault and -noverify is set
-	if err := cmd.AcceptThumbprint(err); err != nil {
-		return err
-	}
-
-	// Accepted unverified thumbprint, try again
-	return cmd.Add(ctx, cluster)
+	return cmd.Fault(cmd.Add(ctx, cluster))
 }

--- a/govc/host/add.go
+++ b/govc/host/add.go
@@ -85,7 +85,7 @@ this defaults to the hosts folder in the specified or default datacenter.`
 }
 
 func (cmd *add) Add(ctx context.Context, parent *object.Folder) error {
-	spec := cmd.HostConnectSpec
+	spec := cmd.Spec(parent.Client())
 
 	req := types.AddStandaloneHost_Task{
 		This:         parent.Reference(),
@@ -137,16 +137,5 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 	}
 
-	err := cmd.Add(ctx, parent)
-	if err == nil {
-		return nil
-	}
-
-	// Check if we failed due to SSLVerifyFault and -noverify is set
-	if err := cmd.AcceptThumbprint(err); err != nil {
-		return err
-	}
-
-	// Accepted unverified thumbprint, try again
-	return cmd.Add(ctx, parent)
+	return cmd.Fault(cmd.Add(ctx, parent))
 }


### PR DESCRIPTION
When using the '-noverify' flag, use the new object.HostCertificateInfo
helper to get the thumbprint, rather than re-trying the task with the
thumbprint from SSLVerifyFault.

GOVC_TLS_KNOWN_HOSTS can also be used to specify host thumbprints.