### PR TITLE
vcsim: stats related fixes

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -23,17 +23,20 @@ load test_helper
 }
 
 @test "vcsim about" {
-  vcsim_env
+  vcsim_env -dc 2 -cluster 3 -vm 0 -ds 0
 
   url="https://$(govc env GOVC_URL)"
 
-  run curl -sk "$url/about"
+  run curl -skf "$url/about"
   assert_matches "CurrentTime" # 1 param (without Context)
   assert_matches "TerminateSession" # 2 params (with Context)
 
-  run curl -sk "$url/debug/vars"
+  run curl -skf "$url/debug/vars"
   assert_success
 
-  run curl -sk "$url/debug/vcsim/vars"
-  assert_success
+  model=$(curl -sfk "$url/debug/vars" | jq .vcsim.Model)
+  [ "$(jq .Datacenter <<<"$model")" == "2" ]
+  [ "$(jq .Cluster <<<"$model")" == "6" ]
+  [ "$(jq .Machine <<<"$model")" == "0" ]
+  [ "$(jq .Datastore <<<"$model")" == "0" ]
 }

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -43,41 +43,41 @@ type Model struct {
 	Autostart bool `json:"-"`
 
 	// Datacenter specifies the number of Datacenter entities to create
-	Datacenter int `json:",omitempty"`
+	Datacenter int
 
 	// Portgroup specifies the number of DistributedVirtualPortgroup entities to create per Datacenter
-	Portgroup int `json:",omitempty"`
+	Portgroup int
 
 	// Host specifies the number of standalone HostSystems entities to create per Datacenter
 	Host int `json:",omitempty"`
 
 	// Cluster specifies the number of ClusterComputeResource entities to create per Datacenter
-	Cluster int `json:",omitempty"`
+	Cluster int
 
 	// ClusterHost specifies the number of HostSystems entities to create within a Cluster
 	ClusterHost int `json:",omitempty"`
 
 	// Pool specifies the number of ResourcePool entities to create per Cluster
-	Pool int `json:",omitempty"`
+	Pool int
 
 	// Datastore specifies the number of Datastore entities to create
 	// Each Datastore will have temporary local file storage and will be mounted
 	// on every HostSystem created by the ModelConfig
-	Datastore int `json:",omitempty"`
+	Datastore int
 
 	// Machine specifies the number of VirtualMachine entities to create per ResourcePool
-	Machine int `json:",omitempty"`
+	Machine int
 
 	// Folder specifies the number of Datacenter to place within a Folder.
 	// This includes a folder for the Datacenter itself and its host, vm, network and datastore folders.
 	// All resources for the Datacenter are placed within these folders, rather than the top-level folders.
-	Folder int `json:",omitempty"`
+	Folder int
 
 	// App specifies the number of VirtualApp to create per Cluster
-	App int `json:",omitempty"`
+	App int
 
 	// Pod specifies the number of StoragePod to create per Cluster
-	Pod int `json:",omitempty"`
+	Pod int
 
 	// total number of inventory objects, set by Count()
 	total int

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -111,13 +111,15 @@ func main() {
 		}
 	}
 
-	expvar.Publish("/debug/vcsim/vars", expvar.Func(func() interface{} {
+	expvar.Publish("vcsim", expvar.Func(func() interface{} {
+		count := model.Count()
+
 		return struct {
 			Registry *simulator.Registry
 			Model    *simulator.Model
 		}{
 			simulator.Map,
-			model,
+			&count,
 		}
 	}))
 


### PR DESCRIPTION
- Use the curl '-f' flag so the tests actually fail on 404 Not Found

- Add some Model validation to the tests

- Use Model.Count to get the current totals when stats are fetched

- Remove 'omitempty' tags from Model field that represent object types,
  making it easier to validate when an object count should be '0'