### PR TITLE
Fix simulator build on Windows.

### DIFF
--- a/simulator/os_unix.go
+++ b/simulator/os_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 /*
 Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 


### PR DESCRIPTION
There's currently a compile error since _unix.go isn't a build flag that gets skipped on Windows:

```
$ GOOS=windows go build github.com/vmware/govmomi/simulator
# github.com/vmware/govmomi/simulator
simulator/os_unix.go:23:11: undefined: syscall.Statfs_t
simulator/os_unix.go:25:9: undefined: syscall.Statfs
simulator/os_windows.go:21:6: (*Datastore).stat redeclared in this block
	previous declaration at simulator/os_unix.go:21:6
```