### PR TITLE
Add object.collect command

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1671,6 +1671,30 @@ Options:
   -t=                       Object type
 ```
 
+## object.collect
+
+```
+Usage: govc object.collect [OPTIONS] [MOID] [PROPERTY]...
+
+Collect managed object properties.
+
+MOID can be an inventory path or ManagedObjectReference.
+MOID defaults to '-', an alias for 'ServiceInstance:ServiceInstance'.
+
+By default only the current property value(s) are collected.  Use the '-n' flag to wait for updates.
+
+Examples:
+  govc object.collect - content
+  govc object.collect -s HostSystem:ha-host hardware.systemInfo.uuid
+  govc object.collect -s /ha-datacenter/vm/foo overallStatus
+  govc object.collect -json -n=-1 EventManager:ha-eventmgr latestEvent | jq .
+  govc object.collect -json -s $(govc object.collect -s - content.perfManager) description.counterType | jq .
+
+Options:
+  -n=0                      Wait for N property updates
+  -s=false                  Output property value only
+```
+
 ## object.destroy
 
 ```

--- a/govc/ls/command.go
+++ b/govc/ls/command.go
@@ -104,6 +104,11 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 			e, err := finder.Element(ctx, *ref)
 			if err == nil {
 				if cmd.typeMatch(*ref) {
+					if e.Path == "/" && ref.Type != "Folder" {
+						// Special case: when given a moref with no ancestors,
+						// just echo the moref.
+						e.Path = ref.String()
+					}
 					lr.Elements = append(lr.Elements, *e)
 				}
 				continue

--- a/govc/object/collect.go
+++ b/govc/object/collect.go
@@ -1,0 +1,239 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type collect struct {
+	*flags.DatacenterFlag
+
+	single bool
+	simple bool
+	n      int
+}
+
+func init() {
+	cli.Register("object.collect", &collect{})
+}
+
+func (cmd *collect) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.simple, "s", false, "Output property value only")
+	f.IntVar(&cmd.n, "n", 0, "Wait for N property updates")
+}
+
+func (cmd *collect) Usage() string {
+	return "[MOID] [PROPERTY]..."
+}
+
+func (cmd *collect) Description() string {
+	return `Collect managed object properties.
+
+MOID can be an inventory path or ManagedObjectReference.
+MOID defaults to '-', an alias for 'ServiceInstance:ServiceInstance'.
+
+By default only the current property value(s) are collected.  Use the '-n' flag to wait for updates.
+
+Examples:
+  govc object.collect - content
+  govc object.collect -s HostSystem:ha-host hardware.systemInfo.uuid
+  govc object.collect -s /ha-datacenter/vm/foo overallStatus
+  govc object.collect -json -n=-1 EventManager:ha-eventmgr latestEvent | jq .
+  govc object.collect -json -s $(govc object.collect -s - content.perfManager) description.counterType | jq .`
+}
+
+func (cmd *collect) Process(ctx context.Context) error {
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+var stringer = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+
+type change struct {
+	cmd            *collect
+	PropertyChange []types.PropertyChange
+}
+
+func (pc *change) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pc.PropertyChange)
+}
+
+func (pc *change) output(name string, rval reflect.Value, rtype reflect.Type) {
+	s := "..."
+
+	kind := rval.Kind()
+
+	if kind == reflect.Ptr || kind == reflect.Interface {
+		if rval.IsNil() {
+			s = ""
+		} else {
+			rval = rval.Elem()
+			kind = rval.Kind()
+		}
+	}
+
+	switch kind {
+	case reflect.Ptr, reflect.Interface:
+	case reflect.Slice:
+		if rval.Len() == 0 {
+			s = ""
+			break
+		}
+
+		etype := rtype.Elem()
+
+		if etype.Kind() != reflect.Interface && etype.Kind() != reflect.Struct || etype.Implements(stringer) {
+			var val []string
+
+			for i := 0; i < rval.Len(); i++ {
+				v := rval.Index(i).Interface()
+
+				if fstr, ok := v.(fmt.Stringer); ok {
+					s = fstr.String()
+				} else {
+					s = fmt.Sprintf("%v", v)
+				}
+
+				val = append(val, s)
+			}
+
+			s = strings.Join(val, ",")
+		}
+	case reflect.Struct:
+		if rtype.Implements(stringer) {
+			s = rval.Interface().(fmt.Stringer).String()
+		}
+	default:
+		s = fmt.Sprintf("%v", rval.Interface())
+	}
+
+	if pc.cmd.simple {
+		fmt.Fprintln(pc.cmd.Out, s)
+		return
+	}
+
+	fmt.Fprintf(pc.cmd.Out, "%s\t%s\t%s\n", name, rtype, s)
+}
+
+func (pc *change) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(pc.cmd.Out, 4, 0, 2, ' ', 0)
+	pc.cmd.Out = tw
+
+	for _, c := range pc.PropertyChange {
+		if c.Val == nil {
+			// type is unknown in this case, as xsi:type was not provided - just skip for now
+			continue
+		}
+
+		rval := reflect.ValueOf(c.Val)
+		rtype := rval.Type()
+
+		if strings.HasPrefix(rtype.Name(), "ArrayOf") {
+			rval = rval.Field(0)
+			rtype = rval.Type()
+		}
+
+		if pc.cmd.single && rtype.Kind() == reflect.Struct && !rtype.Implements(stringer) {
+			for i := 0; i < rval.NumField(); i++ {
+				fval := rval.Field(i)
+				field := rtype.Field(i)
+
+				if field.Anonymous {
+					continue
+				}
+
+				fname := fmt.Sprintf("%s.%s%s", c.Name, strings.ToLower(field.Name[:1]), field.Name[1:])
+				pc.output(fname, fval, field.Type)
+			}
+			continue
+		}
+
+		pc.output(c.Name, rval, rtype)
+	}
+
+	return tw.Flush()
+}
+
+func (cmd *collect) Run(ctx context.Context, f *flag.FlagSet) error {
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	ref := methods.ServiceInstance
+	arg := f.Arg(0)
+
+	switch arg {
+	case "", "-":
+	default:
+		if !ref.FromString(arg) {
+			l, ferr := finder.ManagedObjectList(ctx, arg)
+			if ferr != nil {
+				return err
+			}
+
+			switch len(l) {
+			case 0:
+				return fmt.Errorf("%s not found", arg)
+			case 1:
+				ref = l[0].Object.Reference()
+			default:
+				return flag.ErrHelp
+			}
+		}
+	}
+
+	p := property.DefaultCollector(client)
+
+	var props []string
+	if f.NArg() > 1 {
+		props = f.Args()[1:]
+		cmd.single = len(props) == 1
+	}
+
+	return property.Wait(ctx, p, ref, props, func(pc []types.PropertyChange) bool {
+		_ = cmd.WriteResult(&change{cmd, pc})
+
+		cmd.n--
+
+		return cmd.n == -1
+	})
+}

