### PR TITLE
vcsim: AuthorizationManager additions

### DIFF
--- a/govc/permissions/remove.go
+++ b/govc/permissions/remove.go
@@ -28,8 +28,6 @@ type remove struct {
 	*PermissionFlag
 
 	types.Permission
-
-	role string
 }
 
 func init() {
@@ -60,7 +58,7 @@ func (cmd *remove) Description() string {
 
 Examples:
   govc permissions.remove -principal root
-  govc permissions.remove -principal $USER@vsphere.local -role Admin /dc1/host/cluster1`
+  govc permissions.remove -principal $USER@vsphere.local /dc1/host/cluster1`
 }
 
 func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {

--- a/govc/test/role.bats
+++ b/govc/test/role.bats
@@ -2,14 +2,25 @@
 
 load test_helper
 
-@test "permissions.ls" {
+@test "permissions" {
   vcsim_env
 
-  run govc permissions.ls
-  assert_success
+  perm=$(govc permissions.ls /DC0)
 
   run govc permissions.ls -json
   assert_success
+
+  run govc permissions.set -principal root -role Admin /DC0
+  assert_success
+
+  run govc permissions.ls /DC0
+  refute_line "$perm"
+
+  run govc permissions.remove -principal root /DC0
+  assert_success
+
+  run govc permissions.ls /DC0
+  assert_success "$perm"
 }
 
 @test "role.ls" {


### PR DESCRIPTION
- Implement RemoveEntityPermission, SetEntityPermissions, RetrieveRolePermissions

- Maintain a map to fetch and store permissions, rather than hardcode

- rename "nextId" to "nextID" (avoids go-lint complaint)