### PR TITLE
Corrects host.shutdown

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1881,7 +1881,7 @@ Options:
 ## host.service.ls
 
 ```
-Usage: govc host.service.ls [OPTIONS]
+Usage: govc host.service.ls [OPTIONS] HOST...
 
 List HOST services.
 

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1881,7 +1881,7 @@ Options:
 ## host.service.ls
 
 ```
-Usage: govc host.service.ls [OPTIONS] HOST...
+Usage: govc host.service.ls [OPTIONS]
 
 List HOST services.
 
@@ -1892,7 +1892,7 @@ Options:
 ## host.shutdown
 
 ```
-Usage: govc host.shutdown [OPTIONS]
+Usage: govc host.shutdown [OPTIONS] HOST...
 
 Shutdown HOST.
 

--- a/govc/host/shutdown.go
+++ b/govc/host/shutdown.go
@@ -53,6 +53,10 @@ func (cmd *shutdown) Process(ctx context.Context) error {
 	return nil
 }
 
+func (cmd *shutdown) Usage() string {
+	return `HOST...`
+}
+
 func (cmd *shutdown) Description() string {
 	return `Shutdown HOST.`
 }


### PR DESCRIPTION
host.shutdown expects HOST as an argument.