### PR TITLE
Guest command updates

### DIFF
--- a/gen/vim_wsdl.rb
+++ b/gen/vim_wsdl.rb
@@ -191,7 +191,7 @@ class Simple
   end
 
   def pointer_type?
-    ["UnitNumber"].include?(var_name)
+    ["UnitNumber", "OwnerId", "GroupId"].include?(var_name)
   end
 
   def var_type

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -991,19 +991,30 @@ Options:
 ## guest.chmod
 
 ```
-Usage: govc guest.chmod [OPTIONS] FILE
+Usage: govc guest.chmod [OPTIONS] MODE FILE
 
-Change FILE attributes on VM.
+Change FILE MODE on VM.
 
 Examples:
-  govc guest.chmod -vm $name -perm 0644 /var/log/foo.log
-  govc guest.chown -vm $name -uid 1000 -gid -1000 /var/log/foo.log
+  govc guest.chmod -vm $name 0644 /var/log/foo.log
 
 Options:
-  -gid=0                    Group ID
   -l=:                      Guest VM credentials [GOVC_GUEST_LOGIN]
-  -perm=0                   File permissions
-  -uid=0                    User ID
+  -vm=                      Virtual machine [GOVC_VM]
+```
+
+## guest.chown
+
+```
+Usage: govc guest.chown [OPTIONS] UID[:GID] FILE
+
+Change FILE UID and GID on VM.
+
+Examples:
+  govc guest.chown -vm $name UID[:GID] /var/log/foo.log
+
+Options:
+  -l=:                      Guest VM credentials [GOVC_GUEST_LOGIN]
   -vm=                      Virtual machine [GOVC_VM]
 ```
 
@@ -1102,12 +1113,31 @@ Examples:
   govc guest.mktemp -vm $name
   govc guest.mktemp -vm $name -d
   govc guest.mktemp -vm $name -t myprefix
+  govc guest.mktemp -vm $name -p /var/tmp/$USER
 
 Options:
   -d=false                  Make a directory instead of a file
   -l=:                      Guest VM credentials [GOVC_GUEST_LOGIN]
+  -p=                       If specified, create relative to this directory
   -s=                       Suffix
   -t=                       Prefix
+  -vm=                      Virtual machine [GOVC_VM]
+```
+
+## guest.mv
+
+```
+Usage: govc guest.mv [OPTIONS] SOURCE DEST
+
+Move (rename) files in VM.
+
+Examples:
+  govc guest.mv -vm $name /tmp/foo.sh /tmp/bar.sh
+  govc guest.mv -vm $name -n /tmp/baz.sh /tmp/bar.sh
+
+Options:
+  -l=:                      Guest VM credentials [GOVC_GUEST_LOGIN]
+  -n=false                  Do not overwrite an existing file
   -vm=                      Virtual machine [GOVC_VM]
 ```
 
@@ -1194,6 +1224,25 @@ Options:
   -vm=                      Virtual machine [GOVC_VM]
 ```
 
+## guest.touch
+
+```
+Usage: govc guest.touch [OPTIONS] FILE
+
+Change FILE times on VM.
+
+Examples:
+  govc guest.touch -vm $name /var/log/foo.log
+  govc guest.touch -vm $name -d "$(date -d '1 day ago')" /var/log/foo.log
+
+Options:
+  -a=false                  Change only the access time
+  -c=false                  Do not create any files
+  -d=                       Use DATE instead of current time
+  -l=:                      Guest VM credentials [GOVC_GUEST_LOGIN]
+  -vm=                      Virtual machine [GOVC_VM]
+```
+
 ## guest.upload
 
 ```
@@ -1209,10 +1258,10 @@ Examples:
 
 Options:
   -f=false                  If set, the guest destination file is clobbered
-  -gid=0                    Group ID
+  -gid=<nil>                Group ID
   -l=:                      Guest VM credentials [GOVC_GUEST_LOGIN]
   -perm=0                   File permissions
-  -uid=0                    User ID
+  -uid=<nil>                User ID
   -vm=                      Virtual machine [GOVC_VM]
 ```
 

--- a/govc/flags/int32.go
+++ b/govc/flags/int32.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 type int32Value int32
 
 func (i *int32Value) Set(s string) error {
-	v, err := strconv.ParseInt(s, 0, 64)
+	v, err := strconv.ParseInt(s, 0, 32)
 	*i = int32Value(v)
 	return err
 }
