### PR TITLE
Handle nil TaskInfo in task.Wait callback #2

### DIFF
--- a/task/wait.go
+++ b/task/wait.go
@@ -37,7 +37,7 @@ func (t taskProgress) Detail() string {
 }
 
 func (t taskProgress) Error() error {
-	if t.info != nil && t.info.Error != nil {
+	if t.info.Error != nil {
 		return Error{t.info.Error}
 	}
 
@@ -66,6 +66,11 @@ func (t *taskCallback) fn(pc []types.PropertyChange) bool {
 
 		ti := c.Val.(types.TaskInfo)
 		t.info = &ti
+	}
+
+	// t.info could be nil if pc can't satify the rules above
+	if t.info == nil {
+		return false
 	}
 
 	pr := taskProgress{t.info}

--- a/task/wait_test.go
+++ b/task/wait_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package task
+
+import (
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestCallbackFn(t *testing.T) {
+	cb := &taskCallback{}
+
+	for _, o := range []types.PropertyChangeOp{types.PropertyChangeOpAdd, types.PropertyChangeOpRemove, types.PropertyChangeOpAssign, types.PropertyChangeOpIndirectRemove} {
+		for _, s := range []types.TaskInfoState{types.TaskInfoStateQueued, types.TaskInfoStateRunning, types.TaskInfoStateSuccess, types.TaskInfoStateError} {
+			c := types.PropertyChange{
+				Name: "info",
+				Op:   o,
+				Val: types.TaskInfo{
+					State: s,
+				},
+			}
+			t.Logf("Op: %s State: %s", o, s)
+			cb.fn([]types.PropertyChange{c})
+		}
+	}
+}


### PR DESCRIPTION
We loop over []types.PropertyChange slice and look for a certain name,
op and value before setting t.info.

t.info could be nil if we can't find a PropertyChange that fits into ruleset.
Handle that and also add a test to test that.