--- a/govc/test/ls.bats
+++ b/govc/test/ls.bats
@@ -113,4 +113,11 @@ load test_helper
 
         assert_equal "$items1" "$items2"
     done
+
+    ref=ViewManager:ViewManager
+    path=$(govc ls -L $ref)
+    assert_equal "$ref" "$path"
+
+    path=$(govc ls -L Folder:ha-folder-root)
+    assert_equal "/" "$path"
 }

--- a/property/wait.go
+++ b/property/wait.go
@@ -61,6 +61,10 @@ func Wait(ctx context.Context, c *Collector, obj types.ManagedObjectReference, p
 		},
 	}
 
+	if len(ps) == 0 {
+		req.Spec.PropSet[0].All = types.NewBool(true)
+	}
+
 	err = p.CreateFilter(ctx, req)
 	if err != nil {
 		return err

--- a/vim25/methods/service_content.go
+++ b/vim25/methods/service_content.go
@@ -24,14 +24,14 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-var serviceInstance = types.ManagedObjectReference{
+var ServiceInstance = types.ManagedObjectReference{
 	Type:  "ServiceInstance",
 	Value: "ServiceInstance",
 }
 
 func GetServiceContent(ctx context.Context, r soap.RoundTripper) (types.ServiceContent, error) {
 	req := types.RetrieveServiceContent{
-		This: serviceInstance,
+		This: ServiceInstance,
 	}
 
 	res, err := RetrieveServiceContent(ctx, r, &req)
@@ -44,7 +44,7 @@ func GetServiceContent(ctx context.Context, r soap.RoundTripper) (types.ServiceC
 
 func GetCurrentTime(ctx context.Context, r soap.RoundTripper) (*time.Time, error) {
 	req := types.CurrentTime{
-		This: serviceInstance,
+		This: ServiceInstance,
 	}
 
 	res, err := CurrentTime(ctx, r, &req)

--- a/vim25/mo/ancestors.go
+++ b/vim25/mo/ancestors.go
@@ -39,13 +39,28 @@ func Ancestors(ctx context.Context, rt soap.RoundTripper, pc, obj types.ManagedO
 					&types.SelectionSpec{Name: "traverseParent"},
 				},
 			},
+			&types.TraversalSpec{
+				SelectionSpec: types.SelectionSpec{},
+				Type:          "VirtualMachine",
+				Path:          "parentVApp",
+				Skip:          types.NewBool(false),
+				SelectSet: []types.BaseSelectionSpec{
+					&types.SelectionSpec{Name: "traverseParent"},
+				},
+			},
 		},
 		Skip: types.NewBool(false),
 	}
 
-	pspec := types.PropertySpec{
-		Type:    "ManagedEntity",
-		PathSet: []string{"name", "parent"},
+	pspec := []types.PropertySpec{
+		{
+			Type:    "ManagedEntity",
+			PathSet: []string{"name", "parent"},
+		},
+		{
+			Type:    "VirtualMachine",
+			PathSet: []string{"parentVApp"},
+		},
 	}
 
 	req := types.RetrieveProperties{
@@ -53,13 +68,12 @@ func Ancestors(ctx context.Context, rt soap.RoundTripper, pc, obj types.ManagedO
 		SpecSet: []types.PropertyFilterSpec{
 			{
 				ObjectSet: []types.ObjectSpec{ospec},
-				PropSet:   []types.PropertySpec{pspec},
+				PropSet:   pspec,
 			},
 		},
 	}
 
 	var ifaces []interface{}
-
 	err := RetrievePropertiesForRequest(ctx, rt, req, &ifaces)
 	if err != nil {
 		return nil, err
@@ -93,6 +107,15 @@ func Ancestors(ctx context.Context, rt soap.RoundTripper, pc, obj types.ManagedO
 				default:
 					// ManagedEntity always has a Name, if we hit this point we missed a case above.
 					panic(fmt.Sprintf("%#v Name is empty", me.Reference()))
+				}
+			}
+
+			if me.Parent == nil {
+				// Special case for VirtualMachine within VirtualApp,
+				// unlikely to hit this other than via Finder.Element()
+				switch x := iface.(type) {
+				case VirtualMachine:
+					me.Parent = x.ParentVApp
 				}
 			}
 


### PR DESCRIPTION
Generic interface to the property.Wait method, where properties can be collected from any managed object.

Emacs interface provides MOB (Managed Object Browser) functionality.