@@ -43,4 +43,30 @@ func (i *int32Value) String() string {
 // NewInt32 behaves as flag.IntVar, but using an int32 type.
 func NewInt32(v *int32) flag.Value {
 	return (*int32Value)(v)
+}
+
+type int32ptrValue struct {
+	val **int32
+}
+
+func (i *int32ptrValue) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 32)
+	*i.val = new(int32)
+	**i.val = int32(v)
+	return err
+}
+
+func (i *int32ptrValue) Get() interface{} {
+	if i.val == nil {
+		return -1
+	}
+	return *i.val
+}
+
+func (i *int32ptrValue) String() string {
+	return fmt.Sprintf("%v", i.Get())
+}
+
+func NewOptionalInt32(v **int32) flag.Value {
+	return &int32ptrValue{val: v}
 }

--- a/govc/test/guest_operations_test.sh
+++ b/govc/test/guest_operations_test.sh
@@ -53,7 +53,10 @@ df -h
 cp /etc/motd /data
 EOF
 
-  govc guest.chmod -perm 755 "$script"
+  govc guest.chown 65534 "$script"
+  govc guest.chown 65534:65534 "$script"
+  govc guest.ls "$script" | grep 65534
+  govc guest.chmod 0755 "$script"
   pid=$(govc guest.start "$script" '>&' /tmp/disk.log)
   status=$(govc guest.ps -p "$pid" -json -X | jq .ProcessInfo[].ExitCode)
   govc guest.download /tmp/disk.log -
@@ -63,6 +66,9 @@ EOF
 
   echo "Writing some data to the disks..."
   for d in /etc /data ; do
+    govc guest.touch "$d/motd.bak"
+    govc guest.touch -d "$(date -d '1 day ago')" "$d/motd"
+    govc guest.ls "$d/motd"
     govc guest.download $d/motd - | grep Chop
   done
   govc version | govc guest.upload -f - /etc/motd
@@ -95,6 +101,11 @@ EOF
 
     govc guest.rmdir /data/foo 2>/dev/null && exit 1 # should fail
     govc guest.rmdir /data/foo/bar/baz
+    dir=$(govc guest.mktemp -d -p /data/foo -s govc)
+    file=$(govc guest.mktemp -p "$dir")
+    govc guest.mv -n "$(govc guest.mktemp)" "$file" 2>/dev/null && exit 1 # should fail
+    govc guest.mv "$file" "${file}-old"
+    govc guest.mv "$dir" "${dir}-old"
     govc guest.rmdir -r /data/foo
     govc guest.ls /data | grep -v foo
   else

--- a/govc/vm/guest/file_attr.go
+++ b/govc/vm/guest/file_attr.go
@@ -33,8 +33,8 @@ func newFileAttrFlag(ctx context.Context) (*FileAttrFlag, context.Context) {
 }
 
 func (flag *FileAttrFlag) Register(ctx context.Context, f *flag.FlagSet) {
-	f.Var(flags.NewInt32(&flag.OwnerId), "uid", "User ID")
-	f.Var(flags.NewInt32(&flag.GroupId), "gid", "Group ID")
+	f.Var(flags.NewOptionalInt32(&flag.OwnerId), "uid", "User ID")
+	f.Var(flags.NewOptionalInt32(&flag.GroupId), "gid", "Group ID")
 	f.Int64Var(&flag.Permissions, "perm", 0, "File permissions")
 }
 

--- a/govc/vm/guest/ls.go
+++ b/govc/vm/guest/ls.go
@@ -101,7 +101,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 			switch x := f.Attributes.(type) {
 			case *types.GuestPosixFileAttributes:
 				perm := os.FileMode(x.Permissions).Perm().String()[1:]
-				fmt.Fprintf(tw, "%c%s\t%d\t%d\t", kind, perm, x.OwnerId, x.GroupId)
+				fmt.Fprintf(tw, "%c%s\t%d\t%d\t", kind, perm, *x.OwnerId, *x.GroupId)
 			}
 
 			attr := f.Attributes.GetGuestFileAttributes()

--- a/govc/vm/guest/mktemp.go
+++ b/govc/vm/guest/mktemp.go
@@ -28,6 +28,7 @@ type mktemp struct {
 	*GuestFlag
 
 	dir    bool
+	path   string
 	prefix string
 	suffix string
 }
@@ -41,6 +42,7 @@ func (cmd *mktemp) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.GuestFlag.Register(ctx, f)
 
 	f.BoolVar(&cmd.dir, "d", false, "Make a directory instead of a file")
