### PR TITLE
vcsim: Add HostLocalAccountManager

### DIFF
--- a/simulator/host_local_account_manager.go
+++ b/simulator/host_local_account_manager.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// As of vSphere API 5.1, local groups operations are deprecated, so it's not supported here.
+
+type HostLocalAccountManager struct {
+	mo.HostLocalAccountManager
+
+	users map[string]*types.HostAccountSpec
+}
+
+func NewHostLocalAccountManager(ref types.ManagedObjectReference) object.Reference {
+	m := &HostLocalAccountManager{}
+	m.Self = ref
+	m.users = make(map[string]*types.HostAccountSpec)
+	return m
+}
+
+func (h *HostLocalAccountManager) CreateUser(req *types.CreateUser) soap.HasFault {
+	spec := req.User.GetHostAccountSpec()
+	if _, ok := h.users[spec.Id]; ok {
+		return &methods.CreateUserBody{
+			Fault_: Fault("", &types.AlreadyExists{}),
+		}
+	}
+
+	h.users[spec.Id] = spec
+
+	return &methods.CreateUserBody{
+		Res: &types.CreateUserResponse{},
+	}
+}
+
+func (h *HostLocalAccountManager) RemoveUser(req *types.RemoveUser) soap.HasFault {
+	if _, ok := h.users[req.UserName]; !ok {
+		return &methods.RemoveUserBody{
+			Fault_: Fault("", &types.UserNotFound{}),
+		}
+	}
+
+	delete(h.users, req.UserName)
+
+	return &methods.RemoveUserBody{
+		Res: &types.RemoveUserResponse{},
+	}
+}
+
+func (h *HostLocalAccountManager) UpdateUser(req *types.UpdateUser) soap.HasFault {
+	spec := req.User.GetHostAccountSpec()
+	h.users[spec.Id] = spec
+
+	return &methods.CreateUserBody{
+		Res: &types.CreateUserResponse{},
+	}
+}

--- a/simulator/host_local_account_manager_test.go
+++ b/simulator/host_local_account_manager_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestHostLocalAccountManager(t *testing.T) {
+	ctx := context.Background()
+	m := ESX()
+
+	defer m.Remove()
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts := m.Service.NewServer()
+	defer ts.Close()
+
+	c, err := govmomi.NewClient(ctx, ts.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := types.ManagedObjectReference{Type: "HostLocalAccountManager", Value: "ha-localacctmgr"}
+
+	createUserReq := &types.CreateUser{
+		This: ref,
+		User: &types.HostAccountSpec{
+			Id: "userid",
+		},
+	}
+
+	_, err = methods.CreateUser(ctx, c.Client, createUserReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = methods.CreateUser(ctx, c.Client, createUserReq)
+	if err == nil {
+		t.Fatal("expect err; got nil")
+	}
+
+	updateUserReq := &types.UpdateUser{
+		This: ref,
+		User: &types.HostAccountSpec{
+			Id: "userid",
+		},
+	}
+
+	_, err = methods.UpdateUser(ctx, c.Client, updateUserReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	removeUserReq := &types.RemoveUser{
+		This:     ref,
+		UserName: "userid",
+	}
+
+	_, err = methods.RemoveUser(ctx, c.Client, removeUserReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = methods.RemoveUser(ctx, c.Client, removeUserReq)
+	if err == nil {
+		t.Fatal("expect err; got nil")
+	}
+}

--- a/simulator/service_instance.go
+++ b/simulator/service_instance.go
@@ -75,6 +75,10 @@ func NewServiceInstance(content types.ServiceContent, folder mo.Folder) *Service
 		objects = append(objects, NewIpPoolManager(*s.Content.IpPoolManager))
 	}
 
+	if s.Content.AccountManager != nil {
+		objects = append(objects, NewHostLocalAccountManager(*s.Content.AccountManager))
+	}
+
 	for _, o := range objects {
 		Map.Put(o)
 	}


### PR DESCRIPTION
Support CUD operations on users. Groups operations are not supported
because they are deprecated in 5.1

Fix #947