### PR TITLE
Fix vm.register command template flag

### DIFF
--- a/simulator/folder_test.go
+++ b/simulator/folder_test.go
@@ -279,7 +279,7 @@ func TestRegisterVm(t *testing.T) {
 			f func()
 		}{
 			{
-				new(types.NotSupported), func() { req.AsTemplate = false },
+				new(types.InvalidArgument), func() { req.AsTemplate = false },
 			},
 			{
 				new(types.InvalidArgument), func() { req.Pool = vm.ResourcePool },


### PR DESCRIPTION
- The "as-template" flag has been renamed "template" (as we have in the vm.clone command)

- Add RegisterVm template support to vcsim

- Simplify the vm.register code

Fixes #872