### PR TITLE
Tolerate repeated Close for file follower

### DIFF
--- a/object/datastore_file.go
+++ b/object/datastore_file.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"sync"
 	"time"
 
 	"github.com/vmware/govmomi/vim25/soap"
@@ -347,6 +348,7 @@ type followDatastoreFile struct {
 	r *DatastoreFile
 	c chan struct{}
 	i time.Duration
+	o sync.Once
 }
 
 // Read reads up to len(b) bytes from the DatastoreFile being followed.
@@ -398,11 +400,15 @@ func (f *followDatastoreFile) Read(p []byte) (int, error) {
 
 // Close will stop Follow polling and close the underlying DatastoreFile.
 func (f *followDatastoreFile) Close() error {
-	close(f.c)
+	f.o.Do(func() { close(f.c) })
 	return nil
 }
 
 // Follow returns an io.ReadCloser to stream the file contents as data is appended.
 func (f *DatastoreFile) Follow(interval time.Duration) io.ReadCloser {
-	return &followDatastoreFile{f, make(chan struct{}), interval}
+	return &followDatastoreFile{
+		r: f,
+		c: make(chan struct{}),
+		i: interval,
+	}
 }


### PR DESCRIPTION
Allow repeated calls to Close for datastore file follower without panic.
