### PR TITLE
Add missing dependency in gen script

### DIFF
--- a/gen/Gemfile
+++ b/gen/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "nokogiri"
+gem "test-unit"

--- a/gen/Gemfile.lock
+++ b/gen/Gemfile.lock
@@ -4,9 +4,16 @@ GEM
     mini_portile (0.6.0)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
+    power_assert (0.4.1)
+    test-unit (3.2.3)
+      power_assert
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   nokogiri
+  test-unit
+
+BUNDLED WITH
+   1.14.6


### PR DESCRIPTION
without the fix, I have this error:

```console
 ./gen.sh 
/home/anfernee/go/src/github.com/vmware/govmomi/gen/vim_wsdl.rb:16:in `require': cannot load such file -- test/unit (LoadError)
	from /home/anfernee/go/src/github.com/vmware/govmomi/gen/vim_wsdl.rb:16:in `<top (required)>'
	from gen_from_wsdl.rb:17:in `require'
	from gen_from_wsdl.rb:17:in `<main>'

```