### PR TITLE
Add performance manager and govc metric commands

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1743,6 +1743,127 @@ Options:
   -t=                       Object type
 ```
 
+## metric.change
+
+```
+Usage: govc metric.change [OPTIONS] NAME...
+
+Change counter NAME levels.
+
+Examples:
+  govc metric.change -level 1 net.bytesRx.average net.bytesTx.average
+
+Options:
+  -device-level=0           Level for the per device counter
+  -i=0                      Interval ID
+  -level=0                  Level for the aggregate counter
+```
+
+## metric.info
+
+```
+Usage: govc metric.info [OPTIONS] PATH [NAME]...
+
+Metric info for NAME.
+
+If PATH is a value other than '-', provider summary and instance list are included
+for the given object type.
+
+If NAME is not specified, all available metrics for the given INTERVAL are listed.
+An object PATH must be provided in this case.
+
+Examples:
+  govc metric.info vm/my-vm
+  govc metric.info -i 300 vm/my-vm
+  govc metric.info - cpu.usage.average
+  govc metric.info /dc1/host/cluster cpu.usage.average
+
+Options:
+  -i=0                      Interval ID
+```
+
+## metric.interval.change
+
+```
+Usage: govc metric.interval.change [OPTIONS]
+
+Change historical metric intervals.
+
+Examples:
+  govc metric.interval.change -i 300 -level 2
+  govc metric.interval.change -i 86400 -enabled=false
+
+Options:
+  -enabled=<nil>            Enable or disable
+  -i=0                      Interval ID
+  -level=0                  Level
+```
+
+## metric.interval.info
+
+```
+Usage: govc metric.interval.info [OPTIONS]
+
+List historical metric intervals.
+
+Examples:
+  govc metric.interval.info
+  govc metric.interval.info -i 300
+
+Options:
+  -i=0                      Interval ID
+```
+
+## metric.ls
+
+```
+Usage: govc metric.ls [OPTIONS] PATH
+
+List available metrics for PATH.
+
+Examples:
+  govc metric.ls /dc1/host/cluster1
+  govc metric.ls datastore/*
+  govc metric.ls vm/* | grep mem. | xargs govc metric.sample vm/*
+
+Options:
+  -i=0                      Interval ID
+  -l=false                  Long listing format
+```
+
+## metric.reset
+
+```
+Usage: govc metric.reset [OPTIONS] NAME...
+
+Reset counter NAME to the default level of data collection.
+
+Examples:
+  govc metric.reset net.bytesRx.average net.bytesTx.average
+
+Options:
+  -i=0                      Interval ID
+```
+
+## metric.sample
+
+```
+Usage: govc metric.sample [OPTIONS] PATH... NAME...
+
+Sample for object PATH of metric NAME.
+
+Interval ID defaults to 20 (realtime) if supported, otherwise 300 (5m interval).
+
+Examples:
+  govc metric.sample host/cluster1/* cpu.usage.average
+  govc metric.sample vm/* net.bytesTx.average net.bytesTx.average
+
+Options:
+  -d=30                     Limit object display name to D chars
+  -i=0                      Interval ID
+  -n=6                      Max number of samples
+```
+
 ## object.collect
 
 ```

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1861,7 +1861,9 @@ Examples:
 Options:
   -d=30                     Limit object display name to D chars
   -i=0                      Interval ID
+  -instance=*               Instance
   -n=6                      Max number of samples
+  -t=false                  Include sample times
 ```
 
 ## object.collect

--- a/govc/emacs/govc.el
+++ b/govc/emacs/govc.el
@@ -799,6 +799,47 @@ Inherit SESSION if given."
   :actions (govc-keymap-popup govc-object-mode-map))
 
 
+;;; govc metric mode
+(defun govc-metric-sample ()
+  "Sample metrics."
+  (interactive)
+  (govc-shell-command (govc-format-command "metric.sample" govc-args govc-filter (govc-selection))))
+
+(defun govc-metric-info ()
+  "Wrapper for govc metric.info."
+  (govc-table-info "metric.info" (list govc-args (car govc-filter))))
+
+(defvar govc-metric-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "RET") 'govc-metric-sample)
+    map)
+  "Keymap for `govc-metric-mode'.")
+
+(defun govc-metric ()
+  "Metrics info."
+  (interactive)
+  (let ((session (govc-current-session))
+        (filter (govc-selection))
+        (buffer (get-buffer-create "*govc-metric*")))
+    (pop-to-buffer buffer)
+    (govc-metric-mode)
+    (govc-session-clone session)
+    (if current-prefix-arg (setq govc-args '("-i" "300")))
+    (setq govc-filter filter)
+    (tabulated-list-print)))
+
+(define-derived-mode govc-metric-mode govc-tabulated-list-mode "Metric"
+  "Major mode for handling a govc metric."
+  (setq tabulated-list-format [("Name" 35 t)
+                               ("Group" 15 t)
+                               ("Level" 5 t)
+                               ("Summary" 50)]
+        tabulated-list-sort-key (cons "Name" nil)
+        tabulated-list-padding 2
+        tabulated-list-entries #'govc-metric-info)
+  (tabulated-list-init-header))
+
+
 ;;; govc host mode
 (defun govc-ls-host ()
   "List hosts."
@@ -851,6 +892,7 @@ Inherit SESSION if given."
     (define-key map "E" 'govc-events)
     (define-key map "L" 'govc-logs)
     (define-key map "J" 'govc-host-json-info)
+    (define-key map "M" 'govc-metric)
     (define-key map "N" 'govc-host-esxcli-netstat)
     (define-key map "O" 'govc-object-info)
     (define-key map "c" 'govc-mode-new-session)
@@ -920,10 +962,11 @@ Optionally filter by FILTER and inherit SESSION."
 
 (defvar govc-pool-mode-map
   (let ((map (make-sparse-keymap)))
+    (define-key map "D" 'govc-pool-destroy-selection)
     (define-key map "E" 'govc-events)
     (define-key map "J" 'govc-pool-json-info)
+    (define-key map "M" 'govc-metric)
     (define-key map "O" 'govc-object-info)
-    (define-key map "D" 'govc-pool-destroy-selection)
     (define-key map "c" 'govc-mode-new-session)
     (define-key map "h" 'govc-host-with-session)
     (define-key map "s" 'govc-datastore-with-session)
@@ -1111,6 +1154,7 @@ Optionally filter by FILTER and inherit SESSION."
 (defvar govc-datastore-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map "J" 'govc-datastore-json-info)
+    (define-key map "M" 'govc-metric)
     (define-key map "O" 'govc-object-info)
     (define-key map (kbd "RET") 'govc-datastore-ls-selection)
     (define-key map "c" 'govc-mode-new-session)
@@ -1365,8 +1409,9 @@ Open via `eww' by default, via `browse-url' if ARG is non-nil."
     (define-key map "@" 'govc-vm-reboot-selection)
     (define-key map "&" 'govc-vm-suspend-selection)
     (define-key map "H" 'govc-vm-host)
-    (define-key map "S" 'govc-vm-datastore)
+    (define-key map "M" 'govc-metric)
     (define-key map "P" 'govc-vm-ping)
+    (define-key map "S" 'govc-vm-datastore)
     (define-key map "c" 'govc-mode-new-session)
     (define-key map "h" 'govc-host-with-session)
     (define-key map "p" 'govc-pool-with-session)

--- a/govc/emacs/govc.el
+++ b/govc/emacs/govc.el
@@ -3,7 +3,7 @@
 ;; Author: The govc developers
 ;; URL: https://github.com/vmware/govmomi/tree/master/govc/emacs
 ;; Keywords: convenience
-;; Version: 0.13.0
+;; Version: 0.14.0
 ;; Package-Requires: ((emacs "24.3") (dash "1.5.0") (s "1.9.0") (magit-popup "2.0.50") (json-mode "1.6.0"))
 
 ;; This file is NOT part of GNU Emacs.

--- a/govc/flags/version.go
+++ b/govc/flags/version.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-const Version = "0.13.0"
+const Version = "0.14.0"
 
 type version []int
 

--- a/govc/main.go
+++ b/govc/main.go
@@ -58,6 +58,8 @@ import (
 	_ "github.com/vmware/govmomi/govc/license"
 	_ "github.com/vmware/govmomi/govc/logs"
 	_ "github.com/vmware/govmomi/govc/ls"
+	_ "github.com/vmware/govmomi/govc/metric"
+	_ "github.com/vmware/govmomi/govc/metric/interval"
 	_ "github.com/vmware/govmomi/govc/object"
 	_ "github.com/vmware/govmomi/govc/permissions"
 	_ "github.com/vmware/govmomi/govc/pool"

--- a/govc/metric/change.go
+++ b/govc/metric/change.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*PerformanceFlag
+
+	level  int
+	device int
+}
+
+func init() {
+	cli.Register("metric.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+
+	f.IntVar(&cmd.level, "level", 0, "Level for the aggregate counter")
+	f.IntVar(&cmd.device, "device-level", 0, "Level for the per device counter")
+}
+
+func (cmd *change) Usage() string {
+	return "NAME..."
+}
+
+func (cmd *change) Description() string {
+	return `Change counter NAME levels.
+
+Examples:
+  govc metric.change -level 1 net.bytesRx.average net.bytesTx.average`
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 || (cmd.level == 0 && cmd.device == 0) {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	counters, err := m.CounterInfoByName(ctx)
+	if err != nil {
+		return err
+	}
+
+	var mapping []types.PerformanceManagerCounterLevelMapping
+
+	for _, name := range f.Args() {
+		counter, ok := counters[name]
+		if !ok {
+			return cmd.ErrNotFound(name)
+		}
+
+		mapping = append(mapping, types.PerformanceManagerCounterLevelMapping{
+			CounterId:      counter.Key,
+			AggregateLevel: int32(cmd.level),
+			PerDeviceLevel: int32(cmd.device),
+		})
+	}
+
+	_, err = methods.UpdateCounterLevelMapping(ctx, m.Client(), &types.UpdateCounterLevelMapping{
+		This:            m.Reference(),
+		CounterLevelMap: mapping,
+	})
+
+	return err
+}

--- a/govc/metric/info.go
+++ b/govc/metric/info.go
@@ -1,0 +1,170 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*PerformanceFlag
+}
+
+func init() {
+	cli.Register("metric.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+}
+
+func (cmd *info) Usage() string {
+	return "PATH [NAME]..."
+}
+
+func (cmd *info) Description() string {
+	return `Metric info for NAME.
+
+If PATH is a value other than '-', provider summary and instance list are included
+for the given object type.
+
+If NAME is not specified, all available metrics for the given INTERVAL are listed.
+An object PATH must be provided in this case.
+
+Examples:
+  govc metric.info vm/my-vm
+  govc metric.info -i 300 vm/my-vm
+  govc metric.info - cpu.usage.average
+  govc metric.info /dc1/host/cluster cpu.usage.average`
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	names := f.Args()[1:]
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	counters, err := m.CounterInfoByName(ctx)
+	if err != nil {
+		return err
+	}
+
+	intervals, err := m.HistoricalInterval(ctx)
+	if err != nil {
+		return err
+	}
+	enabled := intervals.Enabled()
+
+	var summary *types.PerfProviderSummary
+	var mids map[int32][]*types.PerfMetricId
+
+	if f.Arg(0) == "-" {
+		if len(names) == 0 {
+			return flag.ErrHelp
+		}
+	} else {
+		objs, err := cmd.ManagedObjects(ctx, f.Args()[:1])
+		if err != nil {
+			return err
+		}
+
+		summary, err = m.ProviderSummary(ctx, objs[0])
+		if err != nil {
+			return err
+		}
+
+		all, err := m.AvailableMetric(ctx, objs[0], cmd.Interval(summary.RefreshRate))
+		if err != nil {
+			return err
+		}
+
+		mids = all.ByKey()
+
+		if len(names) == 0 {
+			nc, _ := m.CounterInfoByKey(ctx)
+
+			for i := range all {
+				id := &all[i]
+				if id.Instance != "" {
+					continue
+				}
+
+				names = append(names, nc[id.CounterId].Name())
+			}
+		}
+	}
+
+	tw := tabwriter.NewWriter(cmd.Out, 2, 0, 2, ' ', 0)
+	cmd.Out = tw
+
+	for _, name := range names {
+		counter, ok := counters[name]
+		if !ok {
+			return cmd.ErrNotFound(name)
+		}
+
+		fmt.Fprintf(cmd.Out, "Name:\t%s\n", name)
+		fmt.Fprintf(cmd.Out, "  Label:\t%s\n", counter.NameInfo.GetElementDescription().Label)
+		fmt.Fprintf(cmd.Out, "  Summary:\t%s\n", counter.NameInfo.GetElementDescription().Summary)
+		fmt.Fprintf(cmd.Out, "  Group:\t%s\n", counter.GroupInfo.GetElementDescription().Label)
+		fmt.Fprintf(cmd.Out, "  Unit:\t%s\n", counter.UnitInfo.GetElementDescription().Label)
+		fmt.Fprintf(cmd.Out, "  Rollup type:\t%s\n", counter.RollupType)
+		fmt.Fprintf(cmd.Out, "  Stats type:\t%s\n", counter.StatsType)
+		fmt.Fprintf(cmd.Out, "  Level:\t%d\n", counter.Level)
+		fmt.Fprintf(cmd.Out, "    Intervals:\t%s\n", enabled[counter.Level])
+		fmt.Fprintf(cmd.Out, "  Per-device level:\t%d\n", counter.PerDeviceLevel)
+		fmt.Fprintf(cmd.Out, "    Intervals:\t%s\n", enabled[counter.PerDeviceLevel])
+
+		if summary != nil {
+			fmt.Fprintf(cmd.Out, "  Realtime:\t%t\n", summary.CurrentSupported)
+			fmt.Fprintf(cmd.Out, "  Historical:\t%t\n", summary.SummarySupported)
+
+			var instances []string
+
+			for _, id := range mids[counter.Key] {
+				if id.Instance != "" {
+					instances = append(instances, id.Instance)
+				}
+			}
+
+			fmt.Fprintf(cmd.Out, "  Instances:\t%s\n", strings.Join(instances, ","))
+		}
+	}
+
+	return tw.Flush()
+}

--- a/govc/metric/interval/change.go
+++ b/govc/metric/interval/change.go
@@ -1,0 +1,111 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interval
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/metric"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*metric.PerformanceFlag
+
+	enabled *bool
+	level   int
+}
+
+func init() {
+	cli.Register("metric.interval.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = metric.NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+
+	f.Var(flags.NewOptionalBool(&cmd.enabled), "enabled", "Enable or disable")
+	f.IntVar(&cmd.level, "level", 0, "Level")
+}
+
+func (cmd *change) Description() string {
+	return `Change historical metric intervals.
+
+Examples:
+  govc metric.interval.change -i 300 -level 2
+  govc metric.interval.change -i 86400 -enabled=false`
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	intervals, err := m.HistoricalInterval(ctx)
+	if err != nil {
+		return err
+	}
+
+	interval := cmd.Interval(0)
+	if interval == 0 {
+		return flag.ErrHelp
+	}
+
+	var current *types.PerfInterval
+
+	for _, i := range intervals {
+		if i.SamplingPeriod == interval {
+			current = &i
+			break
+		}
+	}
+
+	if current == nil {
+		return fmt.Errorf("%d interval ID not found", interval)
+	}
+
+	if cmd.level != 0 {
+		if cmd.level > 4 {
+			return flag.ErrHelp
+		}
+		current.Level = int32(cmd.level)
+	}
+
+	if cmd.enabled != nil {
+		current.Enabled = *cmd.enabled
+	}
+
+	_, err = methods.UpdatePerfInterval(ctx, m.Client(), &types.UpdatePerfInterval{
+		This:     m.Reference(),
+		Interval: *current,
+	})
+
+	return err
+}

--- a/govc/metric/interval/info.go
+++ b/govc/metric/interval/info.go
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interval
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/metric"
+)
+
+type info struct {
+	*metric.PerformanceFlag
+}
+
+func init() {
+	cli.Register("metric.interval.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = metric.NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+}
+
+func (cmd *info) Description() string {
+	return `List historical metric intervals.
+
+Examples:
+  govc metric.interval.info
+  govc metric.interval.info -i 300`
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	intervals, err := m.HistoricalInterval(ctx)
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(cmd.Out, 2, 0, 2, ' ', 0)
+	cmd.Out = tw
+
+	interval := cmd.Interval(0)
+
+	for _, i := range intervals {
+		if interval != 0 && i.SamplingPeriod != interval {
+			continue
+		}
+
+		fmt.Fprintf(cmd.Out, "ID:\t%d\n", i.SamplingPeriod)
+		fmt.Fprintf(cmd.Out, "  Enabled:\t%t\n", i.Enabled)
+		fmt.Fprintf(cmd.Out, "  Interval:\t%s\n", time.Duration(i.SamplingPeriod)*time.Second)
+		fmt.Fprintf(cmd.Out, "  Name:\t%s\n", i.Name)
+		fmt.Fprintf(cmd.Out, "  Level:\t%d\n", i.Level)
+	}
+
+	return tw.Flush()
+}

--- a/govc/metric/ls.go
+++ b/govc/metric/ls.go
@@ -1,0 +1,115 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type ls struct {
+	*PerformanceFlag
+
+	long bool
+}
+
+func init() {
+	cli.Register("metric.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing format")
+}
+
+func (cmd *ls) Usage() string {
+	return "PATH"
+}
+
+func (cmd *ls) Description() string {
+	return `List available metrics for PATH.
+
+Examples:
+  govc metric.ls /dc1/host/cluster1
+  govc metric.ls datastore/*
+  govc metric.ls vm/* | grep mem. | xargs govc metric.sample vm/*`
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	objs, err := cmd.ManagedObjects(ctx, f.Args())
+	if err != nil {
+		return err
+	}
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	s, err := m.ProviderSummary(ctx, objs[0])
+	if err != nil {
+		return err
+	}
+
+	counters, err := m.CounterInfoByKey(ctx)
+	if err != nil {
+		return err
+	}
+
+	mids, err := m.AvailableMetric(ctx, objs[0], cmd.Interval(s.RefreshRate))
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(cmd.Out, 2, 0, 2, ' ', 0)
+	cmd.Out = tw
+
+	for _, id := range mids {
+		if id.Instance != "" {
+			continue
+		}
+
+		info := counters[id.CounterId]
+
+		if cmd.long {
+			fmt.Fprintf(cmd.Out, "%s\t%s\n", info.Name(),
+				info.NameInfo.GetElementDescription().Label)
+			continue
+		}
+
+		fmt.Fprintln(cmd.Out, info.Name())
+	}
+
+	return tw.Flush()
+}

--- a/govc/metric/performance.go
+++ b/govc/metric/performance.go
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/performance"
+)
+
+type PerformanceFlag struct {
+	*flags.DatacenterFlag
+	*flags.OutputFlag
+
+	m *performance.Manager
+
+	interval int
+}
+
+func NewPerformanceFlag(ctx context.Context) (*PerformanceFlag, context.Context) {
+	f := &PerformanceFlag{}
+	f.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	f.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	return f, ctx
+}
+
+func (f *PerformanceFlag) Register(ctx context.Context, fs *flag.FlagSet) {
+	f.DatacenterFlag.Register(ctx, fs)
+	f.OutputFlag.Register(ctx, fs)
+
+	fs.IntVar(&f.interval, "i", 0, "Interval ID")
+}
+
+func (f *PerformanceFlag) Process(ctx context.Context) error {
+	if err := f.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := f.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f *PerformanceFlag) Manager(ctx context.Context) (*performance.Manager, error) {
+	if f.m != nil {
+		return f.m, nil
+	}
+
+	c, err := f.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	f.m = performance.NewManager(c)
+
+	f.m.Sort = true
+
+	return f.m, err
+}
+
+func (f *PerformanceFlag) Interval(val int32) int32 {
+	interval := int32(f.interval)
+
+	if interval == 0 {
+		if val == -1 {
+			// realtime not supported
+			return 300
+		}
+
+		return val
+	}
+
+	return interval
+}
+
+func (f *PerformanceFlag) ErrNotFound(name string) error {
+	return fmt.Errorf("counter %q not found", name)
+}

--- a/govc/metric/reset.go
+++ b/govc/metric/reset.go
@@ -1,0 +1,91 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type reset struct {
+	*PerformanceFlag
+}
+
+func init() {
+	cli.Register("metric.reset", &reset{})
+}
+
+func (cmd *reset) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+}
+
+func (cmd *reset) Usage() string {
+	return "NAME..."
+}
+
+func (cmd *reset) Description() string {
+	return `Reset counter NAME to the default level of data collection.
+
+Examples:
+  govc metric.reset net.bytesRx.average net.bytesTx.average`
+}
+
+func (cmd *reset) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *reset) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	counters, err := m.CounterInfoByName(ctx)
+	if err != nil {
+		return err
+	}
+
+	var ids []int32
+
+	for _, name := range f.Args() {
+		counter, ok := counters[name]
+		if !ok {
+			return cmd.ErrNotFound(name)
+		}
+
+		ids = append(ids, counter.Key)
+	}
+
+	_, err = methods.ResetCounterLevelMapping(ctx, m.Client(), &types.ResetCounterLevelMapping{
+		This:     m.Reference(),
+		Counters: ids,
+	})
+
+	return err
+}

--- a/govc/metric/sample.go
+++ b/govc/metric/sample.go
@@ -1,0 +1,148 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type sample struct {
+	*PerformanceFlag
+
+	d        int
+	n        int
+	instance string
+}
+
+func init() {
+	cli.Register("metric.sample", &sample{})
+}
+
+func (cmd *sample) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.PerformanceFlag, ctx = NewPerformanceFlag(ctx)
+	cmd.PerformanceFlag.Register(ctx, f)
+
+	f.IntVar(&cmd.d, "d", 30, "Limit object display name to D chars")
+	f.IntVar(&cmd.n, "n", 6, "Max number of samples")
+}
+
+func (cmd *sample) Usage() string {
+	return "PATH... NAME..."
+}
+
+func (cmd *sample) Description() string {
+	return `Sample for object PATH of metric NAME.
+
+Interval ID defaults to 20 (realtime) if supported, otherwise 300 (5m interval).
+
+Examples:
+  govc metric.sample host/cluster1/* cpu.usage.average
+  govc metric.sample vm/* net.bytesTx.average net.bytesTx.average`
+}
+
+func (cmd *sample) Process(ctx context.Context) error {
+	if err := cmd.PerformanceFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *sample) Run(ctx context.Context, f *flag.FlagSet) error {
+	m, err := cmd.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	var paths []string
+	var names []string
+
+	byName, err := m.CounterInfoByName(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, arg := range f.Args() {
+		if _, ok := byName[arg]; ok {
+			names = append(names, arg)
+		} else {
+			paths = append(paths, arg)
+		}
+	}
+
+	if len(paths) == 0 || len(names) == 0 {
+		return flag.ErrHelp
+	}
+
+	counters, err := m.CounterInfoByKey(ctx)
+	if err != nil {
+		return err
+	}
+
+	objs, err := cmd.ManagedObjects(ctx, paths)
+	if err != nil {
+		return err
+	}
+
+	s, err := m.ProviderSummary(ctx, objs[0])
+	if err != nil {
+		return err
+	}
+
+	spec := types.PerfQuerySpec{
+		Format:     string(types.PerfFormatCsv),
+		MaxSample:  int32(cmd.n),
+		MetricId:   []types.PerfMetricId{{Instance: cmd.instance}},
+		IntervalId: cmd.Interval(s.RefreshRate),
+	}
+
+	sample, err := m.SampleByName(ctx, spec, names, objs)
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(cmd.Out, 2, 0, 2, ' ', 0)
+	cmd.Out = tw
+
+	for _, s := range sample {
+		metric := s.(*types.PerfEntityMetricCSV)
+
+		var me mo.ManagedEntity
+		_ = m.Properties(ctx, metric.Entity, []string{"name"}, &me)
+
+		name := me.Name
+		if cmd.d > 0 && len(name) > cmd.d {
+			name = name[:cmd.d] + "*"
+		}
+
+		for _, v := range metric.Value {
+			counter := counters[v.Id.CounterId]
+			units := counter.UnitInfo.GetElementDescription().Label
+
+			fmt.Fprintf(cmd.Out, "%s\t%s\t%s\t%s\t%s\n",
+				name, v.Id.Instance, counter.Name(), v.Value, units)
+		}
+	}
+
+	return tw.Flush()
+}

--- a/govc/test/metric.bats
+++ b/govc/test/metric.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "metric.ls" {
+  run govc metric.ls
+  assert_failure
+
+  run govc metric.ls enoent
+  assert_failure
+
+  host=$(govc ls -t HostSystem ./... | head -n 1)
+  pool=$(govc ls -t ResourcePool ./... | head -n 1)
+
+  run govc metric.ls "$host"
+  assert_success
+
+  run govc metric.ls "$pool"
+  assert_success
+}
+
+@test "metric.sample" {
+  host=$(govc ls -t HostSystem ./... | head -n 1)
+  metrics=($(govc metric.ls "$host"))
+
+  run govc metric.sample "$host" enoent
+  assert_failure
+
+  run govc metric.sample "$host" "${metrics[@]}"
+  assert_success
+
+  vm=$(new_ttylinux_vm)
+
+  run govc metric.ls "$vm"
+  assert_output ""
+
+  run govc vm.power -on "$vm"
+  assert_success
+
+  run govc vm.ip "$vm"
+  assert_success
+
+  metrics=($(govc metric.ls "$vm"))
+
+  run govc metric.sample "$vm" "${metrics[@]}"
+  assert_success
+
+  run govc metric.sample "govc-test-*" "${metrics[@]}"
+  assert_success
+}
+
+@test "metric.info" {
+  host=$(govc ls -t HostSystem ./... | head -n 1)
+  metrics=($(govc metric.ls "$host"))
+
+  run govc metric.info "$host" enoent
+  assert_failure
+
+  run govc metric.info "$host"
+  assert_success
+
+  run govc metric.sample "$host" "${metrics[@]}"
+  assert_success
+
+  run govc metric.info "$host" "${metrics[@]}"
+  assert_success
+
+  run govc metric.info - "${metrics[@]}"
+  assert_success
+}

--- a/govc/test/metric.bats
+++ b/govc/test/metric.bats
@@ -15,6 +15,9 @@ load test_helper
   run govc metric.ls "$host"
   assert_success
 
+  run govc metric.ls -json "$host"
+  assert_success
+
   run govc metric.ls "$pool"
   assert_success
 }
@@ -27,6 +30,9 @@ load test_helper
   assert_failure
 
   run govc metric.sample "$host" "${metrics[@]}"
+  assert_success
+
+  run govc metric.sample -json "$host" "${metrics[@]}"
   assert_success
 
   vm=$(new_ttylinux_vm)
@@ -43,6 +49,9 @@ load test_helper
   metrics=($(govc metric.ls "$vm"))
 
   run govc metric.sample "$vm" "${metrics[@]}"
+  assert_success
+
+  run govc metric.sample -json "$vm" "${metrics[@]}"
   assert_success
 
   run govc metric.sample "govc-test-*" "${metrics[@]}"

--- a/govc/test/metric_info_test.sh
+++ b/govc/test/metric_info_test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+types="Datacenter HostSystem ClusterComputeResource ResourcePool VirtualMachine Datastore VirtualApp"
+
+for type in $types ; do
+  echo "$type..."
+
+  obj=$(govc ls -t "$type" ./... | head -n 1)
+  if [ -z "$obj" ] ; then
+    echo "...no instances found"
+    continue
+  fi
+
+  if ! govc metric.info "$obj" 2>/dev/null ; then
+    echo "...N/A" # Datacenter, Datastore on ESX for example
+    continue
+  fi
+
+  govc metric.ls "$obj" | xargs govc metric.sample -n 5 "$obj"
+done

--- a/performance/manager.go
+++ b/performance/manager.go
@@ -1,0 +1,341 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package performance
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// Manager wraps mo.PerformanceManager.
+type Manager struct {
+	object.Common
+
+	Sort bool
+
+	pm struct {
+		sync.Mutex
+		*mo.PerformanceManager
+	}
+
+	providerSummary struct {
+		sync.Mutex
+		m map[string]*types.PerfProviderSummary
+	}
+
+	infoByName struct {
+		sync.Mutex
+		m map[string]*types.PerfCounterInfo
+	}
+
+	infoByKey struct {
+		sync.Mutex
+		m map[int32]*types.PerfCounterInfo
+	}
+}
+
+// NewManager creates a new Manager instance.
+func NewManager(client *vim25.Client) *Manager {
+	m := Manager{
+		Common: object.NewCommon(client, *client.ServiceContent.PerfManager),
+	}
+
+	m.pm.PerformanceManager = new(mo.PerformanceManager)
+
+	return &m
+}
+
+// IntervalList wraps []types.PerfInterval.
+type IntervalList []types.PerfInterval
+
+// Enabled returns a map with Level as the key and enabled PerfInterval.Name(s) as the value.
+func (l IntervalList) Enabled() map[int32]string {
+	enabled := make(map[int32]string)
+
+	for level := int32(0); level <= 4; level++ {
+		var names []string
+
+		for _, interval := range l {
+			if interval.Enabled && interval.Level >= level {
+				names = append(names, interval.Name)
+			}
+		}
+
+		enabled[level] = strings.Join(names, ",")
+	}
+
+	return enabled
+}
+
+// HistoricalInterval gets the PerformanceManager.HistoricalInterval property and wraps as an IntervalList.
+func (m *Manager) HistoricalInterval(ctx context.Context) (IntervalList, error) {
+	var pm mo.PerformanceManager
+
+	err := m.Properties(ctx, m.Reference(), []string{"historicalInterval"}, &pm)
+	if err != nil {
+		return nil, err
+	}
+
+	return IntervalList(pm.HistoricalInterval), nil
+}
+
+// CounterInfo gets the PerformanceManager.PerfCounter property.
+// The property value is only collected once, subsequent calls return the cached value.
+func (m *Manager) CounterInfo(ctx context.Context) ([]types.PerfCounterInfo, error) {
+	m.pm.Lock()
+	defer m.pm.Unlock()
+
+	if len(m.pm.PerfCounter) == 0 {
+		err := m.Properties(ctx, m.Reference(), []string{"perfCounter"}, m.pm.PerformanceManager)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return m.pm.PerfCounter, nil
+}
+
+// CounterInfoByName converts the PerformanceManager.PerfCounter property to a map,
+// where key is types.PerfCounterInfo.Name().
+func (m *Manager) CounterInfoByName(ctx context.Context) (map[string]*types.PerfCounterInfo, error) {
+	m.infoByName.Lock()
+	defer m.infoByName.Unlock()
+
+	if m.infoByName.m != nil {
+		return m.infoByName.m, nil
+	}
+
+	info, err := m.CounterInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.infoByName.m = make(map[string]*types.PerfCounterInfo)
+
+	for i := range info {
+		c := &info[i]
+
+		m.infoByName.m[c.Name()] = c
+	}
+
+	return m.infoByName.m, nil
+}
+
+// CounterInfoByKey converts the PerformanceManager.PerfCounter property to a map,
+// where key is types.PerfCounterInfo.Key.
+func (m *Manager) CounterInfoByKey(ctx context.Context) (map[int32]*types.PerfCounterInfo, error) {
+	m.infoByKey.Lock()
+	defer m.infoByKey.Unlock()
+
+	if m.infoByKey.m != nil {
+		return m.infoByKey.m, nil
+	}
+
+	info, err := m.CounterInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.infoByKey.m = make(map[int32]*types.PerfCounterInfo)
+
+	for i := range info {
+		c := &info[i]
+
+		m.infoByKey.m[c.Key] = c
+	}
+
+	return m.infoByKey.m, nil
+}
+
+// ProviderSummary wraps the QueryPerfProviderSummary method, caching the value based on entity.Type.
+func (m *Manager) ProviderSummary(ctx context.Context, entity types.ManagedObjectReference) (*types.PerfProviderSummary, error) {
+	m.providerSummary.Lock()
+	defer m.providerSummary.Unlock()
+
+	if m.providerSummary.m == nil {
+		m.providerSummary.m = make(map[string]*types.PerfProviderSummary)
+	}
+
+	s, ok := m.providerSummary.m[entity.Type]
+	if ok {
+		return s, nil
+	}
+
+	req := types.QueryPerfProviderSummary{
+		This:   m.Reference(),
+		Entity: entity,
+	}
+
+	res, err := methods.QueryPerfProviderSummary(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	s = &res.Returnval
+
+	m.providerSummary.m[entity.Type] = s
+
+	return s, nil
+}
+
+type groupPerfCounterInfo struct {
+	info map[int32]*types.PerfCounterInfo
+	ids  []types.PerfMetricId
+}
+
+func (d groupPerfCounterInfo) Len() int {
+	return len(d.ids)
+}
+
+func (d groupPerfCounterInfo) Less(i, j int) bool {
+	ci := d.ids[i].CounterId
+	cj := d.ids[j].CounterId
+	gi := d.info[ci].GroupInfo.GetElementDescription()
+	gj := d.info[cj].GroupInfo.GetElementDescription()
+
+	return gi.Key < gj.Key
+}
+
+func (d groupPerfCounterInfo) Swap(i, j int) {
+	d.ids[i], d.ids[j] = d.ids[j], d.ids[i]
+}
+
+// MetricList wraps []types.PerfMetricId
+type MetricList []types.PerfMetricId
+
+// ByKey converts MetricList to map, where key is types.PerfMetricId.CounterId / types.PerfCounterInfo.Key
+func (l MetricList) ByKey() map[int32][]*types.PerfMetricId {
+	ids := make(map[int32][]*types.PerfMetricId, len(l))
+
+	for i := range l {
+		id := &l[i]
+		ids[id.CounterId] = append(ids[id.CounterId], id)
+	}
+
+	return ids
+}
+
+// AvailableMetric wraps the QueryAvailablePerfMetric method.
+// The MetricList is sorted by PerfCounterInfo.GroupInfo.Key if Manager.Sort == true.
+func (m *Manager) AvailableMetric(ctx context.Context, entity types.ManagedObjectReference, interval int32) (MetricList, error) {
+	req := types.QueryAvailablePerfMetric{
+		This:       m.Reference(),
+		Entity:     entity.Reference(),
+		IntervalId: interval,
+	}
+
+	res, err := methods.QueryAvailablePerfMetric(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	if m.Sort {
+		info, err := m.CounterInfoByKey(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		sort.Sort(groupPerfCounterInfo{info, res.Returnval})
+	}
+
+	return MetricList(res.Returnval), nil
+}
+
+// Query wraps the QueryPerf method.
+func (m *Manager) Query(ctx context.Context, spec []types.PerfQuerySpec) ([]types.BasePerfEntityMetricBase, error) {
+	req := types.QueryPerf{
+		This:      m.Reference(),
+		QuerySpec: spec,
+	}
+
+	res, err := methods.QueryPerf(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+// SampleByName uses the spec param as a template, constructing a []types.PerfQuerySpec for the given metrics and entities
+// and invoking the Query method.
+// The spec template can specify instances using the MetricId.Instance field, by default all instances are collected.
+// The spec template MaxSample defaults to 1.
+// If the spec template IntervalId is a historical interval and StartTime is not specified,
+// the StartTime is set to the current time - (IntervalId * MaxSample).
+func (m *Manager) SampleByName(ctx context.Context, spec types.PerfQuerySpec, metrics []string, entity []types.ManagedObjectReference) ([]types.BasePerfEntityMetricBase, error) {
+	info, err := m.CounterInfoByName(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []types.PerfMetricId
+
+	instances := spec.MetricId
+	if len(instances) == 0 {
+		// Default to all instances
+		instances = []types.PerfMetricId{{Instance: "*"}}
+	}
+
+	for _, name := range metrics {
+		counter, ok := info[name]
+		if !ok {
+			return nil, fmt.Errorf("counter %q not found", name)
+		}
+
+		for _, i := range instances {
+			ids = append(ids, types.PerfMetricId{CounterId: counter.Key, Instance: i.Instance})
+		}
+	}
+
+	spec.MetricId = ids
+
+	if spec.MaxSample == 0 {
+		spec.MaxSample = 1
+	}
+
+	if spec.IntervalId >= 60 && spec.StartTime == nil {
+		// Need a StartTime to make use of history
+		now, err := methods.GetCurrentTime(ctx, m.Client())
+		if err != nil {
+			return nil, err
+		}
+
+		// Go back in time
+		x := spec.IntervalId * -1 * spec.MaxSample
+		t := now.Add(time.Duration(x) * time.Second)
+		spec.StartTime = &t
+	}
+
+	var query []types.PerfQuerySpec
+
+	for _, e := range entity {
+		spec.Entity = e.Reference()
+		query = append(query, spec)
+	}
+
+	return m.Query(ctx, query)
+}

--- a/vim25/types/helpers.go
+++ b/vim25/types/helpers.go
@@ -46,3 +46,7 @@ func (r *ManagedObjectReference) FromString(o string) bool {
 
 	return true
 }
+
+func (c *PerfCounterInfo) Name() string {
+	return c.GroupInfo.GetElementDescription().Key + "." + c.NameInfo.GetElementDescription().Key + "." + string(c.RollupType)
+}


### PR DESCRIPTION
* Convert counter IDs to and from stable names, with caching

* Query available metrics, per resource type and interval

* Query N metric samples by name for N resource instances

* Change level per historical interval and per counter