### PR TITLE
Avoid use of Finder all param in govc

### DIFF
--- a/govc/flags/datacenter.go
+++ b/govc/flags/datacenter.go
@@ -77,7 +77,7 @@ func (flag *DatacenterFlag) Process(ctx context.Context) error {
 	})
 }
 
-func (flag *DatacenterFlag) Finder() (*find.Finder, error) {
+func (flag *DatacenterFlag) Finder(all ...bool) (*find.Finder, error) {
 	if flag.finder != nil {
 		return flag.finder, nil
 	}
@@ -87,7 +87,11 @@ func (flag *DatacenterFlag) Finder() (*find.Finder, error) {
 		return nil, err
 	}
 
-	finder := find.NewFinder(c, flag.JSON || flag.Dump)
+	allFlag := false
+	if len(all) == 1 {
+		allFlag = all[0]
+	}
+	finder := find.NewFinder(c, allFlag)
 
 	// Datacenter is not required (ls command for example).
 	// Set for relative func if dc flag is given or

--- a/govc/ls/command.go
+++ b/govc/ls/command.go
@@ -82,7 +82,7 @@ func (cmd *ls) typeMatch(ref types.ManagedObjectReference) bool {
 }
 
 func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
-	finder, err := cmd.Finder()
+	finder, err := cmd.Finder(cmd.All())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use of '-json' flag in any command sets the Finder all param to true.
Only the 'ls' command makes use of this property collection, so limit it to there.

Fixes #1208