### PR TITLE
vcsim: Logout should not unregister PropertyCollector singleton

### DIFF
--- a/simulator/session_manager.go
+++ b/simulator/session_manager.go
@@ -137,8 +137,12 @@ func (s *SessionManager) LoginByToken(ctx *Context, req *types.LoginByToken) soa
 func (s *SessionManager) Logout(ctx *Context, _ *types.Logout) soap.HasFault {
 	session := ctx.Session
 	delete(s.sessions, session.Key)
+	pc := Map.content().PropertyCollector
 
 	for ref, obj := range ctx.Session.Registry.objects {
+		if ref == pc {
+			continue // don't unregister the PropertyCollector singleton
+		}
 		if _, ok := obj.(RegisterObject); ok {
 			ctx.Map.Remove(ref) // Remove RegisterObject handlers
 		}


### PR DESCRIPTION
Unlike other per-session objects, the PC singleton has the same ManagedObjectReference regardless of session instance.
If a 2nd Login creates a new session, and PC singleton is used, the Logout of that session would unregister the PC singleton update listener.

Fixes #1195