### PR TITLE
Avoid possible panic in portgroup EthernetCardBackingInfo

### DIFF
--- a/object/distributed_virtual_portgroup.go
+++ b/object/distributed_virtual_portgroup.go
@@ -18,6 +18,7 @@ package object
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -39,9 +40,15 @@ func NewDistributedVirtualPortgroup(c *vim25.Client, ref types.ManagedObjectRefe
 func (p DistributedVirtualPortgroup) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
 	var dvp mo.DistributedVirtualPortgroup
 	var dvs mo.DistributedVirtualSwitch
+	prop := "config.distributedVirtualSwitch"
 
-	if err := p.Properties(ctx, p.Reference(), []string{"key", "config.distributedVirtualSwitch"}, &dvp); err != nil {
+	if err := p.Properties(ctx, p.Reference(), []string{"key", prop}, &dvp); err != nil {
 		return nil, err
+	}
+
+	// "This property should always be set unless the user's setting does not have System.Read privilege on the object referred to by this property."
+	if dvp.Config.DistributedVirtualSwitch == nil {
+		return nil, fmt.Errorf("no System.Read privilege on: %s.%s", p.Reference(), prop)
 	}
 
 	if err := p.Properties(ctx, *dvp.Config.DistributedVirtualSwitch, []string{"uuid"}, &dvs); err != nil {


### PR DESCRIPTION
DistributedVirtualPortgroup.config.distributedVirtualSwitch can be nil if user
doesn't have the System.Read privilege on the DVS.

Fixes #1098
Fixes #1035