### PR TITLE
Add VirtualDiskManager wrapper to set UUID

### DIFF
--- a/govc/datastore/disk/create.go
+++ b/govc/datastore/disk/create.go
@@ -31,12 +31,14 @@ import (
 type spec struct {
 	types.FileBackedVirtualDiskSpec
 	force bool
+	uuid  string
 }
 
 func (s *spec) Register(ctx context.Context, f *flag.FlagSet) {
 	f.StringVar(&s.AdapterType, "a", string(types.VirtualDiskAdapterTypeLsiLogic), "Disk adapter")
 	f.StringVar(&s.DiskType, "d", string(types.VirtualDiskTypeThin), "Disk format")
 	f.BoolVar(&s.force, "f", false, "Force")
+	f.StringVar(&s.uuid, "uuid", "", "Disk UUID")
 }
 
 type create struct {
@@ -109,6 +111,13 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 	logger := cmd.ProgressLogger(fmt.Sprintf("Creating %s...", dst))
 	defer logger.Wait()
 
-	_, err = task.WaitForResult(ctx, logger)
-	return err
+	if _, err = task.WaitForResult(ctx, logger); err != nil {
+		return err
+	}
+
+	if cmd.uuid != "" {
+		return m.SetVirtualDiskUuid(ctx, dst, dc, cmd.uuid)
+	}
+
+	return nil
 }

--- a/govc/emacs/govc.el
+++ b/govc/emacs/govc.el
@@ -1211,7 +1211,7 @@ Optionally filter by FILTER and inherit SESSION."
   (interactive)
   (delete-other-windows)
   (govc-shell-command
-   (list "datastore.disk.info" (if current-prefix-arg "-c") (govc-selection))))
+   (list "datastore.disk.info" "-uuid" (if current-prefix-arg "-c") (govc-selection))))
 
 (defun govc-datastore-ls-json ()
   "JSON via govc datastore.ls -json on current selection."

--- a/govc/test/datastore.bats
+++ b/govc/test/datastore.bats
@@ -222,6 +222,9 @@ upload_file() {
   run govc datastore.disk.info "$vmdk"
   assert_success
 
+  run govc datastore.disk.info -uuid "$vmdk"
+  assert_success
+
   run govc datastore.rm "$vmdk"
   assert_success
 

--- a/object/virtual_disk_manager.go
+++ b/object/virtual_disk_manager.go
@@ -209,3 +209,19 @@ func (m VirtualDiskManager) QueryVirtualDiskUuid(ctx context.Context, name strin
 
 	return res.Returnval, nil
 }
+
+func (m VirtualDiskManager) SetVirtualDiskUuid(ctx context.Context, name string, dc *Datacenter, uuid string) error {
+	req := types.SetVirtualDiskUuid{
+		This: m.Reference(),
+		Name: name,
+		Uuid: uuid,
+	}
+
+	if dc != nil {
+		ref := dc.Reference()
+		req.Datacenter = &ref
+	}
+
+	_, err := methods.SetVirtualDiskUuid(ctx, m.c, &req)
+	return err
+}

--- a/simulator/virtual_disk_manager.go
+++ b/simulator/virtual_disk_manager.go
@@ -210,3 +210,10 @@ func (m *VirtualDiskManager) QueryVirtualDiskUuid(req *types.QueryVirtualDiskUui
 
 	return body
 }
+
+func (m *VirtualDiskManager) SetVirtualDiskUuid(req *types.SetVirtualDiskUuid) soap.HasFault {
+	body := new(methods.SetVirtualDiskUuidBody)
+	// TODO: validate uuid format and persist
+	body.Res = new(types.SetVirtualDiskUuidResponse)
+	return body
+}


### PR DESCRIPTION
- Add govc datastore.disk.info '-uuid' option to query the disk uuid

- Add govc datastore.disk.create '-uuid' option to set the disk uuid

Fixes #1135