### PR TITLE
vcsim vm.snapshot should be 'nil' if there are not any snapshots

### DIFF
--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -39,6 +39,10 @@ func (v *VirtualMachineSnapshot) RemoveSnapshotTask(req *types.RemoveSnapshot_Ta
 			}
 
 			vm.Snapshot.RootSnapshotList = removeSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This, req.RemoveChildren)
+
+			if len(vm.Snapshot.RootSnapshotList) == 0 {
+				vm.Snapshot = nil
+			}
 		})
 
 		return nil, nil

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -63,7 +63,7 @@ func NewVirtualMachine(parent types.ManagedObjectReference, spec *types.VirtualM
 		MemoryAllocation: &rspec.MemoryAllocation,
 		CpuAllocation:    &rspec.CpuAllocation,
 	}
-	vm.Snapshot = &types.VirtualMachineSnapshotInfo{}
+	vm.Snapshot = nil // intentionally set to nil until a snapshot is created
 	vm.Storage = &types.VirtualMachineStorageInfo{
 		Timestamp: time.Now(),
 	}
@@ -991,8 +991,7 @@ func (vm *VirtualMachine) RemoveAllSnapshotsTask(req *types.RemoveAllSnapshots_T
 
 		refs := allSnapshotsInTree(vm.Snapshot.RootSnapshotList)
 
-		vm.Snapshot.CurrentSnapshot = nil
-		vm.Snapshot.RootSnapshotList = nil
+		vm.Snapshot = nil
 
 		for _, ref := range refs {
 			Map.Remove(ref)

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/vmware/govmomi"
@@ -684,7 +685,13 @@ func TestVmSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vm := object.NewVirtualMachine(c.Client, Map.Any("VirtualMachine").Reference())
+	simVm := Map.Any("VirtualMachine")
+	vm := object.NewVirtualMachine(c.Client, simVm.Reference())
+
+	_, err = fieldValue(reflect.ValueOf(simVm), "snapshot")
+	if err != errEmptyField {
+		t.Fatal("snapshot property should be 'nil' if there are no snapshots")
+	}
 
 	task, err := vm.CreateSnapshot(ctx, "root", "description", true, true)
 	if err != nil {
@@ -694,6 +701,11 @@ func TestVmSnapshot(t *testing.T) {
 	err = task.Wait(ctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	_, err = fieldValue(reflect.ValueOf(simVm), "snapshot")
+	if err == errEmptyField {
+		t.Fatal("snapshot property should not be 'nil' if there are snapshots")
 	}
 
 	task, err = vm.CreateSnapshot(ctx, "child", "description", true, true)
@@ -741,6 +753,11 @@ func TestVmSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	_, err = fieldValue(reflect.ValueOf(simVm), "snapshot")
+	if err == errEmptyField {
+		t.Fatal("snapshot property should not be 'nil' if there are snapshots")
+	}
+
 	_, err = vm.FindSnapshot(ctx, "child")
 	if err == nil {
 		t.Fatal("child should be removed")
@@ -754,6 +771,11 @@ func TestVmSnapshot(t *testing.T) {
 	err = task.Wait(ctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	_, err = fieldValue(reflect.ValueOf(simVm), "snapshot")
+	if err != errEmptyField {
+		t.Fatal("snapshot property should be 'nil' if there are no snapshots")
 	}
 
 	_, err = vm.FindSnapshot(ctx, "root")


### PR DESCRIPTION
vcsim vm.snapshot should be 'nil' if there are not any snapshots

Here are the updated test cases / responses:

## pathSet: ["snapshot"] ##

### RetrievePropertiesEx Request: ###
```xml
<?xml version="1.0" encoding="UTF-8"?>
<SOAP-ENV:Envelope xmlns:ns0="urn:vim25" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
   <SOAP-ENV:Header/>
   <ns1:Body>
      <ns0:RetrievePropertiesEx>
         <ns0:_this type="PropertyCollector">propertyCollector</ns0:_this>
         <ns0:specSet>
            <ns0:propSet>
               <ns0:type>VirtualMachine</ns0:type>
               <ns0:pathSet>snapshot</ns0:pathSet>
            </ns0:propSet>
            <ns0:objectSet>
               <ns0:obj type="VirtualMachine">vm-51</ns0:obj>
            </ns0:objectSet>
         </ns0:specSet>
         <ns0:options/>
      </ns0:RetrievePropertiesEx>
   </ns1:Body>
</SOAP-ENV:Envelope>
```

#### vCenter 6.5 Response: ####
```xml
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <soapenv:Body>
        <RetrievePropertiesExResponse xmlns="urn:vim25">
            <returnval>
                <objects>
                    <obj type="VirtualMachine">vm-2766</obj>
                </objects>
            </returnval>
        </RetrievePropertiesExResponse>
    </soapenv:Body>
</soapenv:Envelope>
```

#### vcsim (master) Response: ####
```xml
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <soapenv:Body>
        <RetrievePropertiesExResponse xmlns="urn:vim25">
            <returnval>
                <objects>
                    <obj type="VirtualMachine">vm-51</obj>
                    <propSet>
                        <name>snapshot</name>
                        <val xmlns:XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" XMLSchema-instance:type="VirtualMachineSnapshotInfo"></val>
                    </propSet>
                </objects>
            </returnval>
        </RetrievePropertiesExResponse>
    </soapenv:Body>
</soapenv:Envelope>
```

#### vcsim (PR) Response: ####
```xml
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <soapenv:Body>
        <RetrievePropertiesExResponse xmlns="urn:vim25">
            <returnval>
                <objects>
                    <obj type="VirtualMachine">vm-51</obj>
                </objects>
            </returnval>
        </RetrievePropertiesExResponse>
    </soapenv:Body>
</soapenv:Envelope>
```

### WaitForUpdatesEx Request: ###
```xml
<?xml version="1.0" encoding="UTF-8"?>
<Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/">
    <Header/>
    <Body>
        <CreateFilter xmlns="urn:vim25">
            <_this type="PropertyCollector">session[8c2aa3e6-a606-4f22-aebd-b027566e67b4]246cecd9-43ab-4423-9aa2-1617b32430a7</_this>
            <spec>
                <propSet>
                    <type>VirtualMachine</type>
                    <pathSet>snapshot</pathSet>
                </propSet>
                <objectSet>
                    <obj type="VirtualMachine">vm-51</obj>
                </objectSet>
            </spec>
            <partialUpdates>false</partialUpdates>
        </CreateFilter>
    </Body>
</Envelope>
```

#### vCenter 6.5 Response: ####
```xml
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <soapenv:Body>
        <WaitForUpdatesExResponse xmlns="urn:vim25">
            <returnval>
                <version>1</version>
                <filterSet>
                    <filter type="PropertyFilter">session[525e409c-d0ed-1e8c-9202-d6337a66c21d]525b18ad-dd84-122a-0f42-0684e26bdf7e</filter>
                    <objectSet>
                        <kind>enter</kind>
                        <obj type="VirtualMachine">vm-2766</obj>
                        <changeSet>
                            <name>snapshot</name>
                            <op>assign</op>
                        </changeSet>
                    </objectSet>
                </filterSet>
            </returnval>
        </WaitForUpdatesExResponse>
    </soapenv:Body>
</soapenv:Envelope>
```

#### vcsim (master) Response: ####
```xml
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <soapenv:Body>
        <WaitForUpdatesExResponse xmlns="urn:vim25">
            <returnval>
                <version>-</version>
                <filterSet>
                    <filter type="PropertyFilter">session[59d333d4-598e-4e15-9271-3142ec7fb0be]8baca587-6c40-455a-b90f-45b215cdde6b</filter>
                    <objectSet>
                        <kind>enter</kind>
                        <obj type="VirtualMachine">vm-51</obj>
                        <changeSet>
                            <name>snapshot</name>
                            <op>assign</op>
                            <val xmlns:XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" XMLSchema-instance:type="VirtualMachineSnapshotInfo"></val>
                        </changeSet>
                    </objectSet>
                </filterSet>
            </returnval>
        </WaitForUpdatesExResponse>
    </soapenv:Body>
</soapenv:Envelope>
```

#### vcsim (PR) Response: ####
```xml
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <soapenv:Body>
        <WaitForUpdatesExResponse xmlns="urn:vim25">
            <returnval>
                <version>-</version>
                <filterSet>
                    <filter type="PropertyFilter">session[c3827318-a3fc-4c9d-af9d-76f186f46090]c0454cf5-395a-40bb-9ba9-29fe43128d9f</filter>
                    <objectSet>
                        <kind>enter</kind>
                        <obj type="VirtualMachine">vm-51</obj>
                        <changeSet>
                            <name>snapshot</name>
                            <op>assign</op>
                        </changeSet>
                    </objectSet>
                </filterSet>
            </returnval>
        </WaitForUpdatesExResponse>
    </soapenv:Body>
</soapenv:Envelope>
```