### PR TITLE
Add option to mark VM as template on OVF/OVA import in govc

### DIFF
--- a/govc/importx/options.go
+++ b/govc/importx/options.go
@@ -55,10 +55,11 @@ type Options struct {
 
 	Annotation string `json:",omitempty"`
 
-	PowerOn      bool
-	InjectOvfEnv bool
-	WaitForIP    bool
-	Name         *string
+	MarkAsTemplate bool
+	PowerOn        bool
+	InjectOvfEnv   bool
+	WaitForIP      bool
+	Name           *string
 }
 
 type OptionsFlag struct {

--- a/govc/importx/ovf.go
+++ b/govc/importx/ovf.go
@@ -160,6 +160,10 @@ func (cmd *ovfx) Deploy(vm *object.VirtualMachine) error {
 		return err
 	}
 
+	if err := cmd.MarkAsTemplate(vm); err != nil {
+		return err
+	}
+
 	if err := cmd.PowerOn(vm); err != nil {
 		return err
 	}
@@ -340,7 +344,7 @@ func (cmd *ovfx) Upload(ctx context.Context, lease *nfc.Lease, item nfc.FileItem
 
 func (cmd *ovfx) PowerOn(vm *object.VirtualMachine) error {
 	ctx := context.TODO()
-	if !cmd.Options.PowerOn {
+	if !cmd.Options.PowerOn || cmd.Options.MarkAsTemplate {
 		return nil
 	}
 
@@ -352,6 +356,22 @@ func (cmd *ovfx) PowerOn(vm *object.VirtualMachine) error {
 	}
 
 	if _, err = task.WaitForResult(ctx, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *ovfx) MarkAsTemplate(vm *object.VirtualMachine) error {
+	ctx := context.TODO()
+	if !cmd.Options.MarkAsTemplate {
+		return nil
+	}
+
+	cmd.Log("Marking VM as template...\n")
+
+	err := vm.MarkAsTemplate(ctx)
+	if err != nil {
 		return err
 	}
 
@@ -411,7 +431,7 @@ func (cmd *ovfx) InjectOvfEnv(vm *object.VirtualMachine) error {
 
 func (cmd *ovfx) WaitForIP(vm *object.VirtualMachine) error {
 	ctx := context.TODO()
-	if !cmd.Options.PowerOn || !cmd.Options.WaitForIP {
+	if !cmd.Options.PowerOn || !cmd.Options.WaitForIP || cmd.Options.MarkAsTemplate {
 		return nil
 	}
 

--- a/govc/importx/spec.go
+++ b/govc/importx/spec.go
@@ -159,6 +159,7 @@ func (cmd *spec) Spec(fpath string) error {
 		DiskProvisioning:   allDiskProvisioningOptions[0],
 		IPAllocationPolicy: allIPAllocationPolicyOptions[0],
 		IPProtocol:         allIPProtocolOptions[0],
+		MarkAsTemplate:     false,
 		PowerOn:            false,
 		WaitForIP:          false,
 		InjectOvfEnv:       false,


### PR DESCRIPTION
We have several use cases inside our org where we need to upload an OVF or OVA file using govc and immediately mark it as a template. This PR adds a `MarkAsTemplate` option in the `import.ovf/ova` spec.