### PR TITLE
Handle empty file name in import.spec

### DIFF
--- a/govc/importx/archive.go
+++ b/govc/importx/archive.go
@@ -53,7 +53,7 @@ func (f *ArchiveFlag) Process(ctx context.Context) error {
 }
 
 func (f *ArchiveFlag) ReadOvf(fpath string) ([]byte, error) {
-	r, _, err := f.Archive.Open(fpath)
+	r, _, err := f.Open(fpath)
 	if err != nil {
 		return nil, err
 	}
@@ -63,11 +63,9 @@ func (f *ArchiveFlag) ReadOvf(fpath string) ([]byte, error) {
 }
 
 func (f *ArchiveFlag) ReadEnvelope(data []byte) (*ovf.Envelope, error) {
-	r := bytes.NewReader(data)
-
-	e, err := ovf.Unmarshal(r)
+	e, err := ovf.Unmarshal(bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse ovf: %s", err.Error())
+		return nil, fmt.Errorf("failed to parse ovf: %s", err)
 	}
 
 	return e, nil

--- a/govc/importx/ovf.go
+++ b/govc/importx/ovf.go
@@ -215,6 +215,7 @@ func (cmd *ovfx) NetworkMap(e *ovf.Envelope) (p []types.OvfNetworkMapping) {
 
 func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 	ctx := context.TODO()
+
 	o, err := cmd.ReadOvf(fpath)
 	if err != nil {
 		return nil, err
@@ -222,7 +223,7 @@ func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 
 	e, err := cmd.ReadEnvelope(o)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse ovf: %s", err.Error())
+		return nil, fmt.Errorf("failed to parse ovf: %s", err)
 	}
 
 	name := "Govc Virtual Appliance"

--- a/govc/importx/spec.go
+++ b/govc/importx/spec.go
@@ -129,14 +129,16 @@ func (cmd *spec) Map(e *ovf.Envelope) (res []Property) {
 }
 
 func (cmd *spec) Spec(fpath string) error {
-	d, err := cmd.ReadOvf(fpath)
-	if err != nil {
-		return err
-	}
+	e := &ovf.Envelope{}
+	if fpath != "" {
+		d, err := cmd.ReadOvf(fpath)
+		if err != nil {
+			return err
+		}
 
-	e, err := cmd.ReadEnvelope(d)
-	if err != nil {
-		return err
+		if e, err = cmd.ReadEnvelope(d); err != nil {
+			return err
+		}
 	}
 
 	var deploymentOptions []string


### PR DESCRIPTION
* empty envelope is used when import.spec file is not provided
* includes minor idiomatic clean up