### PR TITLE
Add linked clone and snapshot support to vm.clone

### DIFF
--- a/govc/test/snapshot.bats
+++ b/govc/test/snapshot.bats
@@ -31,8 +31,14 @@ test_vm_snapshot() {
   run govc snapshot.create -vm "$vm" root
   assert_success
 
+  run govc snapshot.tree -C -vm "$vm"
+  assert_success "root"
+
   run govc snapshot.create -vm "$vm" child
   assert_success
+
+  run govc snapshot.tree -C -vm "$vm"
+  assert_success "child"
 
   run govc snapshot.create -vm "$vm" grand
   assert_success

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -528,14 +528,18 @@ load test_helper
   vm=$(new_empty_vm)
   clone=$(new_id)
 
-  run govc vm.clone -vm $vm $clone
+  run govc vm.clone -vm "$vm" "$clone"
   assert_success
 
-  result=$(govc device.ls -vm $clone | grep disk- | wc -l)
-  [ $result -eq 0 ]
+  clone=$(new_id)
+  run govc vm.clone -vm "$vm" -snapshot X "$clone"
+  assert_failure
 
-  result=$(govc device.ls -vm $clone | grep cdrom- | wc -l)
-  [ $result -eq 0 ]
+  run govc snapshot.create -vm "$vm" X
+  assert_success
+
+  run govc vm.clone -vm "$vm" -snapshot X "$clone"
+  assert_success
 }
 
 @test "vm.clone change resources" {

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -497,7 +497,7 @@ func (v VirtualMachine) RemoveAllSnapshot(ctx context.Context, consolidate *bool
 	return NewTask(v.c, res.Returnval), nil
 }
 
-type snapshotMap map[string][]Reference
+type snapshotMap map[string][]types.ManagedObjectReference
 
 func (m snapshotMap) add(parent string, tree []types.VirtualMachineSnapshotTree) {
 	for i, st := range tree {
@@ -511,7 +511,7 @@ func (m snapshotMap) add(parent string, tree []types.VirtualMachineSnapshotTree)
 		}
 
 		for _, name := range names {
-			m[name] = append(m[name], &tree[i].Snapshot)
+			m[name] = append(m[name], tree[i].Snapshot)
 		}
 
 		m.add(sname, st.ChildSnapshotList)
@@ -522,7 +522,7 @@ func (m snapshotMap) add(parent string, tree []types.VirtualMachineSnapshotTree)
 // 1) snapshot ManagedObjectReference.Value (unique)
 // 2) snapshot name (may not be unique)
 // 3) snapshot tree path (may not be unique)
-func (v VirtualMachine) FindSnapshot(ctx context.Context, name string) (Reference, error) {
+func (v VirtualMachine) FindSnapshot(ctx context.Context, name string) (*types.ManagedObjectReference, error) {
 	var o mo.VirtualMachine
 
 	err := v.Properties(ctx, v.Reference(), []string{"snapshot"}, &o)
@@ -542,7 +542,7 @@ func (v VirtualMachine) FindSnapshot(ctx context.Context, name string) (Referenc
 	case 0:
 		return nil, fmt.Errorf("snapshot %q not found", name)
 	case 1:
-		return s[0], nil
+		return &s[0], nil
 	default:
 		return nil, fmt.Errorf("%q resolves to %d snapshots", name, len(s))
 	}


### PR DESCRIPTION
This is PR #762 with the following changes:

The vm.clone '-link' flag behaves similar to the '-link' flag in other commands, a bool.

The vm.clone '-snapshot' link requires an argument

Add '-C' option to snapshot.tree to print just the name of the current snapshot

Change VirtualMachine.FindSnapshot to return *types.ManagedObjectReference instead of object.Reference

Closes #762