### PR TITLE
vcsim: add autostart option to power on VMs

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -497,7 +497,7 @@ load test_helper
 }
 
 @test "vm.register vcsim" {
-  vcsim_env
+  vcsim_env -autostart=false
 
   host=$GOVC_HOST
   pool=$GOVC_RESOURCE_POOL

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -412,52 +412,27 @@ func TestShutdownGuest(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		finder := find.NewFinder(c.Client, false)
-
-		dc, err := finder.DefaultDatacenter(ctx)
+		vm := object.NewVirtualMachine(c.Client, Map.Any("VirtualMachine").Reference())
+		// shutdown the vm
+		err = vm.ShutdownGuest(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// state should be poweroff
+		state, err := vm.PowerState(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		finder.SetDatacenter(dc)
-
-		vms, err := finder.VirtualMachineList(ctx, "*")
-		// use the default first vm for test
-		if len(vms) > 0 {
-			vmm := vms[0]
-			// powon first
-			task, err := vmm.PowerOn(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			err = task.Wait(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// shutdown the vm
-			err = vmm.ShutdownGuest(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-			// state should be poweroff
-			state, err := vmm.PowerState(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if state != types.VirtualMachinePowerStatePoweredOff {
-				t.Errorf("state=%s", state)
-			}
-
-			// shutdown a poweroff vm should fail
-			err = vmm.ShutdownGuest(ctx)
-			if err == nil {
-				t.Error("expected error: InvalidPowerState")
-			}
+		if state != types.VirtualMachinePowerStatePoweredOff {
+			t.Errorf("state=%s", state)
 		}
 
+		// shutdown a poweroff vm should fail
+		err = vm.ShutdownGuest(ctx)
+		if err == nil {
+			t.Error("expected error: InvalidPowerState")
+		}
 	}
 }
 

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -45,6 +45,7 @@ func main() {
 	flag.IntVar(&model.Pod, "pod", model.Pod, "Number of storage pods per datacenter")
 	flag.IntVar(&model.Portgroup, "pg", model.Portgroup, "Number of port groups")
 	flag.IntVar(&model.Folder, "folder", model.Folder, "Number of folders")
+	flag.BoolVar(&model.Autostart, "autostart", model.Autostart, "Autostart model created VMs")
 
 	isESX := flag.Bool("esx", false, "Simulate standalone ESX")
 	isTLS := flag.Bool("tls", true, "Enable TLS")


### PR DESCRIPTION
When a VM is created, the power state is off.  The autostart option will call vm.PowerOn when true.

Related: #900