### PR TITLE
Support clearing vm boot order

### DIFF
--- a/govc/device/boot.go
+++ b/govc/device/boot.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ func (cmd *boot) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.VirtualMachineFlag.Register(ctx, f)
 
 	f.Int64Var(&cmd.BootDelay, "delay", 0, "Delay in ms before starting the boot sequence")
-	f.StringVar(&cmd.order, "order", "", "Boot device order")
+	f.StringVar(&cmd.order, "order", "", "Boot device order [-,floppy,cdrom,ethernet,disk]")
 	f.Int64Var(&cmd.BootRetryDelay, "retry-delay", 0, "Delay in ms before a boot retry")
 
 	cmd.BootRetryEnabled = types.NewBool(false)
@@ -56,7 +56,8 @@ func (cmd *boot) Description() string {
 	return `Configure VM boot settings.
 
 Examples:
-  govc device.boot -vm $vm -delay 1000 -order floppy,cdrom,ethernet,disk`
+  govc device.boot -vm $vm -delay 1000 -order floppy,cdrom,ethernet,disk
+  govc device.boot -vm $vm -order - # reset boot order`
 }
 
 func (cmd *boot) Process(ctx context.Context) error {

--- a/govc/test/device.bats
+++ b/govc/test/device.bats
@@ -59,6 +59,12 @@ load test_helper
 
   result=$(govc device.ls -vm $vm -boot | wc -l)
   [ $result -eq 4 ]
+
+  run govc device.boot -vm $vm -order -
+  assert_success
+
+  result=$(govc device.ls -vm $vm -boot | wc -l)
+  [ $result -eq 0 ]
 }
 
 @test "device.cdrom" {

--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import (
 
 // Type values for use in BootOrder
 const (
+	DeviceTypeNone     = "-"
 	DeviceTypeCdrom    = "cdrom"
 	DeviceTypeDisk     = "disk"
 	DeviceTypeEthernet = "ethernet"
@@ -754,6 +755,9 @@ func (l VirtualDeviceList) PrimaryMacAddress() string {
 
 // convert a BaseVirtualDevice to a BaseVirtualMachineBootOptionsBootableDevice
 var bootableDevices = map[string]func(device types.BaseVirtualDevice) types.BaseVirtualMachineBootOptionsBootableDevice{
+	DeviceTypeNone: func(types.BaseVirtualDevice) types.BaseVirtualMachineBootOptionsBootableDevice {
+		return &types.VirtualMachineBootOptionsBootableDevice{}
+	},
 	DeviceTypeCdrom: func(types.BaseVirtualDevice) types.BaseVirtualMachineBootOptionsBootableDevice {
 		return &types.VirtualMachineBootOptionsBootableCdromDevice{}
 	},
@@ -773,17 +777,23 @@ var bootableDevices = map[string]func(device types.BaseVirtualDevice) types.Base
 }
 
 // BootOrder returns a list of devices which can be used to set boot order via VirtualMachine.SetBootOptions.
-// The order can any of "ethernet", "cdrom", "floppy" or "disk" or by specific device name.
+// The order can be any of "ethernet", "cdrom", "floppy" or "disk" or by specific device name.
+// A value of "-" will clear the existing boot order on the VC/ESX side.
 func (l VirtualDeviceList) BootOrder(order []string) []types.BaseVirtualMachineBootOptionsBootableDevice {
 	var devices []types.BaseVirtualMachineBootOptionsBootableDevice
 
 	for _, name := range order {
 		if kind, ok := bootableDevices[name]; ok {
+			if name == DeviceTypeNone {
+				// Not covered in the API docs, nor obvious, but this clears the boot order on the VC/ESX side.
+				devices = append(devices, new(types.VirtualMachineBootOptionsBootableDevice))
+				continue
+			}
+
 			for _, device := range l {
 				if l.Type(device) == name {
 					devices = append(devices, kind(device))
 				}
-
 			}
 			continue
 		}

--- a/object/virtual_device_list_test.go
+++ b/object/virtual_device_list_test.go
@@ -793,6 +793,10 @@ func TestBootOrder(t *testing.T) {
 	if len(list.BootOrder([]string{DeviceTypeDisk})) != 0 {
 		t.Error("expected 0 disks")
 	}
+
+	if len(list.BootOrder([]string{DeviceTypeNone})) != 1 {
+		t.Error("expected 1")
+	}
 }
 
 func TestName(t *testing.T) {


### PR DESCRIPTION
The device.boot command and VirtualDeviceList.BootOrder can now clear any existing boot order by using DeviceTypeNone.