### PR TITLE
govc: save sessions using sha256 ID

### DIFF
--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -18,7 +18,7 @@ package flags
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -331,7 +331,7 @@ func (flag *ClientFlag) sessionFile() string {
 	// Key session file off of full URI and insecure setting.
 	// Hash key to get a predictable, canonical format.
 	key := fmt.Sprintf("%s#insecure=%t", url.String(), flag.insecure)
-	name := fmt.Sprintf("%040x", sha1.Sum([]byte(key)))
+	name := fmt.Sprintf("%064x", sha256.Sum256([]byte(key)))
 	return filepath.Join(home, "sessions", name)
 }
 


### PR DESCRIPTION
As sha1 becomes less secure, let's move to sha256 where possible.

Since the client hashes the URI to determine what stored session to reuse,
potential collisions (as unlikely as they might be) could open the way to
session hijacking. Using sha256 affords better protection.
