### PR TITLE
vcsim: add EventManager support

### DIFF
--- a/govc/emacs/govc.el
+++ b/govc/emacs/govc.el
@@ -620,7 +620,7 @@ returned, assuming that's what the user wanted."
   "Events via govc events -n `govc-max-events'."
   (interactive)
   (govc-shell-command
-   (list "events" "-n" govc-max-events (if current-prefix-arg "-f") (govc-selection)) "*govc-event*"))
+   (list "events" "-l" "-n" govc-max-events (if current-prefix-arg "-f") (govc-selection)) "*govc-event*"))
 
 (defun govc-tasks ()
   "Tasks via govc tasks."

--- a/govc/test/cli.bats
+++ b/govc/test/cli.bats
@@ -127,7 +127,7 @@ load test_helper
   assert grep -q GOVC_URL_QUERY=key=val <<<${output}
   assert grep -q GOVC_URL_FRAGMENT=anchor <<<${output}
 
-  password="pa\$sword\!ok"
+  password="pa\$sword!ok"
   run govc env -u "user:${password}@enoent:99999" GOVC_PASSWORD
   assert_output "$password"
 }

--- a/simulator/datacenter.go
+++ b/simulator/datacenter.go
@@ -74,3 +74,14 @@ func createDatacenterFolders(dc *mo.Datacenter, isVC bool) {
 		net.putChild(network)
 	}
 }
+
+func datacenterEventArgument(obj mo.Entity) *types.DatacenterEventArgument {
+	dc, ok := obj.(*mo.Datacenter)
+	if !ok {
+		dc = Map.getEntityDatacenter(obj)
+	}
+	return &types.DatacenterEventArgument{
+		Datacenter:          dc.Self,
+		EntityEventArgument: types.EntityEventArgument{Name: dc.Name},
+	}
+}

