### PR TITLE
WaitOption.MaxWaitSeconds in simulator

### DIFF
--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -532,14 +532,14 @@ func TestWaitForUpdatesOneUpdateCalculation(t *testing.T) {
 			for _, fs := range set.FilterSet {
 				// We expect the enter of VM first
 				if fs.ObjectSet[0].Kind == types.ObjectUpdateKindEnter {
-					wait<-true
+					wait <- true
 					// Keep going
 					continue
 				}
 
 				// We also expect a modify due to the power state change
 				if fs.ObjectSet[0].Kind == types.ObjectUpdateKindModify {
-					wait<-true
+					wait <- true
 					// Now we can return to stop the routine
 					return
 				}

--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
@@ -448,6 +449,115 @@ func TestIncrementalWaitForUpdates(t *testing.T) {
 	_, _ = vm.PowerOff(ctx)
 	_, _ = vm.Destroy(ctx)
 	wg.Wait() // wait for Delete to be reported
+}
+
+func TestWaitForUpdatesOneUpdateCalculation(t *testing.T) {
+	/*
+	 * In this test, we use WaitForUpdatesEx in non-blocking way
+	 * by setting the MaxWaitSeconds to 0.
+	 * We filter on 'runtime.powerState'
+	 * Once we get the first 'enter' update, we change the
+	 * power state of the VM to generate a 'modify' update.
+	 * Once we get the modify, we can stop.
+	 */
+	ctx := context.Background()
+
+	m := VPX()
+	defer m.Remove()
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wait := make(chan bool)
+	pc := property.DefaultCollector(c.Client)
+	obj := Map.Any("VirtualMachine").(*VirtualMachine)
+	ref := obj.Reference()
+	vm := object.NewVirtualMachine(c.Client, ref)
+	filter := new(property.WaitFilter).Add(ref, ref.Type, []string{"runtime.powerState"})
+	// WaitOptions.maxWaitSeconds:
+	// A value of 0 causes WaitForUpdatesEx to do one update calculation and return any results.
+	filter.Options = &types.WaitOptions{
+		MaxWaitSeconds: types.NewInt32(0),
+	}
+	// toggle power state to generate updates
+	state := map[types.VirtualMachinePowerState]func(context.Context) (*object.Task, error){
+		types.VirtualMachinePowerStatePoweredOff: vm.PowerOn,
+		types.VirtualMachinePowerStatePoweredOn:  vm.PowerOff,
+	}
+
+	err = pc.CreateFilter(ctx, filter.CreateFilter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := types.WaitForUpdatesEx{
+		This:    pc.Reference(),
+		Options: filter.Options,
+	}
+
+	go func() {
+		for {
+			res, err := methods.WaitForUpdatesEx(ctx, c.Client, &req)
+			if err != nil {
+				if ctx.Err() == context.Canceled {
+					werr := pc.CancelWaitForUpdates(context.Background())
+					t.Error(werr)
+					return
+				}
+				t.Error(err)
+				return
+			}
+
+			set := res.Returnval
+			if set == nil {
+				// Retry if the result came back empty
+				// Thats a normal case when MaxWaitSeconds is set to 0.
+				// It means we have no updates for now
+				time.Sleep(500 * time.Millisecond)
+				continue
+			}
+
+			req.Version = set.Version
+
+			for _, fs := range set.FilterSet {
+				// We expect the enter of VM first
+				if fs.ObjectSet[0].Kind == types.ObjectUpdateKindEnter {
+					wait<-true
+					// Keep going
+					continue
+				}
+
+				// We also expect a modify due to the power state change
+				if fs.ObjectSet[0].Kind == types.ObjectUpdateKindModify {
+					wait<-true
+					// Now we can return to stop the routine
+					return
+				}
+			}
+		}
+	}()
+
+	// wait for the enter update.
+	<-wait
+
+	// Now change the VM power state, to generate a modify update
+	_, err = state[obj.Runtime.PowerState](ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// wait for the modify update.
+	<-wait
 }
 
 func TestPropertyCollectorWithUnsetValues(t *testing.T) {


### PR DESCRIPTION
Hi,

I saw recently the new simulator package which is amazing, but I also had problems with the MaxWaitSeconds parameter of WaitForUpdatesEx() function; especially with the 0 value which means : 

> do one update calculation and return any results. [(Doc)](https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vmodl.query.PropertyCollector.WaitOptions.html#maxWaitSeconds)

With the current code, if I set a value of 0, it always returns **nothing, immediately**, even if there are updates that should be returned (with an exception of the very first call when Version == "").

The main problem in the current code (from what I understood) is coming from the line:
`simulator/property_collector.go:632`
`... = context.WithTimeout(context.Background(), time.Second*time.Duration(*max))`

which (in case of value *max = 0) creates a timer that fires immediately. 
And then on line,`simulator/property_collector.go:680`
inside the next `select` statement, we fall in the `context.DeadlineExceeded` case without even checking if there is anything updated

I propose a patch for this, 
If the MaxWaitSeconds is zero:
- we don't create a timer (context with timeout)
- we return an empty result instead of continue to loop when there is no updates available

I also added a testcase for this. Maybe the test is not optimal but it fails (does not return) without the patch.

Thanks,
Thibaut.

_PS: (I have to admit, I'm a little bit obsessed with the WaitOption.MaxWaitSeconds parameter of WaitForUpdates() ... cf. #741 ahah)_