### PR TITLE
vcsim: preserve order in QueryIpPools

### DIFF
--- a/simulator/ip_pool_manager.go
+++ b/simulator/ip_pool_manager.go
@@ -102,8 +102,10 @@ func (m *IpPoolManager) DestroyIpPool(req *types.DestroyIpPool) soap.HasFault {
 func (m *IpPoolManager) QueryIpPools(req *types.QueryIpPools) soap.HasFault {
 	pools := []types.IpPool{}
 
-	for _, pool := range m.pools {
-		pools = append(pools, *pool.config)
+	for i := int32(1); i < m.nextPoolId; i++ {
+		if p, ok := m.pools[i]; ok {
+			pools = append(pools, *p.config)
+		}
 	}
 
 	return &methods.QueryIpPoolsBody{


### PR DESCRIPTION
IpPoolManager.pools is a map, so order is not guaranteed.  The test would sometimes fail with:

    ip_pool_manager_test.go:276: expect query result equal to ...