--- a/simulator/esx/event_manager.go
+++ b/simulator/esx/event_manager.go
@@ -1,0 +1,236 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package esx
+
+import "github.com/vmware/govmomi/vim25/types"
+
+// EventInfo is the default template for the EventManager description.eventInfo property.
+// Capture method:
+//   govc object.collect -s -dump EventManager:ha-eventmgr description.eventInfo
+// The captured list has been manually pruned and FullFormat fields changed to use Go's template variable syntax.
+var EventInfo = []types.EventDescriptionEventDetail{
+	{
+		Key:         "UserLoginSessionEvent",
+		Description: "User login",
+		Category:    "info",
+		FullFormat:  "User {{.UserName}}@{{.IpAddress}} logged in as {{.UserAgent}}",
+	},
+	{
+		Key:         "UserLogoutSessionEvent",
+		Description: "User logout",
+		Category:    "info",
+		FullFormat:  "User {{.UserName}}@{{.IpAddress}} logged out (login time: {{.LoginTime}}, number of API invocations: {{.CallCount}}, user agent: {{.UserAgent}})",
+	},
+	{
+		Key:         "DatacenterCreatedEvent",
+		Description: "Datacenter created",
+		Category:    "info",
+		FullFormat:  "Created datacenter {{.Datacenter.Name}} in folder {{.Parent.Name}}",
+	},
+	{
+		Key:         "DatastoreFileMovedEvent",
+		Description: "File or directory moved to datastore",
+		Category:    "info",
+		FullFormat:  "Move of file or directory {{.SourceFile}} from {{.SourceDatastore.Name}} to {{.Datastore.Name}} as {{.TargetFile}}",
+	},
+	{
+		Key:         "DatastoreFileCopiedEvent",
+		Description: "File or directory copied to datastore",
+		Category:    "info",
+		FullFormat:  "Copy of file or directory {{.SourceFile}} from {{.SourceDatastore.Name}} to {{.Datastore.Name}} as {{.TargetFile}}",
+	},
+	{
+		Key:         "DatastoreFileDeletedEvent",
+		Description: "File or directory deleted",
+		Category:    "info",
+		FullFormat:  "Deletion of file or directory {{.TargetFile}} from {{.Datastore.Name}} was initiated",
+	},
+	{
+		Key:         "EnteringMaintenanceModeEvent",
+		Description: "Entering maintenance mode",
+		Category:    "info",
+		FullFormat:  "Host {{.Host.Name}} in {{.Datacenter.Name}} has started to enter maintenance mode",
+	},
+	{
+		Key:         "EnteredMaintenanceModeEvent",
+		Description: "Entered maintenance mode",
+		Category:    "info",
+		FullFormat:  "Host {{.Host.Name}} in {{.Datacenter.Name}} has entered maintenance mode",
+	},
+	{
+		Key:         "ExitMaintenanceModeEvent",
+		Description: "Exit maintenance mode",
+		Category:    "info",
+		FullFormat:  "Host {{.Host.Name}} in {{.Datacenter.Name}} has exited maintenance mode",
+	},
+	{
+		Key:         "VmSuspendedEvent",
+		Description: "VM suspended",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}} is suspended",
+	},
+	{
+		Key:         "VmMigratedEvent",
+		Description: "VM migrated",
+		Category:    "info",
+		FullFormat:  "Migration of virtual machine {{.Vm.Name}} from {{.SourceHost.Name}, {{.SourceDatastore.Name}} to {{.Host.Name}, {{.Ds.Name}} completed",
+	},
+	{
+		Key:         "VmBeingMigratedEvent",
+		Description: "VM migrating",
+		Category:    "info",
+		FullFormat:  "Relocating {{.Vm.Name}} from {{.Host.Name}, {{.Ds.Name}} in {{.Datacenter.Name}} to {{.DestHost.Name}, {{.DestDatastore.Name}} in {{.DestDatacenter.Name}}",
+	},
+	{
+		Key:         "VmMacAssignedEvent",
+		Description: "VM MAC assigned",
+		Category:    "info",
+		FullFormat:  "New MAC address ({{.Mac}}) assigned to adapter {{.Adapter}} for {{.Vm.Name}}",
+	},
+	{
+		Key:         "VmRegisteredEvent",
+		Description: "VM registered",
+		Category:    "info",
+		FullFormat:  "Registered {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmReconfiguredEvent",
+		Description: "VM reconfigured",
+		Category:    "info",
+		FullFormat:  "Reconfigured {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmGuestRebootEvent",
+		Description: "Guest reboot",
+		Category:    "info",
+		FullFormat:  "Guest OS reboot for {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmBeingClonedEvent",
+		Description: "VM being cloned",
+		Category:    "info",
+		FullFormat:  "Cloning {{.Vm.Name}} on host {{.Host.Name}} in {{.Datacenter.Name}} to {{.DestName}} on host {{.DestHost.Name}}",
+	},
+	{
+		Key:         "VmClonedEvent",
+		Description: "VM cloned",
+		Category:    "info",
+		FullFormat:  "Clone of {{.SourceVm.Name}} completed",
+	},
+	{
+		Key:         "VmBeingDeployedEvent",
+		Description: "Deploying VM",
+		Category:    "info",
+		FullFormat:  "Deploying {{.Vm.Name}} on host {{.Host.Name}} in {{.Datacenter.Name}} from template {{.SrcTemplate.Name}}",
+	},
+	{
+		Key:         "VmDeployedEvent",
+		Description: "VM deployed",
+		Category:    "info",
+		FullFormat:  "Template {{.SrcTemplate.Name}} deployed on host {{.Host.Name}}",
+	},
+	{
+		Key:         "VmInstanceUuidAssignedEvent",
+		Description: "Assign a new instance UUID",
+		Category:    "info",
+		FullFormat:  "Assign a new instance UUID ({{.InstanceUuid}}) to {{.Vm.Name}}",
+	},
+	{
+		Key:         "VmPoweredOnEvent",
+		Description: "VM powered on",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}} is powered on",
+	},
+	{
+		Key:         "VmStartingEvent",
+		Description: "VM starting",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on host {{.Host.Name}} in {{.Datacenter.Name}} is starting",
+	},
+	{
+		Key:         "VmSuspendingEvent",
+		Description: "VM being suspended",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}} is being suspended",
+	},
+	{
+		Key:         "VmResumingEvent",
+		Description: "VM resuming",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}} is resumed",
+	},
+	{
+		Key:         "VmBeingCreatedEvent",
+		Description: "Creating VM",
+		Category:    "info",
+		FullFormat:  "Creating {{.Vm.Name}} on host {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmCreatedEvent",
+		Description: "VM created",
+		Category:    "info",
+		FullFormat:  "Created virtual machine {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmRemovedEvent",
+		Description: "VM removed",
+		Category:    "info",
+		FullFormat:  "Removed {{.Vm.Name}} on {{.Host.Name}} from {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmResettingEvent",
+		Description: "VM resetting",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}} is reset",
+	},
+	{
+		Key:         "VmGuestShutdownEvent",
+		Description: "Guest OS shut down",
+		Category:    "info",
+		FullFormat:  "Guest OS shut down for {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmUuidAssignedEvent",
+		Description: "VM UUID assigned",
+		Category:    "info",
+		FullFormat:  "Assigned new BIOS UUID ({{.Uuid}}) to {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmPoweredOffEvent",
+		Description: "VM powered off",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}} is powered off",
+	},
+	{
+		Key:         "VmRelocatedEvent",
+		Description: "VM relocated",
+		Category:    "info",
+		FullFormat:  "Completed the relocation of the virtual machine",
+	},
+	{
+		Key:         "DrsVmMigratedEvent",
+		Description: "DRS VM migrated",
+		Category:    "info",
+		FullFormat:  "DRS migrated {{.Vm.Name}} from {{.SourceHost.Name}} to {{.Host.Name}} in cluster {{.ComputeResource.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "DrsVmPoweredOnEvent",
+		Description: "DRS VM powered on",
+		Category:    "info",
+		FullFormat:  "DRS powered On {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+}

--- a/simulator/event_manager.go
+++ b/simulator/event_manager.go
@@ -1,0 +1,386 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"bytes"
+	"container/ring"
+	"log"
+	"reflect"
+	"text/template"
+	"time"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator/esx"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var (
+	maxPageSize = 1000
+	logEvents   = false
+)
+
+type EventManager struct {
+	mo.EventManager
+
+	root       types.ManagedObjectReference
+	page       *ring.Ring
+	key        int32
+	collectors map[types.ManagedObjectReference]*EventHistoryCollector
+	templates  map[string]*template.Template
+}
+
+func NewEventManager(ref types.ManagedObjectReference) object.Reference {
+	return &EventManager{
+		EventManager: mo.EventManager{
+			Self: ref,
+			Description: types.EventDescription{
+				EventInfo: esx.EventInfo,
+			},
+			MaxCollector: 1000,
+		},
+		root:       Map.content().RootFolder,
+		page:       ring.New(maxPageSize),
+		collectors: make(map[types.ManagedObjectReference]*EventHistoryCollector),
+		templates:  make(map[string]*template.Template),
+	}
+}
+
+func (m *EventManager) CreateCollectorForEvents(ctx *Context, req *types.CreateCollectorForEvents) soap.HasFault {
+	body := new(methods.CreateCollectorForEventsBody)
+	size, err := validatePageSize(req.Filter.MaxCount)
+	if err != nil {
+		body.Fault_ = err
+		return body
+	}
+
+	if len(m.collectors) >= int(m.MaxCollector) {
+		body.Fault_ = Fault("Too many event collectors to create", new(types.InvalidState))
+		return body
+	}
+
+	collector := &EventHistoryCollector{
+		m:    m,
+		page: ring.New(size),
+	}
+	collector.Filter = req.Filter
+	collector.fillPage(size)
+
+	ref := ctx.Session.Put(collector).Reference()
+	m.collectors[ref] = collector
+
+	body.Res = &types.CreateCollectorForEventsResponse{
+		Returnval: ref,
+	}
+
+	return body
+}
+
+// formatMessage applies the EventDescriptionEventDetail.FullFormat template to the given event's FullFormattedMessage field.
+func (m *EventManager) formatMessage(event types.BaseEvent) {
+	id := reflect.ValueOf(event).Elem().Type().Name()
+	e := event.GetEvent()
+
+	t, ok := m.templates[id]
+	if !ok {
+		for _, info := range m.Description.EventInfo {
+			if info.Key == id {
+				t = template.Must(template.New(id).Parse(info.FullFormat))
+				m.templates[id] = t
+				break
+			}
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, event); err != nil {
+		log.Print(err)
+	}
+	e.FullFormattedMessage = buf.String()
+
+	if logEvents {
+		log.Printf("[%s] %s", id, e.FullFormattedMessage)
+	}
+}
+
+func (m *EventManager) PostEvent(ctx *Context, req *types.PostEvent) soap.HasFault {
+	m.key++
+	event := req.EventToPost.GetEvent()
+	event.Key = m.key
+	event.ChainId = event.Key
+	event.CreatedTime = time.Now()
+	event.UserName = ctx.Session.UserName
+
+	m.page = m.page.Next()
+	m.page.Value = req.EventToPost
+	m.formatMessage(req.EventToPost)
+
+	for _, c := range m.collectors {
+		if c.eventMatches(req.EventToPost) {
+			c.page = c.page.Next()
+			c.page.Value = event
+		}
+	}
+
+	return &methods.PostEventBody{
+		Res: new(types.PostEventResponse),
+	}
+}
+
+type EventHistoryCollector struct {
+	mo.EventHistoryCollector
+
+	m    *EventManager
+	page *ring.Ring
+}
+
+// doEntityEventArgument calls f for each entity argument in the event.
+// If f returns true, the iteration stops.
+func doEntityEventArgument(event types.BaseEvent, f func(types.ManagedObjectReference, *types.EntityEventArgument) bool) bool {
+	e := event.GetEvent()
+
+	if arg := e.Vm; arg != nil {
+		if f(arg.Vm, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	if arg := e.Host; arg != nil {
+		if f(arg.Host, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	if arg := e.ComputeResource; arg != nil {
+		if f(arg.ComputeResource, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	if arg := e.Ds; arg != nil {
+		if f(arg.Datastore, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	if arg := e.Net; arg != nil {
+		if f(arg.Network, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	if arg := e.Dvs; arg != nil {
+		if f(arg.Dvs, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	if arg := e.Datacenter; arg != nil {
+		if f(arg.Datacenter, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// eventFilterSelf returns true if self is one of the entity arguments in the event.
+func eventFilterSelf(event types.BaseEvent, self types.ManagedObjectReference) bool {
+	return doEntityEventArgument(event, func(ref types.ManagedObjectReference, _ *types.EntityEventArgument) bool {
+		return self == ref
+	})
+}
+
+// eventFilterChildren returns true if a child of self is one of the entity arguments in the event.
+func eventFilterChildren(event types.BaseEvent, self types.ManagedObjectReference) bool {
+	return doEntityEventArgument(event, func(ref types.ManagedObjectReference, _ *types.EntityEventArgument) bool {
+		seen := false
+
+		var match func(types.ManagedObjectReference)
+
+		match = func(child types.ManagedObjectReference) {
+			if child == self {
+				seen = true
+				return
+			}
+
+			walk(child, match)
+		}
+
+		walk(ref, match)
+
+		return seen
+	})
+}
+
+// entityMatches returns true if the spec Entity filter matches the event.
+func (c *EventHistoryCollector) entityMatches(event types.BaseEvent, spec *types.EventFilterSpec) bool {
+	e := spec.Entity
+	if e == nil {
+		return true
+	}
+
+	isRootFolder := c.m.root == e.Entity
+
+	switch e.Recursion {
+	case types.EventFilterSpecRecursionOptionSelf:
+		return isRootFolder || eventFilterSelf(event, e.Entity)
+	case types.EventFilterSpecRecursionOptionChildren:
+		return eventFilterChildren(event, e.Entity)
+	case types.EventFilterSpecRecursionOptionAll:
+		if isRootFolder || eventFilterSelf(event, e.Entity) {
+			return true
+		}
+		return eventFilterChildren(event, e.Entity)
+	}
+
+	return false
+}
+
+// typeMatches returns true if one of the spec EventTypeId types matches the event.
+func (c *EventHistoryCollector) typeMatches(event types.BaseEvent, spec *types.EventFilterSpec) bool {
+	if len(spec.EventTypeId) == 0 {
+		return true
+	}
+
+	matches := func(name string) bool {
+		for _, id := range spec.EventTypeId {
+			if id == name {
+				return true
+			}
+		}
+		return false
+	}
+	kind := reflect.ValueOf(event).Elem().Type()
+
+	if matches(kind.Name()) {
+		return true // concrete type
+	}
+
+	field, ok := kind.FieldByNameFunc(matches)
+	if ok {
+		return field.Anonymous // base type (embedded field)
+	}
+	return false
+}
+
+// eventMatches returns true one of the filters matches the event.
+func (c *EventHistoryCollector) eventMatches(event types.BaseEvent) bool {
+	spec := c.Filter.(types.EventFilterSpec)
+
+	if !c.typeMatches(event, &spec) {
+		return false
+	}
+
+	// TODO: spec.Time, spec.UserName, etc
+
+	return c.entityMatches(event, &spec)
+}
+
+// filePage copies the manager's latest events into the collector's page with Filter applied.
+func (c *EventHistoryCollector) fillPage(size int) {
+	l := c.page.Len()
+	delta := size - l
+
+	if delta < 0 {
+		// Shrink ring size
+		c.page = c.page.Unlink(-delta)
+		return
+	}
+
+	matches := 0
+	mpage := c.m.page
+	page := c.page
+
+	if delta != 0 {
+		// Grow ring size
+		c.page = c.page.Link(ring.New(delta))
+	}
+
+	for i := 0; i < maxPageSize; i++ {
+		event, ok := mpage.Value.(types.BaseEvent)
+		mpage = mpage.Prev()
+		if !ok {
+			continue
+		}
+
+		if c.eventMatches(event) {
+			page.Value = event
+			page = page.Prev()
+			matches++
+			if matches == size {
+				break
+			}
+		}
+	}
+}
+
+func validatePageSize(count int32) (int, *soap.Fault) {
+	size := int(count)
+
+	if size == 0 {
+		size = 10 // defaultPageSize
+	} else if size < 0 || size > maxPageSize {
+		return -1, Fault("", &types.InvalidArgument{InvalidProperty: "maxCount"})
+	}
+
+	return size, nil
+}
+
+func (c *EventHistoryCollector) SetCollectorPageSize(ctx *Context, req *types.SetCollectorPageSize) soap.HasFault {
+	body := new(methods.SetCollectorPageSizeBody)
+	size, err := validatePageSize(req.MaxCount)
+	if err != nil {
+		body.Fault_ = err
+		return body
+	}
+
+	ctx.WithLock(c.m, func() {
+		c.fillPage(size)
+	})
+
+	body.Res = new(types.SetCollectorPageSizeResponse)
+	return body
+}
+
+func (c *EventHistoryCollector) DestroyCollector(ctx *Context, req *types.DestroyCollector) soap.HasFault {
+	ctx.Session.Remove(req.This)
+
+	ctx.WithLock(c.m, func() {
+		delete(c.m.collectors, req.This)
+	})
+
+	return &methods.DestroyCollectorBody{
+		Res: new(types.DestroyCollectorResponse),
+	}
+}
+
+func (c *EventHistoryCollector) Get() mo.Reference {
+	clone := *c
+
+	c.page.Do(func(val interface{}) {
+		if val == nil {
+			return
+		}
+		clone.LatestPage = append(clone.LatestPage, val.(types.BaseEvent))
+	})
+
+	return &clone
+}

--- a/simulator/event_manager_test.go
+++ b/simulator/event_manager_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/event"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestEventManagerVPX(t *testing.T) {
+	logEvents = testing.Verbose()
+	ctx := context.Background()
+
+	m := VPX()
+	m.Datacenter = 2
+
+	defer m.Remove()
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := event.NewManager(c.Client)
+	count := m.Count()
+
+	root := c.ServiceContent.RootFolder
+	vm := Map.Any("VirtualMachine").(*VirtualMachine)
+	host := Map.Get(vm.Runtime.Host.Reference()).(*HostSystem)
+
+	vmEvents := 6 // BeingCreated + InstanceUuid + Uuid + Created + Starting + PoweredOn
+	tests := []struct {
+		obj    types.ManagedObjectReference
+		expect int
+		ids    []string
+	}{
+		{root, -1 * count.Machine, nil},
+		{root, 1, []string{"SessionEvent"}}, // UserLoginSessionEvent
+		{vm.Reference(), 0, []string{"SessionEvent"}},
+		{root, count.Machine, []string{"VmCreatedEvent"}},     // concrete type
+		{root, count.Machine * vmEvents, []string{"VmEvent"}}, // base type
+		{vm.Reference(), 1, []string{"VmCreatedEvent"}},
+		{vm.Reference(), vmEvents, nil},
+		{host.Reference(), len(host.Vm), []string{"VmCreatedEvent"}},
+		{host.Reference(), len(host.Vm) * vmEvents, nil},
+	}
+
+	for i, test := range tests {
+		n := 0
+		f := func(obj types.ManagedObjectReference, events []types.BaseEvent) error {
+			n += len(events)
+
+			return nil
+		}
+
+		err = e.Events(ctx, []types.ManagedObjectReference{test.obj}, 100, false, false, f, test.ids...)
+		if err != nil {
+			t.Fatalf("%d: %s", i, err)
+		}
+
+		if test.expect < 0 {
+			expect := test.expect * -1
+			if n < expect {
+				t.Errorf("%d: expected at least %d events, got: %d", i, expect, n)
+			}
+			continue
+		}
+
+		if test.expect != n {
+			t.Errorf("%d: expected %d events, got: %d", i, test.expect, n)
+		}
+	}
+}

--- a/simulator/folder_test.go
+++ b/simulator/folder_test.go
@@ -219,7 +219,7 @@ func TestFolderFaults(t *testing.T) {
 		t.Error("expected fault")
 	}
 
-	if f.CreateDatacenter(nil).Fault() == nil {
+	if f.CreateDatacenter(nil, nil).Fault() == nil {
 		t.Error("expected fault")
 	}
 }

--- a/simulator/host_system.go
+++ b/simulator/host_system.go
@@ -71,6 +71,22 @@ func NewHostSystem(host mo.HostSystem) *HostSystem {
 	return hs
 }
 
+func (h *HostSystem) eventArgument() *types.HostEventArgument {
+	return &types.HostEventArgument{
+		Host:                h.Self,
+		EntityEventArgument: types.EntityEventArgument{Name: h.Name},
+	}
+}
+
+func (h *HostSystem) eventArgumentParent() *types.ComputeResourceEventArgument {
+	parent := hostParent(&h.HostSystem)
+
+	return &types.ComputeResourceEventArgument{
+		ComputeResource:     parent.Self,
+		EntityEventArgument: types.EntityEventArgument{Name: parent.Name},
+	}
+}
+
 func hostParent(host *mo.HostSystem) *mo.ComputeResource {
 	switch parent := Map.Get(*host.Parent).(type) {
 	case *mo.ComputeResource:

--- a/simulator/property_collector.go
+++ b/simulator/property_collector.go
@@ -63,6 +63,15 @@ func getObject(ctx *Context, ref types.ManagedObjectReference) (reflect.Value, b
 		obj = &mo.SessionManager{Self: ref}
 	}
 
+	// For objects that use internal types that differ from that of the vim25/mo field types.
+	// See EventHistoryCollector for example.
+	type get interface {
+		Get() mo.Reference
+	}
+	if o, ok := obj.(get); ok {
+		obj = o.Get()
+	}
+
 	rval := reflect.ValueOf(obj).Elem()
 	rtype := rval.Type()
 
@@ -183,7 +192,7 @@ func isEmpty(rval reflect.Value) bool {
 	switch rval.Kind() {
 	case reflect.Ptr:
 		return rval.IsNil()
-	case reflect.String, reflect.Slice:
+	case reflect.String:
 		return rval.Len() == 0
 	}
 

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -350,6 +350,11 @@ func (r *Registry) SearchIndex() *SearchIndex {
 	return r.Get(r.content().SearchIndex.Reference()).(*SearchIndex)
 }
 
+// EventManager returns the EventManager singleton
+func (r *Registry) EventManager() *EventManager {
+	return r.Get(r.content().EventManager.Reference()).(*EventManager)
+}
+
 // FileManager returns the FileManager singleton
 func (r *Registry) FileManager() *FileManager {
 	return r.Get(r.content().FileManager.Reference()).(*FileManager)

--- a/simulator/service_instance.go
+++ b/simulator/service_instance.go
@@ -62,6 +62,7 @@ func NewServiceInstance(content types.ServiceContent, folder mo.Folder) *Service
 		NewLicenseManager(*s.Content.LicenseManager),
 		NewSearchIndex(*s.Content.SearchIndex),
 		NewViewManager(*s.Content.ViewManager),
+		NewEventManager(*s.Content.EventManager),
 		NewTaskManager(*s.Content.TaskManager),
 		NewUserDirectory(*s.Content.UserDirectory),
 		NewOptionManager(s.Content.Setting, setting),

--- a/simulator/view_manager.go
+++ b/simulator/view_manager.go
@@ -149,7 +149,7 @@ func (v *ContainerView) include(o types.ManagedObjectReference) bool {
 	return v.types[o.Type]
 }
 
-func (v *ContainerView) add(root mo.Reference, seen map[types.ManagedObjectReference]bool) {
+func walk(root mo.Reference, f func(child types.ManagedObjectReference)) {
 	var children []types.ManagedObjectReference
 
 	switch e := root.(type) {
@@ -174,6 +174,12 @@ func (v *ContainerView) add(root mo.Reference, seen map[types.ManagedObjectRefer
 	}
 
 	for _, child := range children {
+		f(child)
+	}
+}
+
+func (v *ContainerView) add(root mo.Reference, seen map[types.ManagedObjectReference]bool) {
+	walk(root, func(child types.ManagedObjectReference) {
 		if v.include(child) {
 			if seen[child] == false {
 				seen[child] = true
@@ -184,5 +190,5 @@ func (v *ContainerView) add(root mo.Reference, seen map[types.ManagedObjectRefer
 		if v.Recursive {
 			v.add(Map.Get(child), seen)
 		}
-	}
+	})
 }

--- a/vim25/types/helpers.go
+++ b/vim25/types/helpers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"reflect"
 	"strings"
 	"time"
 )
@@ -85,4 +86,10 @@ func DefaultResourceConfigSpec() ResourceConfigSpec {
 		CpuAllocation:    defaultResourceAllocationInfo(),
 		MemoryAllocation: defaultResourceAllocationInfo(),
 	}
+}
+
+func init() {
+	// Known 6.5 issue where this event type is sent even though it is internal.
+	// This workaround allows us to unmarshal and avoid NPEs.
+	t["HostSubSpecificationUpdateEvent"] = reflect.TypeOf((*HostEvent)(nil)).Elem()
 }


### PR DESCRIPTION
- Add '-dump' support to govc events command, so we can grab events as Go code

- Workaround 6.5 bug where an internal event type (HostSubSpecificationUpdateEvent) was causing an NPE

- Avoid Go 1.9.3 url.Parse error in cli.bats

- PropertyCollector should return empty arrays