### PR TITLE
govc: show rule details for ClusterVmHostRuleInfo rules in cluster.rule.ls

### DIFF
--- a/govc/cluster/rule/info.go
+++ b/govc/cluster/rule/info.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+)
+
+type info struct {
+	*InfoFlag
+}
+
+func init() {
+	cli.Register("cluster.rule.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.InfoFlag, ctx = NewInfoFlag(ctx)
+	cmd.InfoFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	return cmd.InfoFlag.Process(ctx)
+}
+
+func (cmd *info) Description() string {
+	return `Provides detailed infos about cluster rules, their types and rule members.
+
+Examples:
+  govc cluster.rule.info -cluster my_cluster
+  govc cluster.rule.info -cluster my_cluster -name my_rule`
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	var res ruleResult
+
+	rules, err := cmd.Rules(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rule := range rules {
+		ruleName := rule.GetClusterRuleInfo().Name
+		ruleInfo := GetExtendedClusterRuleInfo(rule)
+		if cmd.name == "" || cmd.name == ruleName {
+			res = append(res, fmt.Sprintf("Rule: %s", ruleName))
+			res = append(res, fmt.Sprintf("  Type: %s", ruleInfo.ruleType))
+			switch ruleInfo.ruleType {
+			case "ClusterAffinityRuleSpec", "ClusterAntiAffinityRuleSpec":
+				names, err := cmd.Names(ctx, *ruleInfo.refs)
+				if err != nil {
+					cmd.WriteResult(res)
+					return err
+				}
+
+				for _, ref := range *ruleInfo.refs {
+					res = append(res, fmt.Sprintf("  VM: %s", names[ref]))
+				}
+			case "ClusterVmHostRuleInfo":
+				res = append(res, fmt.Sprintf("  vmGroupName: %s", ruleInfo.vmGroupName))
+				res = append(res, fmt.Sprintf("  affineHostGroupName %s", ruleInfo.affineHostGroupName))
+				res = append(res, fmt.Sprintf("  antiAffineHostGroupName %s", ruleInfo.antiAffineHostGroupName))
+			case "ClusterDependencyRuleInfo":
+				res = append(res, fmt.Sprintf("  VmGroup %s", ruleInfo.VmGroup))
+				res = append(res, fmt.Sprintf("  DependsOnVmGroup %s", ruleInfo.DependsOnVmGroup))
+			default:
+				res = append(res, "unknown rule type, no further rule details known")
+			}
+		}
+
+	}
+
+	return cmd.WriteResult(res)
+}

--- a/govc/cluster/rule/info_flag.go
+++ b/govc/cluster/rule/info_flag.go
@@ -31,6 +31,7 @@ type InfoFlag struct {
 	rules []types.BaseClusterRuleInfo
 
 	name string
+	Long bool
 }
 
 func NewInfoFlag(ctx context.Context) (*InfoFlag, context.Context) {
@@ -43,6 +44,7 @@ func (f *InfoFlag) Register(ctx context.Context, fs *flag.FlagSet) {
 	f.ClusterFlag.Register(ctx, fs)
 
 	fs.StringVar(&f.name, "name", "", "Cluster rule name")
+	fs.BoolVar(&f.Long, "l", false, "Long listing format")
 }
 
 func (f *InfoFlag) Process(ctx context.Context) error {
@@ -83,6 +85,10 @@ type ClusterRuleInfo struct {
 	vmGroupName             string
 	affineHostGroupName     string
 	antiAffineHostGroupName string
+
+	// only ClusterDependencyRuleInfo
+	VmGroup          string
+	DependsOnVmGroup string
 }
 
 func (f *InfoFlag) Rule(ctx context.Context) (*ClusterRuleInfo, error) {
@@ -96,27 +102,36 @@ func (f *InfoFlag) Rule(ctx context.Context) (*ClusterRuleInfo, error) {
 			continue
 		}
 
-		r := &ClusterRuleInfo{info: rule}
-
-		switch info := rule.(type) {
-		case *types.ClusterAffinityRuleSpec:
-			r.ruleType = "ClusterAffinityRuleSpec"
-			r.refs = &info.Vm
-			r.kind = "VirtualMachine"
-		case *types.ClusterAntiAffinityRuleSpec:
-			r.ruleType = "ClusterAntiAffinityRuleSpec"
-			r.refs = &info.Vm
-			r.kind = "VirtualMachine"
-		case *types.ClusterVmHostRuleInfo:
-			r.ruleType = "ClusterVmHostRuleInfo"
-			r.vmGroupName = info.VmGroupName
-			r.affineHostGroupName = info.AffineHostGroupName
-			r.antiAffineHostGroupName = info.AntiAffineHostGroupName
-		}
-		return r, nil
+		r := GetExtendedClusterRuleInfo(rule)
+		return &r, nil
 	}
 
 	return nil, fmt.Errorf("rule %q not found", f.name)
+}
+
+func GetExtendedClusterRuleInfo(rule types.BaseClusterRuleInfo) ClusterRuleInfo {
+	r := ClusterRuleInfo{info: rule}
+
+	switch info := rule.(type) {
+	case *types.ClusterAffinityRuleSpec:
+		r.ruleType = "ClusterAffinityRuleSpec"
+		r.refs = &info.Vm
+		r.kind = "VirtualMachine"
+	case *types.ClusterAntiAffinityRuleSpec:
+		r.ruleType = "ClusterAntiAffinityRuleSpec"
+		r.refs = &info.Vm
+		r.kind = "VirtualMachine"
+	case *types.ClusterVmHostRuleInfo:
+		r.ruleType = "ClusterVmHostRuleInfo"
+		r.vmGroupName = info.VmGroupName
+		r.affineHostGroupName = info.AffineHostGroupName
+		r.antiAffineHostGroupName = info.AntiAffineHostGroupName
+	case *types.ClusterDependencyRuleInfo:
+		r.ruleType = "ClusterDependencyRuleInfo"
+		r.VmGroup = info.VmGroup
+		r.DependsOnVmGroup = info.DependsOnVmGroup
+	}
+	return r
 }
 
 func (f *InfoFlag) Apply(ctx context.Context, update types.ArrayUpdateSpec, info types.BaseClusterRuleInfo) error {

--- a/govc/cluster/rule/info_flag.go
+++ b/govc/cluster/rule/info_flag.go
@@ -72,9 +72,17 @@ func (f *InfoFlag) Rules(ctx context.Context) ([]types.BaseClusterRuleInfo, erro
 type ClusterRuleInfo struct {
 	info types.BaseClusterRuleInfo
 
+	ruleType string
+
+	// only ClusterAffinityRuleSpec and ClusterAntiAffinityRuleSpec
 	refs *[]types.ManagedObjectReference
 
 	kind string
+
+	// only ClusterVmHostRuleInfo
+	vmGroupName             string
+	affineHostGroupName     string
+	antiAffineHostGroupName string
 }
 
 func (f *InfoFlag) Rule(ctx context.Context) (*ClusterRuleInfo, error) {
@@ -92,13 +100,19 @@ func (f *InfoFlag) Rule(ctx context.Context) (*ClusterRuleInfo, error) {
 
 		switch info := rule.(type) {
 		case *types.ClusterAffinityRuleSpec:
+			r.ruleType = "ClusterAffinityRuleSpec"
 			r.refs = &info.Vm
 			r.kind = "VirtualMachine"
 		case *types.ClusterAntiAffinityRuleSpec:
+			r.ruleType = "ClusterAntiAffinityRuleSpec"
 			r.refs = &info.Vm
 			r.kind = "VirtualMachine"
+		case *types.ClusterVmHostRuleInfo:
+			r.ruleType = "ClusterVmHostRuleInfo"
+			r.vmGroupName = info.VmGroupName
+			r.affineHostGroupName = info.AffineHostGroupName
+			r.antiAffineHostGroupName = info.AntiAffineHostGroupName
 		}
-
 		return r, nil
 	}
 

--- a/govc/cluster/rule/ls.go
+++ b/govc/cluster/rule/ls.go
@@ -78,18 +78,26 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 			return err
 		}
 
-		if rule.refs == nil {
-			return nil
+		res = append(res, rule.ruleType+":")
+		switch rule.ruleType {
+		case "ClusterAffinityRuleSpec", "ClusterAntiAffinityRuleSpec":
+			names, err := cmd.Names(ctx, *rule.refs)
+			if err != nil {
+				cmd.WriteResult(res)
+				return err
+			}
+
+			for _, ref := range *rule.refs {
+				res = append(res, names[ref])
+			}
+		case "ClusterVmHostRuleInfo":
+			res = append(res, "VmGroupName="+rule.vmGroupName)
+			res = append(res, "AffineHostGroupName="+rule.affineHostGroupName)
+			res = append(res, "AntiAffineHostGroupName="+rule.antiAffineHostGroupName)
+		default:
+			res = append(res, "unknown rule type, no further rule details known")
 		}
 
-		names, err := cmd.Names(ctx, *rule.refs)
-		if err != nil {
-			return err
-		}
-
-		for _, ref := range *rule.refs {
-			res = append(res, names[ref])
-		}
 	}
 
 	return cmd.WriteResult(res)

--- a/govc/test/cluster.bats
+++ b/govc/test/cluster.bats
@@ -84,6 +84,17 @@ load test_helper
   run govc cluster.rule.ls -cluster DC0_C0 -name pod1 -l=true
   assert_success "$(printf "%s (VM)\n" DC0_C0_RP0_VM{0,1,2,3})"
 
+  run govc cluster.rule.info -cluster DC0_C0
+  assert_success "$(cat <<_EOF_
+Name: pod1
+  Type: ClusterAffinityRuleSpec
+  VM: DC0_C0_RP0_VM0
+  VM: DC0_C0_RP0_VM1
+  VM: DC0_C0_RP0_VM2
+  VM: DC0_C0_RP0_VM3
+_EOF_
+)"
+
   run govc cluster.rule.change -cluster DC0_C0 -name pod1 DC0_C0_RP0_VM{2,3,4}
   assert_success
 
@@ -140,6 +151,20 @@ load test_helper
 
   run govc cluster.rule.ls -cluster DC0_C0 -name my_deps -l
   assert_success "$(printf "%s\n" {'my_app (VmGroup)','my_db (DependsOnVmGroup)'})"
+
+  run govc cluster.rule.info -cluster DC0_C0
+  assert_success "$(cat <<_EOF_
+Name: pod2
+  Type: ClusterVmHostRuleInfo
+  vmGroupName: my_vms
+  affineHostGroupName even_hosts
+  antiAffineHostGroupName odd_hosts
+Name: my_deps
+  Type: ClusterDependencyRuleInfo
+  VmGroup my_app
+  DependsOnVmGroup my_db
+_EOF_
+)"
 
 }
 

--- a/govc/test/cluster.bats
+++ b/govc/test/cluster.bats
@@ -86,7 +86,7 @@ load test_helper
 
   run govc cluster.rule.info -cluster DC0_C0
   assert_success "$(cat <<_EOF_
-Name: pod1
+Rule: pod1
   Type: ClusterAffinityRuleSpec
   VM: DC0_C0_RP0_VM0
   VM: DC0_C0_RP0_VM1
@@ -154,12 +154,12 @@ _EOF_
 
   run govc cluster.rule.info -cluster DC0_C0
   assert_success "$(cat <<_EOF_
-Name: pod2
+Rule: pod2
   Type: ClusterVmHostRuleInfo
   vmGroupName: my_vms
   affineHostGroupName even_hosts
   antiAffineHostGroupName odd_hosts
-Name: my_deps
+Rule: my_deps
   Type: ClusterDependencyRuleInfo
   VmGroup my_app
   DependsOnVmGroup my_db

--- a/govc/test/cluster.bats
+++ b/govc/test/cluster.bats
@@ -72,8 +72,17 @@ load test_helper
   run govc cluster.rule.create -cluster DC0_C0 -name pod1 -affinity DC0_C0_RP0_VM{0,1,2,3}
   assert_success
 
+  run govc cluster.rule.ls -cluster DC0_C0
+  assert_success "pod1"
+
+  run govc cluster.rule.ls -cluster DC0_C0 -l=true
+  assert_success "pod1 (ClusterAffinityRuleSpec)"
+
   run govc cluster.rule.ls -cluster DC0_C0 -name pod1
   assert_success "$(printf "%s\n" DC0_C0_RP0_VM{0,1,2,3})"
+
+  run govc cluster.rule.ls -cluster DC0_C0 -name pod1 -l=true
+  assert_success "$(printf "%s (VM)\n" DC0_C0_RP0_VM{0,1,2,3})"
 
   run govc cluster.rule.change -cluster DC0_C0 -name pod1 DC0_C0_RP0_VM{2,3,4}
   assert_success
@@ -99,6 +108,15 @@ load test_helper
   run govc cluster.rule.remove -cluster DC0_C0 -name pod1
   assert_success
 
+  run govc cluster.rule.ls -cluster DC0_C0 -l
+  assert_success "pod2 (ClusterVmHostRuleInfo)"
+
+  run govc cluster.rule.ls -cluster DC0_C0 -name pod2
+  assert_success "$(printf "%s\n" {my_vms,even_hosts,odd_hosts})"
+
+  run govc cluster.rule.ls -cluster DC0_C0 -name pod2 -l
+  assert_success "$(printf "%s\n" {'my_vms (vmGroupName)','even_hosts (affineHostGroupName)','odd_hosts (antiAffineHostGroupName)'})"
+
   run govc cluster.rule.remove -cluster DC0_C0 -name pod1 -depends
   assert_failure # rule does not exist
 
@@ -113,6 +131,16 @@ load test_helper
 
   run govc cluster.rule.create -cluster DC0_C0 -name my_deps -depends my_app my_db
   assert_success
+
+  run govc cluster.rule.ls -cluster DC0_C0 -l
+  assert_success "$(printf "%s\n" {'pod2 (ClusterVmHostRuleInfo)','my_deps (ClusterDependencyRuleInfo)'})"
+
+  run govc cluster.rule.ls -cluster DC0_C0 -name my_deps
+  assert_success "$(printf "%s\n" {'my_app','my_db'})"
+
+  run govc cluster.rule.ls -cluster DC0_C0 -name my_deps -l
+  assert_success "$(printf "%s\n" {'my_app (VmGroup)','my_db (DependsOnVmGroup)'})"
+
 }
 
 @test "cluster.vm" {


### PR DESCRIPTION
We've head some problems managing our cluster affinity rules with govc. govc wasn't showing any infos in cluster.rule.ls for 'ClusterVmHostRuleInfo' type rules, that match a host group to a VM group. 
With the proposed change cluster.rule.ls can now show you the type of the rule and the additional details for 'ClusterVmHostRuleInfo' type rules.