### PR TITLE
vcsim: avoid data races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install:
 	go install -v github.com/vmware/govmomi/vcsim
 
 go-test:
-	go test -v $(TEST_OPTS) ./...
+	go test -race -v $(TEST_OPTS) ./...
 
 govc-test: install
 	(cd govc/test && ./vendor/github.com/sstephenson/bats/libexec/bats -t .)

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -25,7 +25,15 @@ load test_helper
 @test "vcsim about" {
   vcsim_env
 
-  run curl -sk https://"$(govc env GOVC_URL)"/about
+  url="https://$(govc env GOVC_URL)"
+
+  run curl -sk "$url/about"
   assert_matches "CurrentTime" # 1 param (without Context)
   assert_matches "TerminateSession" # 2 params (with Context)
+
+  run curl -sk "$url/debug/vars"
+  assert_success
+
+  run curl -sk "$url/debug/vcsim/vars"
+  assert_success
 }

--- a/simulator/cluster_compute_resource.go
+++ b/simulator/cluster_compute_resource.go
@@ -49,18 +49,17 @@ func (add *addHost) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	host := NewHostSystem(esx.HostSystem)
 	host.Summary.Config.Name = spec.HostName
 	host.Name = host.Summary.Config.Name
-	host.Runtime.ConnectionState = types.HostSystemConnectionStateDisconnected
+	if add.req.AsConnected {
+		host.Runtime.ConnectionState = types.HostSystemConnectionStateConnected
+	} else {
+		host.Runtime.ConnectionState = types.HostSystemConnectionStateDisconnected
+	}
 
 	cr := add.ClusterComputeResource
 	Map.PutEntity(cr, Map.NewEntity(host))
 
 	cr.Host = append(cr.Host, host.Reference())
-
-	if add.req.AsConnected {
-		host.Runtime.ConnectionState = types.HostSystemConnectionStateConnected
-	}
-
-	addComputeResource(add.ClusterComputeResource.Summary.GetComputeResourceSummary(), host)
+	addComputeResource(cr.Summary.GetComputeResourceSummary(), host)
 
 	return host.Reference(), nil
 }

