### PR TITLE
toolbox: validate request offset in ListFiles

### DIFF
--- a/toolbox/command.go
+++ b/toolbox/command.go
@@ -511,8 +511,11 @@ func (c *CommandServer) ListFiles(header vix.CommandRequestHeader, data []byte) 
 
 	offset := r.Body.Offset + uint64(r.Body.Index)
 	total := uint64(len(files)) - offset
-
-	files = files[offset:]
+	if int(offset) < len(files) {
+		files = files[offset:]
+	} else {
+		total = 0 // offset is not valid (open-vm-tools behaves the same in this case)
+	}
 
 	var remaining uint64
 

--- a/toolbox/command_test.go
+++ b/toolbox/command_test.go
@@ -821,6 +821,10 @@ func TestVixFiles(t *testing.T) {
 		t.Errorf("expected %d, got %d", max, total)
 	}
 
+	// Test invalid offset, making sure it doesn't cause panic (issue #934)
+	ls.Body.Offset += 10
+	_ = c.Request(vix.CommandListFiles, ls)
+
 	// mv $dir ${dir}-old
 	mv = &vix.RenameFileRequest{
 		OldPathName: dir,


### PR DESCRIPTION
The ListFiles handler assumed the 'offset' param was always valid.
It could be invalid if client-side logic is wrong or directory contents have shrunk in between calls.
Either way, we reply with '0' remaining files in this case as open-vm-tools does.

Fixes #934