### PR TITLE
Adjust message slice passed to include

### DIFF
--- a/object/datastore_file.go
+++ b/object/datastore_file.go
@@ -242,12 +242,13 @@ func lastIndexLines(s []byte, line *int, include func(l int, m string) bool) (in
 			break
 		}
 
-		msg := string(s[o:i])
-		i = o
-		*line++
+		msg := string(s[o+1 : i+1])
 		if !include(*line, msg) {
 			done = true
 			break
+		} else {
+			i = o
+			*line++
 		}
 	}
 


### PR DESCRIPTION
This change slides the slice window one element to the right before passing the string into the `include` function. Previously, the string being passed in was `\nmessage` and is now adjusted to `message\n`.

It also fixes a small bug where a single line was returned even if a `tail` value of `0` was specified.