### PR TITLE
vcsim: add support for tags API

### DIFF
--- a/govc/tags/category/create.go
+++ b/govc/tags/category/create.go
@@ -40,9 +40,9 @@ func init() {
 func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
 	cmd.ClientFlag.Register(ctx, f)
-	f.StringVar(&cmd.description, "d", "", "Description of category")
-	f.StringVar(&cmd.types, "t", "", "Associable_types of category")
-	f.BoolVar(&cmd.multi, "m", false, "Cardinality of category")
+	f.StringVar(&cmd.description, "d", "", "Description")
+	f.StringVar(&cmd.types, "t", "", "Associable object types")
+	f.BoolVar(&cmd.multi, "m", false, "Allow multiple tags per object")
 }
 
 func (cmd *create) Process(ctx context.Context) error {
@@ -57,12 +57,13 @@ func (cmd *create) Usage() string {
 }
 
 func (cmd *create) Description() string {
-	return ` Create tag category. 
+	return `Create tag category.
 
 This command will output the ID you just created.
 
 Examples:
-  govc tags.category.create -d "description" -t "categoryType" -m(if set, the cardinality will be true) NAME`
+  govc tags.category.create -d "Host category" -t HostSystem NAME
+  govc tags.category.create -d "Any object category" -m NAME`
 }
 
 func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -82,5 +83,4 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		fmt.Println(*id)
 		return nil
 	})
-
 }

--- a/govc/tags/category/update.go
+++ b/govc/tags/category/update.go
@@ -42,9 +42,9 @@ func (cmd *update) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
 	cmd.ClientFlag.Register(ctx, f)
 	f.StringVar(&cmd.name, "n", "", "Name of category")
