### PR TITLE
Fix govc vm.clone -annotation flag

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -115,6 +115,12 @@ load test_helper
   run govc object.collect -s "vm/$id" config.memoryAllocation.reservation
   assert_success 1024
 
+  run govc vm.change -annotation $$ -vm "$id"
+  assert_success
+
+  run govc object.collect -s "vm/$id" config.annotation
+  assert_success $$
+
   nid=$(new_id)
   run govc vm.change -name $nid -vm $id
   assert_success
@@ -571,8 +577,11 @@ load test_helper
   vm=$(new_empty_vm)
   clone=$(new_id)
 
-  run govc vm.clone -vm "$vm" "$clone"
+  run govc vm.clone -vm "$vm" -annotation $$ "$clone"
   assert_success
+
+  run govc object.collect -s "/$GOVC_DATACENTER/vm/$clone" config.annotation
+  assert_success $$
 
   clone=$(new_id)
   run govc vm.clone -vm "$vm" -snapshot X "$clone"

--- a/govc/vm/change.go
+++ b/govc/vm/change.go
@@ -91,6 +91,7 @@ func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
 	f.Var(flags.NewInt32(&cmd.NumCPUs), "c", "Number of CPUs")
 	f.StringVar(&cmd.GuestId, "g", "", "Guest OS")
 	f.StringVar(&cmd.Name, "name", "", "Display name")
+	f.StringVar(&cmd.Annotation, "annotation", "", "VM description")
 	f.Var(&cmd.extraConfig, "e", "ExtraConfig. <key>=<value>")
 
 	f.Var(flags.NewOptionalBool(&cmd.NestedHVEnabled), "nested-hv-enabled", "Enable nested hardware-assisted virtualization")

--- a/govc/vm/clone.go
+++ b/govc/vm/clone.go
@@ -221,7 +221,7 @@ func (cmd *clone) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	if cmd.cpus > 0 || cmd.memory > 0 {
+	if cmd.cpus > 0 || cmd.memory > 0 || cmd.annotation != "" {
 		vmConfigSpec := types.VirtualMachineConfigSpec{}
 		if cmd.cpus > 0 {
 			vmConfigSpec.NumCPUs = int32(cmd.cpus)


### PR DESCRIPTION
The VM annotation would only be set if -c or -m were also specified.

Add -annotation flag to vm.change command.

Fixes #1118