### PR TITLE
Add STS support for token renewal

### DIFF
--- a/sts/internal/types_test.go
+++ b/sts/internal/types_test.go
@@ -56,8 +56,8 @@ func TestTimestamp(t *testing.T) {
 	timestamp := Timestamp{
 		NS:      WSU,
 		ID:      "_id",
-		Created: Time{created},
-		Expires: Time{created.Add(time.Hour)},
+		Created: created.Format(Time),
+		Expires: created.Add(time.Hour).Format(Time),
 	}
 
 	if !isC14N(timestamp.C14N()) {


### PR DESCRIPTION
Mostly a refactor as "Issue" and "Renew" requests are similar, but also adds new types and their canonicalizers.

Removed time.Time wrapper, using string type instead.
This avoids an issue where xml.Marshal was dropping trailing zeros from the timestamp,
causing an invalid body digest.

Fixes #1093