### PR TITLE
Add device option to WaitForNetIP

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -2169,6 +2169,7 @@ Examples:
   govc vm.clone -vm template-vm new-vm
 
 Options:
+  -annotation=              VM description
   -c=0                      Number of CPUs
   -customization=           Customization Specification Name
   -datastore-cluster=       Datastore cluster [GOVC_DATASTORE_CLUSTER]
@@ -2193,6 +2194,7 @@ Options:
 Usage: govc vm.create [OPTIONS]
 
 Options:
+  -annotation=              VM description
   -c=1                      Number of CPUs
   -datastore-cluster=       Datastore cluster [GOVC_DATASTORE_CLUSTER]
   -disk=                    Disk path (to use existing) OR size (to create new, e.g. 20GB)
@@ -2287,18 +2289,23 @@ These values can also be obtained using:
 
   govc vm.info -json $vm | jq -r .VirtualMachines[].Guest.Net[].IpConfig.IpAddress[].IpAddress
 
+When given the '-n' flag, filters '-a' behavior to the nic specified by MAC address or device name.
+
 The 'esxcli' flag does not require vmware-tools to be installed, but does require the ESX host to
 have the /Net/GuestIPHack setting enabled.
 
 Examples:
   govc vm.ip $vm
   govc vm.ip -a -v4 $vm
+  govc vm.ip -n 00:0c:29:57:7b:c3 $vm
+  govc vm.ip -n ethernet-0 $vm
   govc host.esxcli system settings advanced set -o /Net/GuestIPHack -i 1
   govc vm.ip -esxcli $vm
 
 Options:
   -a=false                  Wait for an IP address on all NICs
   -esxcli=false             Use esxcli instead of guest tools
+  -n=                       Wait for IP address on NIC, specified by device name or MAC
   -v4=false                 Only report IPv4 addresses
 ```
 

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -13,6 +13,21 @@ load test_helper
 
   run govc vm.ip -a -v4 $id
   assert_success
+
+  run govc vm.ip -n $(vm_mac $id) $id
+  assert_success
+
+  run govc vm.ip -n ethernet-0 $id
+  assert_success
+
+  ip=$(govc vm.ip $id)
+
+  # add a second nic
+  run govc vm.network.add -vm $id "VM Network"
+  assert_success
+
+  res=$(govc vm.ip -n ethernet-0 $id)
+  assert_equal $ip $res
 }
 
 @test "vm.ip -esxcli" {

--- a/govc/vm/ip.go
+++ b/govc/vm/ip.go
@@ -36,6 +36,7 @@ type ip struct {
 	esx bool
 	all bool
 	v4  bool
+	nic string
 }
 
 func init() {
@@ -51,6 +52,7 @@ func (cmd *ip) Register(ctx context.Context, f *flag.FlagSet) {
 
 	f.BoolVar(&cmd.esx, "esxcli", false, "Use esxcli instead of guest tools")
 	f.BoolVar(&cmd.all, "a", false, "Wait for an IP address on all NICs")
+	f.StringVar(&cmd.nic, "n", "", "Wait for IP address on NIC, specified by device name or MAC")
 	f.BoolVar(&cmd.v4, "v4", false, "Only report IPv4 addresses")
 }
 
@@ -76,12 +78,16 @@ These values can also be obtained using:
 
   govc vm.info -json $vm | jq -r .VirtualMachines[].Guest.Net[].IpConfig.IpAddress[].IpAddress
 
+When given the '-n' flag, filters '-a' behavior to the nic specified by MAC address or device name.
+
 The 'esxcli' flag does not require vmware-tools to be installed, but does require the ESX host to
 have the /Net/GuestIPHack setting enabled.
 
 Examples:
   govc vm.ip $vm
   govc vm.ip -a -v4 $vm
+  govc vm.ip -n 00:0c:29:57:7b:c3 $vm
+  govc vm.ip -n ethernet-0 $vm
   govc host.esxcli system settings advanced set -o /Net/GuestIPHack -i 1
   govc vm.ip -esxcli $vm`
 }
@@ -131,9 +137,14 @@ func (cmd *ip) Run(ctx context.Context, f *flag.FlagSet) error {
 			}
 		}
 	} else {
+		var hwaddr []string
+		if cmd.nic != "" {
+			hwaddr = strings.Split(cmd.nic, ",")
+		}
+
 		get = func(vm *object.VirtualMachine) (string, error) {
-			if cmd.all {
-				macs, err := vm.WaitForNetIP(ctx, cmd.v4)
+			if cmd.all || hwaddr != nil {
+				macs, err := vm.WaitForNetIP(ctx, cmd.v4, hwaddr...)
 				if err != nil {
 					return "", err
 				}


### PR DESCRIPTION
With this option, WaitForNetIP can specify NIC(s) by MAC address or device name.

Fixes #653