### PR TITLE
Attach and list RDM/LUN

### DIFF
--- a/govc/main.go
+++ b/govc/main.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 
-	_ "github.com/bastienbc/govmomi/govc/vm/rdm"
 	_ "github.com/vmware/govmomi/govc/about"
 	_ "github.com/vmware/govmomi/govc/cluster"
 	_ "github.com/vmware/govmomi/govc/datacenter"
@@ -68,6 +67,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/vm/disk"
 	_ "github.com/vmware/govmomi/govc/vm/guest"
 	_ "github.com/vmware/govmomi/govc/vm/network"
+	_ "github.com/vmware/govmomi/govc/vm/rdm"
 	_ "github.com/vmware/govmomi/govc/vm/snapshot"
 )
 

--- a/govc/main.go
+++ b/govc/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 
+	_ "github.com/bastienbc/govmomi/govc/vm/rdm"
 	_ "github.com/vmware/govmomi/govc/about"
 	_ "github.com/vmware/govmomi/govc/cluster"
 	_ "github.com/vmware/govmomi/govc/datacenter"

--- a/govc/vm/rdm/attach.go
+++ b/govc/vm/rdm/attach.go
@@ -1,0 +1,152 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdm
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type attach struct {
+	*flags.VirtualMachineFlag
+
+	device string
+}
+
+func init() {
+	cli.Register("vm.rdm.attach", &attach{})
+}
+
+func (cmd *attach) Register(ctx context.Context, f *flag.FlagSet) {
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.device, "deviceName", "", "Device Name")
+}
+
+func (cmd *attach) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	controller, err := devices.FindSCSIController("")
+	if err != nil {
+		return err
+	}
+	var VM_withProp mo.VirtualMachine
+	err = vm.Properties(ctx, vm.Reference(), []string{"environmentBrowser"}, &VM_withProp)
+	if err != nil {
+		return err
+	}
+
+	//Query VM To Find Devices avilable for attaching to VM
+	var queryConfigRequest types.QueryConfigTarget
+	queryConfigRequest.This = VM_withProp.EnvironmentBrowser
+	cl, err := cmd.Client()
+	queryConfigResp, err := methods.QueryConfigTarget(ctx, cl, &queryConfigRequest)
+	if err != nil {
+		return err
+	}
+	vmConfigOptions := *queryConfigResp.Returnval
+	for _, ScsiDisk := range vmConfigOptions.ScsiDisk {
+		if !strings.Contains(ScsiDisk.Disk.CanonicalName, cmd.device) {
+			continue
+		}
+		var backing types.VirtualDiskRawDiskMappingVer1BackingInfo
+		backing.CompatibilityMode = "physicalMode"
+		backing.DeviceName = ScsiDisk.Disk.DeviceName
+		for _, descriptor := range ScsiDisk.Disk.Descriptor {
+			if string([]rune(descriptor.Id)[:4]) == "vml." {
+				backing.LunUuid = descriptor.Id
+				break
+			}
+		}
+		var device types.VirtualDisk
+		device.Backing = &backing
+		device.ControllerKey = controller.VirtualController.Key
+
+		var unitNumber *int32
+		scsiCtrlUnitNumber := controller.VirtualController.UnitNumber
+		var u int32
+		for u = 0; u < 16; u++ {
+			free := true
+			for _, device := range devices {
+				if device.GetVirtualDevice().ControllerKey == device.GetVirtualDevice().ControllerKey {
+					if u == *(device.GetVirtualDevice().UnitNumber) || u == *scsiCtrlUnitNumber {
+						free = false
+					}
+				}
+			}
+			if free {
+				unitNumber = &u
+				break
+			}
+		}
+		device.UnitNumber = unitNumber
+
+		spec := types.VirtualMachineConfigSpec{}
+
+		config := &types.VirtualDeviceConfigSpec{
+			Device:    &device,
+			Operation: types.VirtualDeviceConfigSpecOperationAdd,
+		}
+
+		config.FileOperation = types.VirtualDeviceConfigSpecFileOperationCreate
+
+		spec.DeviceChange = append(spec.DeviceChange, config)
+
+		task, err := vm.Reconfigure(ctx, spec)
+		if err != nil {
+			return err
+		}
+
+		err = task.Wait(ctx)
+		if err != nil {
+			return errors.New(fmt.Sprintf("Error adding device %+v \n with backing %+v \nLogged Item:  %s", device, backing, err))
+		}
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Error: No LUN with device name containing %s found.", cmd.device))
+}

