### PR TITLE
vcsim: Add cdrom and scsi controller to Model VMs

### DIFF
--- a/simulator/model.go
+++ b/simulator/model.go
@@ -219,9 +219,15 @@ func (m *Model) Create() error {
 					pool, _ = host.ResourcePool(ctx)
 				}
 
-				devices := []types.BaseVirtualDevice{&nic}
+				devices := object.VirtualDeviceList(esx.VirtualDevice)
 
-				config.DeviceChange, _ = object.VirtualDeviceList(devices).ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+				scsi, _ := devices.CreateSCSIController("pvscsi")
+				ide, _ := devices.FindIDEController("")
+				cdrom, _ := devices.CreateCdrom(ide)
+
+				devices = append(devices, scsi, cdrom, &nic)
+
+				config.DeviceChange, _ = devices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
 
 				task, err := folders.VmFolder.CreateVM(ctx, config, pool, host)
 				if err != nil {

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -279,8 +279,10 @@ func TestReconfigVm(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// VM should have the default list of devices + 1 NIC created by the Model
-	if len(device) != len(esx.VirtualDevice)+1 {
+	// default list of devices + 1 NIC + 1 SCSI controller + 1 CDROM created by the Model
+	mdevices := len(esx.VirtualDevice) + 3
+
+	if len(device) != mdevices {
 		t.Error("device list mismatch")
 	}
 
@@ -301,7 +303,7 @@ func TestReconfigVm(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(device) != len(esx.VirtualDevice) {
+	if len(device) != mdevices-1 {
 		t.Error("device list mismatch")
 	}
 
@@ -320,7 +322,7 @@ func TestReconfigVm(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(device) != len(esx.VirtualDevice)+1 {
+	if len(device) != mdevices {
 		t.Error("device list mismatch")
 	}
 }


### PR DESCRIPTION
Folder.CreateVM does not add these devices, but they are common to need for
testing against the Model VMs.

Fixup (negative) generated device keys to avoid conflicts.