### PR TITLE
Implement EthernetCardBackingInfo for OpaqueNetwork

### DIFF
--- a/find/finder.go
+++ b/find/finder.go
@@ -729,8 +729,12 @@ func (f *Finder) NetworkList(ctx context.Context, path string) ([]object.Network
 	for _, e := range es {
 		ref := e.Object.Reference()
 		switch ref.Type {
-		case "Network", "OpaqueNetwork":
+		case "Network":
 			r := object.NewNetwork(f.client, ref)
+			r.InventoryPath = e.Path
+			ns = append(ns, r)
+		case "OpaqueNetwork":
+			r := object.NewOpaqueNetwork(f.client, ref)
 			r.InventoryPath = e.Path
 			ns = append(ns, r)
 		case "DistributedVirtualPortgroup":

--- a/object/opaque_network.go
+++ b/object/opaque_network.go
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type OpaqueNetwork struct {
+	Common
+}
+
+func NewOpaqueNetwork(c *vim25.Client, ref types.ManagedObjectReference) *OpaqueNetwork {
+	return &OpaqueNetwork{
+		Common: NewCommon(c, ref),
+	}
+}
+
+// EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this Network
+func (n OpaqueNetwork) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
+	var net mo.OpaqueNetwork
+
+	if err := n.Properties(ctx, n.Reference(), []string{"summary"}, &net); err != nil {
+		return nil, err
+	}
+
+	summary, ok := net.Summary.(*types.OpaqueNetworkSummary)
+	if !ok {
+		return nil, fmt.Errorf("%s unsupported network type: %T", n, net.Summary)
+	}
+
+	backing := &types.VirtualEthernetCardOpaqueNetworkBackingInfo{
+		OpaqueNetworkId:   summary.OpaqueNetworkId,
+		OpaqueNetworkType: summary.OpaqueNetworkType,
+	}
+
+	return backing, nil
+}

--- a/vim25/mo/ancestors.go
+++ b/vim25/mo/ancestors.go
@@ -104,6 +104,8 @@ func Ancestors(ctx context.Context, rt soap.RoundTripper, pc, obj types.ManagedO
 					me.Name = x.Name
 				case DistributedVirtualPortgroup:
 					me.Name = x.Name
+				case OpaqueNetwork:
+					me.Name = x.Name
 				default:
 					// ManagedEntity always has a Name, if we hit this point we missed a case above.
 					panic(fmt.Sprintf("%#v Name is empty", me.Reference()))


### PR DESCRIPTION
While OpaqueNetwork extends the Network type, it requires a backing of type
VirtualEthernetCardOpaqueNetworkBackingInfo