### PR TITLE
Add CloneSession support to govc and vcsim

### DIFF
--- a/govc/session/login.go
+++ b/govc/session/login.go
@@ -1,0 +1,195 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type login struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	clone  bool
+	long   bool
+	ticket string
+	cookie string
+}
+
+func init() {
+	cli.Register("session.login", &login{})
+}
+
+func (cmd *login) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.clone, "clone", false, "Acquire clone ticket")
+	f.BoolVar(&cmd.long, "l", false, "Output session cookie")
+	f.StringVar(&cmd.ticket, "ticket", "", "Clone ticket")
+	f.StringVar(&cmd.cookie, "cookie", "", "Set HTTP cookie for an existing session")
+}
+
+func (cmd *login) Process(ctx context.Context) error {
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.ClientFlag.Process(ctx)
+}
+
+func (cmd *login) Description() string {
+	return `Session login.
+
+The session.login command is optional, all other govc commands will auto login when given credentials.
+The session.login command can be used to:
+- Persist a session without writing to disk via the '-cookie' flag
+- Acquire a clone ticket
+- Login using a clone ticket
+- Avoid passing credentials to other govc commands
+
+Examples:
+  govc session.login -u root:password@host
+  ticket=$(govc session.login -u root@host -clone)
+  govc session.login -u root@host -ticket $ticket`
+}
+
+type ticketResult struct {
+	cmd    *login
+	Ticket string `json:",omitempty"`
+	Cookie string `json:",omitempty"`
+}
+
+func (r *ticketResult) Write(w io.Writer) error {
+	var output []string
+
+	for _, val := range []string{r.Ticket, r.Cookie} {
+		if val != "" {
+			output = append(output, val)
+		}
+	}
+
+	if len(output) == 0 {
+		return nil
+	}
+
+	fmt.Fprintln(w, strings.Join(output, " "))
+
+	return nil
+}
+
+// Logout is called by cli.Run()
+// We override ClientFlag's Logout impl to avoid ending a session when -persist-session=false,
+// otherwise Logout would invalidate the cookie and/or ticket.
+func (cmd *login) Logout(ctx context.Context) error {
+	if cmd.long || cmd.clone {
+		return nil
+	}
+	return cmd.ClientFlag.Logout(ctx)
+}
+
+func (cmd *login) cloneSession(ctx context.Context, c *vim25.Client) error {
+	return session.NewManager(c).CloneSession(ctx, cmd.ticket)
+}
+
+func (cmd *login) setCookie(ctx context.Context, c *vim25.Client) error {
+	url := c.URL()
+	jar := c.Client.Jar
+	cookies := jar.Cookies(url)
+	add := true
+
+	cookie := &http.Cookie{
+		Name: soap.SessionCookieName,
+	}
+
+	for _, e := range cookies {
+		if e.Name == cookie.Name {
+			add = false
+			cookie = e
+			break
+		}
+	}
+
+	if cmd.cookie == "" {
+		// This is the cookie from Set-Cookie after a Login or CloneSession
+		cmd.cookie = cookie.Value
+	} else {
+		// The cookie flag is set, set the HTTP header and skip Login()
+		cookie.Value = cmd.cookie
+		if add {
+			cookies = append(cookies, cookie)
+		}
+		jar.SetCookies(url, cookies)
+
+		// Check the session is still valid
+		_, err := methods.GetCurrentTime(ctx, c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (cmd *login) Run(ctx context.Context, f *flag.FlagSet) error {
+	if cmd.ticket != "" {
+		cmd.Login = cmd.cloneSession
+	} else if cmd.cookie != "" {
+		cmd.Login = cmd.setCookie
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := session.NewManager(c)
+	r := &ticketResult{cmd: cmd}
+
+	if cmd.clone {
+		r.Ticket, err = m.AcquireCloneTicket(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.cookie == "" {
+		_ = cmd.setCookie(ctx, c)
+		if cmd.cookie == "" {
+			return flag.ErrHelp
+		}
+	}
+
+	if cmd.long {
+		r.Cookie = cmd.cookie
+	}
+
+	return cmd.WriteResult(r)
+}

--- a/govc/session/logout.go
+++ b/govc/session/logout.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/session"
+)
+
+type logout struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("session.logout", &logout{})
+}
+
+func (cmd *logout) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *logout) Process(ctx context.Context) error {
+	return cmd.ClientFlag.Process(ctx)
+}
+
+func (cmd *logout) Description() string {
+	return `Logout the current session.
+
+By default, govc commands persist sessions and do not logout unless '-persist-session=false' is set.
+The session.logout command can be used to end the current persisted session.
+The session.rm command can be used to remove sessions other than the current session.
+
+Examples:
+  govc session.logout`
+}
+
+func (cmd *logout) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	return session.NewManager(c).Logout(ctx)
+}

--- a/govc/test/session.bats
+++ b/govc/test/session.bats
@@ -38,3 +38,24 @@ load test_helper
   run govc session.rm "$id"
   assert_success
 }
+
+@test "session.login" {
+    esx_env
+
+    # Remove username/password
+    host=$(govc env GOVC_URL)
+
+    # Validate auth is not required for service content
+    run govc about -u "$host"
+    assert_success
+
+    # Auth is required here
+    run govc ls -u "$host"
+    assert_failure
+
+    cookie=$(govc session.login -l)
+    ticket=$(govc session.login -cookie "$cookie" -clone)
+
+    run govc session.login -u "$host" -ticket "$ticket"
+    assert_success
+}

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -21,3 +21,11 @@ load test_helper
     assert_success
   done
 }
