### PR TITLE
Add HostConfigManager field checks

### DIFF
--- a/object/common.go
+++ b/object/common.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	ErrNotSupported = errors.New("not supported (vCenter only)")
+	ErrNotSupported = errors.New("product/version specific feature not supported by target")
 )
 
 // Common contains the fields and functions common to all objects.

--- a/object/host_config_manager.go
+++ b/object/host_config_manager.go
@@ -97,6 +97,11 @@ func (m HostConfigManager) VsanSystem(ctx context.Context) (*HostVsanSystem, err
 		return nil, err
 	}
 
+	// Added in 5.5
+	if h.ConfigManager.VsanSystem == nil {
+		return nil, ErrNotSupported
+	}
+
 	return NewHostVsanSystem(m.c, *h.ConfigManager.VsanSystem), nil
 }
 
@@ -106,6 +111,11 @@ func (m HostConfigManager) AccountManager(ctx context.Context) (*HostAccountMana
 	err := m.Properties(ctx, m.Reference(), []string{"configManager.accountManager"}, &h)
 	if err != nil {
 		return nil, err
+	}
+
+	// Added in 6.0
+	if h.ConfigManager.AccountManager == nil {
+		return nil, ErrNotSupported
 	}
 
 	return NewHostAccountManager(m.c, *h.ConfigManager.AccountManager), nil
@@ -139,6 +149,11 @@ func (m HostConfigManager) CertificateManager(ctx context.Context) (*HostCertifi
 	err := m.Properties(ctx, m.Reference(), []string{"configManager.certificateManager"}, &h)
 	if err != nil {
 		return nil, err
+	}
+
+	// Added in 6.0
+	if h.ConfigManager.CertificateManager == nil {
+		return nil, ErrNotSupported
 	}
 
 	return NewHostCertificateManager(m.c, *h.ConfigManager.CertificateManager, m.Reference()), nil


### PR DESCRIPTION
Avoids panic when used against version that does not support fields
added in 5.5 and 6.0 versions.

Fixes #602