### PR TITLE
Add support for VM export

### DIFF
--- a/govc/export/ovf.go
+++ b/govc/export/ovf.go
@@ -1,0 +1,251 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"flag"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/nfc"
+	"github.com/vmware/govmomi/ovf"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ovfx struct {
+	*flags.VirtualMachineFlag
+
+	dest   string
+	name   string
+	force  bool
+	images bool
+	sha    int
+
+	mf bytes.Buffer
+}
+
+var sha = map[int]func() hash.Hash{
+	1:   sha1.New,
+	256: sha256.New,
+	512: sha512.New,
+}
+
+func init() {
+	cli.Register("export.ovf", &ovfx{})
+}
+
+func (cmd *ovfx) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.name, "name", "", "Specifies target name (defaults to source name)")
+	f.BoolVar(&cmd.force, "f", false, "Overwrite existing")
+	f.BoolVar(&cmd.images, "i", false, "Include image files (*.{iso,img})")
+	f.IntVar(&cmd.sha, "sha", 0, "Generate manifest using SHA 1, 256, 512 or 0 to skip")
+}
+
+func (cmd *ovfx) Usage() string {
+	return "DIR"
+}
+
+func (cmd *ovfx) Description() string {
+	return `Export VM.
+
+Examples:
+  govc export.ovf -vm $vm DIR`
+}
+
+func (cmd *ovfx) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ovfx) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		// TODO: output summary similar to ovftool's
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	if cmd.sha != 0 {
+		if _, ok := sha[cmd.sha]; !ok {
+			return fmt.Errorf("unknown hash: sha%d", cmd.sha)
+		}
+	}
+
+	if cmd.name == "" {
+		cmd.name = vm.Name()
+	}
+
+	cmd.dest = filepath.Join(f.Arg(0), cmd.name)
+
+	target := filepath.Join(cmd.dest, cmd.name+".ovf")
+
+	if !cmd.force {
+		if _, err = os.Stat(target); err == nil {
+			return fmt.Errorf("File already exists: %s", target)
+		}
+	}
+
+	if err = os.MkdirAll(cmd.dest, 0755); err != nil {
+		return err
+	}
+
+	lease, err := vm.Export(ctx)
+	if err != nil {
+		return err
+	}
+
+	info, err := lease.Wait(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	u := lease.StartUpdater(ctx, info)
+	defer u.Done()
+
+	cdp := types.OvfCreateDescriptorParams{
+		Name: cmd.name,
+	}
+
+	for _, i := range info.Items {
+		if !cmd.include(&i) {
+			continue
+		}
+
+		if !strings.HasPrefix(i.Path, cmd.name) {
+			i.Path = cmd.name + "-" + i.Path
+		}
+
+		err = cmd.Download(ctx, lease, i)
+		if err != nil {
+			return err
+		}
+
+		cdp.OvfFiles = append(cdp.OvfFiles, i.File())
+	}
+
+	if err = lease.Complete(ctx); err != nil {
+		return err
+	}
+
+	m := ovf.NewManager(vm.Client())
+
+	desc, err := m.CreateDescriptor(ctx, vm, cdp)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+
+	var w io.Writer = file
+	h, ok := cmd.newHash()
+	if ok {
+		w = io.MultiWriter(file, h)
+	}
+
+	_, err = io.WriteString(w, desc.OvfDescriptor)
+	if err != nil {
+		return err
+	}
+
+	if err = file.Close(); err != nil {
+		return err
+	}
+
+	if cmd.sha == 0 {
+		return nil
+	}
+
+	cmd.addHash(filepath.Base(target), h)
+
+	file, err = os.Create(filepath.Join(cmd.dest, cmd.name+".mf"))
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(file, &cmd.mf)
+	if err != nil {
+		return err
+	}
+
+	return file.Close()
+}
+
+func (cmd *ovfx) include(item *nfc.FileItem) bool {
+	if cmd.images {
+		return true
+	}
+
+	return filepath.Ext(item.Path) == ".vmdk"
+}
+
+func (cmd *ovfx) newHash() (hash.Hash, bool) {
+	if h, ok := sha[cmd.sha]; ok {
+		return h(), true
+	}
+
+	return nil, false
+}
+
+func (cmd *ovfx) addHash(p string, h hash.Hash) {
+	_, _ = fmt.Fprintf(&cmd.mf, "SHA%d(%s)= %x\n", cmd.sha, p, h.Sum(nil))
+}
+
+func (cmd *ovfx) Download(ctx context.Context, lease *nfc.Lease, item nfc.FileItem) error {
+	path := filepath.Join(cmd.dest, item.Path)
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Downloading %s... ", item.Path))
+	defer logger.Wait()
+
+	opts := soap.Download{
+		Progress: logger,
+	}
+
+	if h, ok := cmd.newHash(); ok {
+		opts.Writer = h
+
+		defer cmd.addHash(item.Path, h)
+	}
+
+	return lease.DownloadFile(ctx, path, item, opts)
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/dvs/portgroup"
 	_ "github.com/vmware/govmomi/govc/env"
 	_ "github.com/vmware/govmomi/govc/events"
+	_ "github.com/vmware/govmomi/govc/export"
 	_ "github.com/vmware/govmomi/govc/extension"
 	_ "github.com/vmware/govmomi/govc/fields"
 	_ "github.com/vmware/govmomi/govc/folder"

--- a/govc/test/export.bats
+++ b/govc/test/export.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# ovftool -tt=ovf --noSSLVerify --skipManifestCheck "vi://$GOVC_URL/$GOVC_VM" .
+@test "export.ovf" {
+  esx_env
+
+  id=$(new_ttylinux_vm)
+  dir=$BATS_TMPDIR/$id-export
+
+  run govc export.ovf -vm "$id" "$dir"
+  assert_success
+
+  run ls "$dir/$id/$id-disk-0.vmdk" "$dir/$id/$id.ovf"
+  assert_success
+
+  if [ -e "$dir/$id/$id.mf" ] ; then
+    flunk ".mf was created"
+  fi
+
+  run govc export.ovf -vm "$id" "$dir"
+  assert_failure
+
+  run govc export.ovf -i -f -sha 256 -vm "$id" "$dir"
+  assert_success
+
+  run ls "$dir/$id/$id.mf"
+  assert_success
+
+  # make it an ova
+  (cd "$dir/$id" && tar -cf "../$id.ova" .)
+
+  # ovftool --noSSLVerify --skipManifestCheck --name="$GOVC_VM-import" "$GOVC_VM/$GOVC_VM.ovf" "vi://$GOVC_URL"
+  run govc import.ova -name "${id}-import" "$dir/$id.ova"
+  assert_success
+
+  rm -rf "$dir"
+}

--- a/govc/vm/guest/download.go
+++ b/govc/vm/guest/download.go
@@ -101,5 +101,5 @@ func (cmd *download) Run(ctx context.Context, f *flag.FlagSet) error {
 		defer logger.Wait()
 	}
 
-	return c.ProcessManager.Client().WriteFile(dst, s, n, p)
+	return c.ProcessManager.Client().WriteFile(dst, s, n, p, nil)
 }

