### PR TITLE
vcsim: display correct capacity and free size of datastore.info

### DIFF
--- a/simulator/os_unix.go
+++ b/simulator/os_unix.go
@@ -29,12 +29,10 @@ func (ds *Datastore) stat() error {
 		return err
 	}
 
-	bsize := uint64(stat.Bsize) / 512
-
-	info.FreeSpace = int64(stat.Bfree*bsize) >> 1
+	info.FreeSpace = int64(stat.Bfree * uint64(stat.Bsize))
 
 	ds.Summary.FreeSpace = info.FreeSpace
-	ds.Summary.Capacity = int64(stat.Blocks*bsize) >> 1
+	ds.Summary.Capacity = int64(stat.Blocks * uint64(stat.Bsize))
 
 	return nil
 }


### PR DESCRIPTION
https://github.com/vmware/govmomi/issues/1121

This only fix stat on linux, not windows. 

Not add test part because I don't have windows machine to test, so it may break if govmomi's CI system has windows platform.