### PR TITLE
vcsim: add MakeDirectoryResponse

### DIFF
--- a/simulator/file_manager.go
+++ b/simulator/file_manager.go
@@ -160,6 +160,7 @@ func (f *FileManager) MakeDirectory(req *types.MakeDirectory) soap.HasFault {
 		return body
 	}
 
+	body.Res = new(types.MakeDirectoryResponse)
 	return body
 }
 


### PR DESCRIPTION
Go ignores the empty response, but Python requires it.

Fixes #937