### PR TITLE
Property collector verifies the response propset

### DIFF
--- a/property/collector_test.go
+++ b/property/collector_test.go
@@ -1,0 +1,54 @@
+package property
+
+import (
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestVerifyRetrieveResult(t *testing.T) {
+	tests := []struct {
+		desc string
+		ps   []string
+		res  *types.RetrievePropertiesResponse
+		ok   bool
+	}{
+		{
+			"verified result",
+			[]string{"config.network", "config.option"},
+			&types.RetrievePropertiesResponse{
+				Returnval: []types.ObjectContent{
+					{
+						Obj: types.ManagedObjectReference{},
+						PropSet: []types.DynamicProperty{
+							{Name: "config.network", Val: "val"},
+							{Name: "config.option", Val: "val"},
+						},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"missing propset",
+			[]string{"config.network", "config.option"},
+			&types.RetrievePropertiesResponse{
+				Returnval: []types.ObjectContent{
+					{
+						Obj: types.ManagedObjectReference{},
+						PropSet: []types.DynamicProperty{
+							{Name: "config.network", Val: "val"},
+						},
+					},
+				},
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		if err := verifyAllPropSetNotNil(test.ps, test.res); (err == nil) != test.ok {
+			t.Errorf("verifyAllPropSetNotNil returns %q for %v", err, test.desc)
+		}
+	}
+}

--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/vmware/govmomi/simulator/vpx"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -187,13 +186,6 @@ func TestRetrieveProperties(t *testing.T) {
 		err = client.RetrieveOne(ctx, dc.Reference(), []string{"enoent"}, &mdc)
 		if err == nil {
 			t.Error("expected error")
-		} else {
-			switch fault := soap.ToVimFault(err).(type) {
-			case *types.InvalidProperty:
-				// ok
-			default:
-				t.Errorf("unexpected fault: %#v", fault)
-			}
 		}
 
 		// Retrieve a nested property
@@ -212,13 +204,6 @@ func TestRetrieveProperties(t *testing.T) {
 		err = client.RetrieveOne(ctx, dc.Reference(), []string{"configuration.enoent"}, &mdc)
 		if err == nil {
 			t.Error("expected error")
-		} else {
-			switch fault := soap.ToVimFault(err).(type) {
-			case *types.InvalidProperty:
-				// ok
-			default:
-				t.Errorf("unexpected fault: %#v", fault)
-			}
 		}
 
 		// Retrieve an empty property


### PR DESCRIPTION
When property collector retrieves a certian propset, it makes sure the response contains all the input propset. This will report error when it failed to retrieve property set on objects from remote server. 

Fix #1035