### PR TITLE
Fixed govc host.info logical CPU count

### DIFF
--- a/govc/host/info.go
+++ b/govc/host/info.go
@@ -139,7 +139,7 @@ func (r *infoResult) Write(w io.Writer) error {
 		s := host.Summary
 		h := s.Hardware
 		z := s.QuickStats
-		ncpu := int32(h.NumCpuPkgs * h.NumCpuThreads)
+		ncpu := int32(h.NumCpuThreads)
 		cpuUsage := 100 * float64(z.OverallCpuUsage) / float64(ncpu*h.CpuMhz)
 		memUsage := 100 * float64(z.OverallMemoryUsage) / float64(h.MemorySize>>20)
 


### PR DESCRIPTION
This command was incorrectly multiplying the number of CPU packages by the
total number of CPU threads.  The number of CPU threads is across all CPUs,
so it can be used instead.

Example output prior to the fix:

Name:              internal
  Path:            /path/to/ESX/host
  Manufacturer:    Dell Inc.
  Logical CPUs:    112 CPUs @ 2195MHz
  Processor type:  Intel(R) Xeon(R) Gold 5120 CPU @ 2.20GHz
  CPU usage:       1654 MHz (0.7%)
  Memory:          195266MB
  Memory usage:    73725 MB (37.8%)
  Boot time:       2018-05-11 23:17:05.118699 +0000 UTC
  State:           connected

Example output with the fix applied:

Name:              internal
  Path:            /path/to/ESX/host
  Manufacturer:    Dell Inc.
  Logical CPUs:    56 CPUs @ 2195MHz
  Processor type:  Intel(R) Xeon(R) Gold 5120 CPU @ 2.20GHz
  CPU usage:       1566 MHz (1.3%)
  Memory:          195266MB
  Memory usage:    73715 MB (37.8%)
  Boot time:       2018-05-11 23:17:05.118699 +0000 UTC
  State:           connected

Resolves: #1156