### PR TITLE
toolbox: make gzip optional for directory archive transfer

### DIFF
--- a/govc/vm/guest/download.go
+++ b/govc/vm/guest/download.go
@@ -80,7 +80,7 @@ func (cmd *download) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	c, err := cmd.Toolbox()
 	if err != nil {
-		return nil
+		return err
 	}
 
 	s, n, err := c.Download(ctx, src)

--- a/guest/toolbox/client.go
+++ b/guest/toolbox/client.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -258,6 +259,15 @@ func (r *archiveReader) Read(buf []byte) (int, error) {
 	return nr, err
 }
 
+func isDir(src string) bool {
+	u, err := url.Parse(src)
+	if err != nil {
+		return false
+	}
+
+	return strings.HasSuffix(u.Path, "/")
+}
+
 // Download initiates a file transfer from the guest
 func (c *Client) Download(ctx context.Context, src string) (io.ReadCloser, int64, error) {
 	vc := c.ProcessManager.Client()
@@ -279,7 +289,7 @@ func (c *Client) Download(ctx context.Context, src string) (io.ReadCloser, int64
 		return nil, n, err
 	}
 
-	if strings.HasSuffix(src, "/") || strings.HasPrefix(src, "/archive:/") {
+	if strings.HasPrefix(src, "/archive:/") || isDir(src) {
 		f = &archiveReader{ReadCloser: f} // look for the gzip trailer
 	}
 

--- a/toolbox/hgfs/archive.go
+++ b/toolbox/hgfs/archive.go
@@ -18,8 +18,12 @@ package hgfs
 
 import (
 	"archive/tar"
+	"bufio"
+	"bytes"
 	"compress/gzip"
 	"io"
+	"io/ioutil"
+	"log"
 	"math"
 	"net/url"
 	"os"
@@ -27,6 +31,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/vmware/govmomi/toolbox/vix"
 )
 
 // ArchiveScheme is the default scheme used to register the archive FileHandler
@@ -48,6 +54,14 @@ func NewArchiveHandler() FileHandler {
 
 // Stat implements FileHandler.Stat
 func (*ArchiveHandler) Stat(u *url.URL) (os.FileInfo, error) {
+	switch u.Query().Get("format") {
+	case "tar":
+	case "", "tgz":
+	default:
+		log.Printf("unknown archive format: %q", u)
+		return nil, vix.Error(vix.InvalidArg)
+	}
+
 	return &archive{
 		name: u.Path,
 		size: math.MaxInt64,
@@ -111,26 +125,39 @@ func (a *archive) Sys() interface{} {
 // HTTP clients need to be aware of this and stop reading when they see the 2nd gzip header.
 var gzipHeader = []byte{0x1f, 0x8b, 0x08} // rfc1952 {ID1, ID2, CM}
 
+var gzipTrailer = true
+
 // newArchiveFromGuest returns an hgfs.File implementation to read a directory as a gzip'd tar.
 func (h *ArchiveHandler) newArchiveFromGuest(u *url.URL) (File, error) {
 	r, w := io.Pipe()
 
 	a := &archive{
 		name:   u.Path,
+		done:   r.Close,
 		Reader: r,
 		Writer: w,
 	}
 
-	gz := gzip.NewWriter(a.Writer)
-	tw := tar.NewWriter(gz)
-	a.done = r.Close
+	var z io.Writer = w
+	var c io.Closer = ioutil.NopCloser(nil)
+
+	switch u.Query().Get("format") {
+	case "", "tgz":
+		gz := gzip.NewWriter(w)
+		z = gz
+		c = gz
+	}
+
+	tw := tar.NewWriter(z)
 
 	go func() {
 		err := h.Write(u, tw)
 
 		_ = tw.Close()
-		_ = gz.Close()
-		_, _ = w.Write(gzipHeader)
+		_ = c.Close()
+		if gzipTrailer {
+			_, _ = w.Write(gzipHeader)
+		}
 		_ = w.CloseWithError(err)
 	}()
 
@@ -141,9 +168,11 @@ func (h *ArchiveHandler) newArchiveFromGuest(u *url.URL) (File, error) {
 func (h *ArchiveHandler) newArchiveToGuest(u *url.URL) (File, error) {
 	r, w := io.Pipe()
 
+	buf := bufio.NewReader(r)
+
 	a := &archive{
 		name:   u.Path,
-		Reader: r,
+		Reader: buf,
 		Writer: w,
 	}
 
@@ -162,17 +191,33 @@ func (h *ArchiveHandler) newArchiveToGuest(u *url.URL) (File, error) {
 	go func() {
 		defer wg.Done()
 
-		gz, err := gzip.NewReader(a.Reader)
-		if err != nil {
-			_ = r.CloseWithError(err)
-			cerr = err
-			return
+		c := func() error {
+			// Drain the pipe of tar trailer data (two null blocks)
+			if cerr == nil {
+				_, _ = io.Copy(ioutil.Discard, a.Reader)
+			}
+			return nil
 		}
 
-		tr := tar.NewReader(gz)
+		header, _ := buf.Peek(len(gzipHeader))
+
+		if bytes.Equal(header, gzipHeader) {
+			gz, err := gzip.NewReader(a.Reader)
+			if err != nil {
+				_ = r.CloseWithError(err)
+				cerr = err
+				return
+			}
+
+			c = gz.Close
+			a.Reader = gz
+		}
+
+		tr := tar.NewReader(a.Reader)
 
 		cerr = h.Read(u, tr)
-		_ = gz.Close()
+
+		_ = c()
 		_ = r.CloseWithError(cerr)
 	}()
 

--- a/toolbox/hgfs/archive_test.go
+++ b/toolbox/hgfs/archive_test.go
@@ -85,7 +85,7 @@ func TestReadArchive(t *testing.T) {
 		t.Errorf("status=%d", status)
 	}
 
-	handle, status := c.Open(dir)
+	handle, status := c.Open(dir + "?format=tgz")
 	if status != StatusSuccess {
 		t.Fatalf("status=%d", status)
 	}
@@ -155,7 +155,7 @@ func TestReadArchive(t *testing.T) {
 	}
 
 	nfiles++ // symlink
-	expect := nfiles*len(dirs) + len(dirs)
+	expect := nfiles*len(dirs) + len(dirs) - 1
 	if len(files) != expect {
 		t.Errorf("expected %d, files=%d", expect, len(files))
 	}

--- a/toolbox/toolbox-test.sh
+++ b/toolbox/toolbox-test.sh
@@ -211,8 +211,14 @@ if [ -n "$test" ] ; then
     # Upload source files from this directory
     # and validate that query string is not used as the file/dir name (see hgfs.ArchiveHandler)
     git archive --format tar.gz HEAD | govc guest.upload -f - /tmp/toolbox-src?skip=stuff
+    # Upload .tar
+    git archive --format tar HEAD | govc guest.upload -f - /tmp/toolbox-src
+    # Download .tar
+    govc guest.download "/tmp/toolbox-src?format=tar" - | tar -tvf - | grep "$base"
     # Download a single file as a .tar.gz (note: /archive: prefix is required)
     govc guest.download "/archive:/tmp/toolbox-src/$base" - | tar -tvzf - | grep -v README.md
+    # Download a single file as a .tar (note: /archive: prefix is required)
+    govc guest.download "/archive:/tmp/toolbox-src/$base?format=tar" - | tar -tvf - | grep -v README.md
     govc guest.rmdir -r /tmp/toolbox-src
   fi
 

--- a/toolbox/toolbox-test.sh
+++ b/toolbox/toolbox-test.sh
@@ -205,20 +205,21 @@ if [ -n "$test" ] ; then
   if [ "$verbose" = "false" ] ; then # else you don't want to see this noise
     # Download the $HOME directory, includes toolbox binaries (~30M total)
     # Note: trailing slash is required
-    govc guest.download "$home/" - | tar -tvzf - | grep "$(basename "$home")"/toolbox
+    prefix=$(basename "$home")
+    govc guest.download "$home/?prefix=$prefix/&format=tgz" - | tar -tzvf - | grep "$prefix"/toolbox
 
     govc guest.mkdir -p /tmp/toolbox-src
     # Upload source files from this directory
     # and validate that query string is not used as the file/dir name (see hgfs.ArchiveHandler)
-    git archive --format tar.gz HEAD | govc guest.upload -f - /tmp/toolbox-src?skip=stuff
+    git archive --format tgz HEAD | govc guest.upload -f - /tmp/toolbox-src?skip=stuff
     # Upload .tar
     git archive --format tar HEAD | govc guest.upload -f - /tmp/toolbox-src
     # Download .tar
-    govc guest.download "/tmp/toolbox-src?format=tar" - | tar -tvf - | grep "$base"
+    govc guest.download "/tmp/toolbox-src/" - | tar -tvf - | grep "$base"
     # Download a single file as a .tar.gz (note: /archive: prefix is required)
-    govc guest.download "/archive:/tmp/toolbox-src/$base" - | tar -tvzf - | grep -v README.md
+    govc guest.download "/archive:/tmp/toolbox-src/$base?format=tgz" - | tar -tvzf - | grep -v README.md
     # Download a single file as a .tar (note: /archive: prefix is required)
-    govc guest.download "/archive:/tmp/toolbox-src/$base?format=tar" - | tar -tvf - | grep -v README.md
+    govc guest.download "/archive:/tmp/toolbox-src/$base" - | tar -tvf - | grep -v README.md
     govc guest.rmdir -r /tmp/toolbox-src
   fi
 


### PR DESCRIPTION
In the download case, the "format" query param can be used to specify "tgz" or "tar".

In the upload case, toolbox checks for the gzip header to auto-detect tgz or tar.
