### PR TITLE
govc/version: skip first char in git version mismatch error

### DIFF
--- a/govc/version/command.go
+++ b/govc/version/command.go
@@ -37,7 +37,7 @@ type version struct {
 func init() {
 	// Check that git tag in the release builds match the hardcoded version
 	if gitVersion != "" && gitVersion[1:] != flags.Version {
-		log.Panicf("version mismatch: git=%s vs govc=%s", gitVersion, flags.Version)
+		log.Panicf("version mismatch: git=%s vs govc=%s", gitVersion[1:], flags.Version)
 	}
 
 	cli.Register("version", &version{})


### PR DESCRIPTION
The comparison skips it, so if you set `flags.Version` to `v1.2.3` you can get confusing messages like "version mismatch: git=v1.2.3 vs govc=v1.2.3".