### PR TITLE
Add options to host.autostart.add

### DIFF
--- a/govc/host/autostart/add.go
+++ b/govc/host/autostart/add.go
@@ -19,22 +19,49 @@ package autostart
 import (
 	"context"
 	"flag"
+	"fmt"
+	"strings"
 
 	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
 type add struct {
 	*AutostartFlag
+	// from types.AutoStartPowerInfo
+	StartOrder       int32
+	StartDelay       int32
+	WaitForHeartbeat string
+	StartAction      string
+	StopDelay        int32
+	StopAction       string
 }
 
 func init() {
 	cli.Register("host.autostart.add", &add{})
 }
 
+var waitHeartbeatTypes = []string{
+	string(types.AutoStartWaitHeartbeatSettingSystemDefault),
+	string(types.AutoStartWaitHeartbeatSettingYes),
+	string(types.AutoStartWaitHeartbeatSettingNo),
+}
+
 func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.AutostartFlag, ctx = newAutostartFlag(ctx)
 	cmd.AutostartFlag.Register(ctx, f)
+
+	cmd.StartOrder = -1
+	cmd.StartDelay = -1
+	cmd.StopDelay = -1
+	f.Var(flags.NewInt32(&cmd.StartOrder), "start-order", "Start Order")
+	f.Var(flags.NewInt32(&cmd.StartDelay), "start-delay", "Start Delay")
+	f.Var(flags.NewInt32(&cmd.StopDelay), "stop-delay", "Stop Delay")
+	f.StringVar(&cmd.StartAction, "start-action", "powerOn", "Start Action")
+	f.StringVar(&cmd.StopAction, "stop-action", "systemDefault", "Stop Action")
+	f.StringVar(&cmd.WaitForHeartbeat, "wait", waitHeartbeatTypes[0],
+		fmt.Sprintf("Wait for Hearbeat Setting (%s)", strings.Join(waitHeartbeatTypes, "|")))
 }
 
 func (cmd *add) Process(ctx context.Context) error {
@@ -49,14 +76,13 @@ func (cmd *add) Usage() string {
 }
 
 func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
-	var powerInfo = types.AutoStartPowerInfo{
-		StartAction:      "powerOn",
-		StartDelay:       -1,
-		StartOrder:       -1,
-		StopAction:       "systemDefault",
-		StopDelay:        -1,
-		WaitForHeartbeat: types.AutoStartWaitHeartbeatSettingSystemDefault,
+	powerInfo := types.AutoStartPowerInfo{
+		StartOrder:       cmd.StartOrder,
+		StartDelay:       cmd.StartDelay,
+		WaitForHeartbeat: types.AutoStartWaitHeartbeatSetting(cmd.WaitForHeartbeat),
+		StartAction:      cmd.StartAction,
+		StopDelay:        cmd.StopDelay,
+		StopAction:       cmd.StopAction,
 	}
-
 	return cmd.ReconfigureVMs(f.Args(), powerInfo)
 }


### PR DESCRIPTION
This is to allow for per VM config to the HostAutoStartManager.
Also useful to configure an ordered auto startup.

Example:
govc host.autostart.add  -start-order=1 -start-delay=5 vm1 vm2
govc host.autostart.add  -start-order=3 -start-delay=30 vm3

Tested on ESXi 6.0.0
