### PR TITLE
toolbox: avoid race when closing channels on stop

### DIFF
--- a/toolbox/service.go
+++ b/toolbox/service.go
@@ -164,6 +164,7 @@ func (s *Service) Start() error {
 		for {
 			select {
 			case <-s.stop:
+				s.stopChannel()
 				return
 			case <-time.After(time.Millisecond * 10 * s.delay):
 				if err = s.checkReset(); err != nil {
@@ -197,8 +198,6 @@ func (s *Service) Start() error {
 // Stop cancels the RPC listener routine created via Start
 func (s *Service) Stop() {
 	close(s.stop)
-
-	s.stopChannel()
 }
 
 // Wait blocks until Start returns, allowing any current RPC in progress to complete.

--- a/toolbox/toolbox-test.sh
+++ b/toolbox/toolbox-test.sh
@@ -50,7 +50,7 @@ done
 echo "Building toolbox binaries..."
 pushd "$(git rev-parse --show-toplevel)" >/dev/null
 GOOS=linux GOARCH=amd64 go build -o "$GOPATH/bin/toolbox" -v ./toolbox/toolbox
-GOOS=linux GOARCH=amd64 go test -i -c ./toolbox -o "$GOPATH/bin/toolbox.test"
+GOOS=linux GOARCH=amd64 go test -race -i -c ./toolbox -o "$GOPATH/bin/toolbox.test"
 popd >/dev/null
 
 iso=coreos_production_iso_image.iso


### PR DESCRIPTION
It was possible for the Stop() method close the RPC channels when
the main loop was in the middle of Send/Receive.