### PR TITLE
Minor correction in README.md

### DIFF
--- a/vcsim/README.md
+++ b/vcsim/README.md
@@ -22,7 +22,7 @@ Example using the default settings:
 
 ```
 % export GOVC_URL=https://user:pass@127.0.0.1:8989
-% $GOPATH/vcsim
+% $GOPATH/bin/vcsim
 % govc find
 /
 /DC0


### PR DESCRIPTION
Fix corrects the path of vcsim described in README quickstart
guide.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>