### PR TITLE
Leverage contexts in http uploads

### DIFF
--- a/govc/importx/archive.go
+++ b/govc/importx/archive.go
@@ -182,5 +182,5 @@ func (o Opener) OpenRemote(link string) (io.ReadCloser, int64, error) {
 		return nil, 0, err
 	}
 
-	return o.Download(u, &soap.DefaultDownload)
+	return o.Download(context.Background(), u, &soap.DefaultDownload)
 }

--- a/govc/logs/download.go
+++ b/govc/logs/download.go
@@ -84,7 +84,7 @@ func (cmd *download) DownloadFile(c *vim25.Client, b string) error {
 		p.Progress = logger
 	}
 
-	return c.Client.DownloadFile(dst, u, &p)
+	return c.Client.DownloadFile(context.Background(), dst, u, &p)
 }
 
 func (cmd *download) GenerateLogBundles(m *object.DiagnosticManager, host []*object.HostSystem) ([]types.DiagnosticManagerBundleInfo, error) {

--- a/govc/vm/console.go
+++ b/govc/vm/console.go
@@ -111,7 +111,7 @@ func (cmd *console) Run(ctx context.Context, f *flag.FlagSet) error {
 		param := soap.DefaultDownload
 
 		if cmd.capture == "-" {
-			w, _, derr := c.Download(u, &param)
+			w, _, derr := c.Download(ctx, u, &param)
 			if derr != nil {
 				return derr
 			}
@@ -124,7 +124,7 @@ func (cmd *console) Run(ctx context.Context, f *flag.FlagSet) error {
 			return w.Close()
 		}
 
-		return c.DownloadFile(cmd.capture, u, &param)
+		return c.DownloadFile(ctx, cmd.capture, u, &param)
 	}
 
 	m := session.NewManager(c)

--- a/govc/vm/guest/download.go
+++ b/govc/vm/guest/download.go
@@ -101,5 +101,5 @@ func (cmd *download) Run(ctx context.Context, f *flag.FlagSet) error {
 		defer logger.Wait()
 	}
 
-	return c.ProcessManager.Client().WriteFile(dst, s, n, p, nil)
+	return c.ProcessManager.Client().WriteFile(ctx, dst, s, n, p, nil)
 }

--- a/govc/vm/guest/touch.go
+++ b/govc/vm/guest/touch.go
@@ -115,7 +115,7 @@ func (cmd *touch) Run(ctx context.Context, f *flag.FlagSet) error {
 				return cerr
 			}
 
-			err = c.Client.Upload(new(bytes.Buffer), u, &soap.DefaultUpload)
+			err = c.Client.Upload(ctx, new(bytes.Buffer), u, &soap.DefaultUpload)
 			if err == nil && cmd.date != "" {
 				err = m.ChangeFileAttributes(ctx, cmd.Auth(), name, &attr)
 			}

--- a/guest/toolbox/client.go
+++ b/guest/toolbox/client.go
@@ -114,7 +114,7 @@ func (c *Client) RoundTrip(req *http.Request) (*http.Response, error) {
 	p := soap.DefaultUpload
 	p.ContentLength = size
 
-	err = vc.Client.Upload(&buf, u, &p)
+	err = vc.Client.Upload(ctx, &buf, u, &p)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (c *Client) Run(ctx context.Context, cmd *exec.Cmd) error {
 		p := soap.DefaultUpload
 		p.ContentLength = size
 
-		err = vc.Client.Upload(&buf, u, &p)
+		err = vc.Client.Upload(ctx, &buf, u, &p)
 		if err != nil {
 			return err
 		}
@@ -341,5 +341,5 @@ func (c *Client) Upload(ctx context.Context, src io.Reader, dst string, p soap.U
 		return err
 	}
 
-	return vc.Client.Upload(src, u, &p)
+	return vc.Client.Upload(ctx, src, u, &p)
 }

--- a/guest/toolbox/client.go
+++ b/guest/toolbox/client.go
@@ -129,7 +129,7 @@ func (c *Client) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	f, _, err := vc.Client.Download(u, &soap.DefaultDownload)
+	f, _, err := vc.Client.Download(ctx, u, &soap.DefaultDownload)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (c *Client) Run(ctx context.Context, cmd *exec.Cmd) error {
 			return err
 		}
 
-		f, _, err := vc.Client.Download(u, &soap.DefaultDownload)
+		f, _, err := vc.Client.Download(ctx, u, &soap.DefaultDownload)
 		if err != nil {
 			return err
 		}
@@ -284,7 +284,7 @@ func (c *Client) Download(ctx context.Context, src string) (io.ReadCloser, int64
 
 	p := soap.DefaultDownload
 
-	f, n, err := vc.Download(u, &p)
+	f, n, err := vc.Download(ctx, u, &p)
 	if err != nil {
 		return nil, n, err
 	}

--- a/nfc/lease.go
+++ b/nfc/lease.go
@@ -234,5 +234,5 @@ func (l *Lease) DownloadFile(ctx context.Context, file string, item FileItem, op
 		opts.Progress = progress.Tee(item, opts.Progress)
 	}
 
-	return l.c.DownloadFile(file, item.URL, &opts)
+	return l.c.DownloadFile(ctx, file, item.URL, &opts)
 }

--- a/nfc/lease.go
+++ b/nfc/lease.go
@@ -224,7 +224,7 @@ func (l *Lease) Upload(ctx context.Context, item FileItem, f io.Reader, opts soa
 		opts.Type = "application/x-vnd.vmware-streamVmdk"
 	}
 
-	return l.c.Upload(f, item.URL, &opts)
+	return l.c.Upload(ctx, f, item.URL, &opts)
 }
 
 func (l *Lease) DownloadFile(ctx context.Context, file string, item FileItem, opts soap.Download) error {

--- a/object/datastore.go
+++ b/object/datastore.go
@@ -284,7 +284,7 @@ func (d Datastore) Upload(ctx context.Context, f io.Reader, path string, param *
 	if err != nil {
 		return err
 	}
-	return d.Client().Upload(f, u, p)
+	return d.Client().Upload(ctx, f, u, p)
 }
 
 // UploadFile via soap.Upload with an http service ticket
@@ -293,7 +293,7 @@ func (d Datastore) UploadFile(ctx context.Context, file string, path string, par
 	if err != nil {
 		return err
 	}
-	return d.Client().UploadFile(file, u, p)
+	return d.Client().UploadFile(ctx, file, u, p)
 }
 
 // Download via soap.Download with an http service ticket

--- a/object/datastore.go
+++ b/object/datastore.go
@@ -302,7 +302,7 @@ func (d Datastore) Download(ctx context.Context, path string, param *soap.Downlo
 	if err != nil {
 		return nil, 0, err
 	}
-	return d.Client().Download(u, p)
+	return d.Client().Download(ctx, u, p)
 }
 
 // DownloadFile via soap.Download with an http service ticket
@@ -311,7 +311,7 @@ func (d Datastore) DownloadFile(ctx context.Context, path string, file string, p
 	if err != nil {
 		return err
 	}
-	return d.Client().DownloadFile(file, u, p)
+	return d.Client().DownloadFile(ctx, file, u, p)
 }
 
 // AttachedHosts returns hosts that have this Datastore attached, accessible and writable.

--- a/object/datastore_file.go
+++ b/object/datastore_file.go
@@ -172,7 +172,7 @@ func (f *DatastoreFile) Stat() (os.FileInfo, error) {
 		return nil, err
 	}
 
-	res, err := f.d.Client().DownloadRequest(u, p)
+	res, err := f.d.Client().DownloadRequest(f.ctx, u, p)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (f *DatastoreFile) get() (io.Reader, error) {
 		}
 	}
 
-	res, err := f.d.Client().DownloadRequest(u, p)
+	res, err := f.d.Client().DownloadRequest(f.ctx, u, p)
 	if err != nil {
 		return nil, err
 	}

--- a/vim25/progress/reader.go
+++ b/vim25/progress/reader.go
@@ -18,6 +18,7 @@ package progress
 
 import (
 	"container/list"
+	"context"
 	"fmt"
 	"io"
 	"sync/atomic"
@@ -75,16 +76,16 @@ type reader struct {
 
 	pos  int64
 	size int64
+	bps  uint64
 
-	bps uint64
-
-	ch chan<- Report
+	ch  chan<- Report
+	ctx context.Context
 }
 
-func NewReader(s Sinker, r io.Reader, size int64) *reader {
+func NewReader(ctx context.Context, s Sinker, r io.Reader, size int64) *reader {
 	pr := reader{
-		r: r,
-
+		r:    r,
+		ctx:  ctx,
 		size: size,
 	}
 
@@ -111,7 +112,10 @@ func (r *reader) Read(b []byte) (int, error) {
 		bps:  &r.bps,
 	}
 
-	r.ch <- q
+	select {
+	case r.ch <- q:
+	case <-r.ctx.Done():
+	}
 
 	return n, err
 }
@@ -127,8 +131,11 @@ func (r *reader) Done(err error) {
 		err:  err,
 	}
 
-	r.ch <- q
-	close(r.ch)
+	select {
+	case r.ch <- q:
+		close(r.ch)
+	case <-r.ctx.Done():
+	}
 }
 
 // newBpsLoop returns a sink that monitors and stores throughput.

--- a/vim25/progress/reader_test.go
+++ b/vim25/progress/reader_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package progress
 
 import (
+	"context"
 	"io"
 	"strings"
 	"testing"
@@ -25,7 +26,7 @@ import (
 func TestReader(t *testing.T) {
 	s := "helloworld"
 	ch := make(chan Report, 1)
-	pr := NewReader(&dummySinker{ch}, strings.NewReader(s), int64(len(s)))
+	pr := NewReader(context.Background(), &dummySinker{ch}, strings.NewReader(s), int64(len(s)))
 
 	var buf [10]byte
 	var q Report

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -555,7 +555,7 @@ func (c *Client) Upload(ctx context.Context, f io.Reader, u *url.URL, param *Upl
 	var err error
 
 	if param.Progress != nil {
-		pr := progress.NewReader(param.Progress, f, param.ContentLength)
+		pr := progress.NewReader(ctx, param.Progress, f, param.ContentLength)
 		f = pr
 
 		// Mark progress reader as done when returning from this function.
@@ -633,11 +633,13 @@ var DefaultDownload = Download{
 }
 
 // DownloadRequest wraps http.Client.Do, returning the http.Response without checking its StatusCode
-func (c *Client) DownloadRequest(u *url.URL, param *Download) (*http.Response, error) {
+func (c *Client) DownloadRequest(ctx context.Context, u *url.URL, param *Download) (*http.Response, error) {
 	req, err := http.NewRequest(param.Method, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	req = req.WithContext(ctx)
 
 	for k, v := range param.Headers {
 		req.Header.Add(k, v)
@@ -651,8 +653,8 @@ func (c *Client) DownloadRequest(u *url.URL, param *Download) (*http.Response, e
 }
 
 // Download GETs the remote file from the given URL
-func (c *Client) Download(u *url.URL, param *Download) (io.ReadCloser, int64, error) {
-	res, err := c.DownloadRequest(u, param)
+func (c *Client) Download(ctx context.Context, u *url.URL, param *Download) (io.ReadCloser, int64, error) {
+	res, err := c.DownloadRequest(ctx, u, param)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -672,7 +674,7 @@ func (c *Client) Download(u *url.URL, param *Download) (io.ReadCloser, int64, er
 	return r, res.ContentLength, nil
 }
 
-func (c *Client) WriteFile(file string, src io.Reader, size int64, s progress.Sinker, w io.Writer) error {
+func (c *Client) WriteFile(ctx context.Context, file string, src io.Reader, size int64, s progress.Sinker, w io.Writer) error {
 	var err error
 
 	r := src
@@ -683,7 +685,7 @@ func (c *Client) WriteFile(file string, src io.Reader, size int64, s progress.Si
 	}
 
 	if s != nil {
-		pr := progress.NewReader(s, src, size)
+		pr := progress.NewReader(ctx, s, src, size)
 		src = pr
 
 		// Mark progress reader as done when returning from this function.
@@ -710,16 +712,16 @@ func (c *Client) WriteFile(file string, src io.Reader, size int64, s progress.Si
 }
 
 // DownloadFile GETs the given URL to a local file
-func (c *Client) DownloadFile(file string, u *url.URL, param *Download) error {
+func (c *Client) DownloadFile(ctx context.Context, file string, u *url.URL, param *Download) error {
 	var err error
 	if param == nil {
 		param = &DefaultDownload
 	}
 
-	rc, contentLength, err := c.Download(u, param)
+	rc, contentLength, err := c.Download(ctx, u, param)
 	if err != nil {
 		return err
 	}
 
-	return c.WriteFile(file, rc, contentLength, param.Progress, param.Writer)
+	return c.WriteFile(ctx, file, rc, contentLength, param.Progress, param.Writer)
 }

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -459,6 +459,8 @@ func (c *Client) RoundTrip(ctx context.Context, reqBody, resBody HasFault) error
 		panic(err)
 	}
 
+	req = req.WithContext(ctx)
+
 	req.Header.Set(`Content-Type`, `text/xml; charset="utf-8"`)
 	soapAction := fmt.Sprintf("%s/%s", c.Namespace, c.Version)
 	req.Header.Set(`SOAPAction`, soapAction)
@@ -549,7 +551,7 @@ var DefaultUpload = Upload{
 }
 
 // Upload PUTs the local file to the given URL
-func (c *Client) Upload(f io.Reader, u *url.URL, param *Upload) error {
+func (c *Client) Upload(ctx context.Context, f io.Reader, u *url.URL, param *Upload) error {
 	var err error
 
 	if param.Progress != nil {
@@ -566,6 +568,8 @@ func (c *Client) Upload(f io.Reader, u *url.URL, param *Upload) error {
 	if err != nil {
 		return err
 	}
+
+	req = req.WithContext(ctx)
 
 	req.ContentLength = param.ContentLength
 	req.Header.Set("Content-Type", param.Type)
@@ -594,7 +598,7 @@ func (c *Client) Upload(f io.Reader, u *url.URL, param *Upload) error {
 }
 
 // UploadFile PUTs the local file to the given URL
-func (c *Client) UploadFile(file string, u *url.URL, param *Upload) error {
+func (c *Client) UploadFile(ctx context.Context, file string, u *url.URL, param *Upload) error {
 	if param == nil {
 		p := DefaultUpload // Copy since we set ContentLength
 		param = &p
@@ -613,7 +617,7 @@ func (c *Client) UploadFile(file string, u *url.URL, param *Upload) error {
 
 	param.ContentLength = s.Size()
 
-	return c.Upload(f, u, param)
+	return c.Upload(ctx, f, u, param)
 }
 
 type Download struct {


### PR DESCRIPTION
I hope this finds you well. I am working on a deploy tool to deploy to ESX hosts, I am learning that many of the contexts I pass are not used at lower levels. In short, I am using contexts in a signal handler to reap deploys on termination. It's just not doing that right now. ;)

I attempted to add this to the upload and lease calls so I can get moving on my own project. I hope it finds you well.

I use `(*http.Request).WithContext` to store the context with the request itself, and in other cases I select on the context.

Thanks,

-Erik