### PR TITLE
Change key name according to Datacenter object

### DIFF
--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -390,7 +390,7 @@ func (s *Service) findDatastore(query url.Values) (*Datastore, error) {
 	ctx := context.Background()
 
 	finder := find.NewFinder(s.client, false)
-	dc, err := finder.DatacenterOrDefault(ctx, query.Get("dcName"))
+	dc, err := finder.DatacenterOrDefault(ctx, query.Get("dcPath"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The key is different from the one assigned to the query in the datacenter object. It provokes errors when several datacenters are created.