### PR TITLE
vcsim: apply vm spec NumCoresPerSocket

### DIFF
--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -240,6 +240,9 @@ load test_helper
   run govc object.collect -s -type VirtualMachine / summary.guest.toolsStatus
   assert_matches toolsNotInstalled
 
+  run govc object.collect -s /DC0/vm/DC0_H0_VM0 config.hardware.numCoresPerSocket
+  assert_success 1
+
   run govc object.collect -s -type ClusterComputeResource / summary.effectiveCpu
   assert_number
 

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -152,6 +152,10 @@ func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 		vm.Summary.Config.NumCpu = vm.Config.Hardware.NumCPU
 	}
 
+	if spec.NumCoresPerSocket != 0 {
+		vm.Config.Hardware.NumCoresPerSocket = spec.NumCoresPerSocket
+	}
+
 	vm.Config.ExtraConfig = append(vm.Config.ExtraConfig, spec.ExtraConfig...)
 
 	vm.Config.Modified = time.Now()


### PR DESCRIPTION
We set the default to 1 in the spec, but did not apply to the config.

Fixes #929