### PR TITLE
Handle object names containing a '/'

### DIFF
--- a/find/recurser.go
+++ b/find/recurser.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/vmware/govmomi/list"
 	"github.com/vmware/govmomi/object"
@@ -177,6 +178,7 @@ func (r recurser) List(ctx context.Context, s *spec, root list.Element, parts []
 		return in, nil
 	}
 
+	all := parts
 	pattern := parts[0]
 	parts = parts[1:]
 
@@ -188,6 +190,12 @@ func (r recurser) List(ctx context.Context, s *spec, root list.Element, parts []
 		}
 
 		if !matched {
+			matched = strings.HasSuffix(e.Path, path.Join(all...))
+			if matched {
+				// name contains a '/'
+				out = append(out, e)
+			}
+
 			continue
 		}
 

--- a/govc/emacs/govc.el
+++ b/govc/emacs/govc.el
@@ -367,7 +367,7 @@ Optionally set `GOVC_*' vars in `process-environment' using prefix
 
 (defun govc-process (command handler)
   "Run COMMAND, calling HANDLER upon successful exit of the process."
-  (message command)
+  (message "%s" command)
   (let ((process-environment (govc-environment))
         (exit-code))
     (add-to-list 'govc-command-history command)

--- a/object/common.go
+++ b/object/common.go
@@ -80,11 +80,6 @@ func (c *Common) SetInventoryPath(p string) {
 func (c Common) ObjectName(ctx context.Context) (string, error) {
 	var o mo.ManagedEntity
 
-	name := c.Name()
-	if name != "" {
-		return name, nil
-	}
-
 	err := c.Properties(ctx, c.Reference(), []string{"name"}, &o)
 	if err != nil {
 		return "", err

--- a/property/filter.go
+++ b/property/filter.go
@@ -18,7 +18,7 @@ package property
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"reflect"
 	"strconv"
 	"strings"
@@ -103,7 +103,11 @@ func (f Filter) MatchProperty(prop types.DynamicProperty) bool {
 
 	switch pval := prop.Val.(type) {
 	case string:
-		m, _ := filepath.Match(match.(string), pval)
+		s := match.(string)
+		if s == "*" {
+			return true // TODO: path.Match fails if s contains a '/'
+		}
+		m, _ := path.Match(s, pval)
 		return m
 	default:
 		return reflect.DeepEqual(match, pval)


### PR DESCRIPTION
This only supports leaf nodes in the inventory path.
For example a Network named "my-net/work".

However, this change does not handle parents containing a '/'.
For example Datacenter named "my-data/center" and Cluster named "my-clus/ter",
these paths will not work:

  /my-data/center/vm/my-vm

  host/my-clus/ter/my-host

Fixes #592