### PR TITLE
Destroy event history collectors

### DIFF
--- a/event/manager.go
+++ b/event/manager.go
@@ -180,5 +180,7 @@ func (m Manager) Events(ctx context.Context, objects []types.ManagedObjectRefere
 		proc.addObject(ctx, o)
 	}
 
+	defer proc.destroy()
+
 	return proc.run(ctx, tail)
 }


### PR DESCRIPTION
The EventHistoryCollector objects are tied to a session and there is a max per-session.
Without destroying the collectors, we could max out the collectors causing 'govc events' to return empty.

Fixes #948
Fixes #961