### PR TITLE
Host is optional for MarkAsVirtualMachine

### DIFF
--- a/govc/vm/markastemplate.go
+++ b/govc/vm/markastemplate.go
@@ -25,7 +25,6 @@ import (
 )
 
 type markastemplate struct {
-	*flags.ClientFlag
 	*flags.SearchFlag
 }
 
@@ -34,21 +33,26 @@ func init() {
 }
 
 func (cmd *markastemplate) Register(ctx context.Context, f *flag.FlagSet) {
-	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
-	cmd.ClientFlag.Register(ctx, f)
-
 	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualMachines)
 	cmd.SearchFlag.Register(ctx, f)
 }
 
 func (cmd *markastemplate) Process(ctx context.Context) error {
-	if err := cmd.ClientFlag.Process(ctx); err != nil {
-		return err
-	}
 	if err := cmd.SearchFlag.Process(ctx); err != nil {
 		return err
 	}
 	return nil
+}
+
+func (cmd *markastemplate) Usage() string {
+	return "VM..."
+}
+
+func (cmd *markastemplate) Description() string {
+	return `Mark VM as a virtual machine template.
+
+Examples:
+  govc vm.markastemplate $name`
 }
 
 func (cmd *markastemplate) Run(ctx context.Context, f *flag.FlagSet) error {


### PR DESCRIPTION
The vm.markasvm command had required the host flag,
but it is optional in the API.
Add the pool flag to avoid specifying a host.