### PR TITLE
govc: fix host.info CPU usage

### DIFF
--- a/govc/host/info.go
+++ b/govc/host/info.go
@@ -139,7 +139,7 @@ func (r *infoResult) Write(w io.Writer) error {
 		s := host.Summary
 		h := s.Hardware
 		z := s.QuickStats
-		ncpu := int32(h.NumCpuPkgs * h.NumCpuCores)
+		ncpu := int32(h.NumCpuPkgs * h.NumCpuThreads)
 		cpuUsage := 100 * float64(z.OverallCpuUsage) / float64(ncpu*h.CpuMhz)
 		memUsage := 100 * float64(z.OverallMemoryUsage) / float64(h.MemorySize>>20)
 


### PR DESCRIPTION
Need to use CPU threads as the logical processor count, rather than CPU cores.