### PR TITLE
Add goreleaser to automate release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 secrets.yml
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,57 @@
+---
+project_name: govc
+builds:
+- goos:
+  - linux
+  - darwin
+  - windows
+  - freebsd
+  goarch:
+  - amd64
+  - 386
+  env:
+  - CGO_ENABLED=0
+  main: ./govc/main.go
+  binary: govc
+  flags: -compiler gc
+  ldflags: -X github.com/vmware/govmomi/govc/flags.GitVersion={{.Version}}
+archive:
+  name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
+  format: tar.gz
+  format_overrides:
+    - goos: windows
+      format: zip
+  files:
+  - none*
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - Merge pull request
+      - Merge branch
+brew:
+  github:
+    owner: govmomi
+    name: homebrew-tap
+  commit_author:
+    name: Alfred the Narwhal
+    email: cna-alfred@vmware.com
+  folder: Formula
+  homepage: "https://github.com/vmware/govmomi/blob/master/govc/README.md"
+  description: "govc is a vSphere CLI built on top of govmomi."
+  test: |
+    system "#{bin}/govc version"
+dockers:
+  - image: vmware/govc
+    goos: linux
+    goarch: amd64
+    binary: govc
+    tag_templates:
+    - "{{ .Tag }}"
+    - "v{{ .Major }}"
+    - "v{{ .Major }}.{{ .Minor }}"
+    - latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ sudo: false
 language: go
 
 go:
-   - 1.8
+   - 1.8.x
+   - 1.9.x
+   - '1.10'
+go_import_path: github.com/vmware/govmomi
 
 before_install:
   - make vendor
@@ -11,3 +14,15 @@ before_install:
 script:
   - make check test
   - GOOS=windows make install
+
+after_success:
+  - test -n "$TRAVIS_TAG" && docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: curl -sL http://git.io/goreleaser | bash
+  on:
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux
+    go: '1.10'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+LABEL maintainer="fabio@vmware.com"
+COPY govc /
+ENTRYPOINT [ "/govc" ]

--- a/govc/flags/version.go
+++ b/govc/flags/version.go
@@ -21,13 +21,16 @@ import (
 	"strings"
 )
 
-const Version = "0.17.1"
+const Version = "0.17.1-dev"
+
+var GitVersion string
 
 type version []int
 
 func ParseVersion(s string) (version, error) {
 	v := make(version, 0)
-	ps := strings.Split(s, ".")
+	ds := strings.Split(s, "-")
+	ps := strings.Split(ds[0], ".")
 	for _, p := range ps {
 		i, err := strconv.Atoi(p)
 		if err != nil {

--- a/govc/version/command.go
+++ b/govc/version/command.go
@@ -20,13 +20,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 )
-
-var gitVersion string
 
 type version struct {
 	*flags.EmptyFlag
@@ -35,11 +32,6 @@ type version struct {
 }
 
 func init() {
-	// Check that git tag in the release builds match the hardcoded version
-	if gitVersion != "" && gitVersion[1:] != flags.Version {
-		log.Panicf("version mismatch: git=%s vs govc=%s", gitVersion[1:], flags.Version)
-	}
-
 	cli.Register("version", &version{})
 }
 
@@ -48,8 +40,13 @@ func (cmd *version) Register(ctx context.Context, f *flag.FlagSet) {
 }
 
 func (cmd *version) Run(ctx context.Context, f *flag.FlagSet) error {
+	ver := flags.GitVersion
+	if ver == "" {
+		ver = flags.Version
+	}
+
 	if cmd.require != "" {
-		v, err := flags.ParseVersion(flags.Version)
+		v, err := flags.ParseVersion(ver)
 		if err != nil {
 			panic(err)
 		}
@@ -60,10 +57,11 @@ func (cmd *version) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		if !rv.Lte(v) {
-			return fmt.Errorf("version %s or higher is required, this is version %s", cmd.require, flags.Version)
+			return fmt.Errorf("version %s or higher is required, this is version %s", cmd.require, ver)
 		}
 	}
 
-	fmt.Printf("govc %s\n", flags.Version)
+	fmt.Printf("govc %s\n", ver)
+
 	return nil
 }


### PR DESCRIPTION
This sets up `goreleaser` to cut a new `govc` release and automate the publish process through Travis.

It requires `DOCKER_USERNAME`, `DOCKER_PASSWORD` and `GITHUB_TOKEN` to be available on the Travis job for govmomi in order to make deploy succeed (will set up once it's merged).