### PR TITLE
Fix object name suffix matching in Finder

### DIFF
--- a/find/recurser.go
+++ b/find/recurser.go
@@ -190,7 +190,7 @@ func (r recurser) List(ctx context.Context, s *spec, root list.Element, parts []
 		}
 
 		if !matched {
-			matched = strings.HasSuffix(e.Path, path.Join(all...))
+			matched = strings.HasSuffix(e.Path, "/"+path.Join(all...))
 			if matched {
 				// name contains a '/'
 				out = append(out, e)

--- a/govc/test/ls.bats
+++ b/govc/test/ls.bats
@@ -174,3 +174,19 @@ load test_helper
   path=$(govc ls -L Folder:ha-folder-root)
   assert_equal "/" "$path"
 }
+
+@test "ls substr" {
+  # Test fix for issue #815, introduced by b35abbc
+
+  vcsim_env
+
+  id=$(new_id)
+
+  run govc vm.create -on=false "${id}"
+  assert_success
+
+  run govc vm.create -on=false "bar${id}"
+  assert_success
+
+  assert [ "$(govc ls "vm/$id" | wc -l)" -eq 1 ]
+}


### PR DESCRIPTION
PR #734 (commit b35abbc) added support for matching object names containing a '/',
but introduced a bug where any suffix would match regardless.

Fixes #815