### PR TITLE
Fix dvs.portgroup.info filtering

### DIFF
--- a/govc/flags/version.go
+++ b/govc/flags/version.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-const Version = "0.17.0"
+const Version = "0.17.1"
 
 type version []int
 

--- a/govc/test/network.bats
+++ b/govc/test/network.bats
@@ -176,6 +176,12 @@ load test_helper
   info=$(govc dvs.portgroup.info "$id" | grep VlanId: | uniq | grep 3123)
   [ -n "$info" ]
 
+  info=$(govc dvs.portgroup.info -json "$id" | jq  '.Port[].Config.Setting.Vlan | select(.VlanId == 3123)')
+  [ -n "$info" ]
+
+  info=$(govc dvs.portgroup.info -json "$id" | jq  '.Port[].Config.Setting.Vlan | select(.VlanId == 7777)')
+  [ -z "$info" ]
+
   run govc object.destroy "network/${id}-ExternalNetwork" "network/${id}-InternalNetwork" "network/${id}"
   assert_success
 }

--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -158,7 +158,8 @@ load test_helper
   assert_matches dvportgroup-
 
   run govc object.collect -s -type DistributedVirtualPortgroup / config.name
-  assert_success DC0_DVPG0
+  assert_matches DC0_DVPG0
+  assert_matches DVS0-DVUplinks-
 
   run govc object.collect -s -type DistributedVirtualPortgroup / effectiveRole
   assert_number
@@ -292,7 +293,7 @@ load test_helper
   assert_number
 
   run govc object.collect -s -type Network / summary.accessible
-  assert_success "$(printf "true\ntrue")"
+  assert_success "$(printf "true\ntrue\ntrue")"
 
   run govc object.collect -s -type Network / summary.ipPoolName
   assert_success ""

--- a/object/distributed_virtual_switch.go
+++ b/object/distributed_virtual_switch.go
@@ -66,9 +66,10 @@ func (s DistributedVirtualSwitch) AddPortgroup(ctx context.Context, spec []types
 	return NewTask(s.Client(), res.Returnval), nil
 }
 
