### PR TITLE
vcsim: add support for PropertyCollector incremental updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 
 language: go
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install:
 	go install -v github.com/vmware/govmomi/vcsim
 
 go-test:
-	go test -race -v $(TEST_OPTS) ./...
+	GORACE=history_size=5 go test -timeout 5m -count 1 -race -v $(TEST_OPTS) ./...
 
 govc-test: install
 	(cd govc/test && ./vendor/github.com/sstephenson/bats/libexec/bats -t .)

--- a/govc/events/command.go
+++ b/govc/events/command.go
@@ -164,24 +164,17 @@ func (cmd *events) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	if len(objs) > 0 {
-		// need an event manager
-		m := event.NewManager(c)
+	m := event.NewManager(c)
 
-		// get the event stream
-		err = m.Events(ctx, objs, cmd.Max, cmd.Tail, cmd.Force, func(obj types.ManagedObjectReference, ee []types.BaseEvent) error {
-			var o *types.ManagedObjectReference
-			if len(objs) > 1 {
-				o = &obj
-			}
+	return cmd.WithCancel(ctx, func(wctx context.Context) error {
+		return m.Events(wctx, objs, cmd.Max, cmd.Tail, cmd.Force,
+			func(obj types.ManagedObjectReference, ee []types.BaseEvent) error {
+				var o *types.ManagedObjectReference
+				if len(objs) > 1 {
+					o = &obj
+				}
 
-			return cmd.printEvents(ctx, o, ee, m)
-		}, cmd.Kind...)
-
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+				return cmd.printEvents(ctx, o, ee, m)
+			}, cmd.Kind...)
+	})
 }

--- a/property/collector.go
+++ b/property/collector.go
@@ -111,6 +111,12 @@ func (p *Collector) WaitForUpdates(ctx context.Context, v string) (*types.Update
 	return res.Returnval, nil
 }
 
