### PR TITLE
toolbox: reset session when invalidated by the vmx

### DIFF
--- a/toolbox/backdoor.go
+++ b/toolbox/backdoor.go
@@ -54,7 +54,14 @@ func (b *backdoorChannel) Start() error {
 }
 
 func (b *backdoorChannel) Stop() error {
+	if b.Channel == nil {
+		return nil
+	}
+
 	err := b.Channel.Close()
+
+	b.Channel = nil
+
 	return err
 }
 


### PR DESCRIPTION
Seen cases where ESX is under heavy load and the toolbox session
cookie is invalidated by the vmx.

This change will backoff the polling loop and also re-open the message
channel to get a new session cookie.

On the guest side, this resulted in a flood of:
   Message: Unable to send a message over the communication channel 0
   Message: Unable to poll for messages over the communication channel 0

On the vmx site (vmware.log), this resulted in a flood of:
   GuestMsg: Channel 0, Protocol error, state: 0
   GuestMsg: channel 0: wrong cookie, discarding message.