### PR TITLE
Add option to filter events by type

### DIFF
--- a/event/manager.go
+++ b/event/manager.go
@@ -169,13 +169,13 @@ func (m Manager) EventCategory(ctx context.Context, event types.BaseEvent) (stri
 }
 
 // Get the events from the specified object(s) and optionanlly tail the event stream
-func (m Manager) Events(ctx context.Context, objects []types.ManagedObjectReference, pageSize int32, tail bool, force bool, f func(types.ManagedObjectReference, []types.BaseEvent) error) error {
-
+func (m Manager) Events(ctx context.Context, objects []types.ManagedObjectReference, pageSize int32, tail bool, force bool, f func(types.ManagedObjectReference, []types.BaseEvent) error, kind ...string) error {
+	// TODO: deprecated this method and add one that uses a single config struct, so we can extend further without breaking the method signature.
 	if len(objects) >= m.maxObjects && !force {
 		return fmt.Errorf("Maximum number of objects to monitor (%d) exceeded, refine search", m.maxObjects)
 	}
 
-	proc := newEventProcessor(m, pageSize, f)
+	proc := newEventProcessor(m, pageSize, f, kind)
 	for _, o := range objects {
 		proc.addObject(ctx, o)
 	}

--- a/event/processor.go
+++ b/event/processor.go
@@ -34,16 +34,18 @@ type tailInfo struct {
 type eventProcessor struct {
 	mgr      Manager
 	pageSize int32
+	kind     []string
 	tailers  map[types.ManagedObjectReference]*tailInfo // tailers by collector ref
 	callback func(types.ManagedObjectReference, []types.BaseEvent) error
 }
 
-func newEventProcessor(mgr Manager, pageSize int32, callback func(types.ManagedObjectReference, []types.BaseEvent) error) *eventProcessor {
+func newEventProcessor(mgr Manager, pageSize int32, callback func(types.ManagedObjectReference, []types.BaseEvent) error, kind []string) *eventProcessor {
 	return &eventProcessor{
 		mgr:      mgr,
 		tailers:  make(map[types.ManagedObjectReference]*tailInfo),
 		callback: callback,
 		pageSize: pageSize,
+		kind:     kind,
 	}
 }
 
@@ -53,6 +55,7 @@ func (p *eventProcessor) addObject(ctx context.Context, obj types.ManagedObjectR
 			Entity:    obj,
 			Recursion: types.EventFilterSpecRecursionOptionAll,
 		},
+		EventTypeId: p.kind,
 	}
 
 	collector, err := p.mgr.CreateCollectorForEvents(ctx, filter)

--- a/govc/test/events.bats
+++ b/govc/test/events.bats
@@ -54,6 +54,21 @@ load test_helper
   run govc events vm
   assert_success
   [ ${#lines[@]} -ge $nevents ]
+
+  run govc events -type VmPoweredOffEvent -type VmPoweredOnEvent "vm/$vm"
+  [ ${#lines[@]} -eq 0 ]
+
+  run govc vm.power -on "$vm"
+  assert_success
+
+  run govc events -type VmPoweredOffEvent -type VmPoweredOnEvent "vm/$vm"
+  [ ${#lines[@]} -eq 1 ]
+
+  run govc vm.power -off "$vm"
+  assert_success
+
+  run govc events -type VmPoweredOffEvent -type VmPoweredOnEvent "vm/$vm"
+  [ ${#lines[@]} -eq 2 ]
 }
 
 @test "events json" {


### PR DESCRIPTION
Filtering specific event types reduces the chance of missing events,
while keeping the event history collector page size on the low side.