### PR TITLE
toolbox: avoid blocking the RPC channel when transferring process IO

### DIFF
--- a/toolbox/process_test.go
+++ b/toolbox/process_test.go
@@ -265,6 +265,8 @@ type testRoundTripper struct {
 }
 
 func (c *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Connection", "close") // we need the server to close the connection after 1 request
+
 	err := req.Write(c.IO.In.Writer)
 	if err != nil {
 		return nil, err

--- a/toolbox/toolbox-test.sh
+++ b/toolbox/toolbox-test.sh
@@ -234,6 +234,9 @@ if [ -n "$test" ] ; then
   data=$(govc guest.ps -json)
   govc guest.run -d "$data" jq .
 
+  # test ProcessIO download retries
+  govc version | govc guest.run -d - bash -c "'sleep 2 && cat'"
+
   echo "Waiting for tests to complete..."
   wait
 fi


### PR DESCRIPTION
Prior to this change, if toolbox.Client.Run started a command that
took longer than a minute to run, it would timeout with:

  govc: ServerFaultCode: A general system error occurred: vix error codes = (3016, 0).

With the fault type returned in this case, the client can retry, rather than having to poll
for process status.