### PR TITLE
In progress.Reader emit final report on EOF.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+* In progress.Reader emit final report on EOF.
+
 ### 0.17.0 (2018-02-28)
 
 * Add HostStorageSystem.AttachScsiLun method

--- a/vim25/progress/reader.go
+++ b/vim25/progress/reader.go
@@ -100,11 +100,12 @@ func NewReader(ctx context.Context, s Sinker, r io.Reader, size int64) *reader {
 // underlying channel.
 func (r *reader) Read(b []byte) (int, error) {
 	n, err := r.r.Read(b)
-	if err != nil {
+	r.pos += int64(n)
+
+	if err != nil && err != io.EOF {
 		return n, err
 	}
 
-	r.pos += int64(n)
 	q := readerReport{
 		t:    time.Now(),
 		pos:  r.pos,

--- a/vim25/progress/reader_test.go
+++ b/vim25/progress/reader_test.go
@@ -72,6 +72,7 @@ func TestReader(t *testing.T) {
 
 	// Read EOF
 	_, err = pr.Read(buf[:])
+	q = <-ch
 	if err != io.EOF {
 		t.Errorf("Expected io.EOF, but got: %s", err)
 	}


### PR DESCRIPTION
In go1.10 archive/tar Reader is emitting n, io.EOF with n > 0 (which is valid), this PR makes progress.Reader emit a Report in this case so that we get to 100.0% always.