+func (p *Collector) CancelWaitForUpdates(ctx context.Context) error {
+	req := &types.CancelWaitForUpdates{This: p.Reference()}
+	_, err := methods.CancelWaitForUpdates(ctx, p.roundTripper, req)
+	return err
+}
+
 func (p *Collector) RetrieveProperties(ctx context.Context, req types.RetrieveProperties) (*types.RetrievePropertiesResponse, error) {
 	req.This = p.Reference()
 	return methods.RetrieveProperties(ctx, p.roundTripper, &req)

--- a/property/wait.go
+++ b/property/wait.go
@@ -19,12 +19,14 @@ package property
 import (
 	"context"
 
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
 // WaitFilter provides helpers to construct a types.CreateFilter for use with property.Wait
 type WaitFilter struct {
 	types.CreateFilter
+	Options *types.WaitOptions
 }
 
 // Add a new ObjectSpec and PropertySpec to the WaitFilter
@@ -75,6 +77,7 @@ func Wait(ctx context.Context, c *Collector, obj types.ManagedObjectReference, p
 // creates a new property collector and calls CreateFilter. A new property
 // collector is required because filters can only be added, not removed.
 //
+// If the Context is canceled, a call to CancelWaitForUpdates() is made and its error value is returned.
 // The newly created collector is destroyed before this function returns (both
 // in case of success or error).
 //
@@ -85,7 +88,7 @@ func WaitForUpdates(ctx context.Context, c *Collector, filter *WaitFilter, f fun
 	}
 
 	// Attempt to destroy the collector using the background context, as the
-	// specified context may have timed out or have been cancelled.
+	// specified context may have timed out or have been canceled.
 	defer p.Destroy(context.Background())
 
 	err = p.CreateFilter(ctx, filter.CreateFilter)
@@ -93,20 +96,33 @@ func WaitForUpdates(ctx context.Context, c *Collector, filter *WaitFilter, f fun
 		return err
 	}
 
-	for version := ""; ; {
-		res, err := p.WaitForUpdates(ctx, version)
+	req := types.WaitForUpdatesEx{
+		This:    p.Reference(),
+		Options: filter.Options,
+	}
+
+	for {
+		res, err := methods.WaitForUpdatesEx(ctx, p.roundTripper, &req)
 		if err != nil {
+			if ctx.Err() == context.Canceled {
+				werr := p.CancelWaitForUpdates(context.Background())
+				return werr
+			}
 			return err
 		}
 
-		// Retry if the result came back empty
-		if res == nil {
+		set := res.Returnval
+		if set == nil {
+			if req.Options != nil && req.Options.MaxWaitSeconds != nil {
+				return nil // WaitOptions.MaxWaitSeconds exceeded
+			}
+			// Retry if the result came back empty
 			continue
 		}
 
-		version = res.Version
+		req.Version = set.Version
 
-		for _, fs := range res.FilterSet {
+		for _, fs := range set.FilterSet {
 			if f(fs.ObjectSet) {
 				return nil
 			}

--- a/scripts/debug-xmlformat.sh
+++ b/scripts/debug-xmlformat.sh
@@ -13,6 +13,8 @@ for file in *.req.xml; do
     header Request "$file" "${base}.req.headers"
     xmlformat < "$file"
     file="${base}.res.xml"
-    header Response "$file" "${base}.res.headers"
-    xmlformat < "$file"
+    if [ -e "$file" ] ; then
+      header Response "$file" "${base}.res.headers"
+      xmlformat < "$file"
+    fi
 done

--- a/simulator/property_filter.go
+++ b/simulator/property_filter.go
@@ -17,6 +17,9 @@ limitations under the License.
 package simulator
 
 import (
+	"reflect"
+	"strings"
+
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -26,17 +29,71 @@ import (
 type PropertyFilter struct {
 	mo.PropertyFilter
 
-	pc *PropertyCollector
+	pc   *PropertyCollector
+	refs map[types.ManagedObjectReference]struct{}
 }
 
-func (f *PropertyFilter) DestroyPropertyFilter(c *types.DestroyPropertyFilter) soap.HasFault {
+func (f *PropertyFilter) DestroyPropertyFilter(ctx *Context, c *types.DestroyPropertyFilter) soap.HasFault {
 	body := &methods.DestroyPropertyFilterBody{}
 
 	RemoveReference(&f.pc.Filter, c.This)
 
-	Map.Remove(c.This)
+	ctx.Session.Remove(c.This)
 
 	body.Res = &types.DestroyPropertyFilterResponse{}
 
 	return body
+}
+
+// matches returns true if the change matches one of the filter Spec.PropSet
+func (f *PropertyFilter) matches(ctx *Context, ref types.ManagedObjectReference, change *types.PropertyChange) bool {
+	for _, p := range f.Spec.PropSet {
+		if p.Type != ref.Type {
+			continue
+		}
+
+		if isTrue(p.All) {
+			return true
+		}
+
+		for _, name := range p.PathSet {
+			if name == change.Name {
+				return true
+			}
+
+			// strings.HasPrefix("runtime.powerState", "runtime") == parent field matches
+			if strings.HasPrefix(change.Name, name) {
+				if obj := ctx.Map.Get(ref); obj != nil { // object may have since been deleted
+					change.Name = name
+					change.Val, _ = fieldValue(reflect.ValueOf(obj), name)
+				}
+
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// apply the PropertyFilter.Spec to the given ObjectUpdate
+func (f *PropertyFilter) apply(ctx *Context, change types.ObjectUpdate) types.ObjectUpdate {
+	parents := make(map[string]bool)
+	set := change.ChangeSet
+	change.ChangeSet = nil
+
+	for i, p := range set {
+		if f.matches(ctx, change.Obj, &p) {
+			if p.Name != set[i].Name {
+				// update matches a parent field from the spec.
+				if parents[p.Name] {
+					continue // only return 1 instance of the parent
+				}
+				parents[p.Name] = true
+			}
+			change.ChangeSet = append(change.ChangeSet, p)
+		}
+	}
+
+	return change
 }

--- a/simulator/race_test.go
+++ b/simulator/race_test.go
@@ -24,8 +24,10 @@ import (
 	"time"
 
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/event"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -44,7 +46,61 @@ func TestRace(t *testing.T) {
 	s := m.Service.NewServer()
 	defer s.Close()
 
-	var wg sync.WaitGroup
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := c.Client.ServiceContent
+
+	wctx, cancel := context.WithCancel(ctx)
+	var wg, collectors sync.WaitGroup
+
+	nevents := -1
+	em := event.NewManager(c.Client)
+
+	wg.Add(1)
+	collectors.Add(1)
+	go func() {
+		defer collectors.Done()
+
+		werr := em.Events(wctx, []types.ManagedObjectReference{content.RootFolder}, 50, true, false,
+			func(_ types.ManagedObjectReference, e []types.BaseEvent) error {
+				if nevents == -1 {
+					wg.Done() // make sure we are called at least once before cancel() below
+					nevents = 0
+				}
+
+				nevents += len(e)
+				return nil
+			})
+		if werr != nil {
+			t.Error(werr)
+		}
+	}()
+
+	ntasks := -1
+	tv, err := view.NewManager(c.Client).CreateTaskView(ctx, content.TaskManager)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg.Add(1)
+	collectors.Add(1)
+	go func() {
+		defer collectors.Done()
+
+		werr := tv.Collect(ctx, func(tasks []types.TaskInfo) {
+			if ntasks == -1 {
+				wg.Done() // make sure we are called at least once before cancel() below
+				ntasks = 0
+			}
+			ntasks += len(tasks)
+		})
+		if werr != nil {
+			t.Error(werr)
+		}
+	}()
 
 	for i := 0; i < 2; i++ {
 		spec := types.VirtualMachineConfigSpec{
@@ -58,32 +114,25 @@ func TestRace(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			c, err := govmomi.NewClient(ctx, s.URL, true)
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			finder := find.NewFinder(c.Client, false)
 			pc := property.DefaultCollector(c.Client)
 			dc, err := finder.DefaultDatacenter(ctx)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 
 			finder.SetDatacenter(dc)
 
 			f, err := dc.Folders(ctx)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 
 			pool, err := finder.ResourcePool(ctx, "DC0_C0/Resources")
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
-
-			ticker := time.NewTicker(time.Millisecond * 100)
-			defer ticker.Stop()
 
 			for j := 0; j < 2; j++ {
 				cspec := spec // copy spec and give it a unique name
@@ -92,39 +141,70 @@ func TestRace(t *testing.T) {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
+
 					task, _ := f.VmFolder.CreateVM(ctx, cspec, pool, nil)
-					info, terr := task.WaitForResult(ctx, nil)
+					_, terr := task.WaitForResult(ctx, nil)
 					if terr != nil {
 						t.Error(terr)
 					}
-					go func() {
-						for _ = range ticker.C {
-							var content []types.ObjectContent
-							rerr := pc.RetrieveOne(ctx, info.Result.(types.ManagedObjectReference), nil, &content)
-							if rerr != nil {
-								t.Error(rerr)
-							}
-						}
-					}()
 				}()
 			}
 
 			vms, err := finder.VirtualMachineList(ctx, "*")
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 
 			for i := range vms {
+				props := []string{"runtime.powerState"}
 				vm := vms[i]
+
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					task, _ := vm.PowerOff(ctx)
-					_ = task.Wait(ctx)
+
+					werr := property.Wait(ctx, pc, vm.Reference(), props, func(changes []types.PropertyChange) bool {
+						for _, change := range changes {
+							if change.Name != props[0] {
+								t.Errorf("unexpected property: %s", change.Name)
+							}
+							if change.Val == types.VirtualMachinePowerStatePoweredOff {
+								return true
+							}
+						}
+
+						wg.Add(1)
+						time.AfterFunc(100*time.Millisecond, func() {
+							defer wg.Done()
+
+							task, _ := vm.PowerOff(ctx)
+							_ = task.Wait(ctx)
+						})
+
+						return false
+
+					})
+					if werr != nil {
+						if werr != context.Canceled {
+							t.Error(werr)
+						}
+					}
 				}()
 			}
 		}()
 	}
 
 	wg.Wait()
+
+	// cancel event and tasks collectors, waiting for them to complete
+	cancel()
+	collectors.Wait()
+
+	t.Logf("collected %d events, %d tasks", nevents, ntasks)
+	if nevents == 0 {
+		t.Error("no events collected")
+	}
+	if ntasks == 0 {
+		t.Error("no tasks collected")
+	}
 }

--- a/simulator/session_manager.go
+++ b/simulator/session_manager.go
@@ -138,6 +138,12 @@ func (s *SessionManager) Logout(ctx *Context, _ *types.Logout) soap.HasFault {
 	session := ctx.Session
 	delete(s.sessions, session.Key)
 
+	for ref, obj := range ctx.Session.Registry.objects {
+		if _, ok := obj.(RegisterObject); ok {
+			ctx.Map.Remove(ref) // Remove RegisterObject handlers
+		}
+	}
+
 	ctx.postEvent(&types.UserLogoutSessionEvent{
 		IpAddress: session.IpAddress,
 		UserAgent: session.UserAgent,

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -229,8 +229,11 @@ func TestCreateVm(t *testing.T) {
 						}
 
 					}
-					return false
+					return true
 				})
+				if err != nil {
+					t.Error(err)
+				}
 			}
 		}
 

--- a/vim25/mo/retrieve.go
+++ b/vim25/mo/retrieve.go
@@ -65,6 +65,22 @@ func ObjectContentToType(o types.ObjectContent) (interface{}, error) {
 	return v.Elem().Interface(), nil
 }
 
+// ApplyPropertyChange converts the response of a call to WaitForUpdates
+// and applies it to the given managed object.
+func ApplyPropertyChange(obj Reference, changes []types.PropertyChange) {
+	t := typeInfoForType(obj.Reference().Type)
+	v := reflect.ValueOf(obj)
+
+	for _, p := range changes {
+		rv, ok := t.props[p.Name]
+		if !ok {
+			continue
+		}
+
+		assignValue(v, rv, reflect.ValueOf(p.Val))
+	}
+}
+
 // LoadRetrievePropertiesResponse converts the response of a call to
 // RetrieveProperties to one or more managed objects.
 func LoadRetrievePropertiesResponse(res *types.RetrievePropertiesResponse, dst interface{}) error {


### PR DESCRIPTION
Prior to this change, clients could only call WaitForUpdatesEx once,
which would return the current state.  The next invocation with Version
given would fail as unsupported.  Clients can now use WaitForUpdatesEx
to wait for multiple updates.

The basic idea is that methods should now update object fields using
the `Registry.Update` method instead of setting fields directly.
`Registry.Update` uses the same PropertyChange structure that is sent as
part of the WaitForUpdatesEx response.  `Registry.Update` will also apply
the PropertyChange(s) to the local object, removing the need to set
fields directly.

- govc commands now use Client.Flag.WithCancel to catch SIGINT,
  allowing proper cleanup of collectors

- Add vcsim ListView support to ViewManager

Fixes #922