### PR TITLE
toolbox: SendGuestInfo before the vmx asks us to

### DIFF
--- a/toolbox/service.go
+++ b/toolbox/service.go
@@ -211,6 +211,8 @@ func (s *Service) Dispatch(request []byte) []byte {
 
 // Reset is the default Handler for reset requests
 func (s *Service) Reset([]byte) ([]byte, error) {
+	s.SendGuestInfo() // Send the IP info ASAP
+
 	return []byte("ATR " + s.name), nil
 }
 

--- a/toolbox/service_test.go
+++ b/toolbox/service_test.go
@@ -146,6 +146,7 @@ func TestServiceRun(t *testing.T) {
 	}
 
 	out.reply = append(out.reply,
+		rpciOK, // reply to SendGuestInfo call in Reset()
 		rpciOK, // reply to IP broadcast
 	)
 

--- a/toolbox/toolbox-test.sh
+++ b/toolbox/toolbox-test.sh
@@ -230,6 +230,11 @@ if [ -n "$test" ] ; then
 fi
 
 if [ -n "$start" ] ; then
+  (
+    govc object.collect -n 1 "$(govc find / -type m -name "$vm")" guest.toolsStatus # wait for tools state to transition
+    /usr/bin/time -f "Waiting for VM ip from toolbox...%e" govc vm.ip -v4 -n ethernet-0 "$vm"
+  ) &
+
   echo "Starting toolbox..."
   ssh "${opts[@]}" "core@${ip}" ./toolbox -toolbox.trace=$verbose
 fi


### PR DESCRIPTION
We send the IP (and NIC info) in response to the broadcastIP request.
There can be ~30 seconds between the Reset request (1st call) and the broadcastIP request.
For existing VMs, the IP/NIC info is cached in the vmdb and doesn't take as long.

With this change, the IP/NIC info is pushed asap and takes < 1 second

Before:
```
  guest.toolsStatus  types.VirtualMachineToolsStatus  toolsOk
  Waiting for VM ip from toolbox...30.01
```
After:
```
  guest.toolsStatus  types.VirtualMachineToolsStatus  toolsOk
  Waiting for VM ip from toolbox...0.06
```