### PR TITLE
Add 'Type' field to device.info -json output

### DIFF
--- a/govc/device/info.go
+++ b/govc/device/info.go
@@ -154,7 +154,11 @@ func toInfoList(devices object.VirtualDeviceList) []infoDevice {
 	var res []infoDevice
 
 	for _, device := range devices {
-		res = append(res, infoDevice{devices.Name(device), device})
+		res = append(res, infoDevice{
+			Name:              devices.Name(device),
+			Type:              devices.TypeName(device),
+			BaseVirtualDevice: device,
+		})
 	}
 
 	return res
@@ -162,6 +166,7 @@ func toInfoList(devices object.VirtualDeviceList) []infoDevice {
 
 type infoDevice struct {
 	Name string
+	Type string
 	types.BaseVirtualDevice
 }
 
@@ -173,7 +178,7 @@ func (d *infoDevice) MarshalJSON() ([]byte, error) {
 
 	// TODO: make use of "inline" tag if it comes to be: https://github.com/golang/go/issues/6213
 
-	return append([]byte(fmt.Sprintf(`{"Name":"%s",`, d.Name)), b[1:]...), err
+	return append([]byte(fmt.Sprintf(`{"Name":"%s","Type":"%s",`, d.Name, d.Type)), b[1:]...), err
 }
 
 type infoResult struct {

--- a/govc/test/device.bats
+++ b/govc/test/device.bats
@@ -33,6 +33,8 @@ load test_helper
 
   run govc device.info -vm $vm -json
   assert_matches ethernet-0
+  assert_matches '"Name":' # injected field
+  assert_matches '"Type":' # injected field
 }
 
 @test "device.boot" {


### PR DESCRIPTION
As with the 'Name' field, 'Type' is not a field of BaseVirtualDevice,
but is displayed without the '-json' flag.  Inject a 'Type' field as
we do with 'Name' so it is included with '-json'.

Fixes #1037