### PR TITLE
vcsim: set VirtualDisk backing datastore

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -325,14 +325,19 @@ func (vm *VirtualMachine) configureDevice(devices object.VirtualDeviceList, devi
 	case *types.VirtualDisk:
 		switch b := d.Backing.(type) {
 		case types.BaseVirtualDeviceFileBackingInfo:
+			info := b.GetVirtualDeviceFileBackingInfo()
 			err := dm.createVirtualDisk(&types.CreateVirtualDisk_Task{
 				Datacenter: &dc.Self,
-				Name:       b.GetVirtualDeviceFileBackingInfo().FileName,
+				Name:       info.FileName,
 			})
 
 			if err != nil {
 				return err
 			}
+
+			path, _ := parseDatastorePath(info.FileName)
+			info.Datastore.Type = "Datastore"
+			info.Datastore.Value = path.Datastore
 		}
 	}
 

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -325,6 +325,14 @@ func TestReconfigVm(t *testing.T) {
 	if len(device) != mdevices {
 		t.Error("device list mismatch")
 	}
+
+	for _, d := range device.SelectByType((*types.VirtualDisk)(nil)) {
+		info := d.(*types.VirtualDisk).Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+
+		if info.Datastore.Type == "" || info.Datastore.Value == "" {
+			t.Errorf("invalid datastore for %s", device.Name(d))
+		}
+	}
 }
 
 func TestCreateVmWithDevices(t *testing.T) {


### PR DESCRIPTION
The Model creates a VirtualDisk for each VM as of defe810, but did not set the disk backing Datastore field.

This field is not optional in the wsdl, Go tolerates this, Python does not.

Fixes #856