### PR TITLE
Avoid json encoding error in Go 1.10

### DIFF
--- a/govc/ls/command.go
+++ b/govc/ls/command.go
@@ -137,7 +137,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type listResult struct {
-	*ls
+	*ls      `json:"-"`
 	Elements []list.Element `json:"elements"`
 }
 

--- a/govc/test/ls.bats
+++ b/govc/test/ls.bats
@@ -11,6 +11,9 @@ load test_helper
   n=${#lines[@]}
   [ $n -ge 4 ]
 
+  run govc ls -json
+  assert_success
+
   # list entire inventory
   run govc ls '/**'
   assert_success


### PR DESCRIPTION
The ls command flags shouldn't be included with -json, ignore the embedded field.
This avoids the 1.10 json encoding error against the ClientFlag.Login (func) field.

Fixes #1042