### PR TITLE
Add cluster vm override commands

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -199,6 +199,56 @@ Options:
   -name=                    Cluster group name
 ```
 
+## cluster.override.change
+
+```
+Usage: govc cluster.override.change [OPTIONS]
+
+Change cluster VM overrides.
+
+Examples:
+  govc cluster.override.change -cluster cluster_1 -vm vm_1 -ha-restart-priority high
+  govc cluster.override.change -cluster cluster_1 -vm vm_2 -drs-enabled=false
+  govc cluster.override.change -cluster cluster_1 -vm vm_3 -drs-enabled -drs-mode fullyAutomated
+
+Options:
+  -cluster=                 Cluster [GOVC_CLUSTER]
+  -drs-enabled=<nil>        Enable DRS
+  -drs-mode=                DRS behavior for virtual machines: manual, partiallyAutomated, fullyAutomated
+  -ha-restart-priority=     HA restart priority: disabled, low, medium, high
+  -vm=                      Virtual machine [GOVC_VM]
+```
+
+## cluster.override.info
+
+```
+Usage: govc cluster.override.info [OPTIONS]
+
+Cluster VM overrides info.
+
+Examples:
+  govc cluster.override.info
+  govc cluster.override.info -json
+
+Options:
+  -cluster=                 Cluster [GOVC_CLUSTER]
+```
+
+## cluster.override.remove
+
+```
+Usage: govc cluster.override.remove [OPTIONS]
+
+Remove cluster VM overrides.
+
+Examples:
+  govc cluster.override.remove -cluster cluster_1 -vm vm_1
+
+Options:
+  -cluster=                 Cluster [GOVC_CLUSTER]
+  -vm=                      Virtual machine [GOVC_VM]
+```
+
 ## cluster.rule.change
 
 ```
@@ -228,9 +278,11 @@ Create cluster rule.
 
 Rules are not enabled by default, use the 'enable' flag to enable upon creation or cluster.rule.change after creation.
 
-One of '-affinity', '-anti-affinity' or '-vm-host' must be provided to specify the rule type.
+One of '-affinity', '-anti-affinity', '-depends' or '-vm-host' must be provided to specify the rule type.
 
 With '-affinity' or '-anti-affinity', at least 2 vm NAME arguments must be specified.
+
+With '-depends', vm group NAME and vm group dependency NAME arguments must be specified.
 
 With '-vm-host', use the '-vm-group' flag combined with the '-host-affine-group' and/or '-host-anti-affine-group' flags.
 
@@ -238,11 +290,13 @@ Examples:
   govc cluster.rule.create -name pod1 -enable -affinity vm_a vm_b vm_c
   govc cluster.rule.create -name pod2 -enable -anti-affinity vm_d vm_e vm_f
   govc cluster.rule.create -name pod3 -enable -mandatory -vm-host -vm-group my_vms -host-affine-group my_hosts
+  govc cluster.rule.create -name pod4 -depends vm_group_app vm_group_db
 
 Options:
   -affinity=false           Keep Virtual Machines Together
   -anti-affinity=false      Separate Virtual Machines
   -cluster=                 Cluster [GOVC_CLUSTER]
+  -depends=false            Virtual Machines to Virtual Machines
   -enable=<nil>             Enable rule
   -host-affine-group=       Host affine group name
   -host-anti-affine-group=  Host anti-affine group name