-func (s DistributedVirtualSwitch) FetchDVPorts(ctx context.Context) ([]types.DistributedVirtualPort, error) {
+func (s DistributedVirtualSwitch) FetchDVPorts(ctx context.Context, criteria *types.DistributedVirtualSwitchPortCriteria) ([]types.DistributedVirtualPort, error) {
 	req := &types.FetchDVPorts{
-		This: s.Reference(),
+		This:     s.Reference(),
+		Criteria: criteria,
 	}
 
 	res, err := methods.FetchDVPorts(ctx, s.Client(), req)

--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -63,6 +63,12 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(c *types.AddDVPortgroup_Ta
 				VmVnicNetworkResourcePoolKey: spec.VmVnicNetworkResourcePoolKey,
 			}
 
+			if pg.Config.DefaultPortConfig == nil {
+				pg.Config.DefaultPortConfig = &types.VMwareDVSPortSetting{
+					Vlan: new(types.VmwareDistributedVirtualSwitchVlanIdSpec),
+				}
+			}
+
 			pg.PortKeys = []string{}
 
 			s.Portgroup = append(s.Portgroup, pg.Self)
@@ -113,10 +119,13 @@ func (s *DistributedVirtualSwitch) ReconfigureDvsTask(req *types.ReconfigureDvs_
 					Map.AddReference(pg, &pg.Host, member.Host)
 				}
 			case types.ConfigSpecOperationRemove:
-				if pg := FindReference(host.Network, s.Portgroup...); pg != nil {
-					return nil, &types.ResourceInUse{
-						Type: pg.Type,
-						Name: pg.Value,
+				for _, ref := range host.Vm {
+					vm := Map.Get(ref).(*VirtualMachine)
+					if pg := FindReference(vm.Network, s.Portgroup...); pg != nil {
+						return nil, &types.ResourceInUse{
+							Type: pg.Type,
+							Name: pg.Value,
+						}
 					}
 				}
 
@@ -171,10 +180,6 @@ func (s *DistributedVirtualSwitch) dvPortgroups(_ *types.DistributedVirtualSwitc
 				Setting: pg.Config.DefaultPortConfig,
 			},
 		})
-
-		if pg.PortKeys == nil {
-			continue
-		}
 
 		for _, key := range pg.PortKeys {
 			res = append(res, types.DistributedVirtualPort{

--- a/simulator/finder_test.go
+++ b/simulator/finder_test.go
@@ -67,8 +67,8 @@ func TestFinderVPX(t *testing.T) {
 		{"ManagedObjectList", "/DC0", 1},
 		{"ManagedObjectList", "/F[01]", 2},
 		{"ManagedObjectListChildren", "/*", m.Datacenter + 3},
-		{"ManagedObjectListChildren", "/*/*", 18},
-		{"ManagedObjectListChildren", "/*/*/*", 24},
+		{"ManagedObjectListChildren", "/*/*", 19},
+		{"ManagedObjectListChildren", "/*/*/*", 25},
 		{"FolderList", "/*", m.Folder},
 		{"DatacenterList", "/F0/*", 1},
 		{"DatacenterList", "/DC0", 1},
@@ -91,13 +91,13 @@ func TestFinderVPX(t *testing.T) {
 		{"ClusterComputeResourceList", "/DC0/host/*", m.Cluster},
 		{"HostSystemList", "/DC0/host/*", m.Host + m.ClusterHost},
 		{"HostSystemList", "/F0/DC1/host/F0/*", m.Host + m.ClusterHost},
-		{"HostSystemList", "DC1_H0", 1},             // find . -type HostSystem -name DC1_H0
-		{"ComputeResourceList", "DC1_H0", 1},        // find . -type ComputeResource -name DC1_H0
-		{"ClusterComputeResourceList", "DC1_C0", 1}, // find . -type ClusterComputeResource -name DC1_H0
-		{"NetworkList", "/DC0/network/*", 2 + m.Portgroup},
+		{"HostSystemList", "DC1_H0", 1},                    // find . -type HostSystem -name DC1_H0
+		{"ComputeResourceList", "DC1_H0", 1},               // find . -type ComputeResource -name DC1_H0
+		{"ClusterComputeResourceList", "DC1_C0", 1},        // find . -type ClusterComputeResource -name DC1_H0
+		{"NetworkList", "/DC0/network/*", 3 + m.Portgroup}, // VM Network + DSwitch + DSwitch-Uplinks + m.Portgroup
 		{"NetworkList", "./*", 1},
 		{"NetworkList", "/F0/DC1/network/VM Network", 1},
-		{"NetworkList", "/F0/DC1/network/F0/*", 1 + m.Portgroup},
+		{"NetworkList", "/F0/DC1/network/F0/*", 2 + m.Portgroup},
 		{"NetworkList", "./F0/DC1_DVPG0", 1},
 		{"NetworkList", "./F0/DC1_DVPG0", 1},
 		{"NetworkList", "DC1_DVPG0", 1}, // find . -type Network -name DC1_DVPG0

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"path"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -513,6 +514,17 @@ func (f *Folder) CreateDVSTask(req *types.CreateDVS_Task) soap.HasFault {
 				ForwardingClass: "etherswitch",
 			}
 		}
+
+		dvs.AddDVPortgroupTask(&types.AddDVPortgroup_Task{
+			Spec: []types.DVPortgroupConfigSpec{{
+				Name: dvs.Name + "-DVUplinks" + strings.TrimPrefix(dvs.Self.Value, "dvs"),
+				DefaultPortConfig: &types.VMwareDVSPortSetting{
+					Vlan: &types.VmwareDistributedVirtualSwitchTrunkVlanSpec{
+						VlanId: []types.NumericRange{{Start: 0, End: 4094}},
+					},
+				},
+			}},
+		})
 
 		return dvs.Reference(), nil
 	})

--- a/simulator/model_test.go
+++ b/simulator/model_test.go
@@ -31,6 +31,10 @@ func compareModel(t *testing.T, m *Model) {
 	pools := (m.Pool * m.Cluster * m.Datacenter) + (m.Host+m.Cluster)*m.Datacenter
 	// root folder + Datacenter folders {host,vm,datastore,network} + top-level folders
 	folders := 1 + (4 * m.Datacenter) + (5 * m.Folder)
+	pgs := m.Portgroup
+	if pgs > 0 {
+		pgs++ // uplinks
+	}
 
 	tests := []struct {
 		expect int
@@ -39,7 +43,7 @@ func compareModel(t *testing.T, m *Model) {
 	}{
 		{m.Datacenter, count.Datacenter, "Datacenter"},
 		{m.Cluster * m.Datacenter, count.Cluster, "Cluster"},
-		{m.Portgroup * m.Datacenter, count.Portgroup, "Portgroup"},
+		{pgs * m.Datacenter, count.Portgroup, "Portgroup"},
 		{m.Datastore * m.Datacenter, count.Datastore, "Datastore"},
 		{hosts, count.Host, "Host"},
 		{vms, count.Machine, "VirtualMachine"},

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -40,6 +40,7 @@ var refValueMap = map[string]string{
 	"VirtualMachine":                 "vm",
 	"VirtualMachineSnapshot":         "snapshot",
 	"VmwareDistributedVirtualSwitch": "dvs",
+	"DistributedVirtualSwitch":       "dvs",
 }
 
 // Map is the default Registry instance.


### PR DESCRIPTION
This regression was introduced by 585cf5e , where the DistributedVirtualSwitch
FetchDVPorts wrapper was added to the object package. The new method did not
include the optional 'Criteria' param, so no filtering was applied to the
dvs.portgroup.info command.  The command would panic on uplink portgroups, which
are normally filtered out by default.  But the same panic would happen 0.15 if
the '-uplinkPort' flag is given.

This change also adds an uplink portgroup to simulator switches, which would
reproduce the issue.

The dvs.portgroup.info command now has support for using the '-json' and '-dump' flags.

Fixes #1059
Fixes #1060