### PR TITLE
Remove BaseResourceAllocationInfo

### DIFF
--- a/gen/gen_from_vmodl.rb
+++ b/gen/gen_from_vmodl.rb
@@ -196,6 +196,8 @@ class Vmodl
     @data.map do |k,v|
       next if !v.is_a?(Hash)
       next if v["kind"] != "managed"
+      # rbvmomi/vmodl.db includes pbm mo's, but we don't need the types as they have no properties
+      next if k =~ /^pbm/i
 
       Managed.new(self, k, v)
     end.compact
@@ -214,6 +216,11 @@ vmodl = Vmodl.new(read ARGV[2] || "./rbvmomi/vmodl.db")
 
 File.open(File.join(ARGV.first, "mo/mo.go"), "w") do |io|
   io.print WSDL.header("mo")
+  io.print <<EOF
+import (
+        "github.com/vmware/govmomi/vim25/types"
+)
+EOF
 
   vmodl.
     managed.

--- a/gen/vim_wsdl.rb
+++ b/gen/vim_wsdl.rb
@@ -48,6 +48,9 @@ class Peek
     end
 
     def base?
+      # VrpResourceAllocationInfo is removed in 6.7, so base will no longer generated
+      return false if @name == "ResourceAllocationInfo"
+
       return !children.empty?
     end
   end

