### PR TITLE
Avoid panic if fault detail is nil

### DIFF
--- a/ssoadmin/client.go
+++ b/ssoadmin/client.go
@@ -56,7 +56,7 @@ type Client struct {
 func init() {
 	// Fault types are not in the ssoadmin.wsdl
 	vim.Add("SsoFaultNotAuthenticated", reflect.TypeOf((*vim.NotAuthenticated)(nil)).Elem())
-	vim.Add("SsoNoPermission", reflect.TypeOf((*vim.NoPermission)(nil)).Elem())
+	vim.Add("SsoFaultNoPermission", reflect.TypeOf((*vim.NoPermission)(nil)).Elem())
 	vim.Add("SsoFaultInvalidCredentials", reflect.TypeOf((*vim.InvalidLogin)(nil)).Elem())
 	vim.Add("SsoAdminFaultDuplicateSolutionCertificateFaultFault", reflect.TypeOf((*vim.InvalidArgument)(nil)).Elem())
 }

--- a/vim25/soap/error.go
+++ b/vim25/soap/error.go
@@ -39,7 +39,11 @@ func (s soapFaultError) Error() string {
 	msg := s.fault.String
 
 	if msg == "" {
-		msg = reflect.TypeOf(s.fault.Detail.Fault).Name()
+		if s.fault.Detail.Fault == nil {
+			msg = "unknown fault"
+		} else {
+			msg = reflect.TypeOf(s.fault.Detail.Fault).Name()
+		}
 	}
 
 	return fmt.Sprintf("%s: %s", s.fault.Code, msg)


### PR DESCRIPTION
If the type of fault is not included in the vim25 types registry,
soapFaultError.Error method would panic as the Detail.Fault field is nil.

Fix ssoadmin type registration for the NoPermission fault.