### PR TITLE
Finder: support changing object root in find mode

### DIFF
--- a/find/doc.go
+++ b/find/doc.go
@@ -19,7 +19,7 @@ Package find implements inventory listing and searching.
 
 The Finder is an alternative to the object.SearchIndex FindByInventoryPath() and FindChild() methods.
 SearchIndex.FindByInventoryPath requires an absolute path, whereas the Finder also supports relative paths
-and patterns via filepath.Match.
+and patterns via path.Match.
 SearchIndex.FindChild requires a parent to find the child, whereas the Finder also supports an ancestor via
 recursive object traversal.
 

--- a/find/finder.go
+++ b/find/finder.go
@@ -34,12 +34,14 @@ type Finder struct {
 	client  *vim25.Client
 	r       recurser
 	dc      *object.Datacenter
+	si      *object.SearchIndex
 	folders *object.DatacenterFolders
 }
 
 func NewFinder(client *vim25.Client, all bool) *Finder {
 	f := &Finder{
 		client: client,
+		si:     object.NewSearchIndex(client),
 		r: recurser{
 			Collector: property.DefaultCollector(client),
 			All:       all,
@@ -53,6 +55,38 @@ func (f *Finder) SetDatacenter(dc *object.Datacenter) *Finder {
 	f.dc = dc
 	f.folders = nil
 	return f
+}
+
+// findRoot makes it possible to use "find" mode with a different root path.
+// Example: ResourcePoolList("/dc1/host/cluster1/...")
+func (f *Finder) findRoot(ctx context.Context, root *list.Element, parts []string) bool {
+	if len(parts) == 0 {
+		return false
+	}
+
+	ix := len(parts) - 1
+
+	if parts[ix] != "..." {
+		return false
+	}
+
+	if ix == 0 {
+		return true // We already have the Object for root.Path
+	}
+
+	// Lookup the Object for the new root.Path
+	rootPath := path.Join(root.Path, path.Join(parts[:ix]...))
+
+	ref, err := f.si.FindByInventoryPath(ctx, rootPath)
+	if err != nil || ref == nil {
+		// If we get an error or fail to match, fall through to find() with the original root and path
+		return false
+	}
+
+	root.Path = rootPath
+	root.Object = ref
+
+	return true
 }
 
 func (f *Finder) find(ctx context.Context, arg string, s *spec) ([]list.Element, error) {
@@ -94,7 +128,11 @@ func (f *Finder) find(ctx context.Context, arg string, s *spec) ([]list.Element,
 	}
 
 	if s.listMode(isPath) {
-		return f.r.List(ctx, s, root, parts)
+		if f.findRoot(ctx, &root, parts) {
+			parts = []string{"*"}
+		} else {
+			return f.r.List(ctx, s, root, parts)
+		}
 	}
 
 	s.Parents = append(s.Parents, s.Nested...)
@@ -226,13 +264,8 @@ func (f *Finder) managedObjectList(ctx context.Context, path string, tl bool, in
 	}
 
 	if tl {
-		if path == "/**" || path == "./..." {
-			// TODO: support switching to find mode for any path, not just relative to f.rootFolder or f.dcReference
-			path = "*"
-		} else {
-			s.Contents = true
-			s.ListMode = types.NewBool(true)
-		}
+		s.Contents = true
+		s.ListMode = types.NewBool(true)
 	}
 
 	return f.find(ctx, path, s)

--- a/find/recurser.go
+++ b/find/recurser.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"os"
 	"path"
-	"path/filepath"
 
 	"github.com/vmware/govmomi/list"
 	"github.com/vmware/govmomi/object"
@@ -183,7 +182,7 @@ func (r recurser) List(ctx context.Context, s *spec, root list.Element, parts []
 
 	var out []list.Element
 	for _, e := range in {
-		matched, err := filepath.Match(pattern, path.Base(e.Path))
+		matched, err := path.Match(pattern, path.Base(e.Path))
 		if err != nil {
 			return nil, err
 		}
@@ -208,7 +207,7 @@ func (r recurser) Find(ctx context.Context, s *spec, root list.Element, parts []
 
 	if len(parts) > 0 {
 		pattern := parts[0]
-		matched, err := filepath.Match(pattern, path.Base(root.Path))
+		matched, err := path.Match(pattern, path.Base(root.Path))
 		if err != nil {
 			return nil, err
 		}

--- a/govc/device/info.go
+++ b/govc/device/info.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"text/tabwriter"
 
@@ -73,7 +73,7 @@ func (cmd *info) Usage() string {
 func (cmd *info) match(p string, devices object.VirtualDeviceList) object.VirtualDeviceList {
 	var matches object.VirtualDeviceList
 	match := func(name string) bool {
-		matched, _ := filepath.Match(p, name)
+		matched, _ := path.Match(p, name)
 		return matched
 	}
 

--- a/govc/importx/archive.go
+++ b/govc/importx/archive.go
@@ -110,7 +110,7 @@ func (t *TapeArchive) Open(name string) (io.ReadCloser, int64, error) {
 			return nil, 0, err
 		}
 
-		matched, err := filepath.Match(name, path.Base(h.Name))
+		matched, err := path.Match(name, path.Base(h.Name))
 		if err != nil {
 			return nil, 0, err
 		}

--- a/govc/test/ls.bats
+++ b/govc/test/ls.bats
@@ -22,15 +22,6 @@ load test_helper
   assert_success
   [ ${#lines[@]} -eq 0 ]
 
-  # search entire inventory
-  run govc ls -t HostSystem '/**'
-  assert_success
-  [ ${#lines[@]} -eq 1 ]
-
-  run govc ls -t HostSystem ./...
-  assert_success
-  [ ${#lines[@]} -eq 1 ]
-
   run govc ls host
   assert_success
   [ ${#lines[@]} -ge 1 ]
@@ -38,6 +29,35 @@ load test_helper
   run govc ls enoent
   assert_success
   [ ${#lines[@]} -eq 0 ]
+}
+
+@test "ls -R" {
+  # search entire inventory
+  run govc ls ./...
+  assert_success
+  # should have at least 1 dc + folders, 1 host, 1 network, 1 datastore
+  [ ${#lines[@]} -ge 9 ]
+
+  run govc ls -t HostSystem ./...
+  assert_success
+  [ ${#lines[@]} -eq 1 ]
+
+  run govc ls -t Datacenter /...
+  assert_success
+  [ ${#lines[@]} -eq 1 ]
+
+  run govc ls -t ResourcePool host/...
+  assert_success
+  [ ${#lines[@]} -ge 1 ]
+
+  run govc ls -t ResourcePool vm/...
+  assert_success
+  [ ${#lines[@]} -eq 0 ]
+
+  c=$(govc ls -t ComputeResource ./... | head -1)
+  run govc ls -t ResourcePool "$c/..."
+  assert_success
+  [ ${#lines[@]} -ge 1 ]
 }
 
 @test "ls vm" {


### PR DESCRIPTION
- Use path.Match everywhere, not filepath.Match