### PR TITLE
object: Return correct helper object for OpaqueNetwork

### DIFF
--- a/object/types.go
+++ b/object/types.go
@@ -47,8 +47,10 @@ func NewReference(c *vim25.Client, e types.ManagedObjectReference) Reference {
 		return NewClusterComputeResource(c, e)
 	case "HostSystem":
 		return NewHostSystem(c, e)
-	case "Network", "OpaqueNetwork":
+	case "Network":
 		return NewNetwork(c, e)
+	case "OpaqueNetwork":
+		return NewOpaqueNetwork(c, e)
 	case "ResourcePool":
 		return NewResourcePool(c, e)
 	case "DistributedVirtualSwitch":


### PR DESCRIPTION
Currently, `object.NewReference` returns a generic `Network` object when
called for a `OpaqueNetwork` MO. This has the side effect of breaking
`EthernetCardBackingInfo`, which will no longer contain the information
relevant to NSX that is required to correctly attach to the
logical switch that the backing is trying to connect to.

This corrects this so that such references are correctly returned
`OpaqueNetwork` objects, from which the correct relevant backing formation
can be extracted.