### PR TITLE
Default vm.migrate pool to the host pool

### DIFF
--- a/govc/vm/migrate.go
+++ b/govc/vm/migrate.go
@@ -80,6 +80,7 @@ func (cmd *migrate) Description() string {
 
 Examples:
   govc vm.migrate -host another-host vm-1 vm-2 vm-3
+  govc vm.migrate -pool another-pool vm-1 vm-2 vm-3
   govc vm.migrate -ds another-ds vm-1 vm-2 vm-3`
 }
 
@@ -119,6 +120,13 @@ func (cmd *migrate) Run(ctx context.Context, f *flag.FlagSet) error {
 	pool, err := cmd.ResourcePoolFlag.ResourcePoolIfSpecified()
 	if err != nil {
 		return err
+	}
+
+	if pool == nil && host != nil {
+		pool, err = host.ResourcePool(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	if pool != nil {


### PR DESCRIPTION
The pool is required if the target host is in a different pool than the current.