### PR TITLE
Remove deferred Close() call in follower's Read()

### DIFF
--- a/object/datastore_file.go
+++ b/object/datastore_file.go
@@ -344,8 +344,6 @@ func (f *followDatastoreFile) Read(p []byte) (int, error) {
 	offset := f.r.offset.seek
 	stop := false
 
-	defer f.r.Close()
-
 	for {
 		n, err := f.r.Read(p)
 		if err != nil && err == io.EOF {


### PR DESCRIPTION
This removes the deferred call to `Close()` in the datastore file follower's `Read()` method. This prevents `Close()` from being called prematurely when `EOF` is not encountered after a read.