### PR TITLE
Add method to find a CustomFieldDef by Key

### DIFF
--- a/object/custom_fields_manager.go
+++ b/object/custom_fields_manager.go
@@ -102,7 +102,9 @@ func (m CustomFieldsManager) Set(ctx context.Context, entity types.ManagedObject
 	return err
 }
 
-func (m CustomFieldsManager) Field(ctx context.Context) ([]types.CustomFieldDef, error) {
+type CustomFieldDefList []types.CustomFieldDef
+
+func (m CustomFieldsManager) Field(ctx context.Context) (CustomFieldDefList, error) {
 	var fm mo.CustomFieldsManager
 
 	err := m.Properties(ctx, m.Reference(), []string{"field"}, &fm)
@@ -132,4 +134,13 @@ func (m CustomFieldsManager) FindKey(ctx context.Context, key string) (int32, er
 	}
 
 	return -1, ErrKeyNameNotFound
+}
+
+func (l CustomFieldDefList) ByKey(key int32) *types.CustomFieldDef {
+	for _, def := range l {
+		if def.Key == key {
+			return &def
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Add new type 'CustomFieldDefList' of type '[]types.CustomFieldDef'.

Change the 'CustomFieldManager.Field' method signature so it returns
the new 'CustomFieldDefList' type. This makes it possible to attach
methods on top of the 'CustomFieldDefList' to search the list. This is
not a breaking change because the underlying type is still
'[]types.CustomFieldDef'.

Add 'CustomFieldDefList.ByKey' method to find a 'CustomFieldDef' by the
'Key' attribute.

Resolves: #854