### PR TITLE
Remove tls-handshake-timeout flag

### DIFF
--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -39,19 +39,18 @@ import (
 )
 
 const (
-	envURL                 = "GOVC_URL"
-	envUsername            = "GOVC_USERNAME"
-	envPassword            = "GOVC_PASSWORD"
-	envCertificate         = "GOVC_CERTIFICATE"
-	envPrivateKey          = "GOVC_PRIVATE_KEY"
-	envInsecure            = "GOVC_INSECURE"
-	envPersist             = "GOVC_PERSIST_SESSION"
-	envMinAPIVersion       = "GOVC_MIN_API_VERSION"
-	envVimNamespace        = "GOVC_VIM_NAMESPACE"
-	envVimVersion          = "GOVC_VIM_VERSION"
-	envTLSCaCerts          = "GOVC_TLS_CA_CERTS"
-	envTLSKnownHosts       = "GOVC_TLS_KNOWN_HOSTS"
-	envTLSHandshakeTimeout = "GOVC_TLS_HANDSHAKE_TIMEOUT"
+	envURL           = "GOVC_URL"
+	envUsername      = "GOVC_USERNAME"
+	envPassword      = "GOVC_PASSWORD"
+	envCertificate   = "GOVC_CERTIFICATE"
+	envPrivateKey    = "GOVC_PRIVATE_KEY"
+	envInsecure      = "GOVC_INSECURE"
+	envPersist       = "GOVC_PERSIST_SESSION"
+	envMinAPIVersion = "GOVC_MIN_API_VERSION"
+	envVimNamespace  = "GOVC_VIM_NAMESPACE"
+	envVimVersion    = "GOVC_VIM_VERSION"
+	envTLSCaCerts    = "GOVC_TLS_CA_CERTS"
+	envTLSKnownHosts = "GOVC_TLS_KNOWN_HOSTS"
 )
 
 const cDescr = "ESX or vCenter URL"
@@ -61,21 +60,19 @@ type ClientFlag struct {
 
 	*DebugFlag
 
-	url                 *url.URL
-	username            string
-	password            string
-	cert                string
-	key                 string
-	insecure            bool
-	persist             bool
-	minAPIVersion       string
-	vimNamespace        string
-	vimVersion          string
-	tlsCaCerts          string
-	tlsKnownHosts       string
-	tlsHostHash         string
-	tlsHandshakeTimeout time.Duration
-	client              *vim25.Client
+	url           *url.URL
+	username      string
+	password      string
+	cert          string
+	key           string
+	insecure      bool
+	persist       bool
+	minAPIVersion string
+	vimNamespace  string
+	vimVersion    string
+	tlsCaCerts    string
+	tlsKnownHosts string
+	client        *vim25.Client
 }
 
 var (
@@ -218,15 +215,6 @@ func (flag *ClientFlag) Register(ctx context.Context, f *flag.FlagSet) {
 			usage := fmt.Sprintf("TLS known hosts file [%s]", envTLSKnownHosts)
 			f.StringVar(&flag.tlsKnownHosts, "tls-known-hosts", value, usage)
 		}
-
-		{
-			value, err := time.ParseDuration(os.Getenv(envTLSHandshakeTimeout))
-			if err != nil {
-				value = 10 * time.Second
-			}
-			usage := fmt.Sprintf("TLS handshake timeout [%s]", envTLSHandshakeTimeout)
-			f.DurationVar(&flag.tlsHandshakeTimeout, "tls-handshake-timeout", value, usage)
-		}
 	})
 }
 
@@ -288,7 +276,15 @@ func (flag *ClientFlag) configure(sc *soap.Client) (soap.RoundTripper, error) {
 	}
 
 	if t, ok := sc.Transport.(*http.Transport); ok {
-		t.TLSHandshakeTimeout = flag.tlsHandshakeTimeout
+		var err error
+
+		value := os.Getenv("GOVC_TLS_HANDSHAKE_TIMEOUT")
+		if value != "" {
+			t.TLSHandshakeTimeout, err = time.ParseDuration(value)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// Retry twice when a temporary I/O error occurs.

--- a/govc/test/cli.bats
+++ b/govc/test/cli.bats
@@ -9,22 +9,11 @@ load test_helper
   assert_success
   assert_line "Vendor: VMware, Inc."
 
-  run govc about --tls-handshake-timeout=10s
-  assert_success
-  assert_line "Vendor: VMware, Inc."
-
   run env GOVC_TLS_HANDSHAKE_TIMEOUT=10s govc about
   assert_success
   assert_line "Vendor: VMware, Inc."
 
   run env GOVC_TLS_HANDSHAKE_TIMEOUT=NOT_A_DURATION govc about
-  assert_success
-  assert_line "Vendor: VMware, Inc."
-
-  run govc about --tls-handshake-timeout=1ns
-  assert_failure
-
-  run env GOVC_TLS_HANDSHAKE_TIMEOUT=1ns govc about
   assert_failure
 
   run govc about -json


### PR DESCRIPTION
In the case of overriding http.DefaultTransport connection params, let's just provide the option(s) via environment
variables for now and not add new flags yet.