### PR TITLE
toolbox: make directory archive read/write customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The code in the `govmomi` package is a wrapper for the code that is generated fr
 It primarily provides convenience functions for working with the vSphere API.
 See [godoc.org][godoc] for documentation.
 
-[apiref]:http://pubs.vmware.com/vsphere-60/index.jsp#com.vmware.wssdk.apiref.doc/right-pane.html
+[apiref]:http://pubs.vmware.com/vsphere-6-5/index.jsp#com.vmware.wssdk.apiref.doc/right-pane.html
 [godoc]:http://godoc.org/github.com/vmware/govmomi
 [drone]:https://drone.io
 [dronesrc]:https://github.com/drone/drone

--- a/govc/vm/guest/run.go
+++ b/govc/vm/guest/run.go
@@ -138,8 +138,8 @@ func (cmd *run) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		return cmd.do(hc, req)
-	case "POST":
-		req, err := http.NewRequest("POST", f.Arg(1), os.Stdin)
+	case "POST", "PUT":
+		req, err := http.NewRequest(name, f.Arg(1), os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/property/collector.go
+++ b/property/collector.go
@@ -30,7 +30,7 @@ import (
 // Collector models the PropertyCollector managed object.
 //
 // For more information, see:
-// http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vmodl.query.PropertyCollector.html
+// http://pubs.vmware.com/vsphere-60/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvmodl.query.PropertyCollector.html
 //
 type Collector struct {
 	roundTripper soap.RoundTripper

--- a/toolbox/README.md
+++ b/toolbox/README.md
@@ -12,14 +12,14 @@ overridden and/or extended by consumers.
 
 Feature list from the perspective of vSphere public API interaction.  The properties, objects and methods listed are
 relative to
-the [VirtualMachine](http://pubs.vmware.com/vsphere-60/index.jsp#com.vmware.wssdk.apiref.doc/vim.VirtualMachine.html)
+the [VirtualMachine](http://pubs.vmware.com/vsphere-60/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.VirtualMachine.html)
 managed object type.
 
 ### guest.toolsVersionStatus property
 
 The toolbox reports version as `guestToolsUnmanaged`.
 
-See [ToolsVersionStatus](http://pubs.vmware.com/vsphere-60/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.GuestInfo.ToolsVersionStatus.html)
+See [ToolsVersionStatus](http://pubs.vmware.com/vsphere-60/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.vm.GuestInfo.ToolsVersionStatus.html)
 
 ### guest.toolsRunningStatus and guest.guestState properties
 
@@ -31,7 +31,7 @@ The VMX requests this value via the `Set_Option broadcastIP` RPC.
 
 The default value can be overridden by setting the `Service.PrimaryIP` function.
 
-See [vim.vm.GuestInfo](http://pubs.vmware.com/vsphere-60/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.GuestInfo.html)
+See [vim.vm.GuestInfo](http://pubs.vmware.com/vsphere-60/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.vm.GuestInfo.html)
 
 ### guest.net property
 
@@ -45,9 +45,9 @@ The [PowerCommandHandler](power.go) provides power hooks for customized guest sh
 
 ### GuestAuthManager object
 
-Guest operations can be authenticated using the `VixRelayedCommandHandler.Authenticate` hook.
+Not supported, but authentication can be customized.
 
-See [vim.vm.guest.AuthManager](http://pubs.vmware.com/vsphere-60/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.guest.AuthManager.html)
+See [vim.vm.guest.AuthManager](http://pubs.vmware.com/vsphere-60/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.vm.guest.AuthManager.html)
 
 ### GuestFileManager object
 
@@ -56,7 +56,7 @@ See [vim.vm.guest.AuthManager](http://pubs.vmware.com/vsphere-60/index.jsp#com.v
 | ChangeFileAttributesInGuest     | Yes       | [chmod](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/chmod.go)       |
 |                                 |           | [chown](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/chown.go)       |
 |                                 |           | [touch](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/touch.go)       |
-| CreateTemporaryDirectoryInGuest | Yes       | [mktemp](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/mktemp.go)  |
+| CreateTemporaryDirectoryInGuest | Yes       | [mktemp](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/mktemp.go)     |
 | CreateTemporaryFileInGuest      | Yes       | [mktemp](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/mktemp.go)     |
 | DeleteDirectoryInGuest          | Yes       | [rmdir](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/rmdir.go)       |
 | DeleteFileInGuest               | Yes       | [rm](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/rm.go)             |
@@ -67,14 +67,10 @@ See [vim.vm.guest.AuthManager](http://pubs.vmware.com/vsphere-60/index.jsp#com.v
 | MoveDirectoryInGuest            | Yes       | [mv](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/mv.go)             |
 | MoveFileInGuest                 | Yes       | [mv](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/mv.go)             |
 
-See [vim.vm.guest.FileManager](http://pubs.vmware.com/vsphere-60/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.guest.FileManager.html)
-
-The toolbox provides support for transferring directories to and from guests as gzip'd tar streams, without writing the
-tar file itself to the guest file system.  To disable this feature, set the `hgfs.FileServer.Archive` field to `false`.
+See [vim.vm.guest.FileManager](http://pubs.vmware.com/vsphere-60/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.vm.guest.FileManager.html)
 
 ### GuestProcessManager
 
-The toolbox [ProcessManager](process.go) can manage both OS processes and Go functions running as goroutines.
 Currently, the `ListProcessesInGuest` and `TerminateProcessInGuest` methods only apply those processes and goroutines
 started by `StartProgramInGuest`.
 
@@ -85,7 +81,51 @@ started by `StartProgramInGuest`.
 | StartProgramInGuest            | Yes       | [start](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/start.go)       |
 | TerminateProcessInGuest        | Yes       | [kill](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/kill.go)         |
 
-See [vim.vm.guest.ProcessManager](http://pubs.vmware.com/vsphere-60/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.guest.ProcessManager.html)
+See [vim.vm.guest.ProcessManager](http://pubs.vmware.com/vsphere-60/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.vm.guest.ProcessManager.html)
+
+## Extensions
+
+### Authentication
+
+Guest operations can be authenticated using the `toolbox.CommandServer.Authenticate` hook.
+
+### Go functions
+
+The toolbox [ProcessManager](process.go) can manage both OS processes and Go functions running as go routines.
+
+### File handlers
+
+The `hgfs.FileHandler` interface can be used to customize file transfer.
+
+### Process I/O
+
+The toolbox provides support for I/O redirection without the use of disk files within the guest.
+Access to *stdin*, *stdout* and *stderr* streams is implemented as an `hgfs.FileHandler` within the `ProcessManager`.
+
+See [toolbox.Client](https://github.com/vmware/govmomi/blob/master/guest/toolbox/client.go) and
+[govc guest.run](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/run.go)
+
+### http.RoundTripper
+
+Building on top of the process I/O functionality, `toolbox.NewProcessRoundTrip` can be used to start a Go function to
+implement the [http.RoundTripper](https://golang.org/pkg/net/http/#RoundTripper) interface over vmx guest RPC.  This
+makes it possible to use the Go [http.Client](https://golang.org/pkg/net/http/#Client) without network access to the VM
+or to a port that is bound to the guest's loopback address.  It is intended for use with bootstrap configuration for
+example.
+
+### Directory archives
+
+The toolbox provides support for transferring directories to and from guests as gzip'd tar streams, without writing the
+tar file itself to the guest file system.  Archive supports is implemented as an `hgfs.FileHandler` within the `hgfs`
+package.  See [hgfs.NewArchiveHandler](https://github.com/vmware/govmomi/blob/master/toolbox/hgfs/archive.go)
+
+### Linux /proc file access
+
+With standard vmware-tools, the file size is reported as returned by `stat()` and hence a `Content-Length` header of
+size `0`.  The toolbox reports /proc file size as `hgfs.LargePacketMax` to enable transfer of these files.  Note that if
+the file data fits within in `hgfs.LargePacketMax`, the `Content-Length` header will be correct as it is sent after the
+first read by the vmx.  However, if the file data exceeds `hgfs.LargePacketMax`, the `Content-Length` will be
+`hgfs.LargePacketMax`, and client side will truncate to that size.
 
 ## Testing
 
@@ -100,8 +140,7 @@ without running the test suite.
 
 ## Consumers of the toolbox library
 
-* [Toolbox example main](https://github.com/vmware/govmomi/blob/master/toolbox/toolbox/main.go
-)
+* [Toolbox example main](https://github.com/vmware/govmomi/blob/master/toolbox/toolbox/main.go)
 
 * [VIC tether toolbox extension](https://github.com/vmware/vic/blob/master/lib/tether/toolbox.go)
 

--- a/toolbox/command.go
+++ b/toolbox/command.go
@@ -23,6 +23,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -91,6 +92,8 @@ func commandResult(header vix.CommandRequestHeader, rc int, err error, response 
 		// TODO: inspect err for system error, setting errno
 
 		response = []byte(err.Error())
+
+		log.Printf("[vix] op=%d error: %s", header.OpCode, err)
 	}
 
 	buf := bytes.NewBufferString(fmt.Sprintf("%d %d ", rc, errno))

--- a/toolbox/command_test.go
+++ b/toolbox/command_test.go
@@ -260,11 +260,12 @@ func TestVixInitiateDirTransfer(t *testing.T) {
 	dir := os.TempDir()
 
 	for _, enable := range []bool{true, false} {
-		// validate we behave as open-vm-tools does when the directory archive feature is disabled
-		c.Service.Command.FileServer.Archive = enable
 		expect := vix.NotAFile
 		if enable {
 			expect = vix.OK
+		} else {
+			// validate we behave as open-vm-tools does when the directory archive feature is disabled
+			c.Service.Command.FileServer.RegisterFileHandler(hgfs.ArchiveScheme, nil)
 		}
 
 		fromGuest := &vix.ListFilesRequest{GuestPathName: dir}

--- a/toolbox/hgfs/archive.go
+++ b/toolbox/hgfs/archive.go
@@ -20,12 +20,51 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"io"
+	"math"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 )
+
+// ArchiveScheme is the default scheme used to register the archive FileHandler
+var ArchiveScheme = "archive"
+
+// ArchiveHandler implements a FileHandler for transferring directories.
+type ArchiveHandler struct {
+	Read  func(string, *tar.Reader) error
+	Write func(string, *tar.Writer) error
+}
+
+// NewArchiveHandler returns a FileHandler implementation for transferring directories using gzip'd tar files.
+func NewArchiveHandler() FileHandler {
+	return &ArchiveHandler{
+		Read:  archiveRead,
+		Write: archiveWrite,
+	}
+}
+
+// Stat implements FileHandler.Stat
+func (*ArchiveHandler) Stat(u *url.URL) (os.FileInfo, error) {
+	return &archive{
+		name: u.Path,
+		size: math.MaxInt64,
+	}, nil
+}
+
+// Open implements FileHandler.Open
+func (h *ArchiveHandler) Open(u *url.URL, mode int32) (File, error) {
+	switch mode {
+	case OpenModeReadOnly:
+		return h.newArchiveFromGuest(u.Path)
+	case OpenModeWriteOnly:
+		return h.newArchiveToGuest(u.Path)
+	default:
+		return nil, os.ErrNotExist
+	}
+}
 
 // archive implements the hgfs.File and os.FileInfo interfaces.
 type archive struct {
@@ -73,7 +112,7 @@ func (a *archive) Sys() interface{} {
 var gzipHeader = []byte{0x1f, 0x8b, 0x08} // rfc1952 {ID1, ID2, CM}
 
 // newArchiveFromGuest returns an hgfs.File implementation to read a directory as a gzip'd tar.
-func newArchiveFromGuest(dir string) (File, error) {
+func (h *ArchiveHandler) newArchiveFromGuest(dir string) (File, error) {
 	r, w := io.Pipe()
 
 	a := &archive{
@@ -87,7 +126,7 @@ func newArchiveFromGuest(dir string) (File, error) {
 	a.done = r.Close
 
 	go func() {
-		err := a.pack(tw)
+		err := h.Write(dir, tw)
 
 		_ = tw.Close()
 		_ = gz.Close()
@@ -99,7 +138,7 @@ func newArchiveFromGuest(dir string) (File, error) {
 }
 
 // newArchiveToGuest returns an hgfs.File implementation to expand a gzip'd tar into a directory.
-func newArchiveToGuest(dir string) (File, error) {
+func (h *ArchiveHandler) newArchiveToGuest(dir string) (File, error) {
 	r, w := io.Pipe()
 
 	a := &archive{
@@ -121,25 +160,31 @@ func newArchiveToGuest(dir string) (File, error) {
 
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
+
 		gz, err := gzip.NewReader(a.Reader)
 		if err != nil {
 			_ = r.CloseWithError(err)
+			cerr = err
 			return
 		}
 
 		tr := tar.NewReader(gz)
 
-		cerr = a.unpack(tr)
+		cerr = h.Read(dir, tr)
 		_ = gz.Close()
 		_ = r.CloseWithError(cerr)
-		wg.Done()
 	}()
 
 	return a, nil
 }
 
-// unpack writes the contents of the given tar.Reader to the a.name directory.
-func (a *archive) unpack(tr *tar.Reader) error {
+func (a *archive) Close() error {
+	return a.done()
+}
+
+// archiveRead writes the contents of the given tar.Reader to the given directory.
+func archiveRead(dir string, tr *tar.Reader) error {
 	for {
 		header, err := tr.Next()
 		if err != nil {
@@ -149,7 +194,7 @@ func (a *archive) unpack(tr *tar.Reader) error {
 			return err
 		}
 
-		name := filepath.Join(a.Name(), header.Name)
+		name := filepath.Join(dir, header.Name)
 		mode := os.FileMode(header.Mode)
 
 		switch header.Typeflag {
@@ -182,11 +227,11 @@ func (a *archive) unpack(tr *tar.Reader) error {
 	}
 }
 
-// pack writes the contents of the archive source directory to the given tar.Writer.
-func (a *archive) pack(tw *tar.Writer) error {
-	dir := filepath.Dir(a.name)
+// archiveWrite writes the contents of the given source directory to the given tar.Writer.
+func archiveWrite(name string, tw *tar.Writer) error {
+	dir := filepath.Dir(name)
 
-	return filepath.Walk(a.name, func(file string, fi os.FileInfo, err error) error {
+	return filepath.Walk(name, func(file string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return filepath.SkipDir
 		}
@@ -222,8 +267,4 @@ func (a *archive) pack(tw *tar.Writer) error {
 
 		return err
 	})
-}
-
-func (a *archive) Close() error {
-	return a.done()
 }

--- a/toolbox/hgfs/archive_test.go
+++ b/toolbox/hgfs/archive_test.go
@@ -70,7 +70,7 @@ func TestReadArchive(t *testing.T) {
 	}
 
 	c := NewClient()
-	c.s.Archive = true
+	c.s.RegisterFileHandler(ArchiveScheme, NewArchiveHandler())
 
 	status := c.CreateSession()
 	if status != StatusSuccess {
@@ -224,7 +224,7 @@ func TestWriteArchive(t *testing.T) {
 	_ = gz.Close()
 
 	c := NewClient()
-	c.s.Archive = true
+	c.s.RegisterFileHandler(ArchiveScheme, NewArchiveHandler())
 
 	status := c.CreateSession()
 	if status != StatusSuccess {

--- a/toolbox/hgfs/protocol.go
+++ b/toolbox/hgfs/protocol.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 )
@@ -148,7 +149,8 @@ const (
 // HeaderVersion for HGFS protocol version 4
 const HeaderVersion = 0x1
 
-const largePacketMax = 0xf800 // HGFS_LARGE_PACKET_MAX
+// LargePacketMax is maximum size of an hgfs packet
+const LargePacketMax = 0xf800 // HGFS_LARGE_PACKET_MAX
 
 // Packet flags
 const (
@@ -169,7 +171,7 @@ func (s *Status) Error() string {
 		return s.Err.Error()
 	}
 
-	return fmt.Sprintf("status=%d", s.Code)
+	return fmt.Sprintf("hgfs.Status=%d", s.Code)
 }
 
 // errorStatus maps the given error type to a status code
@@ -291,6 +293,8 @@ func (r *Packet) Reply(payload interface{}, err error) ([]byte, error) {
 			rc = err.Error()
 		}
 		fmt.Fprintf(os.Stderr, "[hgfs] response %#v [%s]\n", p.Header, rc)
+	} else if err != nil {
+		log.Printf("[hgfs] op=%d error: %s", r.Op, err)
 	}
 
 	return p.MarshalBinary()

--- a/toolbox/hgfs/server_test.go
+++ b/toolbox/hgfs/server_test.go
@@ -31,7 +31,6 @@ type Client struct {
 
 func NewClient() *Client {
 	s := NewServer()
-	s.Archive = false
 
 	return &Client{
 		s: s,

--- a/toolbox/service.go
+++ b/toolbox/service.go
@@ -87,6 +87,7 @@ func NewService(rpcIn Channel, rpcOut Channel) *Service {
 	s.Command = registerCommandServer(s)
 	s.Command.FileServer = hgfs.NewServer()
 	s.Command.FileServer.RegisterFileHandler("proc", s.Command.ProcessManager)
+	s.Command.FileServer.RegisterFileHandler(hgfs.ArchiveScheme, hgfs.NewArchiveHandler())
 
 	s.Power = registerPowerCommandHandler(s)
 

--- a/toolbox/toolbox-test.sh
+++ b/toolbox/toolbox-test.sh
@@ -174,7 +174,17 @@ if [ -n "$test" ] ; then
   govc guest.chmod 0755 "$dest"
   govc guest.ls "$dest" | grep rwxr-xr-x
 
+  echo "Testing custom hgfs.FileHandler..."
+  if ! govc guest.download "/echo:$dest" - 2>/dev/null ; then
+      govc guest.download "/echo:$dest?foo=bar" - >/dev/null
+  fi
+
   home=$(govc guest.getenv HOME | cut -d= -f2)
+
+  if date | govc guest.upload -f - /tmp 2>/dev/null ; then
+    echo "guest.upload to directory should fail without .tgz source" 1>&2
+    exit 1
+  fi
 
   if [ "$verbose" = "false" ] ; then # else you don't want to see this noise
     # Download the $HOME directory, includes toolbox binaries (~30M total)

--- a/vcsim/README.md
+++ b/vcsim/README.md
@@ -73,7 +73,7 @@ Example using ESX mode:
 
 The simulator supports a subset of API methods.  However, the generated [govmomi](https://github.com/vmware/govmomi)
 code includes all types and methods defined in the vmodl, which can be used to implement any method documented in the
-[VMware vSphere API Reference](http://pubs.vmware.com/vsphere-65/index.jsp#com.vmware.wssdk.apiref.doc/right-pane.html).
+[VMware vSphere API Reference](http://pubs.vmware.com/vsphere-6-5/index.jsp#com.vmware.wssdk.apiref.doc/right-pane.html).
 
 To see the list of supported methods:
 


### PR DESCRIPTION
Directory archive behavior can now be customized via hgfs.ArchiveRead and hgfs.ArchiveWrite

Follow on to PR #763, moving existing code behind the new hgfs.FileHandler interface:

- Transfer of /proc files

- Directory archive support

Fixes:

- Directory upload would hang if data was not in gzip'd tar format

- Log hgfs and vix errors regardless of Trace being enabled

- Doc updates