### PR TITLE
Fix CustomFieldsManager.FindKey method signature

### DIFF
--- a/object/custom_fields_manager.go
+++ b/object/custom_fields_manager.go
@@ -115,19 +115,19 @@ func (m CustomFieldsManager) Field(ctx context.Context) (CustomFieldDefList, err
 	return fm.Field, nil
 }
 
-func (m CustomFieldsManager) FindKey(ctx context.Context, key string) (int32, error) {
+func (m CustomFieldsManager) FindKey(ctx context.Context, name string) (int32, error) {
 	field, err := m.Field(ctx)
 	if err != nil {
 		return -1, err
 	}
 
 	for _, def := range field {
-		if def.Name == key {
+		if def.Name == name {
 			return def.Key, nil
 		}
 	}
 
-	k, err := strconv.Atoi(key)
+	k, err := strconv.Atoi(name)
 	if err == nil {
 		// assume literal int key
 		return int32(k), nil


### PR DESCRIPTION
Rename string input argument from 'key' to 'name'.

The FindKey method returns the key of a given CustomFieldDef. The
search is performed by comparing the input string argument with
each CustomFieldDef 'Name' attribute. Therefore, the input string
argument must be named 'name' instead of 'key'.

Resolves: #864