--- a/nfc/lease.go
+++ b/nfc/lease.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path"
 
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
@@ -121,6 +122,28 @@ func (l *Lease) newLeaseInfo(li *types.HttpNfcLeaseInfo, items []types.OvfFileIt
 			l.c.SetThumbprint(u.Host, device.SslThumbprint)
 		}
 
+		if len(items) == 0 {
+			// this is an export
+			item := types.OvfFileItem{
+				DeviceId: device.Key,
+				Path:     device.TargetId,
+				Size:     device.FileSize,
+			}
+
+			if item.Size == 0 {
+				item.Size = li.TotalDiskCapacityInKB * 1024
+			}
+
+			if item.Path == "" {
+				item.Path = path.Base(device.Url)
+			}
+
+			info.Items = append(info.Items, NewFileItem(u, item))
+
+			continue
+		}
+
+		// this is an import
 		for _, item := range items {
 			if device.ImportKey == item.DeviceId {
 				info.Items = append(info.Items, NewFileItem(u, item))
@@ -202,4 +225,14 @@ func (l *Lease) Upload(ctx context.Context, item FileItem, f io.Reader, opts soa
 	}
 
 	return l.c.Upload(f, item.URL, &opts)
+}
+
+func (l *Lease) DownloadFile(ctx context.Context, file string, item FileItem, opts soap.Download) error {
+	if opts.Progress == nil {
+		opts.Progress = item
+	} else {
+		opts.Progress = progress.Tee(item, opts.Progress)
+	}
+
+	return l.c.DownloadFile(file, item.URL, &opts)
 }

--- a/nfc/lease_updater.go
+++ b/nfc/lease_updater.go
@@ -47,6 +47,15 @@ func (o FileItem) Sink() chan<- progress.Report {
 	return o.ch
 }
 
+// File converts the FileItem.OvfFileItem to an OvfFile
+func (o FileItem) File() types.OvfFile {
+	return types.OvfFile{
+		DeviceId: o.DeviceId,
+		Path:     o.Path,
+		Size:     o.Size,
+	}
+}
+
 type LeaseUpdater struct {
 	lease *Lease
 

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"path"
 
+	"github.com/vmware/govmomi/nfc"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -756,4 +757,17 @@ func (v VirtualMachine) UpgradeTools(ctx context.Context, options string) (*Task
 	}
 
 	return NewTask(v.c, res.Returnval), nil
+}
+
+func (v VirtualMachine) Export(ctx context.Context) (*nfc.Lease, error) {
+	req := types.ExportVm{
+		This: v.Reference(),
+	}
+
+	res, err := methods.ExportVm(ctx, v.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return nfc.NewLease(v.c, res.Returnval), nil
 }


### PR DESCRIPTION
Follow up to #805 - depends on the ovf+nfc lease code moved
from govc import.ovf cli to higher level packages.

Fixes #692