### PR TITLE
Refactor LoginExtensionByCertificate tunnel usage

### DIFF
--- a/client.go
+++ b/client.go
@@ -58,7 +58,6 @@ package govmomi
 
 import (
 	"context"
-	"crypto/tls"
 	"net/url"
 
 	"github.com/vmware/govmomi/property"
@@ -99,39 +98,9 @@ func NewClient(ctx context.Context, u *url.URL, insecure bool) (*Client, error) 
 	return c, nil
 }
 
-// NewClientWithCertificate creates a new client from a URL. The client authenticates with the
-// server with the certificate before returning if the URL contains user information.
-func NewClientWithCertificate(ctx context.Context, u *url.URL, insecure bool, cert tls.Certificate) (*Client, error) {
-	soapClient := soap.NewClient(u, insecure)
-	soapClient.SetCertificate(cert)
-	vimClient, err := vim25.NewClient(ctx, soapClient)
-	if err != nil {
-		return nil, err
-	}
-
-	c := &Client{
-		Client:         vimClient,
-		SessionManager: session.NewManager(vimClient),
-	}
-
-	if u.User != nil {
-		err = c.LoginExtensionByCertificate(ctx, u.User.Username(), "")
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return c, nil
-}
-
 // Login dispatches to the SessionManager.
 func (c *Client) Login(ctx context.Context, u *url.Userinfo) error {
 	return c.SessionManager.Login(ctx, u)
-}
-
-// Login dispatches to the SessionManager.
-func (c *Client) LoginExtensionByCertificate(ctx context.Context, key string, locale string) error {
-	return c.SessionManager.LoginExtensionByCertificate(ctx, key, locale)
 }
 
 // Logout dispatches to the SessionManager.

--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -434,13 +434,6 @@ func (flag *ClientFlag) login(ctx context.Context, c *vim25.Client) error {
 				return nil          // Avoid SaveSession for non-authenticated session
 			}
 		}
-	} else if flag.cert != "" {
-		// LoginExtensionByCertificate requires extension name as the ExtensionKey parameter.
-		// LoginByToken does not have such a parameter, it only uses the -cert and -key.
-		err := m.LoginExtensionByCertificate(ctx, u.Username(), "")
-		if err != nil {
-			return err
-		}
 	}
 
 	return m.Login(ctx, u)

--- a/govc/test/session.bats
+++ b/govc/test/session.bats
@@ -76,3 +76,21 @@ load test_helper
   run govc session.login -l -token "$(printf $token root@localos)"
   assert_success # non-empty NameID is enough to login
 }
+
+@test "session.loginextension" {
+  vcsim_env -tunnel 0
+
+  run govc session.login -extension com.vmware.vsan.health
+  assert_failure # no certificate
+
+  id=$(new_id)
+  run govc extension.setcert -cert-pem ++ "$id" # generate a cert for testing
+  assert_success
+
+  # vcsim will login if any certificate is provided
+  run govc session.login -extension com.vmware.vsan.health -cert "$id.crt" -key "$id.key"
+  assert_success
+
+  # remove generated cert and key
+  rm "$id".{crt,key}
+}

--- a/session/manager.go
+++ b/session/manager.go
@@ -18,6 +18,7 @@ package session
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"os"
 
@@ -89,17 +90,39 @@ func (sm *Manager) Login(ctx context.Context, u *url.Userinfo) error {
 	return nil
 }
 
