### PR TITLE
Fix govc events output

### DIFF
--- a/govc/test/events.bats
+++ b/govc/test/events.bats
@@ -55,3 +55,19 @@ load test_helper
   assert_success
   [ ${#lines[@]} -ge $nevents ]
 }
+
+@test "events json" {
+  esx_env
+
+  # make sure we fmt.Printf properly
+  govc events | grep -v '%!s(MISSING)'
+
+  govc events -json | jq .
+
+  # test multiple objects
+  govc vm.create "$(new_id)"
+  govc vm.create "$(new_id)"
+
+  govc events 'vm/*'
+  govc events -json 'vm/*' | jq .
+}


### PR DESCRIPTION
With d4d94f4, 'govc events' outputs the following due to Printf usage:

  "[[Fri Oct 13 01:15:06 2017 info User root@192.168.2.1 logged in as govc/0.15.0]] [%!s(MISSING)] %!s(MISSING)"

- Change json field names to uppercase, as we do with other govc commands

- Add "Object" field to json and avoid printing the object header when '-json' is given

- Use time.Time for '-json', as we do in other commands

- A few renames
  - CreatedAt -> CreateTime (same as the Event field name, other types use this name too)
  - "write" -> "print" (other commands use "write")
  - "ev" -> "record"
