### PR TITLE
Add support for Datacenter.PowerOnMultiVM

### DIFF
--- a/govc/test/test_helper.bash
+++ b/govc/test/test_helper.bash
@@ -38,10 +38,15 @@ GOVC_TEST_IMG=govc-images/$(basename $GOVC_TEST_IMG_SRC)
 
 PATH="$GOPATH/bin:$PATH"
 
+vcsim_stop() {
+  kill "$GOVC_SIM_PID"
+  rm -f "$GOVC_SIM_ENV"
+  unset GOVC_SIM_PID
+}
+
 teardown() {
   if [ -n "$GOVC_SIM_PID" ] ; then
-    kill "$GOVC_SIM_PID"
-    rm -f "$GOVC_SIM_ENV"
+    vcsim_stop
   else
     govc ls vm | grep govc-test- | $xargs -r govc vm.destroy
     govc datastore.ls | grep govc-test- | awk '{print ($NF)}' | $xargs -n1 -r govc datastore.rm
@@ -121,7 +126,7 @@ vcsim_env() {
 
   export GOVC_DATASTORE=LocalDS_0
 
-  if [ "$1" != "-esx" ] ; then
+  if [ "$1" != "-esx" ] && [ "$1" != "-esx=true" ]; then
     export GOVC_DATACENTER=DC0 \
            GOVC_HOST=/DC0/host/DC0_C0/DC0_C0_H0 \
            GOVC_RESOURCE_POOL=/DC0/host/DC0_C0/Resources \

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -156,6 +156,31 @@ load test_helper
   assert_success "poweredOn"
 }
 
+@test "vm.power -on -M" {
+  for esx in true false ; do
+    vcsim_env -esx=$esx -autostart=false
+
+    vms=($(govc find / -type m | sort))
+
+    # All VMs are off with -autostart=false
+    off=($(govc find / -type m -runtime.powerState poweredOff | sort))
+    assert_equal "${vms[*]}" "${off[*]}"
+
+    # Power on 1 VM to test that -M is idempotent
+    run govc vm.power -on "${vms[0]}"
+    assert_success
+
+    run govc vm.power -on -M "${vms[@]}"
+    assert_success
+
+    # All VMs should be powered on now
+    on=($(govc find / -type m -runtime.powerState poweredOn | sort))
+    assert_equal "${vms[*]}" "${on[*]}"
+
+    vcsim_stop
+  done
+}
+
 @test "vm.power -force" {
   esx_env
 

--- a/simulator/entity_test.go
+++ b/simulator/entity_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/vmware/govmomi/vim25/methods"
-	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -39,7 +38,7 @@ func TestRename(t *testing.T) {
 	s := m.Service.NewServer()
 	defer s.Close()
 
-	dc := Map.Any("Datacenter").(*mo.Datacenter)
+	dc := Map.Any("Datacenter").(*Datacenter)
 	vmFolder := Map.Get(dc.VmFolder).(*Folder)
 
 	f1 := Map.Get(vmFolder.ChildEntity[0]).(*Folder) // "F1"

--- a/simulator/file_manager.go
+++ b/simulator/file_manager.go
@@ -80,7 +80,7 @@ func (f *FileManager) resolve(dc *types.ManagedObjectReference, name string) (st
 		}
 	}
 
-	folder := Map.Get(*dc).(*mo.Datacenter).DatastoreFolder
+	folder := Map.Get(*dc).(*Datacenter).DatastoreFolder
 
 	ds, fault := f.findDatastore(Map.Get(folder), p.Datastore)
 	if fault != nil {

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -197,13 +197,9 @@ func (f *Folder) CreateDatacenter(ctx *Context, c *types.CreateDatacenter) soap.
 	r := &methods.CreateDatacenterBody{}
 
 	if f.hasChildType("Datacenter") && f.hasChildType("Folder") {
-		dc := &mo.Datacenter{}
+		dc := NewDatacenter(f)
 
 		dc.Name = c.Name
-
-		f.putChild(dc)
-
-		createDatacenterFolders(dc, true)
 
 		r.Res = &types.CreateDatacenterResponse{
 			Returnval: dc.Self,

--- a/simulator/host_system.go
+++ b/simulator/host_system.go
@@ -113,9 +113,7 @@ func addComputeResource(s *types.ComputeResourceSummary, h *HostSystem) {
 // CreateDefaultESX creates a standalone ESX
 // Adds objects of type: Datacenter, Network, ComputeResource, ResourcePool and HostSystem
 func CreateDefaultESX(f *Folder) {
-	dc := &esx.Datacenter
-	f.putChild(dc)
-	createDatacenterFolders(dc, false)
+	dc := NewDatacenter(f)
 
 	host := NewHostSystem(esx.HostSystem)
 

--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -197,7 +197,7 @@ func TestRetrieveProperties(t *testing.T) {
 		}
 
 		// Retrieve a nested property
-		Map.Get(dc.Reference()).(*mo.Datacenter).Configuration.DefaultHardwareVersionKey = "foo"
+		Map.Get(dc.Reference()).(*Datacenter).Configuration.DefaultHardwareVersionKey = "foo"
 		mdc = mo.Datacenter{}
 		err = client.RetrieveOne(ctx, dc.Reference(), []string{"configuration.defaultHardwareVersionKey"}, &mdc)
 		if err != nil {

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -213,8 +213,8 @@ func (r *Registry) getEntityParent(item mo.Entity, kind string) mo.Entity {
 }
 
 // getEntityDatacenter returns the Datacenter containing the given item
-func (r *Registry) getEntityDatacenter(item mo.Entity) *mo.Datacenter {
-	return r.getEntityParent(item, "Datacenter").(*mo.Datacenter)
+func (r *Registry) getEntityDatacenter(item mo.Entity) *Datacenter {
+	return r.getEntityParent(item, "Datacenter").(*Datacenter)
 }
 
 func (r *Registry) getEntityFolder(item mo.Entity, kind string) *Folder {

--- a/simulator/search_index.go
+++ b/simulator/search_index.go
@@ -94,7 +94,7 @@ func (s *SearchIndex) FindChild(req *types.FindChild) soap.HasFault {
 	var children []types.ManagedObjectReference
 
 	switch e := obj.(type) {
-	case *mo.Datacenter:
+	case *Datacenter:
 		children = []types.ManagedObjectReference{e.VmFolder, e.HostFolder, e.DatastoreFolder, e.NetworkFolder}
 	case *Folder:
 		children = e.ChildEntity

--- a/simulator/view_manager.go
+++ b/simulator/view_manager.go
@@ -153,7 +153,7 @@ func walk(root mo.Reference, f func(child types.ManagedObjectReference)) {
 	var children []types.ManagedObjectReference
 
 	switch e := root.(type) {
-	case *mo.Datacenter:
+	case *Datacenter:
 		children = []types.ManagedObjectReference{e.VmFolder, e.HostFolder, e.DatastoreFolder, e.NetworkFolder}
 	case *Folder:
 		children = e.ChildEntity

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -86,6 +86,7 @@ func main() {
 		// Preserve options that also apply to ESX
 		model.Datastore = opts.Datastore
 		model.Machine = opts.Machine
+		model.Autostart = opts.Autostart
 	}
 
 	tag := " (govmomi simulator)"


### PR DESCRIPTION
- Add PowerOnVM method to object.Datacenter

- Add PowerOnMultiVMTask method to simulator.Datacenter

- Add '-M' flag to govc vm.power command

- Make it easier to call vcsim_env multiple times in a single test

- Add vcsim support 