### PR TITLE
Allow DatastoreFile follower to drain current body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+### unreleased
+
+* Allow DatastoreFile.Follow reader to drain current body after stopping
+
 ### 0.11.2 (2016-11-01)
 
 * Avoid possible NPE in VirtualMachine.Device method

--- a/govc/CHANGELOG.md
+++ b/govc/CHANGELOG.md
@@ -1,6 +1,10 @@
 # changelog
 
-### ### 0.11.2 (2016-11-01)
+### unreleased
+
+* datastore.tail -f will exit without error if the file no longer exists
+
+### 0.11.2 (2016-11-01)
 
 * Add object.reload command
 

--- a/govc/flags/version.go
+++ b/govc/flags/version.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-const Version = "0.11.2"
+const Version = "0.11.3"
 
 type version []int
 

--- a/govc/test/datastore_tail_test.sh
+++ b/govc/test/datastore_tail_test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -xe
+
+# This test is not run via bats as the bats pipeline hangs when we background a process
+
+. "$(dirname "$0")"/test_helper.bash
+
+name=$(new_id)
+n=16
+tmp=$(mktemp --tmpdir "${name}-XXXXX")
+
+echo -n | govc datastore.upload - "$name"
+govc datastore.tail -f "$name" > "$tmp" &
+pid=$!
+
+sleep 1
+yes | dd bs=${n}K count=1 2>/dev/null | govc datastore.upload - "$name"
+sleep 2
+
+# stops following when the file has gone away
+govc datastore.mv "$name" "${name}.old"
+wait $pid
+
+govc datastore.download "${name}.old" - | cmp "$tmp" -
+
+rm "$tmp"
+teardown


### PR DESCRIPTION
If the caller's buffer size is smaller than remaining request body, the
caller would miss data.

Return io.EOF if the file has gone away when we wake up in the poll
loop.

See PR #598