### PR TITLE
Handle nil TaskInfo in task.Wait callback

### DIFF
--- a/task/wait.go
+++ b/task/wait.go
@@ -37,7 +37,7 @@ func (t taskProgress) Detail() string {
 }
 
 func (t taskProgress) Error() error {
-	if t.info.Error != nil {
+	if t.info != nil && t.info.Error != nil {
 		return Error{t.info.Error}
 	}
 


### PR DESCRIPTION
Property collector returns nil when it cannot find the task, handle
that case in the Error method which gets called by callback. Otherwise
we panic.

Towards https://github.com/vmware/vic/issues/3868