### PR TITLE
Fix the WaitOptions struct

### DIFF
--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -53154,8 +53154,8 @@ type WaitForUpdatesResponse struct {
 type WaitOptions struct {
 	DynamicData
 
-	MaxWaitSeconds   int32 `xml:"maxWaitSeconds,omitempty"`
-	MaxObjectUpdates int32 `xml:"maxObjectUpdates,omitempty"`
+	MaxWaitSeconds   *int32 `xml:"maxWaitSeconds"`
+	MaxObjectUpdates int32  `xml:"maxObjectUpdates,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
[VMware API Doc](https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vmodl.query.PropertyCollector.WaitOptions.html#maxWaitSeconds) says :

> Data Object - WaitOptions
> field maxWaitSeconds (xsd:int)

> - An unset value causes WaitForUpdatesEx to wait as long as possible for updates.
> - A value of 0 causes WaitForUpdatesEx to do one update calculation and return any results.
> - A positive value causes WaitForUpdatesEx to return null if no updates are available within the specified number of seconds.

As of today the field MaxWaitSeconds in struct WaitOptions is of type **int32** and with tag option **omitempty**. This causes the value 0 to be ignored, and thus the 2nd case listed is not possible.

I changed its type to ***int32** and removed the option **omitempty**.
Now we can : 
- set it to nil (first case)
- set it to 0 (second case)
- set it to 1+ (third case)

Thanks for reviewing
Thibaut