@@ -993,12 +1047,15 @@ Display events.
 Examples:
   govc events vm/my-vm1 vm/my-vm2
   govc events /dc1/vm/* /dc2/vm/*
+  govc events -type VmPoweredOffEvent -type VmPoweredOnEvent
   govc ls -t HostSystem host/* | xargs govc events | grep -i vsan
 
 Options:
   -f=false                  Follow event stream
   -force=false              Disable number objects to monitor limit
+  -l=false                  Long listing format
   -n=25                     Output the last N events
+  -type=[]                  Include only the specified event types
 ```
 
 ## export.ovf
@@ -1945,6 +2002,7 @@ Options:
   -host=                    Host system [GOVC_HOST]
   -refresh=false            Refresh the storage system provider
   -rescan=false             Rescan all host bus adapters
+  -rescan-vmfs=false        Rescan for new VMFSs
   -t=lun                    Type (hba,lun)
   -unclaimed=false          Only show disks that can be used as new VMFS datastores
 ```

--- a/govc/cluster/change.go
+++ b/govc/cluster/change.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,6 +26,16 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+func DrsBehaviorUsage() string {
+	drsModes := []string{
+		string(types.DrsBehaviorManual),
+		string(types.DrsBehaviorPartiallyAutomated),
+		string(types.DrsBehaviorFullyAutomated),
+	}
+
+	return "DRS behavior for virtual machines: " + strings.Join(drsModes, ", ")
+}
+
 type change struct {
 	*flags.DatacenterFlag
 
@@ -48,13 +58,7 @@ func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
 	// DRS
 	f.Var(flags.NewOptionalBool(&cmd.DrsConfig.Enabled), "drs-enabled", "Enable DRS")
 
-	drsModes := []string{
-		string(types.DrsBehaviorManual),
-		string(types.DrsBehaviorPartiallyAutomated),
-		string(types.DrsBehaviorFullyAutomated),
-	}
-	f.StringVar((*string)(&cmd.DrsConfig.DefaultVmBehavior), "drs-mode", "",
-		"DRS behavior for virtual machines: "+strings.Join(drsModes, ", "))
+	f.StringVar((*string)(&cmd.DrsConfig.DefaultVmBehavior), "drs-mode", "", DrsBehaviorUsage())
 
 	// HA
 	f.Var(flags.NewOptionalBool(&cmd.DasConfig.Enabled), "ha-enabled", "Enable HA")

--- a/govc/cluster/override/change.go
+++ b/govc/cluster/override/change.go
@@ -1,0 +1,148 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package override
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/cluster"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*flags.ClusterFlag
+	*flags.VirtualMachineFlag
+
+	drs types.ClusterDrsVmConfigInfo
+	das types.ClusterDasVmConfigInfo
+}
+
+func init() {
+	cli.Register("cluster.override.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	// DRS
+	f.Var(flags.NewOptionalBool(&cmd.drs.Enabled), "drs-enabled", "Enable DRS")
+
+	f.StringVar((*string)(&cmd.drs.Behavior), "drs-mode", "", cluster.DrsBehaviorUsage())
+
+	// HA
+	rp := []string{
+		string(types.DasVmPriorityDisabled),
+		string(types.DasVmPriorityLow),
+		string(types.DasVmPriorityMedium),
+		string(types.DasVmPriorityHigh),
+	}
+	cmd.das.DasSettings = new(types.ClusterDasVmSettings)
+
+	f.StringVar((*string)(&cmd.das.DasSettings.RestartPriority), "ha-restart-priority", "", "HA restart priority: "+strings.Join(rp, ", "))
+}
+
+func (cmd *change) Description() string {
+	return `Change cluster VM overrides.
+
+Examples:
+  govc cluster.override.change -cluster cluster_1 -vm vm_1 -ha-restart-priority high
+  govc cluster.override.change -cluster cluster_1 -vm vm_2 -drs-enabled=false
+  govc cluster.override.change -cluster cluster_1 -vm vm_3 -drs-enabled -drs-mode fullyAutomated`
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.VirtualMachineFlag.Process(ctx)
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	cluster, err := cmd.Cluster()
+	if err != nil {
+		return err
+	}
+
+	config, err := cluster.Configuration(ctx)
+	if err != nil {
+		return err
+	}
+
+	spec := &types.ClusterConfigSpecEx{}
+	cmd.drs.Key = vm.Reference()
+	cmd.das.Key = vm.Reference()
+
+	if cmd.drs.Behavior != "" || cmd.drs.Enabled != nil {
+		op := types.ArrayUpdateOperationAdd
+		for _, c := range config.DrsVmConfig {
+			if c.Key == cmd.drs.Key {
+				op = types.ArrayUpdateOperationEdit
+				break
+			}
+		}
+
+		spec.DrsVmConfigSpec = []types.ClusterDrsVmConfigSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: op,
+				},
+				Info: &cmd.drs,
+			},
+		}
+	}
+
+	if cmd.das.DasSettings.RestartPriority != "" {
+		op := types.ArrayUpdateOperationAdd
+		for _, c := range config.DasVmConfig {
+			if c.Key == cmd.das.Key {
+				op = types.ArrayUpdateOperationEdit
+				break
+			}
+		}
+
+		spec.DasVmConfigSpec = []types.ClusterDasVmConfigSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: op,
+				},
+				Info: &cmd.das,
+			},
+		}
+	}
+
+	if spec.DrsVmConfigSpec == nil && spec.DasVmConfigSpec == nil {
+		return flag.ErrHelp
+	}
+
+	return cmd.Reconfigure(ctx, spec)
+}

--- a/govc/cluster/override/info.go
+++ b/govc/cluster/override/info.go
@@ -1,0 +1,142 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package override
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClusterFlag
+}
+
+func init() {
+	cli.Register("cluster.override.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+}
+
+func (cmd *info) Description() string {
+	return `Cluster VM overrides info.
+
+Examples:
+  govc cluster.override.info
+  govc cluster.override.info -json`
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	return cmd.ClusterFlag.Process(ctx)
+}
+
+type Override struct {
+	id   types.ManagedObjectReference
+	Name string
+	Host string                        `json:",omitempty"`
+	DRS  *types.ClusterDrsVmConfigInfo `json:",omitempty"`
+	DAS  *types.ClusterDasVmConfigInfo `json:",omitempty"`
+}
+
+type infoResult struct {
+	Overrides map[string]*Override
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, entry := range r.Overrides {
+		behavior := fmt.Sprintf("Default (%s)", types.DrsBehaviorFullyAutomated)
+		if entry.DRS != nil {
+			if *entry.DRS.Enabled {
+				behavior = string(entry.DRS.Behavior)
+			}
+		}
+
+		priority := fmt.Sprintf("Default (%s)", types.DasVmPriorityMedium)
+		if entry.DAS != nil {
+			priority = entry.DAS.DasSettings.RestartPriority
+		}
+
+		fmt.Fprintf(tw, "Name:\t%s\n", entry.Name)
+		fmt.Fprintf(tw, "  DRS Automation Level:\t%s\n", strings.Title(behavior))
+		fmt.Fprintf(tw, "  HA Restart Priority:\t%s\n", strings.Title(priority))
+		fmt.Fprintf(tw, "  Host:\t%s\n", entry.Host)
+	}
+
+	return tw.Flush()
+}
+
+func (r *infoResult) entry(id types.ManagedObjectReference) *Override {
+	key := id.String()
+	vm, ok := r.Overrides[key]
+	if !ok {
+		r.Overrides[key] = &Override{id: id}
+		vm = r.Overrides[key]
+	}
+	return vm
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	cluster, err := cmd.Cluster()
+	if err != nil {
+		return err
+	}
+
+	config, err := cluster.Configuration(ctx)
+	if err != nil {
+		return err
+	}
+
+	res := &infoResult{
+		Overrides: make(map[string]*Override),
+	}
+
+	for i := range config.DasVmConfig {
+		vm := res.entry(config.DasVmConfig[i].Key)
+
+		vm.DAS = &config.DasVmConfig[i]
+	}
+
+	for i := range config.DrsVmConfig {
+		vm := res.entry(config.DrsVmConfig[i].Key)
+
+		vm.DRS = &config.DrsVmConfig[i]
+	}
+
+	for _, o := range res.Overrides {
+		// TODO: can optimize to reduce round trips
+		vm := object.NewVirtualMachine(cluster.Client(), o.id)
+		o.Name, _ = vm.ObjectName(ctx)
+		if h, herr := vm.HostSystem(ctx); herr == nil {
+			o.Host, _ = h.ObjectName(ctx)
+		}
+	}
+
+	return cmd.WriteResult(res)
+}

--- a/govc/cluster/override/remove.go
+++ b/govc/cluster/override/remove.go
@@ -1,0 +1,110 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package override
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type remove struct {
+	*flags.ClusterFlag
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("cluster.override.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Description() string {
+	return `Remove cluster VM overrides.
+
+Examples:
+  govc cluster.override.remove -cluster cluster_1 -vm vm_1`
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.VirtualMachineFlag.Process(ctx)
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	cluster, err := cmd.Cluster()
+	if err != nil {
+		return err
+	}
+
+	config, err := cluster.Configuration(ctx)
+	if err != nil {
+		return err
+	}
+
+	spec := &types.ClusterConfigSpecEx{}
+	ref := vm.Reference()
+
+	for _, c := range config.DrsVmConfig {
+		if c.Key == ref {
+			spec.DrsVmConfigSpec = []types.ClusterDrsVmConfigSpec{
+				{
+					ArrayUpdateSpec: types.ArrayUpdateSpec{
+						Operation: types.ArrayUpdateOperationRemove,
+						RemoveKey: ref,
+					},
+				},
+			}
+			break
+		}
+	}
+
+	for _, c := range config.DasVmConfig {
+		if c.Key == ref {
+			spec.DasVmConfigSpec = []types.ClusterDasVmConfigSpec{
+				{
+					ArrayUpdateSpec: types.ArrayUpdateSpec{
+						Operation: types.ArrayUpdateOperationRemove,
+						RemoveKey: ref,
+					},
+				},
+			}
+			break
+		}
+	}
+
+	return cmd.Reconfigure(ctx, spec)
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/about"
 	_ "github.com/vmware/govmomi/govc/cluster"
 	_ "github.com/vmware/govmomi/govc/cluster/group"
+	_ "github.com/vmware/govmomi/govc/cluster/override"
 	_ "github.com/vmware/govmomi/govc/cluster/rule"
 	_ "github.com/vmware/govmomi/govc/datacenter"
 	_ "github.com/vmware/govmomi/govc/datastore"


### PR DESCRIPTION
- Add cluster.override.change command to set VM DRS and HA overrides

- Add cluster.override.remove to remove VM overrides

- Add cluster.override.info to view current VM overrides

- Add cluster.rule.create '-depends' flag to support VM-to-VM dependency rules
