### PR TITLE
toolbox: map exec.ErrNotFound to vix.FileNotFound

### DIFF
--- a/toolbox/command_test.go
+++ b/toolbox/command_test.go
@@ -184,7 +184,7 @@ func TestVixRelayedCommandHandler(t *testing.T) {
 	buf = append(marshal(request), creds...)
 	reply, _ = cmd.Dispatch(buf)
 	rc = vixRC(reply)
-	if rc != vix.Fail {
+	if rc != vix.FileNotFound {
 		t.Fatalf("%q", reply)
 	}
 


### PR DESCRIPTION
Before:

```bash
% govc guest.run h8ctl
govc: ServerFaultCode: A general system error occurred: vix error codes = (1, 0).
```

```xml
  <soapenv:Fault>
   <faultcode>ServerFaultCode</faultcode>
   <faultstring>A general system error occurred: vix error codes = (1, 0).</faultstring>
   <detail>
    <SystemErrorFault xmlns="urn:vim25" xsi:type="SystemError">
     <reason>vix error codes = (1, 0).</reason>
    </SystemErrorFault>
   </detail>
  </soapenv:Fault>
```

After:

```bash
% govc guest.run h8ctl
govc: ServerFaultCode: File h8ctl was not found
```

```xml
  <soapenv:Fault>
   <faultcode>ServerFaultCode</faultcode>
   <faultstring>File h8ctl was not found</faultstring>
   <detail>
    <FileNotFoundFault xmlns="urn:vim25" xsi:type="FileNotFound">
     <file>h8ctl</file>
    </FileNotFoundFault>
   </detail>
  </soapenv:Fault>
```
