### PR TITLE
Add the option to describe a VM using the annotation option

### DIFF
--- a/govc/vm/clone.go
+++ b/govc/vm/clone.go
@@ -49,6 +49,7 @@ type clone struct {
 	template      bool
 	customization string
 	waitForIP     bool
+	annotation    string
 
 	Client         *vim25.Client
 	Datacenter     *object.Datacenter
@@ -99,6 +100,7 @@ func (cmd *clone) Register(ctx context.Context, f *flag.FlagSet) {
 	f.BoolVar(&cmd.template, "template", false, "Create a Template")
 	f.StringVar(&cmd.customization, "customization", "", "Customization Specification Name")
 	f.BoolVar(&cmd.waitForIP, "waitip", false, "Wait for VM to acquire IP address")
+	f.StringVar(&cmd.annotation, "annotation", "", "VM description")
 }
 
 func (cmd *clone) Usage() string {
@@ -226,6 +228,7 @@ func (cmd *clone) Run(ctx context.Context, f *flag.FlagSet) error {
 		if cmd.memory > 0 {
 			vmConfigSpec.MemoryMB = int64(cmd.memory)
 		}
+		vmConfigSpec.Annotation = cmd.annotation
 		task, err := vm.Reconfigure(ctx, vmConfigSpec)
 		if err != nil {
 			return err

--- a/govc/vm/create.go
+++ b/govc/vm/create.go
@@ -49,6 +49,7 @@ type create struct {
 	on         bool
 	force      bool
 	controller string
+	annotation string
 
 	iso              string
 	isoDatastoreFlag *flags.DatastoreFlag
@@ -107,6 +108,7 @@ func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 	f.BoolVar(&cmd.on, "on", true, "Power on VM. Default is true if -disk argument is given.")
 	f.BoolVar(&cmd.force, "force", false, "Create VM if vmx already exists")
 	f.StringVar(&cmd.controller, "disk.controller", "scsi", "Disk controller type")
+	f.StringVar(&cmd.annotation, "annotation", "", "VM description")
 
 	f.StringVar(&cmd.iso, "iso", "", "ISO path")
 	cmd.isoDatastoreFlag, ctx = flags.NewCustomDatastoreFlag(ctx)
@@ -274,10 +276,11 @@ func (cmd *create) createVM(ctx context.Context) (*object.Task, error) {
 	var err error
 
 	spec := &types.VirtualMachineConfigSpec{
-		Name:     cmd.name,
-		GuestId:  cmd.guestID,
-		NumCPUs:  int32(cmd.cpus),
-		MemoryMB: int64(cmd.memory),
+		Name:       cmd.name,
+		GuestId:    cmd.guestID,
+		NumCPUs:    int32(cmd.cpus),
+		MemoryMB:   int64(cmd.memory),
+		Annotation: cmd.annotation,
 	}
 
 	devices, err = cmd.addStorage(nil)


### PR DESCRIPTION
govc does not provide command line options to describe a VM.
Using the annotation field in VirtualMachineConfigSpec, vm.create and vm.clone now both have this option.