### PR TITLE
vcsim: set VirtualMachine summary.config.instanceUuid

### DIFF
--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -296,6 +296,16 @@ load test_helper
 
   run govc object.collect -s -type Network / summary.ipPoolName
   assert_success ""
+
+  # check that uuid and instanceUuid are set under both config and summary.config
+  for prop in config summary.config ; do
+    uuids=$(govc object.collect -s -type m / "$prop.uuid" | sort)
+    [ -n "$uuids" ]
+    iuuids=$(govc object.collect -s -type m / "$prop.instanceUuid" | sort)
+    [ -n "$iuuids" ]
+
+    [ "$uuids" != "$iuuids" ]
+  done
 }
 
 @test "object.collect view" {

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -157,6 +157,9 @@ func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 		{spec.GuestId, &vm.Summary.Config.GuestId},
 		{spec.GuestId, &vm.Summary.Config.GuestFullName},
 		{spec.Uuid, &vm.Config.Uuid},
+		{spec.Uuid, &vm.Summary.Config.Uuid},
+		{spec.InstanceUuid, &vm.Config.InstanceUuid},
+		{spec.InstanceUuid, &vm.Summary.Config.InstanceUuid},
 		{spec.Version, &vm.Config.Version},
 		{spec.Files.VmPathName, &vm.Config.Files.VmPathName},
 		{spec.Files.VmPathName, &vm.Summary.Config.VmPathName},
@@ -257,8 +260,6 @@ func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 	vm.Config.ExtraConfig = append(vm.Config.ExtraConfig, spec.ExtraConfig...)
 
 	vm.Config.Modified = time.Now()
-
-	vm.Summary.Config.Uuid = vm.Config.Uuid
 }
 
 func validateGuestID(id string) types.BaseMethodFault {


### PR DESCRIPTION
In commit 274f3d6 , the config.instanceUuid property was set, but we missed the summary.config field.

Fixes #1022