### PR TITLE
Include "Name" in device.info -json

### DIFF
--- a/govc/test/device.bats
+++ b/govc/test/device.bats
@@ -30,6 +30,8 @@ load test_helper
 
   result=$(govc device.info -vm $vm -net "VM Network" | grep "MAC Address" | wc -l)
   [ $result -eq 1 ]
+
+  govc device.info -vm $vm -json | assert_matches ethernet-0
 }
 
 @test "device.boot" {


### PR DESCRIPTION
The VirtualDevice type does not have the "Name" field, so we have to inject it via MarshalJSON.

Fixes #823