### PR TITLE
import.spec not to assign deploymentOption

### DIFF
--- a/govc/importx/options.go
+++ b/govc/importx/options.go
@@ -38,7 +38,7 @@ type Network struct {
 
 type Options struct {
 	AllDeploymentOptions []string `json:",omitempty"`
-	Deployment           string
+	Deployment           string   `json:",omitempty"`
 
 	AllDiskProvisioningOptions []string `json:",omitempty"`
 	DiskProvisioning           string

--- a/govc/importx/spec.go
+++ b/govc/importx/spec.go
@@ -29,9 +29,6 @@ import (
 )
 
 var (
-	// all possible ovf property values
-	// the first element being the default value
-	allDeploymentOptions         = []string{"small", "medium", "large"}
 	allDiskProvisioningOptions   = []string{"thin", "monolithicSparse", "monolithicFlat", "twoGbMaxExtentSparse", "twoGbMaxExtentFlat", "seSparse", "eagerZeroedThick", "thick", "sparse", "flat"}
 	allIPAllocationPolicyOptions = []string{"dhcpPolicy", "transientPolicy", "fixedPolicy", "fixedAllocatedPolicy"}
 	allIPProtocolOptions         = []string{"IPv4", "IPv6"}
@@ -132,10 +129,8 @@ func (cmd *spec) Spec(fpath string) error {
 		return err
 	}
 
-	var deploymentOptions = allDeploymentOptions
+	var deploymentOptions []string
 	if e.DeploymentOption != nil && e.DeploymentOption.Configuration != nil {
-		deploymentOptions = nil
-
 		// add default first
 		for _, c := range e.DeploymentOption.Configuration {
 			if c.Default != nil && *c.Default {
@@ -151,14 +146,18 @@ func (cmd *spec) Spec(fpath string) error {
 	}
 
 	o := Options{
-		Deployment:         deploymentOptions[0],
 		DiskProvisioning:   allDiskProvisioningOptions[0],
 		IPAllocationPolicy: allIPAllocationPolicyOptions[0],
 		IPProtocol:         allIPProtocolOptions[0],
 		PowerOn:            false,
 		WaitForIP:          false,
 		InjectOvfEnv:       false,
-		PropertyMapping:    cmd.Map(e)}
+		PropertyMapping:    cmd.Map(e),
+	}
+
+	if deploymentOptions != nil {
+		o.Deployment = deploymentOptions[0]
+	}
 
 	if e.VirtualSystem != nil && e.VirtualSystem.Annotation != nil {
 		for _, a := range e.VirtualSystem.Annotation {
@@ -173,7 +172,9 @@ func (cmd *spec) Spec(fpath string) error {
 	}
 
 	if cmd.verbose {
-		o.AllDeploymentOptions = deploymentOptions
+		if deploymentOptions != nil {
+			o.AllDeploymentOptions = deploymentOptions
+		}
 		o.AllDiskProvisioningOptions = allDiskProvisioningOptions
 		o.AllIPAllocationPolicyOptions = allIPAllocationPolicyOptions
 		o.AllIPProtocolOptions = allIPProtocolOptions

--- a/govc/importx/spec.go
+++ b/govc/importx/spec.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/ovf"
@@ -91,9 +92,18 @@ func (cmd *spec) Map(e *ovf.Envelope) (res []Property) {
 
 	for _, p := range e.VirtualSystem.Product {
 		for i, v := range p.Property {
+			if v.UserConfigurable == nil || !*v.UserConfigurable {
+				continue
+			}
+
 			d := ""
 			if v.Default != nil {
 				d = *v.Default
+			}
+
+			// vSphere only accept True/False as boolean values for some reason
+			if v.Type == "boolean" {
+				d = strings.Title(d)
 			}
 
 			// From OVF spec, section 9.5.1:

--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -57,6 +57,21 @@ load test_helper
   rm -f ${file}
 }
 
+@test "import.ovf with import.spec result" {
+  esx_env
+
+  file=$($mktemp --tmpdir govc-test-XXXXX)
+  name=$(new_id)
+  
+  govc import.spec $GOVC_IMAGES/${TTYLINUX_NAME}.ovf > ${file}
+  
+  run govc import.ovf -name="${name}" -options="${file}" $GOVC_IMAGES/${TTYLINUX_NAME}.ovf
+  assert_success
+
+  run govc vm.destroy "${name}"
+  assert_success
+}
+
 @test "import.ovf with name as argument" {
   esx_env
 


### PR DESCRIPTION
We used to forcefully assign deploymentOption among [small, medium, large]
when we call import.spec on an ova/ovf that doesn't include
deploymentOption. This could generate an option file that cannot be
accepted by import.ova or import.ovf. After this change we only assign
deploymentOption when it's included in ova/ovf file.

Fixes #487