--- a/govc/pool/change.go
+++ b/govc/pool/change.go
@@ -41,10 +41,10 @@ func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.DatacenterFlag.Register(ctx, f)
 	cmd.ResourceConfigSpecFlag = &ResourceConfigSpecFlag{
 		ResourceConfigSpec: types.ResourceConfigSpec{
-			CpuAllocation: &types.ResourceAllocationInfo{
+			CpuAllocation: types.ResourceAllocationInfo{
 				Shares: new(types.SharesInfo),
 			},
-			MemoryAllocation: &types.ResourceAllocationInfo{
+			MemoryAllocation: types.ResourceAllocationInfo{
 				Shares: new(types.SharesInfo),
 			},
 		},
@@ -82,8 +82,7 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	for _, a := range []types.BaseResourceAllocationInfo{cmd.CpuAllocation, cmd.MemoryAllocation} {
-		ra := a.GetResourceAllocationInfo()
+	for _, ra := range []*types.ResourceAllocationInfo{&cmd.CpuAllocation, &cmd.MemoryAllocation} {
 		if ra.Shares.Level == "" {
 			ra.Shares = nil
 		}

--- a/govc/pool/info.go
+++ b/govc/pool/info.go
@@ -191,8 +191,7 @@ func (r *infoResult) Write(w io.Writer) error {
 	return tw.Flush()
 }
 
-func writeInfo(w io.Writer, name string, units string, ru *types.ResourcePoolResourceUsage, b types.BaseResourceAllocationInfo) {
-	ra := b.GetResourceAllocationInfo()
+func writeInfo(w io.Writer, name string, units string, ru *types.ResourcePoolResourceUsage, ra types.ResourceAllocationInfo) {
 	usage := 100.0 * float64(ru.OverallUsage) / float64(ru.MaxUsage)
 	shares := ""
 	limit := "unlimited"

--- a/govc/pool/resource_config_spec.go
+++ b/govc/pool/resource_config_spec.go
@@ -61,20 +61,19 @@ func (s *ResourceConfigSpecFlag) Register(ctx context.Context, f *flag.FlagSet) 
 	opts := []struct {
 		name  string
 		units string
-		types.BaseResourceAllocationInfo
+		*types.ResourceAllocationInfo
 	}{
-		{"CPU", "MHz", s.CpuAllocation},
-		{"Memory", "MB", s.MemoryAllocation},
+		{"CPU", "MHz", &s.CpuAllocation},
+		{"Memory", "MB", &s.MemoryAllocation},
 	}
 
 	for _, opt := range opts {
 		prefix := strings.ToLower(opt.name)[:3]
-		ra := opt.GetResourceAllocationInfo()
-		shares := (*sharesInfo)(ra.Shares)
+		shares := (*sharesInfo)(opt.Shares)
 
-		f.Var(flags.NewOptionalInt64(&ra.Limit), prefix+".limit", opt.name+" limit in "+opt.units)
-		f.Var(flags.NewOptionalInt64(&ra.Reservation), prefix+".reservation", opt.name+" reservation in "+opt.units)
-		f.Var(flags.NewOptionalBool(&ra.ExpandableReservation), prefix+".expandable", opt.name+" expandable reservation")
+		f.Var(flags.NewOptionalInt64(&opt.Limit), prefix+".limit", opt.name+" limit in "+opt.units)
+		f.Var(flags.NewOptionalInt64(&opt.Reservation), prefix+".reservation", opt.name+" reservation in "+opt.units)
+		f.Var(flags.NewOptionalBool(&opt.ExpandableReservation), prefix+".expandable", opt.name+" expandable reservation")
 		f.Var(shares, prefix+".shares", opt.name+" shares level or number")
 	}
 }

--- a/simulator/esx/resource_pool.go
+++ b/simulator/esx/resource_pool.go
@@ -53,7 +53,7 @@ var ResourcePool = mo.ResourcePool{
 			Entity:        &types.ManagedObjectReference{Type: "ResourcePool", Value: "ha-root-pool"},
 			ChangeVersion: "",
 			LastModified:  (*time.Time)(nil),
-			CpuAllocation: &types.ResourceAllocationInfo{
+			CpuAllocation: types.ResourceAllocationInfo{
 				DynamicData:           types.DynamicData{},
 				Reservation:           types.NewInt64(4121),
 				ExpandableReservation: types.NewBool(false),
@@ -65,7 +65,7 @@ var ResourcePool = mo.ResourcePool{
 				},
 				OverheadLimit: nil,
 			},
-			MemoryAllocation: &types.ResourceAllocationInfo{
+			MemoryAllocation: types.ResourceAllocationInfo{
 				DynamicData:           types.DynamicData{},
 				Reservation:           types.NewInt64(961),
 				ExpandableReservation: types.NewBool(false),
@@ -133,7 +133,7 @@ var ResourcePool = mo.ResourcePool{
 		Entity:        &types.ManagedObjectReference{Type: "ResourcePool", Value: "ha-root-pool"},
 		ChangeVersion: "",
 		LastModified:  (*time.Time)(nil),
-		CpuAllocation: &types.ResourceAllocationInfo{
+		CpuAllocation: types.ResourceAllocationInfo{
 			DynamicData:           types.DynamicData{},
 			Reservation:           types.NewInt64(4121),
 			ExpandableReservation: types.NewBool(false),
@@ -145,7 +145,7 @@ var ResourcePool = mo.ResourcePool{
 			},
 			OverheadLimit: nil,
 		},
-		MemoryAllocation: &types.ResourceAllocationInfo{
+		MemoryAllocation: types.ResourceAllocationInfo{
 			DynamicData:           types.DynamicData{},
 			Reservation:           types.NewInt64(961),
 			ExpandableReservation: types.NewBool(false),

--- a/simulator/resource_pool.go
+++ b/simulator/resource_pool.go
@@ -43,26 +43,14 @@ func NewResourcePool() *ResourcePool {
 	return pool
 }
 
-func (p *ResourcePool) allFieldsSet(spec types.BaseResourceAllocationInfo) bool {
-	if spec == nil {
-		return false
-	}
-
-	info := spec.GetResourceAllocationInfo()
-
+func (p *ResourcePool) allFieldsSet(info types.ResourceAllocationInfo) bool {
 	return info.Reservation != nil &&
 		info.Limit != nil &&
 		info.ExpandableReservation != nil &&
 		info.Shares != nil
 }
 
-func (p *ResourcePool) allFieldsValid(spec types.BaseResourceAllocationInfo) bool {
-	if spec == nil {
-		return false
-	}
-
-	info := spec.GetResourceAllocationInfo()
-
+func (p *ResourcePool) allFieldsValid(info types.ResourceAllocationInfo) bool {
 	if info.Reservation != nil {
 		if *info.Reservation < 0 {
 			return false
@@ -142,14 +130,7 @@ func (p *ResourcePool) CreateResourcePool(c *types.CreateResourcePool) soap.HasF
 	return body
 }
 
-func (p *ResourcePool) updateAllocation(kind string, spec types.BaseResourceAllocationInfo, cfg types.BaseResourceAllocationInfo) *soap.Fault {
-	if spec == nil {
-		return nil
-	}
-
-	src := spec.GetResourceAllocationInfo()
-	dst := cfg.GetResourceAllocationInfo()
-
+func (p *ResourcePool) updateAllocation(kind string, src types.ResourceAllocationInfo, dst *types.ResourceAllocationInfo) *soap.Fault {
 	if !p.allFieldsValid(src) {
 		return Fault("", &types.InvalidArgument{
 			InvalidProperty: fmt.Sprintf("spec.%sAllocation", kind),
@@ -189,12 +170,12 @@ func (p *ResourcePool) UpdateConfig(c *types.UpdateConfig) soap.HasFault {
 	spec := c.Config
 
 	if spec != nil {
-		if err := p.updateAllocation("memory", spec.MemoryAllocation, p.Config.MemoryAllocation); err != nil {
+		if err := p.updateAllocation("memory", spec.MemoryAllocation, &p.Config.MemoryAllocation); err != nil {
 			body.Fault_ = err
 			return body
 		}
 
-		if err := p.updateAllocation("cpu", spec.CpuAllocation, p.Config.CpuAllocation); err != nil {
+		if err := p.updateAllocation("cpu", spec.CpuAllocation, &p.Config.CpuAllocation); err != nil {
 			body.Fault_ = err
 			return body
 		}

--- a/simulator/resource_pool_test.go
+++ b/simulator/resource_pool_test.go
@@ -53,7 +53,7 @@ func TestResourcePool(t *testing.T) {
 
 	parent := object.NewResourcePool(c, esx.ResourcePool.Self)
 
-	spec.CpuAllocation.GetResourceAllocationInfo().Reservation = nil
+	spec.CpuAllocation.Reservation = nil
 	// missing required field (Reservation) for create
 	_, err = parent.Create(ctx, "fail", spec)
 	if err == nil {
@@ -82,7 +82,7 @@ func TestResourcePool(t *testing.T) {
 		t.Error("expected new pool Self reference")
 	}
 
-	*spec.CpuAllocation.GetResourceAllocationInfo().Reservation = -1
+	*spec.CpuAllocation.Reservation = -1
 	// invalid field value (Reservation) for update
 	err = child.UpdateConfig(ctx, "", &spec)
 	if err == nil {
@@ -90,7 +90,7 @@ func TestResourcePool(t *testing.T) {
 	}
 
 	// valid config update
-	*spec.CpuAllocation.GetResourceAllocationInfo().Reservation = 10
+	*spec.CpuAllocation.Reservation = 10
 	err = child.UpdateConfig(ctx, "", &spec)
 	if err != nil {
 		t.Error(err)
@@ -102,7 +102,7 @@ func TestResourcePool(t *testing.T) {
 		t.Error(err)
 	}
 
-	if *p.Config.CpuAllocation.GetResourceAllocationInfo().Reservation != 10 {
+	if *p.Config.CpuAllocation.Reservation != 10 {
 		t.Error("config not updated")
 	}
 
@@ -275,45 +275,41 @@ func TestResourcePoolValidation(t *testing.T) {
 
 	tests := []func() bool{
 		func() bool {
-			return pool.allFieldsSet(nil)
-		},
-		func() bool {
-			r := new(types.ResourceAllocationInfo)
-			return pool.allFieldsSet(r)
+			return pool.allFieldsSet(types.ResourceAllocationInfo{})
 		},
 		func() bool {
 			spec := types.DefaultResourceConfigSpec()
-			spec.CpuAllocation.GetResourceAllocationInfo().Limit = nil
+			spec.CpuAllocation.Limit = nil
 			return pool.allFieldsSet(spec.CpuAllocation)
 		},
 		func() bool {
 			spec := types.DefaultResourceConfigSpec()
-			spec.CpuAllocation.GetResourceAllocationInfo().Reservation = nil
+			spec.CpuAllocation.Reservation = nil
 			return pool.allFieldsSet(spec.CpuAllocation)
 		},
 		func() bool {
 			spec := types.DefaultResourceConfigSpec()
-			spec.CpuAllocation.GetResourceAllocationInfo().ExpandableReservation = nil
+			spec.CpuAllocation.ExpandableReservation = nil
 			return pool.allFieldsSet(spec.CpuAllocation)
 		},
 		func() bool {
 			spec := types.DefaultResourceConfigSpec()
-			spec.CpuAllocation.GetResourceAllocationInfo().Shares = nil
+			spec.CpuAllocation.Shares = nil
 			return pool.allFieldsSet(spec.CpuAllocation)
 		},
 		func() bool {
 			spec := types.DefaultResourceConfigSpec()
-			spec.CpuAllocation.GetResourceAllocationInfo().Reservation = types.NewInt64(-1)
+			spec.CpuAllocation.Reservation = types.NewInt64(-1)
 			return pool.allFieldsValid(spec.CpuAllocation)
 		},
 		func() bool {
 			spec := types.DefaultResourceConfigSpec()
-			spec.CpuAllocation.GetResourceAllocationInfo().Limit = types.NewInt64(-100)
+			spec.CpuAllocation.Limit = types.NewInt64(-100)
 			return pool.allFieldsValid(spec.CpuAllocation)
 		},
 		func() bool {
 			spec := types.DefaultResourceConfigSpec()
-			shares := spec.CpuAllocation.GetResourceAllocationInfo().Shares
+			shares := spec.CpuAllocation.Shares
 			shares.Level = types.SharesLevelCustom
 			shares.Shares = -1
 			return pool.allFieldsValid(spec.CpuAllocation)

--- a/vim25/types/helpers.go
+++ b/vim25/types/helpers.go
@@ -61,8 +61,8 @@ func (c *PerfCounterInfo) Name() string {
 	return c.GroupInfo.GetElementDescription().Key + "." + c.NameInfo.GetElementDescription().Key + "." + string(c.RollupType)
 }
 
-func defaultResourceAllocationInfo() *ResourceAllocationInfo {
-	return &ResourceAllocationInfo{
+func defaultResourceAllocationInfo() ResourceAllocationInfo {
+	return ResourceAllocationInfo{
 		Reservation:           NewInt64(0),
 		ExpandableReservation: NewBool(true),
 		Limit: NewInt64(-1),

--- a/vim25/types/if.go
+++ b/vim25/types/if.go
@@ -2360,16 +2360,6 @@ func init() {
 	t["BaseReplicationVmFault"] = reflect.TypeOf((*ReplicationVmFault)(nil)).Elem()
 }
 
-func (b *ResourceAllocationInfo) GetResourceAllocationInfo() *ResourceAllocationInfo { return b }
-
-type BaseResourceAllocationInfo interface {
-	GetResourceAllocationInfo() *ResourceAllocationInfo
-}
-
-func init() {
-	t["BaseResourceAllocationInfo"] = reflect.TypeOf((*ResourceAllocationInfo)(nil)).Elem()
-}
-
 func (b *ResourceInUse) GetResourceInUse() *ResourceInUse { return b }
 
 type BaseResourceInUse interface {

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -39100,11 +39100,11 @@ func init() {
 type ResourceConfigSpec struct {
 	DynamicData
 
-	Entity           *ManagedObjectReference    `xml:"entity,omitempty"`
-	ChangeVersion    string                     `xml:"changeVersion,omitempty"`
-	LastModified     *time.Time                 `xml:"lastModified"`
-	CpuAllocation    BaseResourceAllocationInfo `xml:"cpuAllocation,typeattr"`
-	MemoryAllocation BaseResourceAllocationInfo `xml:"memoryAllocation,typeattr"`
+	Entity           *ManagedObjectReference `xml:"entity,omitempty"`
+	ChangeVersion    string                  `xml:"changeVersion,omitempty"`
+	LastModified     *time.Time              `xml:"lastModified"`
+	CpuAllocation    ResourceAllocationInfo  `xml:"cpuAllocation"`
+	MemoryAllocation ResourceAllocationInfo  `xml:"memoryAllocation"`
 }
 
 func init() {
@@ -48356,8 +48356,8 @@ type VirtualMachineConfigInfo struct {
 	ConsolePreferences           *VirtualMachineConsolePreferences          `xml:"consolePreferences,omitempty"`
 	DefaultPowerOps              VirtualMachineDefaultPowerOpInfo           `xml:"defaultPowerOps"`
 	Hardware                     VirtualHardware                            `xml:"hardware"`
-	CpuAllocation                BaseResourceAllocationInfo                 `xml:"cpuAllocation,omitempty,typeattr"`
-	MemoryAllocation             BaseResourceAllocationInfo                 `xml:"memoryAllocation,omitempty,typeattr"`
+	CpuAllocation                *ResourceAllocationInfo                    `xml:"cpuAllocation,omitempty"`
+	MemoryAllocation             *ResourceAllocationInfo                    `xml:"memoryAllocation,omitempty"`
 	LatencySensitivity           *LatencySensitivity                        `xml:"latencySensitivity,omitempty"`
 	MemoryHotAddEnabled          *bool                                      `xml:"memoryHotAddEnabled"`
 	CpuHotAddEnabled             *bool                                      `xml:"cpuHotAddEnabled"`
@@ -48493,8 +48493,8 @@ type VirtualMachineConfigSpec struct {
 	VirtualICH7MPresent          *bool                             `xml:"virtualICH7MPresent"`
 	VirtualSMCPresent            *bool                             `xml:"virtualSMCPresent"`
 	DeviceChange                 []BaseVirtualDeviceConfigSpec     `xml:"deviceChange,omitempty,typeattr"`
-	CpuAllocation                BaseResourceAllocationInfo        `xml:"cpuAllocation,omitempty,typeattr"`
-	MemoryAllocation             BaseResourceAllocationInfo        `xml:"memoryAllocation,omitempty,typeattr"`
+	CpuAllocation                *ResourceAllocationInfo           `xml:"cpuAllocation,omitempty"`
+	MemoryAllocation             *ResourceAllocationInfo           `xml:"memoryAllocation,omitempty"`
 	LatencySensitivity           *LatencySensitivity               `xml:"latencySensitivity,omitempty"`
 	CpuAffinity                  *VirtualMachineAffinityInfo       `xml:"cpuAffinity,omitempty"`
 	MemoryAffinity               *VirtualMachineAffinityInfo       `xml:"memoryAffinity,omitempty"`


### PR DESCRIPTION
VrpResourceAllocationInfo has been removed in 6.7, so the BaseResourceAllocationInfo
interface is no longer needed.

We already made a breaking ResourcePool related change cc2ed7d,
want to do this before the next govmomi release even though 6.7 has yet to be released.