### PR TITLE
vcsim: add fault message to PropertyCollector RetrieveProperties

### DIFF
--- a/simulator/property_collector.go
+++ b/simulator/property_collector.go
@@ -498,7 +498,12 @@ func (pc *PropertyCollector) RetrievePropertiesEx(ctx *Context, r *types.Retriev
 	res, fault := pc.collect(ctx, r)
 
 	if fault != nil {
-		body.Fault_ = Fault("", fault)
+		switch fault.(type) {
+		case *types.ManagedObjectNotFound:
+			body.Fault_ = Fault("The object has already been deleted or has not been completely created", fault)
+		default:
+			body.Fault_ = Fault("", fault)
+		}
 	} else {
 		objects := res.Objects[:0]
 		for _, o := range res.Objects {


### PR DESCRIPTION
Found inconsistent Fault message comparing to real vCenter. When trying to retrieve object which is not found, I should get the message "The object has already been deleted or has not been completely created". 

Steps to test:
1. Create ResourcePool
2. Destroy ResourcePool
3. Try RetrieveProperties with deleted pool identifier