### PR TITLE
PBM Support in govmomi - Additional PBM functionality

### DIFF
--- a/pbm/client_test.go
+++ b/pbm/client_test.go
@@ -65,6 +65,7 @@ func TestClient(t *testing.T) {
 
 	category := types.PbmProfileCategoryEnumREQUIREMENT
 
+	// 1. Query all the profiles on the vCenter.
 	ids, err := pc.QueryProfile(ctx, rtype, string(category))
 	if err != nil {
 		t.Fatal(err)
@@ -78,6 +79,7 @@ func TestClient(t *testing.T) {
 
 	var cids []string
 
+	// 2. Retrieve the content of all profiles.
 	policies, err := pc.RetrieveContent(ctx, ids)
 	if err != nil {
 		t.Fatal(err)
@@ -91,10 +93,12 @@ func TestClient(t *testing.T) {
 	sort.Strings(qids)
 	sort.Strings(cids)
 
+	// Check whether ids retreived from QueryProfile and RetrieveContent are identical.
 	if !reflect.DeepEqual(qids, cids) {
 		t.Error("ids mismatch")
 	}
 
+	// 3. Get list of datastores in a cluster if cluster name is specified.
 	root := c.ServiceContent.RootFolder
 	var datastores []vim.ManagedObjectReference
 	var kind []string
@@ -130,7 +134,7 @@ func TestClient(t *testing.T) {
 
 	_ = v.Destroy(ctx)
 
-	t.Logf("checking %d datatores", len(datastores))
+	t.Logf("checking %d datatores for compatibility results", len(datastores))
 
 	var hubs []types.PbmPlacementHub
 
@@ -149,10 +153,149 @@ func TestClient(t *testing.T) {
 		})
 	}
 
+	// 4. Get the compatibility results for all the profiles on the vCenter.
 	res, err := pc.CheckRequirements(ctx, hubs, nil, req)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Logf("%d results", len(res))
+	t.Logf("CheckRequirements results: %d", len(res))
+
+	// user spec for the profile.
+	// VSAN profile with 2 capability instances - hostFailuresToTolerate = 2, stripeWidth = 1
+	pbmCreateSpecForVSAN := CapabilityProfileCreateSpec{
+		Name:        "Kubernetes-VSAN-TestPolicy",
+		Description: "VSAN Test policy create",
+		Category:    string(types.PbmProfileCategoryEnumREQUIREMENT),
+		CapabilityList: []Capability{
+			Capability{
+				ID:        "hostFailuresToTolerate",
+				Namespace: "VSAN",
+				PropertyList: []Property{
+					Property{
+						ID:       "hostFailuresToTolerate",
+						Value:    "2",
+						DataType: "int",
+					},
+				},
+			},
+			Capability{
+				ID:        "stripeWidth",
+				Namespace: "VSAN",
+				PropertyList: []Property{
+					Property{
+						ID:       "stripeWidth",
+						Value:    "1",
+						DataType: "int",
+					},
+				},
+			},
+		},
+	}
+
+	// Create PBM capability spec for the above defined user spec.
+	createSpecVSAN, err := CreateCapabilityProfileSpec(pbmCreateSpecForVSAN)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 5. Create SPBM VSAN profile.
+	vsanProfileID, err := pc.CreateProfile(ctx, *createSpecVSAN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("VSAN Profile: %q successfully created", vsanProfileID.UniqueId)
+
+	// 6. Verify if profile created exists by issuing a RetrieveContent request.
+	_, err = pc.RetrieveContent(ctx, []types.PbmProfileId{*vsanProfileID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Profile: %q exists on vCenter", vsanProfileID.UniqueId)
+
+	// 7. Get compatible datastores for the VSAN profile.
+	compatibleDatastores := res.CompatibleDatastores()
+	t.Logf("Found %d compatible-datastores for profile: %q", len(compatibleDatastores), vsanProfileID.UniqueId)
+
+	// 8. Get non-compatible datastores for the VSAN profile.
+	nonCompatibleDatastores := res.NonCompatibleDatastores()
+	t.Logf("Found %d non-compatible datastores for profile: %q", len(nonCompatibleDatastores), vsanProfileID.UniqueId)
+
+	// Check whether count of compatible and non-compatible datastores match the total number of datastores.
+	if (len(nonCompatibleDatastores) + len(compatibleDatastores)) != len(datastores) {
+		t.Error("datastore count mismatch")
+	}
+
+	// user spec for the profile.
+	// VSAN profile with 2 capability instances - stripeWidth = 1 and an SIOC profile.
+	pbmCreateSpecVSANandSIOC := CapabilityProfileCreateSpec{
+		Name:        "Kubernetes-VSAN-SIOC-TestPolicy",
+		Description: "VSAN-SIOC-Test policy create",
+		Category:    string(types.PbmProfileCategoryEnumREQUIREMENT),
+		CapabilityList: []Capability{
+			Capability{
+				ID:        "stripeWidth",
+				Namespace: "VSAN",
+				PropertyList: []Property{
+					Property{
+						ID:       "stripeWidth",
+						Value:    "1",
+						DataType: "int",
+					},
+				},
+			},
+			Capability{
+				ID:        "spm@DATASTOREIOCONTROL",
+				Namespace: "spm",
+				PropertyList: []Property{
+					Property{
+						ID:       "limit",
+						Value:    "200",
+						DataType: "int",
+					},
+					Property{
+						ID:       "reservation",
+						Value:    "1000",
+						DataType: "int",
+					},
+					Property{
+						ID:       "shares",
+						Value:    "2000",
+						DataType: "int",
+					},
+				},
+			},
+		},
+	}
+
+	// Create PBM capability spec for the above defined user spec.
+	createSpecVSANandSIOC, err := CreateCapabilityProfileSpec(pbmCreateSpecVSANandSIOC)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 9. Create SPBM VSAN profile.
+	vsansiocProfileID, err := pc.CreateProfile(ctx, *createSpecVSANandSIOC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("VSAN-SIOC Profile: %q successfully created", vsansiocProfileID.UniqueId)
+
+	// 9. Get ProfileID by Name
+	profileID, err := pc.ProfileIDByName(ctx, "Kubernetes-VSAN-SIOC-TestPolicy")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vsansiocProfileID.UniqueId != profileID {
+		t.Errorf("vsan-sioc profile: %q and retrieved profileID: %q successfully matched", vsansiocProfileID.UniqueId, profileID)
+	}
+	t.Logf("VSAN-SIOC profile: %q and retrieved profileID: %q successfully matched", vsansiocProfileID.UniqueId, profileID)
+
+	// 10. Delete VSAN and VSAN-SIOC profile.
+	_, err = pc.DeleteProfile(ctx, []types.PbmProfileId{*vsanProfileID, *vsansiocProfileID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Profile: %+v successfully deleted", []types.PbmProfileId{*vsanProfileID, *vsansiocProfileID})
 }

--- a/pbm/pbm_util.go
+++ b/pbm/pbm_util.go
@@ -1,0 +1,146 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pbm
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/vmware/govmomi/pbm/types"
+)
+
+// A struct to capture pbm create spec details.
+type CapabilityProfileCreateSpec struct {
+	Name           string
+	Description    string
+	Category       string
+	CapabilityList []Capability
+}
+
+// A struct to capture pbm capability instance details.
+type Capability struct {
+	ID           string
+	Namespace    string
+	PropertyList []Property
+}
+
+// A struct to capture pbm property instance details.
+type Property struct {
+	ID       string
+	Operator string
+	Value    string
+	DataType string
+}
+
+func CreateCapabilityProfileSpec(pbmCreateSpec CapabilityProfileCreateSpec) (*types.PbmCapabilityProfileCreateSpec, error) {
+	capabilities, err := createCapabilityInstances(pbmCreateSpec.CapabilityList)
+	if err != nil {
+		return nil, err
+	}
+
+	pbmCapabilityProfileSpec := types.PbmCapabilityProfileCreateSpec{
+		Name:        pbmCreateSpec.Name,
+		Description: pbmCreateSpec.Description,
+		Category:    pbmCreateSpec.Category,
+		ResourceType: types.PbmProfileResourceType{
+			ResourceType: string(types.PbmProfileResourceTypeEnumSTORAGE),
+		},
+		Constraints: &types.PbmCapabilitySubProfileConstraints{
+			SubProfiles: []types.PbmCapabilitySubProfile{
+				types.PbmCapabilitySubProfile{
+					Capability: capabilities,
+				},
+			},
+		},
+	}
+	return &pbmCapabilityProfileSpec, nil
+}
+
+func createCapabilityInstances(rules []Capability) ([]types.PbmCapabilityInstance, error) {
+	var capabilityInstances []types.PbmCapabilityInstance
+	for _, capabilityRule := range rules {
+		capability := types.PbmCapabilityInstance{
+			Id: types.PbmCapabilityMetadataUniqueId{
+				Namespace: capabilityRule.Namespace,
+				Id:        capabilityRule.ID,
+			},
+		}
+
+		var propertyInstances []types.PbmCapabilityPropertyInstance
+		for _, propertyRule := range capabilityRule.PropertyList {
+			property := types.PbmCapabilityPropertyInstance{
+				Id: propertyRule.ID,
+			}
+			if propertyRule.Operator != "" {
+				property.Operator = propertyRule.Operator
+			}
+			var err error
+			switch strings.ToLower(propertyRule.DataType) {
+			case "int":
+				// Go int32 is marshalled to xsi:int whereas Go int is marshalled to xsi:long when sending down the wire.
+				var val int32
+				val, err = verifyPropertyValueIsInt(propertyRule.Value, propertyRule.DataType)
+				property.Value = val
+			case "bool":
+				var val bool
+				val, err = verifyPropertyValueIsBoolean(propertyRule.Value, propertyRule.DataType)
+				property.Value = val
+			case "string":
+				property.Value = propertyRule.Value
+			case "set":
+				set := types.PbmCapabilityDiscreteSet{}
+				for _, val := range strings.Split(propertyRule.Value, ",") {
+					set.Values = append(set.Values, val)
+				}
+				property.Value = set
+			default:
+				return nil, fmt.Errorf("invalid value: %q with datatype: %q", propertyRule.Value, propertyRule.Value)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("invalid value: %q with datatype: %q", propertyRule.Value, propertyRule.Value)
+			}
+			propertyInstances = append(propertyInstances, property)
+		}
+		constraintInstances := []types.PbmCapabilityConstraintInstance{
+			types.PbmCapabilityConstraintInstance{
+				PropertyInstance: propertyInstances,
+			},
+		}
+		capability.Constraint = constraintInstances
+		capabilityInstances = append(capabilityInstances, capability)
+	}
+	return capabilityInstances, nil
+}
+
+// Verify if the capability value is of type integer.
+func verifyPropertyValueIsInt(propertyValue string, dataType string) (int32, error) {
+	val, err := strconv.ParseInt(propertyValue, 10, 32)
+	if err != nil {
+		return -1, err
+	}
+	return int32(val), nil
+}
+
+// Verify if the capability value is of type integer.
+func verifyPropertyValueIsBoolean(propertyValue string, dataType string) (bool, error) {
+	val, err := strconv.ParseBool(propertyValue)
+	if err != nil {
+		return false, err
+	}
+	return val, nil
+}


### PR DESCRIPTION
Added additional wrapper functions for PBM support in govmomi. The below functionalities are included.

-  GetCompatibleDatastores
-  GetNonCompatibleDatastores
-  CreatePbmCapabilityProfileSpec
-  CreatePbmProfile
-  UpdatePbmProfile
-  DeletePbmProfile
-  QueryAssociatedEntity
-  QueryAssociatedEntities
-  GetPbmProfileIDByName

I have also included unit tests for all the above PBM functions. 

Current support is added for CREATING following PBM profiles:
1. VSAN profile.
2. VSAN + SIOC profile.
3. Tag Based profile.

@dougm : Please take a look.
@divyenpatel @tusharnt @pdhamdhere 