### PR TITLE
govc: fix vm.clone to use -net flag when source does not have a NIC

### DIFF
--- a/govc/flags/network.go
+++ b/govc/flags/network.go
@@ -129,3 +129,19 @@ func (flag *NetworkFlag) Device() (types.BaseVirtualDevice, error) {
 
 	return device, nil
 }
+
+// Change applies update backing and hardware address changes to the given network device.
+func (flag *NetworkFlag) Change(device types.BaseVirtualDevice, update types.BaseVirtualDevice) {
+	current := device.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+	changed := update.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+
+	current.Backing = changed.Backing
+
+	if changed.MacAddress != "" {
+		current.MacAddress = changed.MacAddress
+	}
+
+	if changed.AddressType != "" {
+		current.AddressType = changed.AddressType
+	}
+}

--- a/govc/vm/network/change.go
+++ b/govc/vm/network/change.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	"github.com/vmware/govmomi/vim25/types"
 )
 
 type change struct {
@@ -103,18 +102,7 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	current := net.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-	changed := dev.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-
-	current.Backing = changed.Backing
-
-	if changed.MacAddress != "" {
-		current.MacAddress = changed.MacAddress
-	}
-
-	if changed.AddressType != "" {
-		current.AddressType = changed.AddressType
-	}
+	cmd.NetworkFlag.Change(net, dev)
 
 	return vm.EditDevice(ctx, net)
 }


### PR DESCRIPTION
- Add vcsim support for VirtualDeviceConfigSpecOperationEdit

- vcsim CloneVM now includes source VM's devices and applies VirtualMachineRelocateSpec.DeviceChange

Fixes #960