### PR TITLE
Lookup Service support

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/vmware/govmomi/test"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
@@ -74,7 +75,7 @@ func TestNewClient(t *testing.T) {
 	}
 
 	// invalid login
-	u.Path = "/sdk"
+	u.Path = vim25.Path
 	u.User = url.UserPassword("ENOENT", "EINVAL")
 	_, err = NewClient(context.Background(), u, true)
 	if err == nil {

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
@@ -61,7 +62,7 @@ const (
 )
 
 var urlDescription = fmt.Sprintf("ESX or vCenter URL [%s]", envURL)
-var urlFlag = flag.String("url", getEnvString(envURL, "https://username:password@host/sdk"), urlDescription)
+var urlFlag = flag.String("url", getEnvString(envURL, "https://username:password@host"+vim25.Path), urlDescription)
 
 var insecureDescription = fmt.Sprintf("Don't verify the server's certificate chain [%s]", envInsecure)
 var insecureFlag = flag.Bool("insecure", getEnvBool(envInsecure, false), insecureDescription)

--- a/gen/gen.sh
+++ b/gen/gen.sh
@@ -51,3 +51,5 @@ generate() {
 
 generate "../vim25" "vim" "./rbvmomi/vmodl.db" # from github.com/vmware/rbvmomi@f6907e6
 generate "../pbm" "pbm"
+# originally generated, then manually pruned as there are several vim25 types that are duplicated.
+# generate "../lookup" "lookup" # lookup.wsdl from build 4571810

--- a/govc/emacs/govc.el
+++ b/govc/emacs/govc.el
@@ -966,7 +966,7 @@ Inherit SESSION if given."
 ;;; govc host mode
 (defun govc-ls-host ()
   "List hosts."
-  (govc "ls" "-t" "HostSystem" "host/*"))
+  (govc "ls" "-t" "HostSystem" "./..."))
 
 (defun govc-esxcli-netstat-info ()
   "Wrapper for govc host.esxcli network ip connection list."
@@ -1456,7 +1456,8 @@ With prefix \\[universal-argument] ARG, launches an interactive console (VMRC)."
 
 (defun govc-vm-info ()
   "Wrapper for govc vm.info."
-  (govc-table-info "vm.info" (list "-r" (or govc-filter (setq govc-filter "*")))))
+  (unless (string-empty-p govc-session-datacenter)
+    (govc-table-info "vm.info" (list "-r" (or govc-filter (setq govc-filter "*"))))))
 
 (defun govc-vm-host ()
   "Host info via `govc-host' with host(s) of current selection."

--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -51,6 +51,8 @@ const (
 	envVimVersion    = "GOVC_VIM_VERSION"
 	envTLSCaCerts    = "GOVC_TLS_CA_CERTS"
 	envTLSKnownHosts = "GOVC_TLS_KNOWN_HOSTS"
+
+	defaultMinVimVersion = "5.5"
 )
 
 const cDescr = "ESX or vCenter URL"
@@ -187,7 +189,7 @@ func (flag *ClientFlag) Register(ctx context.Context, f *flag.FlagSet) {
 		{
 			env := os.Getenv(envMinAPIVersion)
 			if env == "" {
-				env = soap.DefaultMinVimVersion
+				env = defaultMinVimVersion
 			}
 
 			flag.minAPIVersion = env
@@ -196,7 +198,7 @@ func (flag *ClientFlag) Register(ctx context.Context, f *flag.FlagSet) {
 		{
 			value := os.Getenv(envVimNamespace)
 			if value == "" {
-				value = soap.DefaultVimNamespace
+				value = vim25.Namespace
 			}
 			usage := fmt.Sprintf("Vim namespace [%s]", envVimNamespace)
 			f.StringVar(&flag.vimNamespace, "vim-namespace", value, usage)
@@ -205,7 +207,7 @@ func (flag *ClientFlag) Register(ctx context.Context, f *flag.FlagSet) {
 		{
 			value := os.Getenv(envVimVersion)
 			if value == "" {
-				value = soap.DefaultVimVersion
+				value = vim25.Version
 			}
 			usage := fmt.Sprintf("Vim version [%s]", envVimVersion)
 			f.StringVar(&flag.vimVersion, "vim-version", value, usage)
@@ -577,7 +579,7 @@ func (flag *ClientFlag) Environ(extra bool) []string {
 		u.User = nil
 	}
 
-	if u.Path == "/sdk" {
+	if u.Path == vim25.Path {
 		u.Path = ""
 	}
 	u.Fragment = ""

--- a/govc/main.go
+++ b/govc/main.go
@@ -70,6 +70,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/pool"
 	_ "github.com/vmware/govmomi/govc/role"
 	_ "github.com/vmware/govmomi/govc/session"
+	_ "github.com/vmware/govmomi/govc/sso/service"
 	_ "github.com/vmware/govmomi/govc/task"
 	_ "github.com/vmware/govmomi/govc/vapp"
 	_ "github.com/vmware/govmomi/govc/version"

--- a/govc/object/collect.go
+++ b/govc/object/collect.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
@@ -317,7 +318,7 @@ func (cmd *collect) Run(ctx context.Context, f *flag.FlagSet) error {
 	filter := new(property.WaitFilter)
 
 	if cmd.raw == "" {
-		ref := methods.ServiceInstance
+		ref := vim25.ServiceInstance
 		arg := f.Arg(0)
 
 		if len(cmd.kind) != 0 {

--- a/govc/sso/service/ls.go
+++ b/govc/sso/service/ls.go
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/lookup"
+	"github.com/vmware/govmomi/lookup/types"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	long bool
+
+	types.LookupServiceRegistrationFilter
+}
+
+func init() {
+	cli.Register("sso.service.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing format")
+
+	cmd.LookupServiceRegistrationFilter.EndpointType = new(types.LookupServiceRegistrationEndpointType)
+	cmd.LookupServiceRegistrationFilter.ServiceType = new(types.LookupServiceRegistrationServiceType)
+	f.StringVar(&cmd.SiteId, "s", "", "Site ID")
+	f.StringVar(&cmd.NodeId, "n", "", "Node ID")
+	f.StringVar(&cmd.ServiceType.Type, "t", "", "Service type")
+	f.StringVar(&cmd.ServiceType.Product, "p", "", "Service product")
+	f.StringVar(&cmd.EndpointType.Type, "T", "", "Endpoint type")
+	f.StringVar(&cmd.EndpointType.Protocol, "P", "", "Endpoint protocol")
+}
+
+func (cmd *ls) Description() string {
+	return `List platform services.
+
+Examples:
+  govc sso.service.ls
+  govc sso.service.ls -t vcenterserver -P vmomi
+  govc sso.service.ls -t sso:sts
+  govc sso.service.ls -t sso:sts -json | jq -r .[].ServiceEndpoints[].Url`
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+type infoResult []types.LookupServiceRegistrationInfo
+
+func (r infoResult) Dump() interface{} {
+	return []types.LookupServiceRegistrationInfo(r)
+}
+
+func (r infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, info := range r {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", info.ServiceType.Product, info.ServiceType.Type, info.ServiceId)
+	}
+
+	return tw.Flush()
+}
+
+type infoResultLong []types.LookupServiceRegistrationInfo
+
+func (r infoResultLong) Dump() interface{} {
+	return []types.LookupServiceRegistrationInfo(r)
+}
+
+func (r infoResultLong) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, info := range r {
+		for _, s := range info.ServiceEndpoints {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				info.ServiceType.Product, info.ServiceType.Type, info.ServiceId,
+				s.EndpointType.Protocol, s.EndpointType.Type, s.Url)
+		}
+	}
+
+	return tw.Flush()
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	vc, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	c, err := lookup.NewClient(ctx, vc)
+	if err != nil {
+		return err
+	}
+
+	info, err := c.List(ctx, &cmd.LookupServiceRegistrationFilter)
+	if err != nil {
+		return err
+	}
+
+	if cmd.long {
+		return cmd.WriteResult(infoResultLong(info))
+	}
+	return cmd.WriteResult(infoResult(info))
+}

--- a/govc/test/sso.bats
+++ b/govc/test/sso.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "sso.service.ls" {
+  vcsim_env
+
+  run govc sso.service.ls
+  assert_success
+
+  run govc sso.service.ls -l
+  assert_success
+
+  run govc sso.service.ls -json
+  assert_success
+
+  run govc sso.service.ls -dump
+  assert_success
+
+  [ -z "$(govc sso.service.ls -t enoent)" ]
+
+  govc sso.service.ls -t sso:sts | grep com.vmware.cis | grep -v https:
+  govc sso.service.ls -t sso:sts -l | grep https:
+  govc sso.service.ls -p com.vmware.cis -t sso:sts -P wsTrust -T com.vmware.cis.cs.identity.sso -l | grep wsTrust
+  govc sso.service.ls -P vmomi | grep vcenterserver | grep -v https:
+  govc sso.service.ls -P vmomi -l | grep https:
+}

--- a/lookup/client.go
+++ b/lookup/client.go
@@ -1,0 +1,135 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lookup
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"log"
+	"net/url"
+
+	"github.com/vmware/govmomi/lookup/methods"
+	"github.com/vmware/govmomi/lookup/types"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	vim "github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	Namespace = "lookup"
+	Version   = "2.0"
+	Path      = "/lookupservice" + vim25.Path
+)
+
+var (
+	ServiceInstance = vim.ManagedObjectReference{
+		Type:  "LookupServiceInstance",
+		Value: "ServiceInstance",
+	}
+)
+
+// Client is a soap.Client targeting the SSO Lookup Service API endpoint.
+type Client struct {
+	*soap.Client
+
+	ServiceContent types.LookupServiceContent
+}
+
+// NewClient returns a client targeting the SSO Lookup Service API endpoint.
+func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
+	sc := c.Client.NewServiceClient(Path, Namespace)
+	sc.Version = Version
+
+	req := types.RetrieveServiceContent{
+		This: ServiceInstance,
+	}
+
+	res, err := methods.RetrieveServiceContent(ctx, sc, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{sc, res.Returnval}, nil
+}
+
+func (c *Client) List(ctx context.Context, filter *types.LookupServiceRegistrationFilter) ([]types.LookupServiceRegistrationInfo, error) {
+	req := types.List{
+		This:           *c.ServiceContent.ServiceRegistration,
+		FilterCriteria: filter,
+	}
+
+	res, err := methods.List(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+	return res.Returnval, nil
+}
+
+func (c *Client) SiteID(ctx context.Context) (string, error) {
+	req := types.GetSiteId{
+		This: *c.ServiceContent.ServiceRegistration,
+	}
+
+	res, err := methods.GetSiteId(ctx, c, &req)
+	if err != nil {
+		return "", err
+	}
+	return res.Returnval, nil
+}
+
+// EndpointURL uses the Lookup Service to find the endpoint URL and thumbprint for the given filter.
+// If the endpoint is found, its TLS certificate is also added to the vim25.Client's trusted host thumbprints.
+// If the Lookup Service is not available, the given path is returned as the default.
+func EndpointURL(ctx context.Context, c *vim25.Client, path string, filter *types.LookupServiceRegistrationFilter) string {
+	if lu, err := NewClient(ctx, c); err == nil {
+		info, _ := lu.List(ctx, filter)
+		if len(info) != 0 && len(info[0].ServiceEndpoints) != 0 {
+			endpoint := &info[0].ServiceEndpoints[0]
+			path = endpoint.Url
+
+			if u, err := url.Parse(path); err == nil {
+				if c.Thumbprint(u.Host) == "" {
+					c.SetThumbprint(u.Host, endpointThumbprint(endpoint))
+				}
+			}
+		}
+	}
+	return path
+}
+
+// endpointThumbprint converts the base64 encoded endpoint certificate to a SHA1 thumbprint.
+func endpointThumbprint(endpoint *types.LookupServiceRegistrationEndpoint) string {
+	if len(endpoint.SslTrust) == 0 {
+		return ""
+	}
+	enc := endpoint.SslTrust[0]
+
+	b, err := base64.StdEncoding.DecodeString(enc)
+	if err != nil {
+		log.Printf("base64.Decode(%q): %s", enc, err)
+		return ""
+	}
+
+	cert, err := x509.ParseCertificate(b)
+	if err != nil {
+		log.Printf("x509.ParseCertificate(%q): %s", enc, err)
+		return ""
+	}
+
+	return soap.ThumbprintSHA1(cert)
+}

--- a/lookup/client_test.go
+++ b/lookup/client_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lookup
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/simulator/vpx"
+)
+
+func TestClient(t *testing.T) {
+	// lookup/simulator/simulator_test.go has the functional test..
+	// in this test we just verify requests to /lookup/sdk return 404
+	s := simulator.New(simulator.NewServiceInstance(vpx.ServiceContent, vpx.RootFolder))
+
+	ts := s.NewServer()
+	defer ts.Close()
+
+	ctx := context.Background()
+
+	vc, err := govmomi.NewClient(ctx, ts.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = NewClient(ctx, vc.Client)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), http.StatusText(404)) {
+		t.Errorf("err=%s", err)
+	}
+}

--- a/lookup/methods/methods.go
+++ b/lookup/methods/methods.go
@@ -1,0 +1,224 @@
+/*
+Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package methods
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/lookup/types"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type CreateBody struct {
+	Req    *types.Create         `xml:"urn:lookup Create,omitempty"`
+	Res    *types.CreateResponse `xml:"urn:lookup CreateResponse,omitempty"`
+	Fault_ *soap.Fault           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CreateBody) Fault() *soap.Fault { return b.Fault_ }
+
+func Create(ctx context.Context, r soap.RoundTripper, req *types.Create) (*types.CreateResponse, error) {
+	var reqBody, resBody CreateBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DeleteBody struct {
+	Req    *types.Delete         `xml:"urn:lookup Delete,omitempty"`
+	Res    *types.DeleteResponse `xml:"urn:lookup DeleteResponse,omitempty"`
+	Fault_ *soap.Fault           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DeleteBody) Fault() *soap.Fault { return b.Fault_ }
+
+func Delete(ctx context.Context, r soap.RoundTripper, req *types.Delete) (*types.DeleteResponse, error) {
+	var reqBody, resBody DeleteBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetBody struct {
+	Req    *types.Get         `xml:"urn:lookup Get,omitempty"`
+	Res    *types.GetResponse `xml:"urn:lookup GetResponse,omitempty"`
+	Fault_ *soap.Fault        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetBody) Fault() *soap.Fault { return b.Fault_ }
+
+func Get(ctx context.Context, r soap.RoundTripper, req *types.Get) (*types.GetResponse, error) {
+	var reqBody, resBody GetBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetLocaleBody struct {
+	Req    *types.GetLocale         `xml:"urn:lookup GetLocale,omitempty"`
+	Res    *types.GetLocaleResponse `xml:"urn:lookup GetLocaleResponse,omitempty"`
+	Fault_ *soap.Fault              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetLocaleBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetLocale(ctx context.Context, r soap.RoundTripper, req *types.GetLocale) (*types.GetLocaleResponse, error) {
+	var reqBody, resBody GetLocaleBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetSiteIdBody struct {
+	Req    *types.GetSiteId         `xml:"urn:lookup GetSiteId,omitempty"`
+	Res    *types.GetSiteIdResponse `xml:"urn:lookup GetSiteIdResponse,omitempty"`
+	Fault_ *soap.Fault              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetSiteIdBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetSiteId(ctx context.Context, r soap.RoundTripper, req *types.GetSiteId) (*types.GetSiteIdResponse, error) {
+	var reqBody, resBody GetSiteIdBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ListBody struct {
+	Req    *types.List         `xml:"urn:lookup List,omitempty"`
+	Res    *types.ListResponse `xml:"urn:lookup ListResponse,omitempty"`
+	Fault_ *soap.Fault         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ListBody) Fault() *soap.Fault { return b.Fault_ }
+
+func List(ctx context.Context, r soap.RoundTripper, req *types.List) (*types.ListResponse, error) {
+	var reqBody, resBody ListBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveHaBackupConfigurationBody struct {
+	Req    *types.RetrieveHaBackupConfiguration         `xml:"urn:lookup RetrieveHaBackupConfiguration,omitempty"`
+	Res    *types.RetrieveHaBackupConfigurationResponse `xml:"urn:lookup RetrieveHaBackupConfigurationResponse,omitempty"`
+	Fault_ *soap.Fault                                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveHaBackupConfigurationBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveHaBackupConfiguration(ctx context.Context, r soap.RoundTripper, req *types.RetrieveHaBackupConfiguration) (*types.RetrieveHaBackupConfigurationResponse, error) {
+	var reqBody, resBody RetrieveHaBackupConfigurationBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveServiceContentBody struct {
+	Req    *types.RetrieveServiceContent         `xml:"urn:lookup RetrieveServiceContent,omitempty"`
+	Res    *types.RetrieveServiceContentResponse `xml:"urn:lookup RetrieveServiceContentResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveServiceContentBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveServiceContent(ctx context.Context, r soap.RoundTripper, req *types.RetrieveServiceContent) (*types.RetrieveServiceContentResponse, error) {
+	var reqBody, resBody RetrieveServiceContentBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SetBody struct {
+	Req    *types.Set         `xml:"urn:lookup Set,omitempty"`
+	Res    *types.SetResponse `xml:"urn:lookup SetResponse,omitempty"`
+	Fault_ *soap.Fault        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetBody) Fault() *soap.Fault { return b.Fault_ }
+
+func Set(ctx context.Context, r soap.RoundTripper, req *types.Set) (*types.SetResponse, error) {
+	var reqBody, resBody SetBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SetLocaleBody struct {
+	Req    *types.SetLocale         `xml:"urn:lookup SetLocale,omitempty"`
+	Res    *types.SetLocaleResponse `xml:"urn:lookup SetLocaleResponse,omitempty"`
+	Fault_ *soap.Fault              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetLocaleBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SetLocale(ctx context.Context, r soap.RoundTripper, req *types.SetLocale) (*types.SetLocaleResponse, error) {
+	var reqBody, resBody SetLocaleBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/lookup/simulator/registration_info.go
+++ b/lookup/simulator/registration_info.go
@@ -1,0 +1,129 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"github.com/google/uuid"
+	"github.com/vmware/govmomi/lookup"
+	"github.com/vmware/govmomi/lookup/types"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+)
+
+var (
+	siteID = "vcsim"
+)
+
+// registrationInfo returns a ServiceRegistration populated with vcsim's OptionManager settings.
+// The complete list can be captured using: govc sso.service.ls -dump
+func registrationInfo() []types.LookupServiceRegistrationInfo {
+	vc := simulator.Map.Get(vim25.ServiceInstance).(*simulator.ServiceInstance)
+	setting := simulator.Map.OptionManager().Setting
+	opts := make(map[string]string, len(setting))
+
+	for _, o := range setting {
+		opt := o.GetOptionValue()
+		if val, ok := opt.Value.(string); ok {
+			opts[opt.Key] = val
+		}
+	}
+
+	trust := []string{opts["vcsim.server.cert"]}
+	sdk := opts["vcsim.server.url"] + vim25.Path
+	admin := opts["config.vpxd.sso.default.admin"]
+	owner := opts["config.vpxd.sso.solutionUser.name"]
+	instance := opts["VirtualCenter.InstanceName"]
+
+	// Real PSC has 30+ services by default, we just provide a few that are useful for vmomi interaction..
+	return []types.LookupServiceRegistrationInfo{
+		{
+			LookupServiceRegistrationCommonServiceInfo: types.LookupServiceRegistrationCommonServiceInfo{
+				LookupServiceRegistrationMutableServiceInfo: types.LookupServiceRegistrationMutableServiceInfo{
+					ServiceVersion: lookup.Version,
+					ServiceEndpoints: []types.LookupServiceRegistrationEndpoint{
+						{
+							Url: opts["config.vpxd.sso.sts.uri"],
+							EndpointType: types.LookupServiceRegistrationEndpointType{
+								Protocol: "wsTrust",
+								Type:     "com.vmware.cis.cs.identity.sso",
+							},
+							SslTrust: trust,
+						},
+					},
+				},
+				OwnerId: admin,
+				ServiceType: types.LookupServiceRegistrationServiceType{
+					Product: "com.vmware.cis",
+					Type:    "sso:sts",
+				},
+			},
+			ServiceId: siteID + ":" + uuid.New().String(),
+			SiteId:    siteID,
+		},
+		{
+			LookupServiceRegistrationCommonServiceInfo: types.LookupServiceRegistrationCommonServiceInfo{
+				LookupServiceRegistrationMutableServiceInfo: types.LookupServiceRegistrationMutableServiceInfo{
+					ServiceVersion: vim25.Version,
+					ServiceEndpoints: []types.LookupServiceRegistrationEndpoint{
+						{
+							Url: sdk,
+							EndpointType: types.LookupServiceRegistrationEndpointType{
+								Protocol: "vmomi",
+								Type:     "com.vmware.vim",
+							},
+							SslTrust: trust,
+							EndpointAttributes: []types.LookupServiceRegistrationAttribute{
+								{
+									Key:   "cis.common.ep.localurl",
+									Value: sdk,
+								},
+							},
+						},
+					},
+					ServiceAttributes: []types.LookupServiceRegistrationAttribute{
+						{
+							Key:   "com.vmware.cis.cm.GroupInternalId",
+							Value: "com.vmware.vim.vcenter",
+						},
+						{
+							Key:   "com.vmware.vim.vcenter.instanceName",
+							Value: instance,
+						},
+						{
+							Key:   "com.vmware.cis.cm.ControlScript",
+							Value: "service-control-default-vmon",
+						},
+						{
+							Key:   "com.vmware.cis.cm.HostId",
+							Value: uuid.New().String(),
+						},
+					},
+					ServiceNameResourceKey:        "AboutInfo.vpx.name",
+					ServiceDescriptionResourceKey: "AboutInfo.vpx.name",
+				},
+				OwnerId: owner,
+				ServiceType: types.LookupServiceRegistrationServiceType{
+					Product: "com.vmware.cis",
+					Type:    "vcenterserver",
+				},
+				NodeId: uuid.New().String(),
+			},
+			ServiceId: vc.Content.About.InstanceUuid,
+			SiteId:    siteID,
+		},
+	}
+}

--- a/lookup/simulator/simulator.go
+++ b/lookup/simulator/simulator.go
@@ -1,0 +1,158 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"github.com/vmware/govmomi/lookup"
+	"github.com/vmware/govmomi/lookup/methods"
+	"github.com/vmware/govmomi/lookup/types"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/soap"
+	vim "github.com/vmware/govmomi/vim25/types"
+)
+
+var content = types.LookupServiceContent{
+	LookupService:                vim.ManagedObjectReference{Type: "LookupLookupService", Value: "lookupService"},
+	ServiceRegistration:          &vim.ManagedObjectReference{Type: "LookupServiceRegistration", Value: "ServiceRegistration"},
+	DeploymentInformationService: vim.ManagedObjectReference{Type: "LookupDeploymentInformationService", Value: "deploymentInformationService"},
+	L10n: vim.ManagedObjectReference{Type: "LookupL10n", Value: "l10n"},
+}
+
+func New() *simulator.Registry {
+	r := simulator.NewRegistry()
+	r.Namespace = lookup.Namespace
+	r.Path = lookup.Path
+
+	r.Put(&ServiceInstance{
+		ManagedObjectReference: lookup.ServiceInstance,
+		Content:                content,
+	})
+	r.Put(&ServiceRegistration{
+		ManagedObjectReference: *content.ServiceRegistration,
+		Info: registrationInfo(),
+	})
+
+	return r
+}
+
+type ServiceInstance struct {
+	vim.ManagedObjectReference
+
+	Content types.LookupServiceContent
+}
+
+func (s *ServiceInstance) RetrieveServiceContent(_ *types.RetrieveServiceContent) soap.HasFault {
+	return &methods.RetrieveServiceContentBody{
+		Res: &types.RetrieveServiceContentResponse{
+			Returnval: s.Content,
+		},
+	}
+}
+
+type ServiceRegistration struct {
+	vim.ManagedObjectReference
+
+	Info []types.LookupServiceRegistrationInfo
+}
+
+func (s *ServiceRegistration) GetSiteId(_ *types.GetSiteId) soap.HasFault {
+	return &methods.GetSiteIdBody{
+		Res: &types.GetSiteIdResponse{
+			Returnval: siteID,
+		},
+	}
+}
+
+func matchServiceType(filter, info *types.LookupServiceRegistrationServiceType) bool {
+	if filter.Product != "" {
+		if filter.Product != info.Product {
+			return false
+		}
+	}
+
+	if filter.Type != "" {
+		if filter.Type != info.Type {
+			return false
+		}
+	}
+
+	return true
+}
+
+func matchEndpointType(filter, info *types.LookupServiceRegistrationEndpointType) bool {
+	if filter.Protocol != "" {
+		if filter.Protocol != info.Protocol {
+			return false
+		}
+	}
+
+	if filter.Type != "" {
+		if filter.Type != info.Type {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (s *ServiceRegistration) List(req *types.List) soap.HasFault {
+	body := new(methods.ListBody)
+	filter := req.FilterCriteria
+
+	if filter == nil {
+		// This is what a real PSC returns if FilterCriteria is nil.
+		body.Fault_ = simulator.Fault("LookupFaultServiceFault", &vim.SystemError{
+			Reason: "Invalid fault",
+		})
+		return body
+	}
+	body.Res = new(types.ListResponse)
+
+	for _, info := range s.Info {
+		if filter.SiteId != "" {
+			if filter.SiteId != info.SiteId {
+				continue
+			}
+		}
+		if filter.NodeId != "" {
+			if filter.NodeId != info.NodeId {
+				continue
+			}
+		}
+		if filter.ServiceType != nil {
+			if !matchServiceType(filter.ServiceType, &info.ServiceType) {
+				continue
+			}
+		}
+		if filter.EndpointType != nil {
+			services := info.ServiceEndpoints
+			info.ServiceEndpoints = nil
+			for _, service := range services {
+				if !matchEndpointType(filter.EndpointType, &service.EndpointType) {
+					continue
+				}
+				info.ServiceEndpoints = append(info.ServiceEndpoints, service)
+			}
+			if len(info.ServiceEndpoints) == 0 {
+				continue
+			}
+		}
+		body.Res.Returnval = append(body.Res.Returnval, info)
+	}
+
+	return body
+}

--- a/lookup/simulator/simulator_test.go
+++ b/lookup/simulator/simulator_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/lookup"
+	"github.com/vmware/govmomi/lookup/types"
+	"github.com/vmware/govmomi/simulator"
+)
+
+func TestClient(t *testing.T) {
+	ctx := context.Background()
+
+	model := simulator.VPX()
+
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	model.Service.RegisterSDK(New())
+
+	vc, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := lookup.NewClient(ctx, vc.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id, err := c.SiteID(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != siteID {
+		t.Errorf("SiteID=%s", id)
+	}
+
+	vc.Logout(ctx) // List does not require authentication
+
+	_, err = c.List(ctx, nil)
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	// test filters that should return 1 service
+	filters := []*types.LookupServiceRegistrationFilter{
+		&types.LookupServiceRegistrationFilter{
+			ServiceType: &types.LookupServiceRegistrationServiceType{
+				Product: "com.vmware.cis",
+				Type:    "vcenterserver",
+			},
+			EndpointType: &types.LookupServiceRegistrationEndpointType{
+				Protocol: "vmomi",
+				Type:     "com.vmware.vim",
+			},
+		},
+		&types.LookupServiceRegistrationFilter{
+			ServiceType: &types.LookupServiceRegistrationServiceType{
+				Type: "sso:sts",
+			},
+		},
+		&types.LookupServiceRegistrationFilter{
+			ServiceType: &types.LookupServiceRegistrationServiceType{},
+			EndpointType: &types.LookupServiceRegistrationEndpointType{
+				Protocol: "vmomi",
+			},
+		},
+	}
+
+	for _, filter := range filters {
+		info, err := c.List(ctx, filter)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(info) != 1 {
+			t.Errorf("len=%d", len(info))
+		}
+
+		filter.ServiceType.Type = "enoent"
+
+		info, err = c.List(ctx, filter)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(info) != 0 {
+			t.Errorf("len=%d", len(info))
+		}
+	}
+
+	// "empty" filters should return all services
+	filters = []*types.LookupServiceRegistrationFilter{
+		&types.LookupServiceRegistrationFilter{},
+		&types.LookupServiceRegistrationFilter{
+			ServiceType:  new(types.LookupServiceRegistrationServiceType),
+			EndpointType: new(types.LookupServiceRegistrationEndpointType),
+		},
+		&types.LookupServiceRegistrationFilter{
+			EndpointType: new(types.LookupServiceRegistrationEndpointType),
+		},
+		&types.LookupServiceRegistrationFilter{
+			ServiceType: new(types.LookupServiceRegistrationServiceType),
+		},
+	}
+
+	for _, filter := range filters {
+		info, err := c.List(ctx, filter)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(info) != 2 {
+			t.Errorf("len=%d", len(info))
+		}
+	}
+}

--- a/lookup/types/types.go
+++ b/lookup/types/types.go
@@ -1,0 +1,412 @@
+/*
+Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"reflect"
+
+	"github.com/vmware/govmomi/vim25/types"
+	vim "github.com/vmware/govmomi/vim25/types"
+)
+
+type Create CreateRequestType
+
+func init() {
+	types.Add("lookup:Create", reflect.TypeOf((*Create)(nil)).Elem())
+}
+
+type CreateRequestType struct {
+	This       vim.ManagedObjectReference          `xml:"_this"`
+	ServiceId  string                              `xml:"serviceId"`
+	CreateSpec LookupServiceRegistrationCreateSpec `xml:"createSpec"`
+}
+
+func init() {
+	types.Add("lookup:CreateRequestType", reflect.TypeOf((*CreateRequestType)(nil)).Elem())
+}
+
+type CreateResponse struct {
+}
+
+type Delete DeleteRequestType
+
+func init() {
+	types.Add("lookup:Delete", reflect.TypeOf((*Delete)(nil)).Elem())
+}
+
+type DeleteRequestType struct {
+	This      vim.ManagedObjectReference `xml:"_this"`
+	ServiceId string                     `xml:"serviceId"`
+}
+
+func init() {
+	types.Add("lookup:DeleteRequestType", reflect.TypeOf((*DeleteRequestType)(nil)).Elem())
+}
+
+type DeleteResponse struct {
+}
+
+type Get GetRequestType
+
+func init() {
+	types.Add("lookup:Get", reflect.TypeOf((*Get)(nil)).Elem())
+}
+
+type GetLocale GetLocaleRequestType
+
+func init() {
+	types.Add("lookup:GetLocale", reflect.TypeOf((*GetLocale)(nil)).Elem())
+}
+
+type GetLocaleRequestType struct {
+	This vim.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("lookup:GetLocaleRequestType", reflect.TypeOf((*GetLocaleRequestType)(nil)).Elem())
+}
+
+type GetLocaleResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
+type GetRequestType struct {
+	This      vim.ManagedObjectReference `xml:"_this"`
+	ServiceId string                     `xml:"serviceId"`
+}
+
+func init() {
+	types.Add("lookup:GetRequestType", reflect.TypeOf((*GetRequestType)(nil)).Elem())
+}
+
+type GetResponse struct {
+	Returnval LookupServiceRegistrationInfo `xml:"returnval"`
+}
+
+type GetSiteId GetSiteIdRequestType
+
+func init() {
+	types.Add("lookup:GetSiteId", reflect.TypeOf((*GetSiteId)(nil)).Elem())
+}
+
+type GetSiteIdRequestType struct {
+	This vim.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("lookup:GetSiteIdRequestType", reflect.TypeOf((*GetSiteIdRequestType)(nil)).Elem())
+}
+
+type GetSiteIdResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
+type List ListRequestType
+
+func init() {
+	types.Add("lookup:List", reflect.TypeOf((*List)(nil)).Elem())
+}
+
+type ListRequestType struct {
+	This           vim.ManagedObjectReference       `xml:"_this"`
+	FilterCriteria *LookupServiceRegistrationFilter `xml:"filterCriteria,omitempty"`
+}
+
+func init() {
+	types.Add("lookup:ListRequestType", reflect.TypeOf((*ListRequestType)(nil)).Elem())
+}
+
+type ListResponse struct {
+	Returnval []LookupServiceRegistrationInfo `xml:"returnval,omitempty"`
+}
+
+type LookupFaultEntryExistsFault struct {
+	LookupFaultServiceFault
+
+	Name string `xml:"name"`
+}
+
+func init() {
+	types.Add("lookup:LookupFaultEntryExistsFault", reflect.TypeOf((*LookupFaultEntryExistsFault)(nil)).Elem())
+}
+
+type LookupFaultEntryExistsFaultFault LookupFaultEntryExistsFault
+
+func init() {
+	types.Add("lookup:LookupFaultEntryExistsFaultFault", reflect.TypeOf((*LookupFaultEntryExistsFaultFault)(nil)).Elem())
+}
+
+type LookupFaultEntryNotFoundFault struct {
+	LookupFaultServiceFault
+
+	Name string `xml:"name"`
+}
+
+func init() {
+	types.Add("lookup:LookupFaultEntryNotFoundFault", reflect.TypeOf((*LookupFaultEntryNotFoundFault)(nil)).Elem())
+}
+
+type LookupFaultEntryNotFoundFaultFault LookupFaultEntryNotFoundFault
+
+func init() {
+	types.Add("lookup:LookupFaultEntryNotFoundFaultFault", reflect.TypeOf((*LookupFaultEntryNotFoundFaultFault)(nil)).Elem())
+}
+
+type LookupFaultServiceFault struct {
+	vim.MethodFault
+
+	ErrorMessage string `xml:"errorMessage,omitempty"`
+}
+
+func init() {
+	types.Add("lookup:LookupFaultServiceFault", reflect.TypeOf((*LookupFaultServiceFault)(nil)).Elem())
+}
+
+type LookupFaultUnsupportedSiteFault struct {
+	LookupFaultServiceFault
+
+	OperatingSite string `xml:"operatingSite"`
+	RequestedSite string `xml:"requestedSite"`
+}
+
+func init() {
+	types.Add("lookup:LookupFaultUnsupportedSiteFault", reflect.TypeOf((*LookupFaultUnsupportedSiteFault)(nil)).Elem())
+}
+
+type LookupFaultUnsupportedSiteFaultFault LookupFaultUnsupportedSiteFault
+
+func init() {
+	types.Add("lookup:LookupFaultUnsupportedSiteFaultFault", reflect.TypeOf((*LookupFaultUnsupportedSiteFaultFault)(nil)).Elem())
+}
+
+type LookupHaBackupNodeConfiguration struct {
+	vim.DynamicData
+
+	DbType    string `xml:"dbType"`
+	DbJdbcUrl string `xml:"dbJdbcUrl"`
+	DbUser    string `xml:"dbUser"`
+	DbPass    string `xml:"dbPass"`
+}
+
+func init() {
+	types.Add("lookup:LookupHaBackupNodeConfiguration", reflect.TypeOf((*LookupHaBackupNodeConfiguration)(nil)).Elem())
+}
+
+type LookupServiceContent struct {
+	vim.DynamicData
+
+	LookupService                vim.ManagedObjectReference  `xml:"lookupService"`
+	ServiceRegistration          *vim.ManagedObjectReference `xml:"serviceRegistration,omitempty"`
+	DeploymentInformationService vim.ManagedObjectReference  `xml:"deploymentInformationService"`
+	L10n                         vim.ManagedObjectReference  `xml:"l10n"`
+}
+
+func init() {
+	types.Add("lookup:LookupServiceContent", reflect.TypeOf((*LookupServiceContent)(nil)).Elem())
+}
+
+type LookupServiceRegistrationAttribute struct {
+	vim.DynamicData
+
+	Key   string `xml:"key"`
+	Value string `xml:"value"`
+}
+
+func init() {
+	types.Add("lookup:LookupServiceRegistrationAttribute", reflect.TypeOf((*LookupServiceRegistrationAttribute)(nil)).Elem())
+}
+
+type LookupServiceRegistrationCommonServiceInfo struct {
+	LookupServiceRegistrationMutableServiceInfo
+
+	OwnerId     string                               `xml:"ownerId"`
+	ServiceType LookupServiceRegistrationServiceType `xml:"serviceType"`
+	NodeId      string                               `xml:"nodeId,omitempty"`
+}
+
+func init() {
+	types.Add("lookup:LookupServiceRegistrationCommonServiceInfo", reflect.TypeOf((*LookupServiceRegistrationCommonServiceInfo)(nil)).Elem())
+}
+
+type LookupServiceRegistrationCreateSpec struct {
+	LookupServiceRegistrationCommonServiceInfo
+}
+
+func init() {
+	types.Add("lookup:LookupServiceRegistrationCreateSpec", reflect.TypeOf((*LookupServiceRegistrationCreateSpec)(nil)).Elem())
+}
+
+type LookupServiceRegistrationEndpoint struct {
+	vim.DynamicData
+
+	Url                string                                `xml:"url"`
+	EndpointType       LookupServiceRegistrationEndpointType `xml:"endpointType"`
+	SslTrust           []string                              `xml:"sslTrust,omitempty"`
+	EndpointAttributes []LookupServiceRegistrationAttribute  `xml:"endpointAttributes,omitempty"`
+}
+
+func init() {
+	types.Add("lookup:LookupServiceRegistrationEndpoint", reflect.TypeOf((*LookupServiceRegistrationEndpoint)(nil)).Elem())
+}
+
+type LookupServiceRegistrationEndpointType struct {
+	vim.DynamicData
+
+	Protocol string `xml:"protocol,omitempty"`
+	Type     string `xml:"type,omitempty"`
+}
+
+func init() {
+	types.Add("lookup:LookupServiceRegistrationEndpointType", reflect.TypeOf((*LookupServiceRegistrationEndpointType)(nil)).Elem())
+}
+
+type LookupServiceRegistrationFilter struct {
+	vim.DynamicData
+
+	SiteId       string                                 `xml:"siteId,omitempty"`
+	NodeId       string                                 `xml:"nodeId,omitempty"`
+	ServiceType  *LookupServiceRegistrationServiceType  `xml:"serviceType,omitempty"`
+	EndpointType *LookupServiceRegistrationEndpointType `xml:"endpointType,omitempty"`
+}
+
+func init() {
+	types.Add("lookup:LookupServiceRegistrationFilter", reflect.TypeOf((*LookupServiceRegistrationFilter)(nil)).Elem())
+}
+
+type LookupServiceRegistrationInfo struct {
+	LookupServiceRegistrationCommonServiceInfo
+
+	ServiceId string `xml:"serviceId"`
+	SiteId    string `xml:"siteId"`
+}
+
+func init() {
+	types.Add("lookup:LookupServiceRegistrationInfo", reflect.TypeOf((*LookupServiceRegistrationInfo)(nil)).Elem())
+}
+
+type LookupServiceRegistrationMutableServiceInfo struct {
+	vim.DynamicData
+
+	ServiceVersion                string                               `xml:"serviceVersion"`
+	VendorNameResourceKey         string                               `xml:"vendorNameResourceKey,omitempty"`
+	VendorNameDefault             string                               `xml:"vendorNameDefault,omitempty"`
+	VendorProductInfoResourceKey  string                               `xml:"vendorProductInfoResourceKey,omitempty"`
+	VendorProductInfoDefault      string                               `xml:"vendorProductInfoDefault,omitempty"`
+	ServiceEndpoints              []LookupServiceRegistrationEndpoint  `xml:"serviceEndpoints,omitempty"`
+	ServiceAttributes             []LookupServiceRegistrationAttribute `xml:"serviceAttributes,omitempty"`
+	ServiceNameResourceKey        string                               `xml:"serviceNameResourceKey,omitempty"`
+	ServiceNameDefault            string                               `xml:"serviceNameDefault,omitempty"`
+	ServiceDescriptionResourceKey string                               `xml:"serviceDescriptionResourceKey,omitempty"`
+	ServiceDescriptionDefault     string                               `xml:"serviceDescriptionDefault,omitempty"`
+}
+
+func init() {
+	types.Add("lookup:LookupServiceRegistrationMutableServiceInfo", reflect.TypeOf((*LookupServiceRegistrationMutableServiceInfo)(nil)).Elem())
+}
+
+type LookupServiceRegistrationServiceType struct {
+	vim.DynamicData
+
+	Product string `xml:"product"`
+	Type    string `xml:"type"`
+}
+
+func init() {
+	types.Add("lookup:LookupServiceRegistrationServiceType", reflect.TypeOf((*LookupServiceRegistrationServiceType)(nil)).Elem())
+}
+
+type LookupServiceRegistrationSetSpec struct {
+	LookupServiceRegistrationMutableServiceInfo
+}
+
+func init() {
+	types.Add("lookup:LookupServiceRegistrationSetSpec", reflect.TypeOf((*LookupServiceRegistrationSetSpec)(nil)).Elem())
+}
+
+type RetrieveHaBackupConfiguration RetrieveHaBackupConfigurationRequestType
+
+func init() {
+	types.Add("lookup:RetrieveHaBackupConfiguration", reflect.TypeOf((*RetrieveHaBackupConfiguration)(nil)).Elem())
+}
+
+type RetrieveHaBackupConfigurationRequestType struct {
+	This vim.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("lookup:RetrieveHaBackupConfigurationRequestType", reflect.TypeOf((*RetrieveHaBackupConfigurationRequestType)(nil)).Elem())
+}
+
+type RetrieveHaBackupConfigurationResponse struct {
+	Returnval LookupHaBackupNodeConfiguration `xml:"returnval"`
+}
+
+type RetrieveServiceContent RetrieveServiceContentRequestType
+
+func init() {
+	types.Add("lookup:RetrieveServiceContent", reflect.TypeOf((*RetrieveServiceContent)(nil)).Elem())
+}
+
+type RetrieveServiceContentRequestType struct {
+	This vim.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("lookup:RetrieveServiceContentRequestType", reflect.TypeOf((*RetrieveServiceContentRequestType)(nil)).Elem())
+}
+
+type RetrieveServiceContentResponse struct {
+	Returnval LookupServiceContent `xml:"returnval"`
+}
+
+type Set SetRequestType
+
+func init() {
+	types.Add("lookup:Set", reflect.TypeOf((*Set)(nil)).Elem())
+}
+
+type SetLocale SetLocaleRequestType
+
+func init() {
+	types.Add("lookup:SetLocale", reflect.TypeOf((*SetLocale)(nil)).Elem())
+}
+
+type SetLocaleRequestType struct {
+	This   vim.ManagedObjectReference `xml:"_this"`
+	Locale string                     `xml:"locale"`
+}
+
+func init() {
+	types.Add("lookup:SetLocaleRequestType", reflect.TypeOf((*SetLocaleRequestType)(nil)).Elem())
+}
+
+type SetLocaleResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
+type SetRequestType struct {
+	This        vim.ManagedObjectReference       `xml:"_this"`
+	ServiceId   string                           `xml:"serviceId"`
+	ServiceSpec LookupServiceRegistrationSetSpec `xml:"serviceSpec"`
+}
+
+func init() {
+	types.Add("lookup:SetRequestType", reflect.TypeOf((*SetRequestType)(nil)).Elem())
+}
+
+type SetResponse struct {
+}

--- a/pbm/client.go
+++ b/pbm/client.go
@@ -27,6 +27,18 @@ import (
 	vim "github.com/vmware/govmomi/vim25/types"
 )
 
+const (
+	Namespace = "pbm"
+	Path      = "/pbm" + vim25.Path
+)
+
+var (
+	ServiceInstance = vim.ManagedObjectReference{
+		Type:  "PbmServiceInstance",
+		Value: "ServiceInstance",
+	}
+)
+
 type Client struct {
 	*soap.Client
 
@@ -34,13 +46,10 @@ type Client struct {
 }
 
 func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
-	sc := c.Client.NewServiceClient("/pbm/sdk", "urn:pbm")
+	sc := c.Client.NewServiceClient(Path, Namespace)
 
 	req := types.PbmRetrieveServiceContent{
-		This: vim.ManagedObjectReference{
-			Type:  "PbmServiceInstance",
-			Value: "ServiceInstance",
-		},
+		This: ServiceInstance,
 	}
 
 	res, err := methods.PbmRetrieveServiceContent(ctx, sc, &req)

--- a/simulator/property_collector.go
+++ b/simulator/property_collector.go
@@ -121,7 +121,7 @@ func fieldValueInterface(f reflect.StructField, rval reflect.Value) interface{} 
 			if strings.HasPrefix(kind, "Base") {
 				kind = kind[4:]
 			}
-			akind, _ := typeFunc("ArrayOf" + kind)
+			akind, _ := defaultMapType("ArrayOf" + kind)
 			a := reflect.New(akind)
 			a.Elem().FieldByName(kind).Set(rval)
 			pval = a.Interface()

--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -1138,7 +1138,7 @@ func TestIssue945(t *testing.T) {
    </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>`
 
-	method, err := UnmarshalBody([]byte(xml))
+	method, err := UnmarshalBody(defaultMapType, []byte(xml))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/simulator/service_instance.go
+++ b/simulator/service_instance.go
@@ -19,8 +19,10 @@ package simulator
 import (
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator/vpx"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -36,7 +38,7 @@ func NewServiceInstance(content types.ServiceContent, folder mo.Folder) *Service
 
 	s := &ServiceInstance{}
 
-	s.Self = methods.ServiceInstance
+	s.Self = vim25.ServiceInstance
 	s.Content = content
 
 	Map.Put(s)
@@ -49,6 +51,7 @@ func NewServiceInstance(content types.ServiceContent, folder mo.Folder) *Service
 	if content.About.ApiType == "HostAgent" {
 		CreateDefaultESX(f)
 	} else {
+		content.About.InstanceUuid = uuid.New().String()
 		setting = vpx.Setting
 	}
 

--- a/simulator/session_manager.go
+++ b/simulator/session_manager.go
@@ -196,6 +196,7 @@ var internalContext = &Context{
 		},
 		Registry: NewRegistry(),
 	},
+	Map: Map,
 }
 
 var invalidLogin = Fault("Login failure", new(types.InvalidLogin))
@@ -210,6 +211,7 @@ type Context struct {
 	Session *Session
 	Header  soap.Header
 	Caller  *types.ManagedObjectReference
+	Map     *Registry
 }
 
 // mapSession maps an HTTP cookie to a Session.

--- a/simulator/simulator_test.go
+++ b/simulator/simulator_test.go
@@ -154,7 +154,7 @@ func TestUnmarshal(t *testing.T) {
 	}
 
 	for i, req := range requests {
-		method, err := UnmarshalBody([]byte(req.data))
+		method, err := UnmarshalBody(vim25MapType, []byte(req.data))
 		if err != nil {
 			t.Errorf("failed to decode %d (%s): %s", i, req, err)
 		}
@@ -197,8 +197,7 @@ func TestUnmarshalError(t *testing.T) {
 	}
 
 	for i, data := range requests {
-		_, err := UnmarshalBody([]byte(data))
-		if err != nil {
+		if _, err := UnmarshalBody(vim25MapType, []byte(data)); err != nil {
 			continue
 		}
 		t.Errorf("expected %d (%s) to return an error", i, data)
@@ -415,34 +414,22 @@ func TestServeHTTPErrors(t *testing.T) {
 		t.Error("expected MethodNotFound fault")
 	}
 
-	// unregister type, covering the ServeHTTP UnmarshalBody error path
-	typeFunc = func(name string) (reflect.Type, bool) {
-		return nil, false
-	}
-
-	_, err = methods.GetCurrentTime(ctx, client)
-	if err == nil {
-		t.Error("expected error")
-	}
-
-	typeFunc = types.TypeFunc() // reset
-
 	// cover the does not implement method error path
-	Map.objects[methods.ServiceInstance] = &errorNoSuchMethod{}
+	Map.objects[vim25.ServiceInstance] = &errorNoSuchMethod{}
 	_, err = methods.GetCurrentTime(ctx, client)
 	if err == nil {
 		t.Error("expected error")
 	}
 
 	// cover the xml encode error path
-	Map.objects[methods.ServiceInstance] = &errorMarshal{}
+	Map.objects[vim25.ServiceInstance] = &errorMarshal{}
 	_, err = methods.GetCurrentTime(ctx, client)
 	if err == nil {
 		t.Error("expected error")
 	}
 
 	// cover the no such object path
-	Map.Remove(methods.ServiceInstance)
+	Map.Remove(vim25.ServiceInstance)
 	_, err = methods.GetCurrentTime(ctx, client)
 	if err == nil {
 		t.Error("expected error")
@@ -454,7 +441,7 @@ func TestServeHTTPErrors(t *testing.T) {
 	if !ok {
 		t.Fatalf("fault=%#v", fault)
 	}
-	if f.Obj != methods.ServiceInstance {
+	if f.Obj != vim25.ServiceInstance {
 		t.Errorf("obj=%#v", f.Obj)
 	}
 

--- a/simulator/vpx/setting.go
+++ b/simulator/vpx/setting.go
@@ -58,6 +58,10 @@ var Setting = []types.BaseOptionValue{
 		Value: "https://127.0.0.1/sso-adminserver/sdk/vsphere.local",
 	},
 	&types.OptionValue{
+		Key:   "VirtualCenter.InstanceName",
+		Value: "127.0.0.1",
+	},
+	&types.OptionValue{
 		Key:   "event.batchsize",
 		Value: int32(2000),
 	},

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -29,6 +29,7 @@ import (
 	"syscall"
 
 	"github.com/google/uuid"
+	lookup "github.com/vmware/govmomi/lookup/simulator"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/simulator/esx"
 )
@@ -127,6 +128,10 @@ func main() {
 	model.Service.ServeMux = http.DefaultServeMux // expvar.init registers "/debug/vars" with the DefaultServeMux
 
 	s := model.Service.NewServer()
+
+	if !*isESX {
+		model.Service.RegisterSDK(lookup.New())
+	}
 
 	fmt.Fprintf(out, "export GOVC_URL=%s GOVC_SIM_PID=%d\n", s.URL, os.Getpid())
 	if out != os.Stdout {

--- a/vim25/client.go
+++ b/vim25/client.go
@@ -25,6 +25,19 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+const (
+	Namespace = "vim25"
+	Version   = "6.5"
+	Path      = "/sdk"
+)
+
+var (
+	ServiceInstance = types.ManagedObjectReference{
+		Type:  "ServiceInstance",
+		Value: "ServiceInstance",
+	}
+)
+
 // Client is a tiny wrapper around the vim25/soap Client that stores session
 // specific state (i.e. state that only needs to be retrieved once after the
 // client has been created). This means the client can be reused after
@@ -43,19 +56,26 @@ type Client struct {
 // NewClient creates and returns a new client wirh the ServiceContent field
 // filled in.
 func NewClient(ctx context.Context, rt soap.RoundTripper) (*Client, error) {
-	serviceContent, err := methods.GetServiceContent(ctx, rt)
-	if err != nil {
-		return nil, err
-	}
-
 	c := Client{
-		ServiceContent: serviceContent,
-		RoundTripper:   rt,
+		RoundTripper: rt,
 	}
 
 	// Set client if it happens to be a soap.Client
 	if sc, ok := rt.(*soap.Client); ok {
 		c.Client = sc
+
+		if c.Namespace == "" {
+			c.Namespace = "urn:" + Namespace
+		}
+		if c.Version == "" {
+			c.Version = Version
+		}
+	}
+
+	var err error
+	c.ServiceContent, err = methods.GetServiceContent(ctx, rt)
+	if err != nil {
+		return nil, err
 	}
 
 	return &c, nil

--- a/vim25/methods/service_content.go
+++ b/vim25/methods/service_content.go
@@ -24,14 +24,15 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-var ServiceInstance = types.ManagedObjectReference{
+// copy of vim25.ServiceInstance to avoid import cycle
+var serviceInstance = types.ManagedObjectReference{
 	Type:  "ServiceInstance",
 	Value: "ServiceInstance",
 }
 
 func GetServiceContent(ctx context.Context, r soap.RoundTripper) (types.ServiceContent, error) {
 	req := types.RetrieveServiceContent{
-		This: ServiceInstance,
+		This: serviceInstance,
 	}
 
 	res, err := RetrieveServiceContent(ctx, r, &req)
@@ -44,7 +45,7 @@ func GetServiceContent(ctx context.Context, r soap.RoundTripper) (types.ServiceC
 
 func GetCurrentTime(ctx context.Context, r soap.RoundTripper) (*time.Time, error) {
 	req := types.CurrentTime{
-		This: ServiceInstance,
+		This: serviceInstance,
 	}
 
 	res, err := CurrentTime(ctx, r, &req)


### PR DESCRIPTION
- Lookup Service client API (govmomi/lookup)

- Add namespacing to vcsim to support multiple API endpoints

- Lookup Service API simulator (govmomi/lookup/simulator vcsim plugin)

- Lookup Service CLI client (govc sso.service.ls command)

Fixes #1063

Fixes #1074