### PR TITLE
govc: allow columns in guest login password

### DIFF
--- a/govc/CHANGELOG.md
+++ b/govc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+### 0.17.0 (undef)
+
+* Allow columns in password for guest login.
+
 ### 0.16.0 (2017-11-08)
 
 * Add export.ovf command

--- a/govc/vm/guest/auth.go
+++ b/govc/vm/guest/auth.go
@@ -39,7 +39,7 @@ func (flag *AuthFlag) String() string {
 }
 
 func (flag *AuthFlag) Set(s string) error {
-	c := strings.Split(s, ":")
+	c := strings.SplitN(s, ":", 2)
 	if len(c) > 0 {
 		flag.auth.Username = c[0]
 		if len(c) > 1 {


### PR DESCRIPTION
fixes #971 by using SplitN instead of Split and so keeping columns in the password.