### PR TITLE
Attach context to HTTP requests for cancellations

### DIFF
--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -392,29 +392,7 @@ func (c *Client) do(ctx context.Context, req *http.Request) (*http.Response, err
 		return c.Client.Do(req)
 	}
 
-	var resc = make(chan *http.Response, 1)
-	var errc = make(chan error, 1)
-
-	// Perform request from separate routine.
-	go func() {
-		res, err := c.Client.Do(req)
-		if err != nil {
-			errc <- err
-		} else {
-			resc <- res
-		}
-	}()
-
-	// Wait for request completion of context expiry.
-	select {
-	case <-ctx.Done():
-		c.t.CancelRequest(req)
-		return nil, ctx.Err()
-	case err := <-errc:
-		return nil, err
-	case res := <-resc:
-		return res, nil
-	}
+	return c.Client.Do(req.WithContext(ctx))
 }
 
 func (c *Client) RoundTrip(ctx context.Context, reqBody, resBody HasFault) error {


### PR DESCRIPTION
`http.Transport.CancelRequest` is deprecated, and `http.Request.WithContext` should be used instead.

The motivation for this change is that there appears to be a connection leak somewhere in govmomi where it doesn't close response bodies, leaving connections and goroutines leaked. We're running a long-running server that interacts with vSphere fairly regularly, and whenever we have requests that get their contexts cancelled, the goroutine count goes up and the number of open TCP connections to our vSphere API goes up. After digging through the code, I found that this is the only place where HTTP requests are made, and as far as I can see if `soap.Client.do` returns a response, then `soap.Client.Do` will `defer res.Body.Close()`. So, then my guess is that `http.Client.Do` returns a response, but `soap.Client.do` doesn't return it, which as far as I can see is only possible when the `c.t.CancelRequest` branch is called.

My hope is that this change will keep the cancellation functionality while also removing a possibility for a connection to leak if the request _is_ cancelled.