### PR TITLE
Adding LoginByToken to RoundTrip routine.

### DIFF
--- a/session/keep_alive.go
+++ b/session/keep_alive.go
@@ -114,10 +114,9 @@ func (k *keepAlive) RoundTrip(ctx context.Context, req, res soap.HasFault) error
 	if err != nil {
 		return err
 	}
-
 	// Start ticker on login, stop ticker on logout.
 	switch req.(type) {
-	case *methods.LoginBody, *methods.LoginExtensionByCertificateBody:
+	case *methods.LoginBody, *methods.LoginExtensionByCertificateBody, *methods.LoginByTokenBody:
 		k.start()
 	case *methods.LogoutBody:
 		k.stop()


### PR DESCRIPTION
This change is adding LoginByTokenBody to RoundTrip method which enables
WCP to use session.KeepAlive to maintain a persistent session with VC
using token based login.