+	f.StringVar(&cmd.path, "p", "", "If specified, create relative to this directory")
 	f.StringVar(&cmd.prefix, "t", "", "Prefix")
 	f.StringVar(&cmd.suffix, "s", "", "Suffix")
 }
@@ -58,7 +60,8 @@ func (cmd *mktemp) Description() string {
 Examples:
   govc guest.mktemp -vm $name
   govc guest.mktemp -vm $name -d
-  govc guest.mktemp -vm $name -t myprefix`
+  govc guest.mktemp -vm $name -t myprefix
+  govc guest.mktemp -vm $name -p /var/tmp/$USER`
 }
 
 func (cmd *mktemp) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -72,7 +75,7 @@ func (cmd *mktemp) Run(ctx context.Context, f *flag.FlagSet) error {
 		mk = m.CreateTemporaryDirectory
 	}
 
-	name, err := mk(ctx, cmd.Auth(), cmd.prefix, cmd.suffix)
+	name, err := mk(ctx, cmd.Auth(), cmd.prefix, cmd.suffix, cmd.path)
 	if err != nil {
 		return err
 	}

--- a/govc/vm/guest/mv.go
+++ b/govc/vm/guest/mv.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,59 +19,67 @@ package guest
 import (
 	"context"
 	"flag"
-	"strconv"
 
 	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-type chmod struct {
+type mv struct {
 	*GuestFlag
+
+	noclobber bool
 }
 
 func init() {
-	cli.Register("guest.chmod", &chmod{})
+	cli.Register("guest.mv", &mv{})
 }
 
-func (cmd *chmod) Register(ctx context.Context, f *flag.FlagSet) {
+func (cmd *mv) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.GuestFlag, ctx = newGuestFlag(ctx)
 	cmd.GuestFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.noclobber, "n", false, "Do not overwrite an existing file")
 }
 
-func (cmd *chmod) Process(ctx context.Context) error {
+func (cmd *mv) Process(ctx context.Context) error {
 	if err := cmd.GuestFlag.Process(ctx); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (cmd *chmod) Usage() string {
-	return "MODE FILE"
+func (cmd *mv) Usage() string {
+	return "SOURCE DEST"
 }
 
-func (cmd *chmod) Description() string {
-	return `Change FILE MODE on VM.
+func (cmd *mv) Description() string {
+	return `Move (rename) files in VM.
 
 Examples:
-  govc guest.chmod -vm $name 0644 /var/log/foo.log`
+  govc guest.mv -vm $name /tmp/foo.sh /tmp/bar.sh
+  govc guest.mv -vm $name -n /tmp/baz.sh /tmp/bar.sh`
 }
 
-func (cmd *chmod) Run(ctx context.Context, f *flag.FlagSet) error {
-	if f.NArg() != 2 {
-		return flag.ErrHelp
-	}
-
+func (cmd *mv) Run(ctx context.Context, f *flag.FlagSet) error {
 	m, err := cmd.FileManager()
 	if err != nil {
 		return err
 	}
 
-	var attr types.GuestPosixFileAttributes
+	src := f.Arg(0)
+	dst := f.Arg(1)
 
-	attr.Permissions, err = strconv.ParseInt(f.Arg(0), 0, 64)
+	err = m.MoveFile(ctx, cmd.Auth(), src, dst, !cmd.noclobber)
+
 	if err != nil {
-		return err
+		if soap.IsSoapFault(err) {
+			soapFault := soap.ToSoapFault(err)
+			if _, ok := soapFault.VimFault().(types.NotAFile); ok {
+				err = m.MoveDirectory(ctx, cmd.Auth(), src, dst)
+			}
+		}
 	}
 
-	return m.ChangeFileAttributes(ctx, cmd.Auth(), f.Arg(1), &attr)
+	return err
 }

--- a/govc/vm/guest/touch.go
+++ b/govc/vm/guest/touch.go
@@ -1,0 +1,126 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guest
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type touch struct {
+	*GuestFlag
+
+	nocreate bool
+	atime    bool
+	date     string
+}
+
+func init() {
+	cli.Register("guest.touch", &touch{})
+}
+
+func (cmd *touch) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.atime, "a", false, "Change only the access time")
+	f.BoolVar(&cmd.nocreate, "c", false, "Do not create any files")
+	f.StringVar(&cmd.date, "d", "", "Use DATE instead of current time")
+}
+
+func (cmd *touch) Process(ctx context.Context) error {
+	if err := cmd.GuestFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *touch) Usage() string {
+	return "FILE"
+}
+
+func (cmd *touch) Description() string {
+	return `Change FILE times on VM.
+
+Examples:
+  govc guest.touch -vm $name /var/log/foo.log
+  govc guest.touch -vm $name -d "$(date -d '1 day ago')" /var/log/foo.log`
+}
+
+func (cmd *touch) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	m, err := cmd.FileManager()
+	if err != nil {
+		return err
+	}
+
+	name := f.Arg(0)
+
+	var attr types.GuestFileAttributes
+	now := time.Now()
+
+	if cmd.date != "" {
+		now, err = time.Parse(time.UnixDate, cmd.date)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.atime {
+		attr.AccessTime = &now
+	} else {
+		attr.ModificationTime = &now
+	}
+
+	err = m.ChangeFileAttributes(ctx, cmd.Auth(), name, &attr)
+	if err != nil && !cmd.nocreate && soap.IsSoapFault(err) {
+		fault := soap.ToSoapFault(err)
+		if _, ok := fault.VimFault().(types.FileNotFound); ok {
+			// create a new empty file
+			url, cerr := m.InitiateFileTransferToGuest(ctx, cmd.Auth(), name, &attr, 0, false)
+			if cerr != nil {
+				return cerr
+			}
+
+			u, cerr := cmd.ParseURL(url)
+			if cerr != nil {
+				return cerr
+			}
+
+			c, cerr := cmd.Client()
+			if cerr != nil {
+				return cerr
+			}
+
+			err = c.Client.Upload(new(bytes.Buffer), u, &soap.DefaultUpload)
+			if err == nil && cmd.date != "" {
+				err = m.ChangeFileAttributes(ctx, cmd.Auth(), name, &attr)
+			}
+		}
+	}
+
+	return err
+}

--- a/guest/file_manager.go
+++ b/guest/file_manager.go
@@ -49,13 +49,14 @@ func (m FileManager) ChangeFileAttributes(ctx context.Context, auth types.BaseGu
 	return err
 }
 
-func (m FileManager) CreateTemporaryDirectory(ctx context.Context, auth types.BaseGuestAuthentication, prefix, suffix string) (string, error) {
+func (m FileManager) CreateTemporaryDirectory(ctx context.Context, auth types.BaseGuestAuthentication, prefix, suffix string, path string) (string, error) {
 	req := types.CreateTemporaryDirectoryInGuest{
-		This:   m.Reference(),
-		Vm:     m.vm,
-		Auth:   auth,
-		Prefix: prefix,
-		Suffix: suffix,
+		This:          m.Reference(),
+		Vm:            m.vm,
+		Auth:          auth,
+		Prefix:        prefix,
+		Suffix:        suffix,
+		DirectoryPath: path,
 	}
 
 	res, err := methods.CreateTemporaryDirectoryInGuest(ctx, m.c, &req)
@@ -66,13 +67,14 @@ func (m FileManager) CreateTemporaryDirectory(ctx context.Context, auth types.Ba
 	return res.Returnval, nil
 }
 
-func (m FileManager) CreateTemporaryFile(ctx context.Context, auth types.BaseGuestAuthentication, prefix, suffix string) (string, error) {
+func (m FileManager) CreateTemporaryFile(ctx context.Context, auth types.BaseGuestAuthentication, prefix, suffix string, path string) (string, error) {
 	req := types.CreateTemporaryFileInGuest{
-		This:   m.Reference(),
-		Vm:     m.vm,
-		Auth:   auth,
-		Prefix: prefix,
-		Suffix: suffix,
+		This:          m.Reference(),
+		Vm:            m.vm,
+		Auth:          auth,
+		Prefix:        prefix,
+		Suffix:        suffix,
+		DirectoryPath: path,
 	}
 
 	res, err := methods.CreateTemporaryFileInGuest(ctx, m.c, &req)

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -18341,9 +18341,9 @@ func init() {
 type GuestPosixFileAttributes struct {
 	GuestFileAttributes
 
-	OwnerId     int32 `xml:"ownerId,omitempty"`
-	GroupId     int32 `xml:"groupId,omitempty"`
-	Permissions int64 `xml:"permissions,omitempty"`
+	OwnerId     *int32 `xml:"ownerId"`
+	GroupId     *int32 `xml:"groupId"`
+	Permissions int64  `xml:"permissions,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
- Remove FileAttr flags from guest.chmod command,
  chown functionality moved to its own command

- GuestPosixFileAttributes OwnerId and GroupId fields are now pointers,
  rather than omitempty ints to allow chown with root uid:gid

- Add optional path to guest mktemp file methods

- Add guest.touch and guest.mv commands