### PR TITLE
Corrects vm.info usage with required args

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -3103,7 +3103,14 @@ Options:
 ## vm.info
 
 ```
-Usage: govc vm.info [OPTIONS]
+Usage: govc vm.info [OPTIONS] VM...
+
+Display info for VM.
+
+Examples:
+  govc vm.info $vm
+  govc vm.info -json $vm
+  govc find . -type m -runtime.powerState poweredOn | xargs govc vm.info
 
 Options:
   -e=false                  Show ExtraConfig

--- a/govc/vm/info.go
+++ b/govc/vm/info.go
@@ -83,6 +83,19 @@ func (cmd *info) Process(ctx context.Context) error {
 	return nil
 }
 
+func (cmd *info) Usage() string {
+	return `VM...`
+}
+
+func (cmd *info) Description() string {
+	return `Display info for VM.
+
+Examples:
+  govc vm.info $vm
+  govc vm.info -json $vm
+  govc find . -type m -runtime.powerState poweredOn | xargs govc vm.info`
+}
+
 func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 	c, err := cmd.Client()
 	if err != nil {


### PR DESCRIPTION
Generated `USAGE.md` with `make docs`. Also added some examples