-func (sm *Manager) LoginExtensionByCertificate(ctx context.Context, key string, locale string) error {
+// LoginExtensionByCertificate uses the vCenter SDK tunnel to login using a client certificate.
+// The client certificate can be set using the soap.Client.SetCertificate method.
+// See: https://kb.vmware.com/s/article/2004305
+func (sm *Manager) LoginExtensionByCertificate(ctx context.Context, key string) error {
+	c := sm.client
+	u := c.URL()
+	if u.Hostname() != "sdkTunnel" {
+		sc := c.Tunnel()
+		c = &vim25.Client{
+			Client:         sc,
+			RoundTripper:   sc,
+			ServiceContent: c.ServiceContent,
+		}
+		// When http.Transport.Proxy is used, our thumbprint checker is bypassed, resulting in:
+		// "Post https://sdkTunnel:8089/sdk: x509: certificate is valid for $vcenter_hostname, not sdkTunnel"
+		// The only easy way around this is to disable verification for the call to LoginExtensionByCertificate().
+		// TODO: find a way to avoid disabling InsecureSkipVerify.
+		c.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
+	}
+
 	req := types.LoginExtensionByCertificate{
 		This:         sm.Reference(),
 		ExtensionKey: key,
-		Locale:       locale,
+		Locale:       Locale,
 	}
 
-	login, err := methods.LoginExtensionByCertificate(ctx, sm.client, &req)
+	login, err := methods.LoginExtensionByCertificate(ctx, c, &req)
 	if err != nil {
 		return err
 	}
+
+	// Copy the session cookie
+	sm.client.Jar.SetCookies(u, c.Jar.Cookies(c.URL()))
 
 	sm.userSession = &login.Returnval
 	return nil

--- a/simulator/session_manager.go
+++ b/simulator/session_manager.go
@@ -88,6 +88,25 @@ func (s *SessionManager) Login(ctx *Context, req *types.Login) soap.HasFault {
 	return body
 }
 
+func (s *SessionManager) LoginExtensionByCertificate(ctx *Context, req *types.LoginExtensionByCertificate) soap.HasFault {
+	body := new(methods.LoginExtensionByCertificateBody)
+
+	if ctx.req.TLS == nil || len(ctx.req.TLS.PeerCertificates) == 0 {
+		body.Fault_ = Fault("", new(types.NoClientCertificate))
+		return body
+	}
+
+	if req.ExtensionKey == "" || ctx.Session != nil {
+		body.Fault_ = invalidLogin
+	} else {
+		body.Res = &types.LoginExtensionByCertificateResponse{
+			Returnval: createSession(ctx, req.ExtensionKey, req.Locale),
+		}
+	}
+
+	return body
+}
+
 func (s *SessionManager) LoginByToken(ctx *Context, req *types.LoginByToken) soap.HasFault {
 	body := new(methods.LoginByTokenBody)
 

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -55,6 +55,7 @@ func main() {
 	cert := flag.String("tlscert", "", "Path to TLS certificate file")
 	key := flag.String("tlskey", "", "Path to TLS key file")
 	env := flag.String("E", "-", "Output vcsim variables to the given fifo or stdout")
+	tunnel := flag.Int("tunnel", -1, "SDK tunnel port")
 	flag.BoolVar(&simulator.Trace, "trace", simulator.Trace, "Trace SOAP to stderr")
 
 	flag.Parse()
@@ -128,6 +129,13 @@ func main() {
 	model.Service.ServeMux = http.DefaultServeMux // expvar.init registers "/debug/vars" with the DefaultServeMux
 
 	s := model.Service.NewServer()
+
+	if *tunnel >= 0 {
+		s.Tunnel = *tunnel
+		if err := s.StartTunnel(); err != nil {
+			log.Fatal(err)
+		}
+	}
 
 	if !*isESX {
 		model.Service.RegisterSDK(lookup.New())


### PR DESCRIPTION
Originally, a call to soap.Client.SetCertificate configured the client's proxy to use the SDK for every requests.
However, the SDK tunnel is only required for the LoginExtensionByCertificate call itself.  After we have a session,
the normal path can be used without the SDK tunnel.  Use of the SDK tunnel is now limited to within the SessionManager
LoginExtensionByCertificate wrapper.

- Add govc session.login -extension flag

- Add vcsim LoginExtensionByCertificate implementation

- Add govc extension.setcert -set flag (handy for generating test certs)

- Remove govmomi.Client LoginExtensionByCertificate related methods