--- a/govc/vm/rdm/attach.go
+++ b/govc/vm/rdm/attach.go
@@ -45,6 +45,13 @@ func (cmd *attach) Register(ctx context.Context, f *flag.FlagSet) {
 	f.StringVar(&cmd.device, "deviceName", "", "Device Name")
 }
 
+func (cmd *attach) Description() string {
+	return `Attach DEVICE to VM with RDM.
+
+Examples:
+  govc vm.rdm.attach -vm VM -deviceName DEVICE`
+}
+
 func (cmd *attach) Process(ctx context.Context) error {
 	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
 		return err

--- a/govc/vm/rdm/ls.go
+++ b/govc/vm/rdm/ls.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	vmConfigOptions, err := vm.QueryEnvironmentBrowser(ctx)
+	vmConfigOptions, err := vm.QueryConfigTarget(ctx)
 	if err != nil {
 		return err
 	}

--- a/govc/vm/rdm/ls.go
+++ b/govc/vm/rdm/ls.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ls struct {
+	*flags.VirtualMachineFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("vm.rdm.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	var VM_withProp mo.VirtualMachine
+	err = vm.Properties(ctx, vm.Reference(), []string{"environmentBrowser"}, &VM_withProp)
+	if err != nil {
+		return err
+	}
+
+	//Query VM To Find Devices available
+	var queryConfigRequest types.QueryConfigTarget
+	queryConfigRequest.This = VM_withProp.EnvironmentBrowser
+	cl, err := cmd.Client()
+	queryConfigResp, err := methods.QueryConfigTarget(ctx, cl, &queryConfigRequest)
+	if err != nil {
+		return err
+	}
+	vmConfigOptions := *queryConfigResp.Returnval
+	res := infoResult{
+		Disks: vmConfigOptions.ScsiDisk,
+	}
+	return cmd.WriteResult(&res)
+}
+
+type infoResult struct {
+	Disks []types.VirtualMachineScsiDiskDeviceInfo
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+	for _, disk := range r.Disks {
+		fmt.Fprintf(tw, "Name:\t%s\n", disk.Name)
+		fmt.Fprintf(tw, "	Device name:\t%s\n", disk.Disk.DeviceName)
+		fmt.Fprintf(tw, "	Device path:\t%s\n", disk.Disk.DevicePath)
+		fmt.Fprintf(tw, "	Canonical Name:\t%s\n", disk.Disk.CanonicalName)
+
+		var uids []string
+		for _, descriptor := range disk.Disk.Descriptor {
+			uids = append(uids, descriptor.Id)
+		}
+
+		fmt.Fprintf(tw, "	UIDS:\t%s\n", strings.Join(uids, " ,"))
+	}
+	return tw.Flush()
+}

--- a/govc/vm/rdm/ls.go
+++ b/govc/vm/rdm/ls.go
@@ -47,6 +47,13 @@ func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.OutputFlag.Register(ctx, f)
 }
 
+func (cmd *ls) Description() string {
+	return `List available devices that could be attach to VM with RDM.
+
+Examples:
+  govc vm.rdm.ls -vm VM`
+}
+
 func (cmd *ls) Process(ctx context.Context) error {
 
 	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -691,7 +691,7 @@ func (v VirtualMachine) Unregister(ctx context.Context) error {
 }
 
 // QueryEnvironmentBrowser is a helper to get the environmentBrowser property.
-func (v VirtualMachine) QueryEnvironmentBrowser(ctx context.Context) (*types.ConfigTarget, error) {
+func (v VirtualMachine) QueryConfigTarget(ctx context.Context) (*types.ConfigTarget, error) {
 	var vm mo.VirtualMachine
 
 	err := v.Properties(ctx, v.Reference(), []string{"environmentBrowser"}, &vm)

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -689,3 +689,24 @@ func (v VirtualMachine) Unregister(ctx context.Context) error {
 	_, err := methods.UnregisterVM(ctx, v.Client(), &req)
 	return err
 }
+
+// QueryEnvironmentBrowser is a helper to get the environmentBrowser property.
+func (v VirtualMachine) QueryEnvironmentBrowser(ctx context.Context) (*types.ConfigTarget, error) {
+	var vm mo.VirtualMachine
+
+	err := v.Properties(ctx, v.Reference(), []string{"environmentBrowser"}, &vm)
+	if err != nil {
+		return nil, err
+	}
+
+	req := types.QueryConfigTarget{
+		This: vm.EnvironmentBrowser,
+	}
+
+	res, err := methods.QueryConfigTarget(ctx, v.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}


### PR DESCRIPTION
govc does not provide command line options to:

- attach RDM using the device name.
- list available devices for a specific VM, retrieving various useful information ( UIDS, Device name, Device path, ... )