### PR TITLE
Add -product-version flag to dvs.create

### DIFF
--- a/govc/CHANGELOG.md
+++ b/govc/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### unreleased
 
+* Add `-product-version` flag to dvs.create
+
 * datastore.tail -f will exit without error if the file no longer exists
 
 ### 0.11.2 (2016-11-01)

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -593,8 +593,13 @@ Create DVS (DistributedVirtualSwitch) in datacenter.
 The dvs is added to the folder specified by the 'folder' flag. If not given,
 this defaults to the network folder in the specified or default datacenter.
 
+Examples:
+  govc dvs.create DSwitch
+  govc dvs.create -product-version 5.5.0 DSwitch
+
 Options:
   -folder=                  Inventory folder [GOVC_FOLDER]
+  -product-version=         DVS product version
 ```
 
 ## dvs.portgroup.add

--- a/govc/dvs/create.go
+++ b/govc/dvs/create.go
@@ -45,6 +45,9 @@ func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.configSpec = new(types.VMwareDVSConfigSpec)
 
 	cmd.DVSCreateSpec.ConfigSpec = cmd.configSpec
+	cmd.DVSCreateSpec.ProductInfo = new(types.DistributedVirtualSwitchProductSpec)
+
+	f.StringVar(&cmd.ProductInfo.Version, "product-version", "", "DVS product version")
 }
 
 func (cmd *create) Usage() string {
@@ -55,7 +58,11 @@ func (cmd *create) Description() string {
 	return `Create DVS (DistributedVirtualSwitch) in datacenter.
 
 The dvs is added to the folder specified by the 'folder' flag. If not given,
-this defaults to the network folder in the specified or default datacenter.`
+this defaults to the network folder in the specified or default datacenter.
+
+Examples:
+  govc dvs.create DSwitch
+  govc dvs.create -product-version 5.5.0 DSwitch`
 }
 
 func (cmd *create) Process(ctx context.Context) error {


### PR DESCRIPTION
If DVS is created without this flag, only hosts with version >= the VC
version can be added to the DVS by default.