### PR TITLE
Include empty VirtualMachineConfigSpec annotation

### DIFF
--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -50136,7 +50136,7 @@ type VirtualMachineConfigSpec struct {
 	LocationId                   string                            `xml:"locationId,omitempty"`
 	GuestId                      string                            `xml:"guestId,omitempty"`
 	AlternateGuestName           string                            `xml:"alternateGuestName,omitempty"`
-	Annotation                   string                            `xml:"annotation"`
+	Annotation                   *string                           `xml:"annotation"`
 	Files                        *VirtualMachineFileInfo           `xml:"files,omitempty"`
 	Tools                        *ToolsConfigInfo                  `xml:"tools,omitempty"`
 	Flags                        *VirtualMachineFlagInfo           `xml:"flags,omitempty"`

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -50136,7 +50136,7 @@ type VirtualMachineConfigSpec struct {
 	LocationId                   string                            `xml:"locationId,omitempty"`
 	GuestId                      string                            `xml:"guestId,omitempty"`
 	AlternateGuestName           string                            `xml:"alternateGuestName,omitempty"`
-	Annotation                   string                            `xml:"annotation,omitempty"`
+	Annotation                   string                            `xml:"annotation"`
 	Files                        *VirtualMachineFileInfo           `xml:"files,omitempty"`
 	Tools                        *ToolsConfigInfo                  `xml:"tools,omitempty"`
 	Flags                        *VirtualMachineFlagInfo           `xml:"flags,omitempty"`


### PR DESCRIPTION
Include annotations in VirtualMachineConfigSpec even if they are empty.
Empty annotations are needed in order to clear an existing annotation.