### PR TITLE
Update wsdl generator

### DIFF
--- a/gen/vim_wsdl.rb
+++ b/gen/vim_wsdl.rb
@@ -191,7 +191,7 @@ class Simple
   end
 
   def pointer_type?
-    ["UnitNumber", "OwnerId", "GroupId"].include?(var_name)
+    ["UnitNumber", "OwnerId", "GroupId", "MaxWaitSeconds"].include?(var_name)
   end
 
   def var_type
@@ -230,6 +230,9 @@ class Simple
           pkg = "types."
         end
         t = "#{pkg}AnyType"
+        if ["Value"].include?(var_name)
+          self.need_omitempty = false
+        end
       when "byte"
       when "double"
         t = "float64"

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -28546,7 +28546,7 @@ func init() {
 type MethodActionArgument struct {
 	DynamicData
 
-	Value AnyType `xml:"value,omitempty,typeattr"`
+	Value AnyType `xml:"value,typeattr"`
 }
 
 func init() {
@@ -31074,7 +31074,7 @@ type OptionValue struct {
 	DynamicData
 
 	Key   string  `xml:"key"`
-	Value AnyType `xml:"value,typeattr"` // TODO: update wsdl generator to skip omitempty for this field
+	Value AnyType `xml:"value,typeattr"`
 }
 
 func init() {


### PR DESCRIPTION
This preserves the manual changes made in PRs #738 and #741
to remove omitempty tags from:

- OptionValue.Value

- MaxWaitSeconds WaitOptions