### PR TITLE
Issue #1250 - Add ability to specify delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Refer to the [CHANGELOG](CHANGELOG.md) for version to version changes.
 
 * [Libretto](https://github.com/apcera/libretto/tree/master/virtualmachine/vsphere)
 
+* [Telegraf](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/vsphere)
+
 ## Related projects
 
 * [rbvmomi](https://github.com/vmware/rbvmomi)

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -97,20 +97,6 @@ func New(instance *ServiceInstance) *Service {
 	return s
 }
 
-// NewWithDelay returns an initialized simulator Service instance with a delay configured
-func NewWithDelay(instance *ServiceInstance, delay *DelayConfig) *Service {
-	s := &Service{
-		readAll: ioutil.ReadAll,
-		sm:      Map.SessionManager(),
-		sdk:     make(map[string]*Registry),
-		delay:   delay,
-	}
-
-	s.client, _ = vim25.NewClient(context.Background(), s)
-
-	return s
-}
-
 type serverFaultBody struct {
 	Reason *soap.Fault `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
 }

--- a/vcsim/README.md
+++ b/vcsim/README.md
@@ -114,6 +114,15 @@ rm -f $govc_sim_env
 Tests written in Go can also use the [simulator package](https://godoc.org/github.com/vmware/govmomi/simulator)
 directly, rather than the vcsim binary.
 
+## Introducing delays
+Sometimes, especially when debugging software, it can be useful to introduce delays to simulate network latency or a poorly performing vCenter. There are three command line options for dealing with delays.
+
+```-delay <ms>``` Adds a constant delay (experessed in milliseconds) to every call
+
+```-method-delay <method:milliseconds,method:milliseconds...>``` Adds a specified delay to individual methods. If both ```-method-delay``` and ```-delay``` are specified, they are added together
+
+```delay-jitter``` Specifies a jitter, i.e. a random value added to or subtracted from the delay. It is specified as a <i>Coefficient of Variation</i>, which is the same as the standard deviation divided by the mean. A reasonable starting value is 0.5, as it gives a nice variation without extreme outliers.
+
 ## Projects using vcsim
 
 * [VMware VIC Engine](https://github.com/vmware/vic)
@@ -121,6 +130,8 @@ directly, rather than the vcsim binary.
 * [Kubernetes](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/vsphere)
 
 * [Ansible](https://github.com/ansible/vcenter-test-container)
+
+* [Telegraf](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/vsphere)
 
 ## Related projects
 

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -65,7 +65,7 @@ func main() {
 
 	flag.IntVar(&model.DelayConfig.Delay, "delay", model.DelayConfig.Delay, "Method response delay across all methods")
 	methodDelayP := flag.String("method-delay", "", "Delay per method on the form 'method1:delay1,method2:delay2...'")
-	flag.Float64Var(&model.DelayConfig.DelayJitter, "delay-jitter", model.DelayConfig.DelayJitter, "Delay jitter coefficient of variation (tip: 1.0 is a good starting value)")
+	flag.Float64Var(&model.DelayConfig.DelayJitter, "delay-jitter", model.DelayConfig.DelayJitter, "Delay jitter coefficient of variation (tip: 0.5 is a good starting value)")
 
 	flag.Parse()
 

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/google/uuid"
@@ -61,12 +63,37 @@ func main() {
 	tunnel := flag.Int("tunnel", -1, "SDK tunnel port")
 	flag.BoolVar(&simulator.Trace, "trace", simulator.Trace, "Trace SOAP to stderr")
 
+	flag.IntVar(&model.DelayConfig.Delay, "delay", model.DelayConfig.Delay, "Method response delay across all methods")
+	methodDelayP := flag.String("method-delay", "", "Delay per method on the form 'method1:delay1,method2:delay2...'")
+	flag.Float64Var(&model.DelayConfig.DelayJitter, "delay-jitter", model.DelayConfig.DelayJitter, "Delay jitter coefficient of variation (tip: 1.0 is a good starting value)")
+
 	flag.Parse()
+
+	methodDelay := *methodDelayP
 
 	switch flag.Arg(0) {
 	case "uuidgen": // util-linux not installed on Travis CI
 		fmt.Println(uuid.New().String())
 		return
+	}
+
+	if methodDelay != "" {
+		m := make(map[string]int)
+		for _, s := range strings.Split(methodDelay, ",") {
+			s := strings.TrimSpace(s)
+			tuples := strings.Split(s, ":")
+			if len(tuples) == 2 {
+				key := tuples[0]
+				value, err := strconv.Atoi(tuples[1])
+				if err != nil {
+					log.Fatalf("Incorrect format of method-delay argument: %s", err)
+				}
+				m[key] = value
+			} else {
+				log.Fatal("Incorrect method delay format.")
+			}
+		}
+		model.DelayConfig.MethodDelay = m
 	}
 
 	var err error
@@ -92,6 +119,9 @@ func main() {
 		model.Datastore = opts.Datastore
 		model.Machine = opts.Machine
 		model.Autostart = opts.Autostart
+		model.DelayConfig.Delay = opts.DelayConfig.Delay
+		model.DelayConfig.MethodDelay = opts.DelayConfig.MethodDelay
+		model.DelayConfig.DelayJitter = opts.DelayConfig.DelayJitter
 	}
 
 	tag := " (govmomi simulator)"


### PR DESCRIPTION
Resolves issue #1250 

From the README:

## Introducing delays
Sometimes, especially when debugging software, it can be useful to introduce delays to simulate network latency or a poorly performing vCenter. There are three command line options for dealing with delays.

```-delay <ms>``` Adds a constant delay (experessed in milliseconds) to every call

```-method-delay <method:milliseconds,method:milliseconds...>``` Adds a specified delay to individual methods. If both ```-method-delay``` and ```-delay``` are specified, they are added together

```delay-jitter``` Specifies a jitter, i.e. a random value added to or subtracted from the delay. It is specified as a <i>Coefficient of Variation</i>, which is the same as the standard deviation divided by the mean. A reasonable starting value is 0.5, as it gives a nice variation without extreme outliers.