### PR TITLE
Add view and filter support to object.collect command

### DIFF
--- a/event/processor.go
+++ b/event/processor.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@ import (
 	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25/types"
 )
-
-const latestPageProp = "latestPage"
 
 type tailInfo struct {
 	t         *eventTailer
@@ -81,53 +79,47 @@ func (p *eventProcessor) run(ctx context.Context, tail bool) error {
 		return nil
 	}
 
-	var err error
 	var collectors []types.ManagedObjectReference
 	for _, t := range p.tailers {
 		collectors = append(collectors, t.collector)
 	}
 
-	if len(p.tailers) > 1 {
-		// create and populate a ListView
-		viewMgr := view.NewManager(p.mgr.Client())
-		var listView *view.ListView
-		listView, err = viewMgr.CreateListView(ctx, collectors)
-		if err != nil {
-			return err
-		}
+	c := property.DefaultCollector(p.mgr.Client())
+	props := []string{"latestPage"}
 
-		count := 0
-		// Retrieve the property from the objects in the ListView
-		err = property.WaitForView(ctx, property.DefaultCollector(p.mgr.Client()), listView.Reference(), collectors[0], []string{latestPageProp}, func(c types.ManagedObjectReference, pc []types.PropertyChange) bool {
-			if err = p.process(c, pc); err != nil {
+	if len(collectors) == 1 {
+		// only one object to follow, don't bother creating a view
+		return property.Wait(ctx, c, collectors[0], props, func(pc []types.PropertyChange) bool {
+			if err := p.process(collectors[0], pc); err != nil {
 				return false
 			}
 
-			count++
-			if count == len(collectors) && !tail {
-				return true
-			}
-
-			return false
+			return !tail
 		})
+	}
 
+	// create and populate a ListView
+	m := view.NewManager(p.mgr.Client())
+
+	list, err := m.CreateListView(ctx, collectors)
+	if err != nil {
 		return err
 	}
 
-	// only one object to follow
-	err = property.Wait(ctx, property.DefaultCollector(p.mgr.Client()), collectors[0], []string{latestPageProp}, func(pc []types.PropertyChange) bool {
-		if err = p.process(collectors[0], pc); err != nil {
-			return false
+	defer list.Destroy(context.Background())
+
+	ref := list.Reference()
+	filter := new(property.WaitFilter).Add(ref, collectors[0].Type, props, list.TraversalSpec())
+
+	return property.WaitForUpdates(ctx, c, filter, func(updates []types.ObjectUpdate) bool {
+		for _, update := range updates {
+			if err := p.process(update.Obj, update.ChangeSet); err != nil {
+				return false
+			}
 		}
 
-		if !tail {
-			return true
-		}
-
-		return false
+		return !tail
 	})
-
-	return err
 }
 
 func (p *eventProcessor) process(c types.ManagedObjectReference, pc []types.PropertyChange) error {
@@ -137,10 +129,6 @@ func (p *eventProcessor) process(c types.ManagedObjectReference, pc []types.Prop
 	}
 
 	for _, u := range pc {
-		if u.Name != latestPageProp {
-			continue
-		}
-
 		evs := t.t.newEvents(u.Val.(types.ArrayOfEvent).Event)
 		if len(evs) == 0 {
 			continue

--- a/govc/object/find.go
+++ b/govc/object/find.go
@@ -237,6 +237,10 @@ func (cmd *find) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	filter := property.Filter{}
 
+	if len(props)%2 != 0 {
+		return flag.ErrHelp
+	}
+
 	for i := 0; i < len(props); i++ {
 		key := props[i]
 		if !strings.HasPrefix(key, "-") {

--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -133,6 +133,31 @@ load test_helper
   assert_success
 }
 
+@test "object.collect view" {
+  vcsim_env -dc 2 -folder 1
+
+  run govc object.collect -type m
+  assert_success
+
+  run govc object.collect -type m / -name '*C0*'
+  assert_success
+
+  run govc object.collect -type m / -name
+  assert_success
+
+  run govc object.collect -type m / name runtime.powerState
+  assert_success
+
+  run govc object.collect -type m -type h /F0 name
+  assert_success
+
+  run govc object.collect -type n / name
+  assert_success
+
+  run govc object.collect -type enoent / name
+  assert_failure
+}
+
 @test "object.find" {
   esx_env
 

--- a/property/wait.go
+++ b/property/wait.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,7 +22,50 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-// Wait waits for any of the specified properties of the specified managed
+// WaitFilter provides helpers to construct a types.CreateFilter for use with property.Wait
+type WaitFilter struct {
+	types.CreateFilter
+}
+
+// Add a new ObjectSpec and PropertySpec to the WaitFilter
+func (f *WaitFilter) Add(obj types.ManagedObjectReference, kind string, ps []string, set ...types.BaseSelectionSpec) *WaitFilter {
+	spec := types.ObjectSpec{
+		Obj:       obj,
+		SelectSet: set,
+	}
+
+	pset := types.PropertySpec{
+		Type:    kind,
+		PathSet: ps,
+	}
+
+	if len(ps) == 0 {
+		pset.All = types.NewBool(true)
+	}
+
+	f.Spec.ObjectSet = append(f.Spec.ObjectSet, spec)
+
+	f.Spec.PropSet = append(f.Spec.PropSet, pset)
+
+	return f
+}
+
+// Wait creates a new WaitFilter and calls the specified function for each ObjectUpdate via WaitForUpdates
+func Wait(ctx context.Context, c *Collector, obj types.ManagedObjectReference, ps []string, f func([]types.PropertyChange) bool) error {
+	filter := new(WaitFilter).Add(obj, obj.Type, ps)
+
+	return WaitForUpdates(ctx, c, filter, func(updates []types.ObjectUpdate) bool {
+		for _, update := range updates {
+			if f(update.ChangeSet) {
+				return true
+			}
+		}
+
+		return false
+	})
+}
+
+// WaitForUpdates waits for any of the specified properties of the specified managed
 // object to change. It calls the specified function for every update it
 // receives. If this function returns false, it continues waiting for
 // subsequent updates. If this function returns true, it stops waiting and
@@ -35,7 +78,7 @@ import (
 // The newly created collector is destroyed before this function returns (both
 // in case of success or error).
 //
-func Wait(ctx context.Context, c *Collector, obj types.ManagedObjectReference, ps []string, f func([]types.PropertyChange) bool) error {
+func WaitForUpdates(ctx context.Context, c *Collector, filter *WaitFilter, f func([]types.ObjectUpdate) bool) error {
 	p, err := c.Create(ctx)
 	if err != nil {
 		return err
@@ -45,91 +88,13 @@ func Wait(ctx context.Context, c *Collector, obj types.ManagedObjectReference, p
 	// specified context may have timed out or have been cancelled.
 	defer p.Destroy(context.Background())
 
-	req := types.CreateFilter{
-		Spec: types.PropertyFilterSpec{
-			ObjectSet: []types.ObjectSpec{
-				{
-					Obj: obj,
-				},
-			},
-			PropSet: []types.PropertySpec{
-				{
-					PathSet: ps,
-					Type:    obj.Type,
-				},
-			},
-		},
-	}
-
-	if len(ps) == 0 {
-		req.Spec.PropSet[0].All = types.NewBool(true)
-	}
-
-	err = p.CreateFilter(ctx, req)
-	if err != nil {
-		return err
-	}
-	return waitLoop(ctx, p, func(_ types.ManagedObjectReference, pc []types.PropertyChange) bool {
-		return f(pc)
-	})
-}
-
-// WaitForView waits for any of the specified properties of the managed
-// objects in the View to change. It calls the specified function for every update it
-// receives. If this function returns false, it continues waiting for
-// subsequent updates. If this function returns true, it stops waiting and
-// returns.
-//
-// To only receive updates for the View's specified managed objects, the function
-// creates a new property collector and calls CreateFilter. A new property
-// collector is required because filters can only be added, not removed.
-//
-// The newly created collector is destroyed before this function returns (both
-// in case of success or error).
-//
-// The code assumes that all objects in the View are the same type
-func WaitForView(ctx context.Context, c *Collector, view types.ManagedObjectReference, obj types.ManagedObjectReference, ps []string, f func(types.ManagedObjectReference, []types.PropertyChange) bool) error {
-	p, err := c.Create(ctx)
+	err = p.CreateFilter(ctx, filter.CreateFilter)
 	if err != nil {
 		return err
 	}
 
-	// Attempt to destroy the collector using the background context, as the
-	// specified context may have timed out or have been cancelled.
-	defer p.Destroy(context.Background())
-
-	req := types.CreateFilter{
-		Spec: types.PropertyFilterSpec{
-			ObjectSet: []types.ObjectSpec{
-				{
-					Obj: view,
-					SelectSet: []types.BaseSelectionSpec{
-						&types.TraversalSpec{
-							SelectionSpec: types.SelectionSpec{
-								Name: "traverseEntities",
-							},
-							Path: "view",
-							Type: view.Type}},
-				},
-			},
-			PropSet: []types.PropertySpec{
-				{
-					Type:    obj.Type,
-					PathSet: ps,
-				},
-			},
-		}}
-
-	err = p.CreateFilter(ctx, req)
-	if err != nil {
-		return err
-	}
-	return waitLoop(ctx, p, f)
-}
-
-func waitLoop(ctx context.Context, c *Collector, f func(types.ManagedObjectReference, []types.PropertyChange) bool) error {
 	for version := ""; ; {
-		res, err := c.WaitForUpdates(ctx, version)
+		res, err := p.WaitForUpdates(ctx, version)
 		if err != nil {
 			return err
 		}
@@ -142,12 +107,9 @@ func waitLoop(ctx context.Context, c *Collector, f func(types.ManagedObjectRefer
 		version = res.Version
 
 		for _, fs := range res.FilterSet {
-			for _, os := range fs.ObjectSet {
-				if f(os.Obj, os.ChangeSet) {
-					return nil
-				}
+			if f(fs.ObjectSet) {
+				return nil
 			}
 		}
 	}
-
 }

--- a/view/container_view.go
+++ b/view/container_view.go
@@ -19,30 +19,20 @@ package view
 import (
 	"context"
 
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
-	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
 type ContainerView struct {
-	object.Common
+	ManagedObjectView
 }
 
 func NewContainerView(c *vim25.Client, ref types.ManagedObjectReference) *ContainerView {
 	return &ContainerView{
-		Common: object.NewCommon(c, ref),
+		ManagedObjectView: *NewManagedObjectView(c, ref),
 	}
-}
-
-func (v ContainerView) Destroy(ctx context.Context) error {
-	req := types.DestroyView{
-		This: v.Reference(),
-	}
-	_, err := methods.DestroyView(ctx, v.Client(), &req)
-	return err
 }
 
 // Retrieve populates dst as property.Collector.Retrieve does, for all entities in the view of types specified by kind.

--- a/view/list_view.go
+++ b/view/list_view.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,28 +19,19 @@ package view
 import (
 	"context"
 
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
 type ListView struct {
-	object.Common
+	ManagedObjectView
 }
 
 func NewListView(c *vim25.Client, ref types.ManagedObjectReference) *ListView {
 	return &ListView{
-		Common: object.NewCommon(c, ref),
+		ManagedObjectView: *NewManagedObjectView(c, ref),
 	}
-}
-
-func (v ListView) Destroy(ctx context.Context) error {
-	req := types.DestroyView{
-		This: v.Reference(),
-	}
-	_, err := methods.DestroyView(ctx, v.Client(), &req)
-	return err
 }
 
 func (v ListView) Add(ctx context.Context, refs []types.ManagedObjectReference) error {

--- a/view/managed_object_view.go
+++ b/view/managed_object_view.go
@@ -1,0 +1,52 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ManagedObjectView struct {
+	object.Common
+}
+
+func NewManagedObjectView(c *vim25.Client, ref types.ManagedObjectReference) *ManagedObjectView {
+	return &ManagedObjectView{
+		Common: object.NewCommon(c, ref),
+	}
+}
+
+func (v *ManagedObjectView) TraversalSpec() *types.TraversalSpec {
+	return &types.TraversalSpec{
+		Path: "view",
+		Type: v.Reference().Type,
+	}
+}
+
+func (v *ManagedObjectView) Destroy(ctx context.Context) error {
+	req := types.DestroyView{
+		This: v.Reference(),
+	}
+
+	_, err := methods.DestroyView(ctx, v.Client(), &req)
+	return err
+}


### PR DESCRIPTION
Refactor property wait related methods:

- Add property.WaitFilter helper

- Expose a more generic property.WaitForUpdates

- Remove property.WaitForView (use property.WaitForUpdates instead)

- Refactor event collector to use property.WaitForUpdates

- Add TraversalSpec method to *View types