-	f.StringVar(&cmd.description, "d", "", "Description of category")
-	f.StringVar(&cmd.types, "t", "", "Associable_types of category")
-	f.StringVar(&cmd.multi, "m", "", "Cardinality of category")
+	f.StringVar(&cmd.description, "d", "", "Description")
+	f.StringVar(&cmd.types, "t", "", "Associable object types")
+	f.StringVar(&cmd.multi, "m", "", "Allow multiple tags per object")
 }
 
 func (cmd *update) Process(ctx context.Context) error {
@@ -59,8 +59,8 @@ func (cmd *update) Usage() string {
 }
 
 func (cmd *update) Description() string {
-	return `Update category. 
-	
+	return `Update category.
+
 Cardinality can be either "SINGLE" or "MULTIPLE."
 
 Examples:
@@ -76,7 +76,7 @@ func (cmd *update) Run(ctx context.Context, f *flag.FlagSet) error {
 	return withClient(ctx, cmd.ClientFlag, func(c *tags.RestClient) error {
 
 		category := new(tags.CategoryUpdateSpec)
-		categoryTemp := new(tags.CategoryUpdate)
+		categoryTemp := new(tags.Category)
 		if cmd.name != "" {
 			categoryTemp.Name = cmd.name
 		}

--- a/govc/tags/create.go
+++ b/govc/tags/create.go
@@ -53,8 +53,8 @@ func (cmd *create) Usage() string {
 }
 
 func (cmd *create) Description() string {
-	return `Create tag. 
-	
+	return `Create tag.
+
 This command will output the ID you just created.
 
 Examples:

--- a/govc/tags/update.go
+++ b/govc/tags/update.go
@@ -56,8 +56,8 @@ func (cmd *update) Usage() string {
 }
 
 func (cmd *update) Description() string {
-	return `Update tag. 
-	
+	return `Update tag.
+
 Examples:
   govc tags.update -n NAME -d DESCRIPTION ID`
 }
@@ -71,7 +71,7 @@ func (cmd *update) Run(ctx context.Context, f *flag.FlagSet) error {
 	return withClient(ctx, cmd.ClientFlag, func(c *tags.RestClient) error {
 
 		tag := new(tags.TagUpdateSpec)
-		tagTemp := new(tags.TagUpdate)
+		tagTemp := new(tags.Tag)
 		if cmd.name != "" {
 			tagTemp.Name = cmd.name
 		}

--- a/govc/test/tags.bats
+++ b/govc/test/tags.bats
@@ -2,10 +2,8 @@
 
 load test_helper
 
-#testing tags.category.* commands
-@test "tags.category.*" {
-  esx_env
-  export GOVC_DATASTORE=vsanDatastore
+@test "tags.category" {
+  vcsim_env
 
   category_name=$(new_id)
   des="new_des"
@@ -15,7 +13,7 @@ load test_helper
 
   category_id=${output}
   run govc tags.category.ls
-  
+
   ls_result=$(govc tags.category.ls | grep ${category_name} | wc -l)
   [ ${ls_result} -eq 1 ]
 
@@ -35,16 +33,17 @@ load test_helper
   [ ${info_des} -eq 1 ]
 }
 
-#testing tags.* commands
-@test "tags.*" {
-  esx_env
-  export GOVC_DATASTORE=vsanDatastore
+@test "tags" {
+  vcsim_env
 
-  category=$(govc tags.category.ls -json | jq -r '.[].CategoryID')
+  run govc tags.category.create -d "desc" -m "$(new_id)"
+  assert_success
+
+  category="$output"
   test_name="test_name"
   des_tag="update_des_tag"
 
-  run govc tags.create ${test_name} ${category}
+  run govc tags.create -d "desc" ${test_name} ${category}
   assert_success
 
   tag_id=${output}
@@ -66,14 +65,18 @@ load test_helper
   [ ${des_result} -eq 1 ]
 }
 
-#testing tags.association.* commands
-@test "tags.association.*" {
-  esx_env
-  export GOVC_DATASTORE=vsanDatastore
+@test "tags.association" {
+  vcsim_env
 
-  category=$(govc tags.category.ls -json | jq -r '.[].CategoryID')
-  tag=$(govc tags.ls -json | jq -r '.[].TagID')
-  tag_name=$(govc tags.ls -json | jq -r '.[].Name')
+  run govc tags.category.create -d "desc" -m "$(new_id)"
+  assert_success
+  category="$output"
+
+  run govc tags.create -d "desc" "$(new_id)" "$category"
+  assert_success
+  tag=$output
+
+  tag_name=$(govc tags.ls -json | jq -r ".[] | select(.TagID == \"$tag\") | .Name")
   run govc find . -type h
   object=${lines[0]}
 

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -1,0 +1,330 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/vmware/govmomi/vapi/tags"
+	vim "github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	Path              = "/rest/com/vmware"
+	SessionCookieName = "vmware-api-session-id"
+)
+
+type handler struct {
+	*http.ServeMux
+	sync.Mutex
+	Category    map[string]*tags.Category
+	Tag         map[string]*tags.Tag
+	Association map[string]map[tags.AssociatedObject]bool
+}
+
+// New creates a vAPI simulator.
+func New(u *url.URL, settings []vim.BaseOptionValue) (string, http.Handler) {
+	s := &handler{
+		ServeMux:    http.NewServeMux(),
+		Category:    make(map[string]*tags.Category),
+		Tag:         make(map[string]*tags.Tag),
+		Association: make(map[string]map[tags.AssociatedObject]bool),
+	}
+
+	handlers := []struct {
+		p string
+		m http.HandlerFunc
+	}{
+		{"cis/session", s.session},
+		{"cis/tagging/category", s.category},
+		{"cis/tagging/category/", s.categoryID},
+		{"cis/tagging/tag", s.tag},
+		{"cis/tagging/tag/", s.tagID},
+		{"cis/tagging/tag-association", s.association},
+	}
+
+	for i := range handlers {
+		h := handlers[i]
+		s.HandleFunc(Path+"/"+h.p, func(w http.ResponseWriter, r *http.Request) {
+			s.Lock()
+			defer s.Unlock()
+
+			h.m(w, r)
+		})
+	}
+
+	return Path + "/", s
+}
+
+// ok responds with http.StatusOK and json encodes val if given.
+func (s *handler) ok(w http.ResponseWriter, val ...interface{}) {
+	w.WriteHeader(http.StatusOK)
+
+	if len(val) == 0 {
+		return
+	}
+
+	err := json.NewEncoder(w).Encode(struct {
+		Value interface{} `json:"value,omitempty"`
+	}{
+		val[0],
+	})
+
+	if err != nil {
+		log.Panic(err)
+	}
+}
+
+func (s *handler) fail(w http.ResponseWriter, kind string) {
+	w.WriteHeader(http.StatusBadRequest)
+
+	err := json.NewEncoder(w).Encode(struct {
+		Type  string `json:"type"`
+		Value struct {
+			Messages []string `json:"messages,omitempty"`
+		} `json:"value,omitempty"`
+	}{
+		Type: kind,
+	})
+
+	if err != nil {
+		log.Panic(err)
+	}
+}
+
+// ServeHTTP handles vAPI requests.
+func (s *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost, http.MethodDelete, http.MethodGet, http.MethodPatch:
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	h, _ := s.Handler(r)
+	h.ServeHTTP(w, r)
+}
+
+func (s *handler) decode(r *http.Request, w http.ResponseWriter, val interface{}) bool {
+	defer r.Body.Close()
+	err := json.NewDecoder(r.Body).Decode(val)
+	if err != nil {
+		log.Printf("%s %s: %s", r.Method, r.RequestURI, err)
+		w.WriteHeader(http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+func (s *handler) session(w http.ResponseWriter, r *http.Request) {
+	var id string
+
+	switch r.Method {
+	case http.MethodPost:
+		id = uuid.New().String()
+		// TODO: save session
+		http.SetCookie(w, &http.Cookie{
+			Name:  SessionCookieName,
+			Value: id,
+		})
+		s.ok(w)
+	case http.MethodDelete:
+		// TODO: delete session
+		s.ok(w)
+	case http.MethodGet:
+		// TODO: test is session is valid
+		s.ok(w, id)
+	}
+}
+
+func (s *handler) action(r *http.Request) string {
+	return r.URL.Query().Get("~action")
+}
+
+func (s *handler) id(r *http.Request) string {
+	id := path.Base(r.URL.Path)
+	return strings.TrimPrefix(id, "id:")
+}
+
+func newID(kind string) string {
+	return fmt.Sprintf("urn:vmomi:InventoryService%s:%s:GLOBAL", kind, uuid.New().String())
+}
+
+func (s *handler) category(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var spec tags.CategoryCreateSpec
+		if s.decode(r, w, &spec) {
+			for _, category := range s.Category {
+				if category.Name == spec.CreateSpec.Name {
+					s.fail(w, "com.vmware.vapi.std.errors.already_exists")
+					return
+				}
+			}
+			id := newID("Category")
+			spec.CreateSpec.ID = id
+			s.Category[id] = &spec.CreateSpec
+			s.ok(w, id)
+		}
+	case http.MethodGet:
+		var ids []string
+		for id := range s.Category {
+			ids = append(ids, id)
+		}
+
+		s.ok(w, ids)
+	}
+}
+
+func (s *handler) categoryID(w http.ResponseWriter, r *http.Request) {
+	id := s.id(r)
+
+	o, ok := s.Category[id]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodDelete:
+		delete(s.Category, id)
+		s.ok(w)
+	case http.MethodPatch:
+		var spec tags.CategoryUpdateSpec
+		if s.decode(r, w, &spec) {
+			o.Update(&spec.UpdateSpec)
+			s.ok(w)
+		}
+	case http.MethodGet:
+		s.ok(w, o)
+	}
+}
+
+func (s *handler) tag(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var spec tags.TagCreateSpec
+		if s.decode(r, w, &spec) {
+			for _, tag := range s.Tag {
+				if tag.Name == spec.CreateSpec.Name {
+					s.fail(w, "com.vmware.vapi.std.errors.already_exists")
+					return
+				}
+			}
+			id := newID("Tag")
+			spec.CreateSpec.ID = id
+			s.Tag[id] = &spec.CreateSpec
+			s.Association[id] = make(map[tags.AssociatedObject]bool)
+			s.ok(w, id)
+		}
+	case http.MethodGet:
+		var ids []string
+		for id := range s.Tag {
+			ids = append(ids, id)
+		}
+		s.ok(w, ids)
+	}
+}
+
+func (s *handler) tagID(w http.ResponseWriter, r *http.Request) {
+	id := s.id(r)
+
+	switch s.action(r) {
+	case "list-tags-for-category":
+		var ids []string
+		for _, tag := range s.Tag {
+			if tag.CategoryID == id {
+				ids = append(ids, tag.ID)
+			}
+		}
+		s.ok(w, ids)
+		return
+	}
+
+	o, ok := s.Tag[id]
+	if !ok {
+		log.Printf("tag not found: %s", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodDelete:
+		delete(s.Tag, id)
+		delete(s.Association, id)
+		s.ok(w)
+	case http.MethodPatch:
+		var spec tags.TagUpdateSpec
+		if s.decode(r, w, &spec) {
+			o.Update(&spec.UpdateSpec)
+			s.ok(w)
+		}
+	case http.MethodGet:
+		s.ok(w, o)
+	}
+}
+
+func (s *handler) association(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	var spec tags.TagAssociationSpec
+	if !s.decode(r, w, &spec) {
+		return
+	}
+
+	if spec.TagID != "" {
+		if _, exists := s.Association[spec.TagID]; !exists {
+			log.Printf("association tag not found: %s", spec.TagID)
+			http.NotFound(w, r)
+			return
+		}
+	}
+
+	switch s.action(r) {
+	case "attach":
+		s.Association[spec.TagID][*spec.ObjectID] = true
+		s.ok(w)
+	case "detach":
+		delete(s.Association[spec.TagID], *spec.ObjectID)
+		s.ok(w)
+	case "list-attached-tags":
+		var ids []string
+		for id, objs := range s.Association {
+			if objs[*spec.ObjectID] {
+				ids = append(ids, id)
+			}
+		}
+		s.ok(w, ids)
+	case "list-attached-objects":
+		var ids []tags.AssociatedObject
+		for id := range s.Association[spec.TagID] {
+			ids = append(ids, id)
+		}
+		s.ok(w, ids)
+	}
+}

--- a/vapi/tags/categories.go
+++ b/vapi/tags/categories.go
@@ -28,39 +28,40 @@ const (
 )
 
 type CategoryCreateSpec struct {
-	CreateSpec CategoryCreate `json:"create_spec"`
+	CreateSpec Category `json:"create_spec"`
 }
 
 type CategoryUpdateSpec struct {
-	UpdateSpec CategoryUpdate `json:"update_spec,omitempty"`
-}
-
-type CategoryCreate struct {
-	AssociableTypes []string `json:"associable_types"`
-	Cardinality     string   `json:"cardinality"`
-	Description     string   `json:"description"`
-	Name            string   `json:"name"`
-}
-
-type CategoryUpdate struct {
-	AssociableTypes []string `json:"associable_types,omitempty"`
-	Cardinality     string   `json:"cardinality,omitempty"`
-	Description     string   `json:"description,omitempty"`
-	Name            string   `json:"name,omitempty"`
+	UpdateSpec Category `json:"update_spec,omitempty"`
 }
 
 type Category struct {
-	ID              string   `json:"id"`
-	Description     string   `json:"description"`
-	Name            string   `json:"name"`
-	Cardinality     string   `json:"cardinality"`
-	AssociableTypes []string `json:"associable_types"`
-	UsedBy          []string `json:"used_by"`
+	ID              string   `json:"id,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Description     string   `json:"description,omitempty"`
+	Cardinality     string   `json:"cardinality,omitempty"`
+	AssociableTypes []string `json:"associable_types,omitempty"`
+	UsedBy          []string `json:"used_by,omitempty"`
 }
 
 type CategoryInfo struct {
 	Name       string
 	CategoryID string
+}
+
+func (c *Category) Update(src *Category) {
+	if src.Name != "" {
+		c.Name = src.Name
+	}
+	if src.Description != "" {
+		c.Description = src.Description
+	}
+	if src.Cardinality != "" {
+		c.Cardinality = src.Cardinality
+	}
+	if src.AssociableTypes != nil {
+		c.AssociableTypes = src.AssociableTypes
+	}
 }
 
 func (c *RestClient) CreateCategoryIfNotExist(ctx context.Context, name string, description string, categoryType string, multiValue bool) (*string, error) {
@@ -76,7 +77,12 @@ func (c *RestClient) CreateCategoryIfNotExist(ctx context.Context, name string, 
 		} else {
 			multiValueStr = "SINGLE"
 		}
-		categoryCreate := CategoryCreate{[]string{categoryType}, multiValueStr, description, name}
+		categoryCreate := Category{
+			AssociableTypes: []string{categoryType},
+			Cardinality:     multiValueStr,
+			Description:     description,
+			Name:            name,
+		}
 		spec := CategoryCreateSpec{categoryCreate}
 		id, err := c.CreateCategory(ctx, &spec)
 		if err != nil {

--- a/vapi/tags/tag_association.go
+++ b/vapi/tags/tag_association.go
@@ -34,7 +34,7 @@ type AssociatedObject struct {
 
 type TagAssociationSpec struct {
 	ObjectID *AssociatedObject `json:"object_id,omitempty"`
-	TagID    *string           `json:"tag_id,omitempty"`
+	TagID    string            `json:"tag_id,omitempty"`
 }
 
 type AttachedTagsInfo struct {
@@ -53,7 +53,7 @@ func (c *RestClient) getAssociatedObject(ref *types.ManagedObjectReference) *Ass
 	return &object
 }
 
-func (c *RestClient) getAssociationSpec(tagID *string, ref *types.ManagedObjectReference) *TagAssociationSpec {
+func (c *RestClient) getAssociationSpec(tagID string, ref *types.ManagedObjectReference) *TagAssociationSpec {
 	object := c.getAssociatedObject(ref)
 	spec := TagAssociationSpec{
 		TagID:    tagID,
@@ -63,7 +63,7 @@ func (c *RestClient) getAssociationSpec(tagID *string, ref *types.ManagedObjectR
 }
 
 func (c *RestClient) AttachTagToObject(ctx context.Context, tagID string, ref *types.ManagedObjectReference) error {
-	spec := c.getAssociationSpec(&tagID, ref)
+	spec := c.getAssociationSpec(tagID, ref)
 	_, _, status, err := c.call(ctx, http.MethodPost, fmt.Sprintf("%s?~action=attach", TagAssociationURL), *spec, nil)
 
 	if status != http.StatusOK || err != nil {
@@ -73,7 +73,7 @@ func (c *RestClient) AttachTagToObject(ctx context.Context, tagID string, ref *t
 }
 
 func (c *RestClient) DetachTagFromObject(ctx context.Context, tagID string, ref *types.ManagedObjectReference) error {
-	spec := c.getAssociationSpec(&tagID, ref)
+	spec := c.getAssociationSpec(tagID, ref)
 	_, _, status, err := c.call(ctx, http.MethodPost, fmt.Sprintf("%s?~action=detach", TagAssociationURL), *spec, nil)
 
 	if status != http.StatusOK || err != nil {
@@ -83,7 +83,7 @@ func (c *RestClient) DetachTagFromObject(ctx context.Context, tagID string, ref 
 }
 
 func (c *RestClient) ListAttachedTags(ctx context.Context, ref *types.ManagedObjectReference) ([]string, error) {
-	spec := c.getAssociationSpec(nil, ref)
+	spec := c.getAssociationSpec("", ref)
 	stream, _, status, err := c.call(ctx, http.MethodPost, fmt.Sprintf("%s?~action=list-attached-tags", TagAssociationURL), *spec, nil)
 
 	if status != http.StatusOK || err != nil {
@@ -120,7 +120,7 @@ func (c *RestClient) ListAttachedTagsByName(ctx context.Context, ref *types.Mana
 }
 
 func (c *RestClient) ListAttachedObjects(ctx context.Context, tagID string) ([]AssociatedObject, error) {
-	spec := c.getAssociationSpec(&tagID, nil)
+	spec := c.getAssociationSpec(tagID, nil)
 	stream, _, status, err := c.call(ctx, http.MethodPost, fmt.Sprintf("%s?~action=list-attached-objects", TagAssociationURL), *spec, nil)
 	if status != http.StatusOK || err != nil {
 		return nil, fmt.Errorf("list object failed with status code: %d, error message: %s", status, err)

--- a/vapi/tags/tags.go
+++ b/vapi/tags/tags.go
@@ -28,34 +28,39 @@ const (
 )
 
 type TagCreateSpec struct {
-	CreateSpec TagCreate `json:"create_spec"`
-}
-
-type TagCreate struct {
-	CategoryID  string `json:"category_id"`
-	Description string `json:"description"`
-	Name        string `json:"name"`
+	CreateSpec Tag `json:"create_spec"`
 }
 
 type TagUpdateSpec struct {
-	UpdateSpec TagUpdate `json:"update_spec,omitempty"`
-}
-
-type TagUpdate struct {
-	Description string `json:"description,omitempty"`
-	Name        string `json:"name,omitempty"`
+	UpdateSpec Tag `json:"update_spec"`
 }
 
 type Tag struct {
-	ID          string   `json:"id"`
-	Description string   `json:"description"`
-	Name        string   `json:"name"`
-	CategoryID  string   `json:"category_id"`
-	UsedBy      []string `json:"used_by"`
+	ID          string   `json:"id,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	CategoryID  string   `json:"category_id,omitempty"`
+	UsedBy      []string `json:"used_by,omitempty"`
+}
+
+func (t *Tag) Update(src *Tag) {
+	if src.Name != "" {
+		t.Name = src.Name
+	}
+	if src.Description != "" {
+		t.Description = src.Description
+	}
+	if src.CategoryID != "" {
+		t.CategoryID = src.CategoryID
+	}
 }
 
 func (c *RestClient) CreateTagIfNotExist(ctx context.Context, name string, description string, categoryID string) (*string, error) {
-	tagCreate := TagCreate{categoryID, description, name}
+	tagCreate := Tag{
+		Name:        name,
+		Description: description,
+		CategoryID:  categoryID,
+	}
 	spec := TagCreateSpec{tagCreate}
 	id, err := c.CreateTag(ctx, &spec)
 	if err == nil {

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/vmware/govmomi/simulator/esx"
 	"github.com/vmware/govmomi/simulator/vpx"
 	sts "github.com/vmware/govmomi/sts/simulator"
+	vapi "github.com/vmware/govmomi/vapi/simulator"
 )
 
 func main() {
@@ -142,6 +143,10 @@ func main() {
 	if !*isESX {
 		// STS simulator
 		path, handler := sts.New(s.URL, vpx.Setting)
+		model.Service.ServeMux.Handle(path, handler)
+
+		// vAPI simulator
+		path, handler = vapi.New(s.URL, vpx.Setting)
 		model.Service.ServeMux.Handle(path, handler)
 
 		// Lookup Service simulator


### PR DESCRIPTION
- Collapse some duplicate types in the tags package

- tags.bats now works against vcsim

Fixes #1178