+
+@test "vcsim about" {
+  vcsim_env
+
+  run curl -sk https://"$(govc env GOVC_URL)"/about
+  assert_matches "CurrentTime" # 1 param (without Context)
+  assert_matches "TerminateSession" # 2 params (with Context)
+}

--- a/simulator/session_manager_test.go
+++ b/simulator/session_manager_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -157,5 +157,30 @@ func TestSessionManagerAuth(t *testing.T) {
 
 	if !strings.Contains(pc.Reference().Value, session.Key) {
 		t.Errorf("invalid ref=%s", pc.Reference())
+	}
+
+	ticket, err := c.SessionManager.AcquireCloneTicket(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.SessionManager.CloneSession(ctx, ticket)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.SessionManager.CloneSession(ctx, ticket)
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	_, err = methods.GetCurrentTime(ctx, c)
+	if err != nil {
+		t.Error(err)
 	}
 }

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ func (s *Service) call(ctx *Context, method *Method) soap.HasFault {
 
 	if session == nil {
 		switch method.Name {
-		case "RetrieveServiceContent", "Login", "RetrieveProperties", "RetrievePropertiesEx":
+		case "RetrieveServiceContent", "Login", "RetrieveProperties", "RetrievePropertiesEx", "CloneSession":
 			// ok for now, TODO: authz
 		default:
 			fault := &types.NotAuthenticated{
@@ -257,7 +257,11 @@ func (s *Service) About(w http.ResponseWriter, r *http.Request) {
 			}
 			seen[m.Name] = true
 
-			if m.Type.NumIn() != 2 || m.Type.NumOut() != 1 || m.Type.Out(0) != f {
+			in := m.Type.NumIn()
+			if in < 2 || in > 3 { // at least 2 params (receiver and request), optionally a 3rd param (context)
+				continue
+			}
+			if m.Type.NumOut() != 1 || m.Type.Out(0) != f { // all methods return soap.HasFault
 				continue
 			}
 

--- a/vcsim/README.md
+++ b/vcsim/README.md
@@ -79,7 +79,7 @@ code includes all types and methods defined in the vmodl, which can be used to i
 To see the list of supported methods:
 
 ```
-curl -k https://user:pass@127.0.0.1:8989/about
+curl -sk https://user:pass@127.0.0.1:8989/about
 ```
 
 ## Listen address

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ const (
 	DefaultVimNamespace  = "urn:vim25"
 	DefaultVimVersion    = "6.5"
 	DefaultMinVimVersion = "5.5"
+	SessionCookieName    = "vmware_soap_session"
 )
 
 type header struct {
@@ -168,7 +169,7 @@ func (c *Client) NewServiceClient(path string, namespace string) *Client {
 
 	// Set SOAP Header cookie
 	for _, cookie := range client.Jar.Cookies(u) {
-		if cookie.Name == "vmware_soap_session" {
+		if cookie.Name == SessionCookieName {
 			client.cookie = cookie.Value
 			break
 		}


### PR DESCRIPTION
- Fix simulator.Service.About to support optional context param

- Don't require govc Login, ServiceContent does not require it