### PR TITLE
vcsim: Fixed leading "/" requirement in FindByInventoryPath

### DIFF
--- a/simulator/search_index.go
+++ b/simulator/search_index.go
@@ -57,15 +57,18 @@ func (s *SearchIndex) FindByDatastorePath(r *types.FindByDatastorePath) soap.Has
 func (s *SearchIndex) FindByInventoryPath(req *types.FindByInventoryPath) soap.HasFault {
 	body := &methods.FindByInventoryPathBody{Res: new(types.FindByInventoryPathResponse)}
 
-	path := strings.Split(req.InventoryPath, "/")
-	if len(path) <= 1 {
+	split := func(c rune) bool {
+		return c == '/'
+	}
+	path := strings.FieldsFunc(req.InventoryPath, split)
+	if len(path) < 1 {
 		return body
 	}
 
 	root := Map.content().RootFolder
 	o := &root
 
-	for _, name := range path[1:] {
+	for _, name := range path {
 		f := s.FindChild(&types.FindChild{Entity: *o, Name: name})
 
 		o = f.(*methods.FindChildBody).Res.Returnval


### PR DESCRIPTION
https://code.vmware.com/apis/358/vsphere#/doc/vim.SearchIndex.html#findByInventoryPath

Finds a managed entity based on its location in the inventory. The path is separated by slashes ('/').
For example, a path should be of the form "My Folder/My Datacenter/vm/Discovered VM/VM1".
A leading slash or trailing slash is ignored.
Thus, the following paths all represents the same object: "a/b", "/a/b", "a/b/", and '/a/b/'.
Slashes in names must be represented using %2f, following the standard URL syntax.
Any object in the inventory can be retrieved using this method, including resource pools and hosts.