### PR TITLE
vcsim: VirtualDisk file backing datastore is optional

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -346,9 +346,12 @@ func (vm *VirtualMachine) configureDevice(devices object.VirtualDeviceList, devi
 				return err
 			}
 
-			path, _ := parseDatastorePath(info.FileName)
-			info.Datastore.Type = "Datastore"
-			info.Datastore.Value = path.Datastore
+			p, _ := parseDatastorePath(info.FileName)
+
+			info.Datastore = &types.ManagedObjectReference{
+				Type:  "Datastore",
+				Value: p.Datastore,
+			}
 		}
 	}
 
@@ -404,8 +407,8 @@ func (vm *VirtualMachine) genVmdkPath() (string, types.BaseMethodFault) {
 			}
 		}
 
-		f.Close()
-		os.Remove(f.Name())
+		_ = f.Close()
+		_ = os.Remove(f.Name())
 
 		return path.Join(vmdir, filename), nil
 	}

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -351,14 +351,6 @@ func TestCreateVmWithDevices(t *testing.T) {
 
 	c := m.Service.client
 
-	finder := find.NewFinder(c, false)
-	finder.SetDatacenter(object.NewDatacenter(c, esx.Datacenter.Reference()))
-
-	ds, err := finder.DefaultDatastore(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	folder := object.NewFolder(c, esx.Datacenter.VmFolder)
 	pool := object.NewResourcePool(c, esx.ResourcePool.Self)
 
@@ -367,13 +359,12 @@ func TestCreateVmWithDevices(t *testing.T) {
 	ide, _ := devices.CreateIDEController()
 	cdrom, _ := devices.CreateCdrom(ide.(*types.VirtualIDEController))
 	scsi, _ := devices.CreateSCSIController("scsi")
-	disk := devices.CreateDisk(
-		scsi.(*types.VirtualLsiLogicController),
-		ds.Reference(),
-		// Empty filename should also work because in esx server it will assign a
-		// name like '[LocalDS_0] foo/foo_1.vmdk' if it's empty.
-		"")
-
+	disk := &types.VirtualDisk{
+		VirtualDevice: types.VirtualDevice{
+			Backing: new(types.VirtualDiskFlatVer2BackingInfo), // Leave fields empty to test defaults
+		},
+	}
+	devices.AssignController(disk, scsi.(*types.VirtualLsiLogicController))
 	devices = append(devices, ide, cdrom, scsi, disk)
 	create, _ := devices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
 


### PR DESCRIPTION
Issue #868 added default behavior for the VirtualDisk backing FileName,
but left the assumption that the Datastore field was also set.

Also remove a few go lint/vet warnings.

Fixes #871