### PR TITLE
Use base type for DVS backing info

### DIFF
--- a/object/distributed_virtual_portgroup.go
+++ b/object/distributed_virtual_portgroup.go
@@ -38,7 +38,7 @@ func NewDistributedVirtualPortgroup(c *vim25.Client, ref types.ManagedObjectRefe
 // EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this DistributedVirtualPortgroup
 func (p DistributedVirtualPortgroup) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
 	var dvp mo.DistributedVirtualPortgroup
-	var dvs mo.VmwareDistributedVirtualSwitch // TODO: should be mo.BaseDistributedVirtualSwitch
+	var dvs mo.DistributedVirtualSwitch
 
 	if err := p.Properties(ctx, p.Reference(), []string{"key", "config.distributedVirtualSwitch"}, &dvp); err != nil {
 		return nil, err

--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -23,11 +23,11 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-type VmwareDistributedVirtualSwitch struct {
-	mo.VmwareDistributedVirtualSwitch
+type DistributedVirtualSwitch struct {
+	mo.DistributedVirtualSwitch
 }
 
-func (s *VmwareDistributedVirtualSwitch) AddDVPortgroupTask(c *types.AddDVPortgroup_Task) soap.HasFault {
+func (s *DistributedVirtualSwitch) AddDVPortgroupTask(c *types.AddDVPortgroup_Task) soap.HasFault {
 	task := CreateTask(s, "addDVPortgroup", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		f := Map.getEntityParent(s, "Folder").(*Folder)
 
@@ -70,7 +70,7 @@ func (s *VmwareDistributedVirtualSwitch) AddDVPortgroupTask(c *types.AddDVPortgr
 	}
 }
 
-func (s *VmwareDistributedVirtualSwitch) ReconfigureDvsTask(req *types.ReconfigureDvs_Task) soap.HasFault {
+func (s *DistributedVirtualSwitch) ReconfigureDvsTask(req *types.ReconfigureDvs_Task) soap.HasFault {
 	task := CreateTask(s, "reconfigureDvs", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		spec := req.Spec.GetDVSConfigSpec()
 

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -409,7 +409,7 @@ func (f *Folder) MoveIntoFolderTask(c *types.MoveIntoFolder_Task) soap.HasFault 
 
 func (f *Folder) CreateDVSTask(c *types.CreateDVS_Task) soap.HasFault {
 	task := CreateTask(f, "createDVS", func(t *Task) (types.AnyType, types.BaseMethodFault) {
-		dvs := &VmwareDistributedVirtualSwitch{}
+		dvs := &DistributedVirtualSwitch{}
 		dvs.Name = c.Spec.ConfigSpec.GetDVSConfigSpec().Name
 		dvs.Entity().Name = dvs.Name
 


### PR DESCRIPTION
The DVS EthernetCardBackingInfo method was originally written to use the
mo.VmwareDistributedVirtualSwitch type due to a limitation that required
the Go type to be the same as the managed object type.

That limitation was fixed in b34f346, allowing for use of base types.

The simulator also uses the base DistributedVirtualSwitch type now to cover that case.

Fixes #843