### PR TITLE
Add method to move host into cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * SetRootCAs on the soap.Client returns an error for invalid certificates
 
+* Add ClusterComputeResource.MoveInto method
+
 ### 0.18.0 (2018-05-24)
 
 * Add VirtualDiskManager wrapper to set UUID

--- a/object/cluster_compute_resource.go
+++ b/object/cluster_compute_resource.go
@@ -69,11 +69,16 @@ func (c ClusterComputeResource) AddHost(ctx context.Context, spec types.HostConn
 	return NewTask(c.c, res.Returnval), nil
 }
 
-func (c ClusterComputeResource) MoveInto(ctx context.Context, host *HostSystem) (*Task, error) {
+func (c ClusterComputeResource) MoveInto(ctx context.Context, hosts ...*HostSystem) (*Task, error) {
 	req := types.MoveInto_Task{
 		This: c.Reference(),
-		Host: []types.ManagedObjectReference{host.Reference()},
 	}
+
+	hostReferences := make([]types.ManagedObjectReference, len(hosts))
+	for i, host := range hosts {
+		hostReferences[i] = host.Reference()
+	}
+	req.Host = hostReferences
 
 	res, err := methods.MoveInto_Task(ctx, c.c, &req)
 	if err != nil {

--- a/object/cluster_compute_resource.go
+++ b/object/cluster_compute_resource.go
@@ -68,3 +68,17 @@ func (c ClusterComputeResource) AddHost(ctx context.Context, spec types.HostConn
 
 	return NewTask(c.c, res.Returnval), nil
 }
+
+func (c ClusterComputeResource) MoveInto(ctx context.Context, host *HostSystem) (*Task, error) {
+	req := types.MoveInto_Task{
+		This: c.Reference(),
+		Host: []types.ManagedObjectReference{host.Reference()},
+	}
+
+	res, err := methods.MoveInto_Task(ctx, c.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(c.c, res.Returnval), nil
+}


### PR DESCRIPTION
Wraps the `MoveInto_Task` on `ClusterComputeResource`.