### PR TITLE
Remove omitempty tag from AffinitySet field

### DIFF
--- a/gen/vim_wsdl.rb
+++ b/gen/vim_wsdl.rb
@@ -202,7 +202,12 @@ class Simple
     t = self.type
     prefix = ""
 
-    prefix += "[]" if slice?
+    if slice?
+      prefix += "[]"
+      if ["AffinitySet"].include?(var_name)
+        self.need_omitempty = false
+      end
+    end
 
     if t =~ /^xsd:(.*)$/
       t = $1

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -48188,7 +48188,7 @@ func init() {
 type VirtualMachineAffinityInfo struct {
 	DynamicData
 
-	AffinitySet []int32 `xml:"affinitySet,omitempty"`
+	AffinitySet []int32 `xml:"affinitySet"`
 }
 
 func init() {

--- a/vim25/types/types_test.go
+++ b/vim25/types/types_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/vmware/govmomi/vim25/xml"
@@ -88,5 +89,28 @@ func TestVirtualMachineConfigSpec(t *testing.T) {
 	_, err := xml.MarshalIndent(spec, "", " ")
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestVirtualMachineAffinityInfo(t *testing.T) {
+	// See https://github.com/vmware/govmomi/issues/1008
+	in := VirtualMachineAffinityInfo{
+		AffinitySet: []int32{0, 1, 2, 3},
+	}
+
+	b, err := xml.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out VirtualMachineAffinityInfo
+
+	err = xml.Unmarshal(b, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("%#v vs %#v", in, out)
 	}
 }


### PR DESCRIPTION
Avoids the an issue where Go will omit array elements with a value of '0'.

Fixes #1008