### PR TITLE
Add basic VirtualNVMEController support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+### unreleased (N/A
+
+* Update to vim25/6.5 API
+
 ### 0.11.4 (2016-11-15)
 
 * Add object.AuthorizationManager methods: RetrieveRolePermissions, RetrieveAllPermissions, AddRole, RemoveRole, UpdateRole

--- a/govc/CHANGELOG.md
+++ b/govc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+### unreleased (N/A)
+
+* Add basic NVME controller support
+
 ### 0.11.4 (2016-11-15)
 
 * Add role create, remove, update, ls and usage commands

--- a/govc/vm/create.go
+++ b/govc/vm/create.go
@@ -330,13 +330,23 @@ func (cmd *create) createVM(ctx context.Context) (*object.Task, error) {
 
 func (cmd *create) addStorage(devices object.VirtualDeviceList) (object.VirtualDeviceList, error) {
 	if cmd.controller != "ide" {
-		scsi, err := devices.CreateSCSIController(cmd.controller)
-		if err != nil {
-			return nil, err
-		}
+		if cmd.controller == "nvme" {
+			nvme, err := devices.CreateNVMEController()
+			if err != nil {
+				return nil, err
+			}
 
-		devices = append(devices, scsi)
-		cmd.controller = devices.Name(scsi)
+			devices = append(devices, nvme)
+			cmd.controller = devices.Name(nvme)
+		} else {
+			scsi, err := devices.CreateSCSIController(cmd.controller)
+			if err != nil {
+				return nil, err
+			}
+
+			devices = append(devices, scsi)
+			cmd.controller = devices.Name(scsi)
+		}
 	}
 
 	// If controller is specified to be IDE or if an ISO is specified, add IDE controller.


### PR DESCRIPTION
Requires vim-version set to 6.5 either via vim-version flag or via
GOVC_VIM_VERSION environment variable. Eg;

```
govc vm.create -vim-version=6.5 -on=false -ds=SSD -net "VM Network" -m 2048 -c 2 -g "vmkernel65Guest" -net.adapter=vmxnet3 -disk.controller nvme esxi
```