### PR TITLE
Fix snapshot.tree on vm with no snapshots

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -483,6 +483,10 @@ load test_helper
   vm=$(new_ttylinux_vm)
   id=$(new_id)
 
+  # No snapshots == no output
+  run govc snapshot.tree -vm "$vm"
+  assert_success ""
+
   run govc snapshot.remove -vm "$vm" '*'
   assert_success
 

--- a/govc/vm/snapshot/tree.go
+++ b/govc/vm/snapshot/tree.go
@@ -54,6 +54,16 @@ func (cmd *tree) Register(ctx context.Context, f *flag.FlagSet) {
 	f.BoolVar(&cmd.id, "i", false, "Print the snapshot id")
 }
 
+func (cmd *tree) Description() string {
+	return `List VM snapshots in a tree-like format.
+
+The command will exit 0 with no output if VM does not have any snapshots.
+
+Examples:
+  govc snapshot.tree -vm my-vm
+  govc snapshot.tree -vm my-vm -D -i`
+}
+
 func (cmd *tree) Process(ctx context.Context) error {
 	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
 		return err
@@ -117,6 +127,10 @@ func (cmd *tree) Run(ctx context.Context, f *flag.FlagSet) error {
 	err = vm.Properties(ctx, vm.Reference(), []string{"snapshot"}, &o)
 	if err != nil {
 		return err
+	}
+
+	if o.Snapshot == nil {
+		return nil
 	}
 
 	if cmd.current && o.Snapshot.CurrentSnapshot == nil {


### PR DESCRIPTION
Instead of panic (since Snapshot==nil), exit 0 with no output.

Fixes #611