--- a/simulator/custom_fields_manager.go
+++ b/simulator/custom_fields_manager.go
@@ -101,9 +101,11 @@ func (c *CustomFieldsManager) SetField(req *types.SetField) soap.HasFault {
 	body := &methods.SetFieldBody{}
 
 	entity := Map.Get(req.Entity).(mo.Entity).Entity()
-	entity.CustomValue = append(entity.CustomValue, &types.CustomFieldStringValue{
-		CustomFieldValue: types.CustomFieldValue{Key: req.Key},
-		Value:            req.Value,
+	Map.WithLock(entity, func() {
+		entity.CustomValue = append(entity.CustomValue, &types.CustomFieldStringValue{
+			CustomFieldValue: types.CustomFieldValue{Key: req.Key},
+			Value:            req.Value,
+		})
 	})
 
 	body.Res = &types.SetFieldResponse{}

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math/rand"
 	"path"
-	"sync"
 
 	"github.com/google/uuid"
 
@@ -32,12 +31,10 @@ import (
 
 type Folder struct {
 	mo.Folder
-
-	m sync.Mutex
 }
 
 // update references when objects are added/removed from a Folder
-func (f *Folder) update(o mo.Reference, u func(types.ManagedObjectReference, []types.ManagedObjectReference) []types.ManagedObjectReference) {
+func (f *Folder) update(o mo.Reference, u func(mo.Reference, *[]types.ManagedObjectReference, types.ManagedObjectReference)) {
 	ref := o.Reference()
 
 	if f.Parent == nil {
@@ -53,9 +50,9 @@ func (f *Folder) update(o mo.Reference, u func(types.ManagedObjectReference, []t
 
 	switch ref.Type {
 	case "Network", "DistributedVirtualSwitch", "DistributedVirtualPortgroup":
-		dc.Network = u(ref, dc.Network)
+		u(dc, &dc.Network, ref)
 	case "Datastore":
-		dc.Datastore = u(ref, dc.Datastore)
+		u(dc, &dc.Datastore, ref)
 	}
 }
 
@@ -70,12 +67,9 @@ func networkSummary(n *mo.Network) *types.NetworkSummary {
 func (f *Folder) putChild(o mo.Entity) {
 	Map.PutEntity(f, o)
 
-	f.m.Lock()
-	defer f.m.Unlock()
+	f.ChildEntity = append(f.ChildEntity, o.Reference())
 
-	f.ChildEntity = AddReference(o.Reference(), f.ChildEntity)
-
-	f.update(o, AddReference)
+	f.update(o, Map.AddReference)
 
 	switch e := o.(type) {
 	case *mo.Network:
@@ -90,12 +84,9 @@ func (f *Folder) putChild(o mo.Entity) {
 func (f *Folder) removeChild(o mo.Reference) {
 	Map.Remove(o.Reference())
 
-	f.m.Lock()
-	defer f.m.Unlock()
+	RemoveReference(&f.ChildEntity, o.Reference())
 
-	f.ChildEntity = RemoveReference(o.Reference(), f.ChildEntity)
-
-	f.update(o, RemoveReference)
+	f.update(o, Map.RemoveReference)
 }
 
 func (f *Folder) hasChildType(kind string) bool {
@@ -240,6 +231,7 @@ func (f *Folder) CreateClusterEx(c *types.CreateClusterEx) soap.HasFault {
 type createVM struct {
 	*Folder
 
+	ctx *Context
 	req *types.CreateVM_Task
 
 	register bool
@@ -291,27 +283,31 @@ func (c *createVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	c.Folder.putChild(vm)
 
 	host := Map.Get(*vm.Runtime.Host).(*HostSystem)
-	host.Vm = append(host.Vm, vm.Self)
+	Map.AppendReference(host, &host.Vm, vm.Self)
 
 	for i := range vm.Datastore {
 		ds := Map.Get(vm.Datastore[i]).(*Datastore)
-		ds.Vm = append(ds.Vm, vm.Self)
+		Map.AppendReference(ds, &ds.Vm, vm.Self)
 	}
 
-	switch rp := Map.Get(*vm.ResourcePool).(type) {
-	case *ResourcePool:
-		rp.Vm = append(rp.Vm, vm.Self)
-	case *VirtualApp:
-		rp.Vm = append(rp.Vm, vm.Self)
-	}
+	pool := Map.Get(*vm.ResourcePool)
+	// This can be an internal call from VirtualApp.CreateChildVMTask, where pool is already locked.
+	c.ctx.WithLock(pool, func() {
+		switch rp := pool.(type) {
+		case *ResourcePool:
+			rp.Vm = append(rp.Vm, vm.Self)
+		case *VirtualApp:
+			rp.Vm = append(rp.Vm, vm.Self)
+		}
+	})
 
 	return vm.Reference(), nil
 }
 
-func (f *Folder) CreateVMTask(c *types.CreateVM_Task) soap.HasFault {
+func (f *Folder) CreateVMTask(ctx *Context, c *types.CreateVM_Task) soap.HasFault {
 	return &methods.CreateVM_TaskBody{
 		Res: &types.CreateVM_TaskResponse{
-			Returnval: NewTask(&createVM{f, c, false}).Run(),
+			Returnval: NewTask(&createVM{f, ctx, c, false}).Run(),
 		},
 	}
 }
@@ -319,6 +315,7 @@ func (f *Folder) CreateVMTask(c *types.CreateVM_Task) soap.HasFault {
 type registerVM struct {
 	*Folder
 
+	ctx *Context
 	req *types.RegisterVM_Task
 }
 
@@ -367,6 +364,7 @@ func (c *registerVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	create := NewTask(&createVM{
 		Folder:   c.Folder,
 		register: true,
+		ctx:      c.ctx,
 		req: &types.CreateVM_Task{
 			This: c.Folder.Reference(),
 			Config: types.VirtualMachineConfigSpec{
@@ -389,10 +387,12 @@ func (c *registerVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	return create.Info.Result, nil
 }
 
-func (f *Folder) RegisterVMTask(c *types.RegisterVM_Task) soap.HasFault {
+func (f *Folder) RegisterVMTask(ctx *Context, c *types.RegisterVM_Task) soap.HasFault {
+	ctx.Caller = &f.Self
+
 	return &methods.RegisterVM_TaskBody{
 		Res: &types.RegisterVM_TaskResponse{
-			Returnval: NewTask(&registerVM{f, c}).Run(),
+			Returnval: NewTask(&registerVM{f, ctx, c}).Run(),
 		},
 	}
 }

--- a/simulator/host_datastore_system.go
+++ b/simulator/host_datastore_system.go
@@ -72,7 +72,7 @@ func (dss *HostDatastoreSystem) add(ds *Datastore) *soap.Fault {
 	dss.Datastore = append(dss.Datastore, ds.Self)
 	dss.Host.Datastore = dss.Datastore
 	parent := hostParent(dss.Host)
-	parent.Datastore = AddReference(ds.Self, parent.Datastore)
+	Map.AddReference(parent, &parent.Datastore, ds.Self)
 
 	browser := &HostDatastoreBrowser{}
 	browser.Datastore = dss.Datastore

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -34,50 +34,50 @@ import (
 // This is a simple helper for tests running against a simulator, to populate an inventory
 // with commonly used models.
 type Model struct {
-	Service *Service
+	Service *Service `json:"-"`
 
-	ServiceContent types.ServiceContent
-	RootFolder     mo.Folder
+	ServiceContent types.ServiceContent `json:"-"`
+	RootFolder     mo.Folder            `json:"-"`
 
 	// Autostart will power on Model created VMs when true
-	Autostart bool
+	Autostart bool `json:"-"`
 
 	// Datacenter specifies the number of Datacenter entities to create
-	Datacenter int
+	Datacenter int `json:",omitempty"`
 
 	// Portgroup specifies the number of DistributedVirtualPortgroup entities to create per Datacenter
-	Portgroup int
+	Portgroup int `json:",omitempty"`
 
 	// Host specifies the number of standalone HostSystems entities to create per Datacenter
-	Host int
+	Host int `json:",omitempty"`
 
 	// Cluster specifies the number of ClusterComputeResource entities to create per Datacenter
-	Cluster int
+	Cluster int `json:",omitempty"`
 
 	// ClusterHost specifies the number of HostSystems entities to create within a Cluster
-	ClusterHost int
+	ClusterHost int `json:",omitempty"`
 
 	// Pool specifies the number of ResourcePool entities to create per Cluster
-	Pool int
+	Pool int `json:",omitempty"`
 
 	// Datastore specifies the number of Datastore entities to create
 	// Each Datastore will have temporary local file storage and will be mounted
 	// on every HostSystem created by the ModelConfig
-	Datastore int
+	Datastore int `json:",omitempty"`
 
 	// Machine specifies the number of VirtualMachine entities to create per ResourcePool
-	Machine int
+	Machine int `json:",omitempty"`
 
 	// Folder specifies the number of Datacenter to place within a Folder.
 	// This includes a folder for the Datacenter itself and its host, vm, network and datastore folders.
 	// All resources for the Datacenter are placed within these folders, rather than the top-level folders.
-	Folder int
+	Folder int `json:",omitempty"`
 
 	// App specifies the number of VirtualApp to create per Cluster
-	App int
+	App int `json:",omitempty"`
 
 	// Pod specifies the number of StoragePod to create per Cluster
-	Pod int
+	Pod int `json:",omitempty"`
 
 	// total number of inventory objects, set by Count()
 	total int

--- a/simulator/portgroup.go
+++ b/simulator/portgroup.go
@@ -53,22 +53,11 @@ func (s *DistributedVirtualPortgroup) ReconfigureDVPortgroupTask(req *types.Reco
 func (s *DistributedVirtualPortgroup) DestroyTask(req *types.Destroy_Task) soap.HasFault {
 	task := CreateTask(s, "destroy", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		vswitch := Map.Get(*s.Config.DistributedVirtualSwitch).(*DistributedVirtualSwitch)
-		for i, pg := range vswitch.Portgroup {
-			if pg.Reference() == s.Reference() {
-				vswitch.Portgroup = append(vswitch.Portgroup[:i], vswitch.Portgroup[i+1:]...)
-				break
-			}
-		}
+		Map.RemoveReference(vswitch, &vswitch.Portgroup, s.Reference())
+		Map.removeString(vswitch, &vswitch.Summary.PortgroupName, s.Name)
 
 		f := Map.getEntityParent(vswitch, "Folder").(*Folder)
 		f.removeChild(s.Reference())
-
-		for i, name := range vswitch.Summary.PortgroupName {
-			if name == s.Name {
-				vswitch.Summary.PortgroupName = append(vswitch.Summary.PortgroupName[:i],
-					vswitch.Summary.PortgroupName[i+1:]...)
-			}
-		}
 
 		return nil, nil
 	})

--- a/simulator/property_filter.go
+++ b/simulator/property_filter.go
@@ -32,7 +32,7 @@ type PropertyFilter struct {
 func (f *PropertyFilter) DestroyPropertyFilter(c *types.DestroyPropertyFilter) soap.HasFault {
 	body := &methods.DestroyPropertyFilterBody{}
 
-	f.pc.Filter = RemoveReference(c.This, f.pc.Filter)
+	RemoveReference(&f.pc.Filter, c.This)
 
 	Map.Remove(c.This)
 

--- a/simulator/race_test.go
+++ b/simulator/race_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestRace(t *testing.T) {
+	ctx := context.Background()
+
+	m := VPX()
+
+	defer m.Remove()
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 2; i++ {
+		spec := types.VirtualMachineConfigSpec{
+			Name:    fmt.Sprintf("race-test-%d", i),
+			GuestId: string(types.VirtualMachineGuestOsIdentifierOtherGuest),
+			Files: &types.VirtualMachineFileInfo{
+				VmPathName: "[LocalDS_0]",
+			},
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := govmomi.NewClient(ctx, s.URL, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			finder := find.NewFinder(c.Client, false)
+			pc := property.DefaultCollector(c.Client)
+			dc, err := finder.DefaultDatacenter(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			finder.SetDatacenter(dc)
+
+			f, err := dc.Folders(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			pool, err := finder.ResourcePool(ctx, "DC0_C0/Resources")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ticker := time.NewTicker(time.Millisecond * 100)
+			defer ticker.Stop()
+
+			for j := 0; j < 2; j++ {
+				cspec := spec // copy spec and give it a unique name
+				cspec.Name += fmt.Sprintf("-%d", j)
+
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					task, _ := f.VmFolder.CreateVM(ctx, cspec, pool, nil)
+					info, terr := task.WaitForResult(ctx, nil)
+					if terr != nil {
+						t.Error(terr)
+					}
+					go func() {
+						for _ = range ticker.C {
+							var content []types.ObjectContent
+							rerr := pc.RetrieveOne(ctx, info.Result.(types.ManagedObjectReference), nil, &content)
+							if rerr != nil {
+								t.Error(rerr)
+							}
+						}
+					}()
+				}()
+			}
+
+			vms, err := finder.VirtualMachineList(ctx, "*")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for i := range vms {
+				vm := vms[i]
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					task, _ := vm.PowerOff(ctx)
+					_ = task.Wait(ctx)
+				}()
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/simulator/registry_test.go
+++ b/simulator/registry_test.go
@@ -61,9 +61,9 @@ func TestRemoveReference(t *testing.T) {
 
 	n := len(refs)
 
-	nr := RemoveReference(refs[2], refs)
+	RemoveReference(&refs, refs[2])
 
-	if len(nr) != n-1 {
-		t.Errorf("%d", len(nr))
+	if len(refs) != n-1 {
+		t.Errorf("%d", len(refs))
 	}
 }

--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -32,13 +32,14 @@ func (v *VirtualMachineSnapshot) RemoveSnapshotTask(req *types.RemoveSnapshot_Ta
 		Map.Remove(req.This)
 
 		vm := Map.Get(v.Vm).(*VirtualMachine)
+		Map.WithLock(vm, func() {
+			if vm.Snapshot.CurrentSnapshot != nil && *vm.Snapshot.CurrentSnapshot == req.This {
+				parent := findParentSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This)
+				vm.Snapshot.CurrentSnapshot = parent
+			}
 
-		if vm.Snapshot.CurrentSnapshot != nil && *vm.Snapshot.CurrentSnapshot == req.This {
-			parent := findParentSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This)
-			vm.Snapshot.CurrentSnapshot = parent
-		}
-
-		vm.Snapshot.RootSnapshotList = removeSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This, req.RemoveChildren)
+			vm.Snapshot.RootSnapshotList = removeSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This, req.RemoveChildren)
+		})
 
 		return nil, nil
 	})
@@ -54,8 +55,7 @@ func (v *VirtualMachineSnapshot) RevertToSnapshotTask(req *types.RevertToSnapsho
 	task := CreateTask(v, "revertToSnapshot", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		vm := Map.Get(v.Vm).(*VirtualMachine)
 
-		ref := v.Reference()
-		vm.Snapshot.CurrentSnapshot = &ref
+		Map.WithLock(vm, func() { vm.Snapshot.CurrentSnapshot = &v.Self })
 
 		return nil, nil
 	})

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -691,14 +691,20 @@ func TestVmSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	task.Wait(ctx)
+	err = task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	task, err = vm.CreateSnapshot(ctx, "child", "description", true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	task.Wait(ctx)
+	err = task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = vm.FindSnapshot(ctx, "child")
 	if err != nil {
@@ -710,21 +716,30 @@ func TestVmSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	task.Wait(ctx)
+	err = task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	task, err = vm.RevertToSnapshot(ctx, "root", true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	task.Wait(ctx)
+	err = task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	task, err = vm.RemoveSnapshot(ctx, "child", false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	task.Wait(ctx)
+	err = task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = vm.FindSnapshot(ctx, "child")
 	if err == nil {
@@ -736,7 +751,10 @@ func TestVmSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	task.Wait(ctx)
+	err = task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = vm.FindSnapshot(ctx, "root")
 	if err == nil {

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -18,9 +18,11 @@ package main
 
 import (
 	"crypto/tls"
+	"expvar"
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"runtime"
@@ -108,6 +110,18 @@ func main() {
 			model.Service.TLS.Certificates = []tls.Certificate{c}
 		}
 	}
+
+	expvar.Publish("/debug/vcsim/vars", expvar.Func(func() interface{} {
+		return struct {
+			Registry *simulator.Registry
+			Model    *simulator.Model
+		}{
+			simulator.Map,
+			model,
+		}
+	}))
+
+	model.Service.ServeMux = http.DefaultServeMux // expvar.init registers "/debug/vars" with the DefaultServeMux
 
 	s := model.Service.NewServer()
 


### PR DESCRIPTION
The method call dispatcher locks the receiver object, so methods do not need to explicitly do so.
However, methods that touch other objects need to use the Registry WithLock method or helpers that use it underneath.

We may still need to cover some other paths, such as reading within PropertyCollector.  And we can fine tune to opt-out of
locking where it isn't needed.  But the race detector is happier now as-is.

Fixes #990