### PR TITLE
vcsim: do not include DVS in HostSystem.Network

### DIFF
--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -106,11 +106,10 @@ func (s *DistributedVirtualSwitch) ReconfigureDvsTask(req *types.ReconfigureDvs_
 
 			switch types.ConfigSpecOperation(member.Operation) {
 			case types.ConfigSpecOperationAdd:
-				if FindReference(host.Network, s.Self) != nil {
+				if FindReference(s.Summary.HostMember, member.Host) != nil {
 					return nil, &types.AlreadyExists{Name: host.Name}
 				}
 
-				Map.AppendReference(host, &host.Network, s.Self)
 				Map.AppendReference(host, &host.Network, s.Portgroup...)
 				s.Summary.HostMember = append(s.Summary.HostMember, member.Host)
 
@@ -129,8 +128,7 @@ func (s *DistributedVirtualSwitch) ReconfigureDvsTask(req *types.ReconfigureDvs_
 					}
 				}
 
-				Map.RemoveReference(host, &host.Network, s.Self)
-				RemoveReference(&s.Summary.HostMember, s.Self)
+				RemoveReference(&s.Summary.HostMember, member.Host)
 			case types.ConfigSpecOperationEdit:
 				return nil, &types.NotSupported{}
 			}


### PR DESCRIPTION
The HostSystem.Network field should only include Network types.