### PR TITLE
Add vslm package and govc disk commands

### DIFF
--- a/govc/disk/create.go
+++ b/govc/disk/create.go
@@ -1,0 +1,103 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type disk struct {
+	*flags.DatastoreFlag
+
+	size units.ByteSize
+	keep *bool
+}
+
+func init() {
+	cli.Register("disk.create", &disk{})
+}
+
+func (cmd *disk) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	_ = cmd.size.Set("10G")
+	f.Var(&cmd.size, "size", "Size of new disk")
+	f.Var(flags.NewOptionalBool(&cmd.keep), "keep", "Keep disk after VM is deleted")
+}
+
+func (cmd *disk) Usage() string {
+	return "NAME"
+}
+
+func (cmd *disk) Description() string {
+	return `Create disk NAME on DS.
+
+Examples:
+  govc disk.create -size 24G my-disk`
+}
+
+func (cmd *disk) Run(ctx context.Context, f *flag.FlagSet) error {
+	name := f.Arg(0)
+	if name == "" {
+		return flag.ErrHelp
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := vslm.NewObjectManager(ds.Client())
+
+	spec := types.VslmCreateSpec{
+		Name:              name,
+		CapacityInMB:      int64(cmd.size) / units.MB,
+		KeepAfterDeleteVm: cmd.keep,
+		BackingSpec: &types.VslmCreateSpecDiskFileBackingSpec{
+			VslmCreateSpecBackingSpec: types.VslmCreateSpecBackingSpec{
+				Datastore: ds.Reference(),
+			},
+			ProvisioningType: string(types.BaseConfigInfoDiskFileBackingInfoProvisioningTypeThin),
+		},
+	}
+
+	task, err := m.CreateDisk(ctx, spec)
+	if err != nil {
+		return nil
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Creating %s...", spec.Name))
+
+	res, err := task.WaitForResult(ctx, logger)
+	logger.Wait()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(res.Result.(types.VStorageObject).Config.Id.Id)
+
+	return nil
+}

--- a/govc/disk/ls.go
+++ b/govc/disk/ls.go
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type ls struct {
+	*flags.DatastoreFlag
+	long bool
+}
+
+func init() {
+	cli.Register("disk.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing format")
+}
+
+func (cmd *ls) Usage() string {
+	return "[ID]..."
+}
+
+func (cmd *ls) Description() string {
+	return `List disk IDs on DS.
+
+Examples:
+  govc disk.ls
+  govc disk.ls -l
+  govc disk.ls -l e9b06a8b-d047-4d3c-b15b-43ea9608b1a6`
+}
+
+type lsResult struct {
+	cmd     *ls
+	Objects []*types.VStorageObject
+}
+
+func (r *lsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(r.cmd.Out, 2, 0, 2, ' ', 0)
+
+	for _, o := range r.Objects {
+		_, _ = fmt.Fprintf(tw, "%s\t%s", o.Config.Id.Id, o.Config.Name)
+		if r.cmd.long {
+			created := o.Config.CreateTime.Format(time.Stamp)
+			size := units.FileSize(o.Config.CapacityInMB * 1024 * 1024)
+			_, _ = fmt.Fprintf(tw, "\t%s\t%s", size, created)
+		}
+		_, _ = fmt.Fprintln(tw)
+	}
+
+	return tw.Flush()
+}
+
+func (r *lsResult) Dump() interface{} {
+	return r.Objects
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := vslm.NewObjectManager(ds.Client())
+	res := lsResult{cmd: cmd}
+
+	ids := f.Args()
+	if len(ids) == 0 {
+		oids, err := m.List(ctx, ds)
+		if err != nil {
+			return err
+		}
+		for _, id := range oids {
+			ids = append(ids, id.Id)
+		}
+	}
+
+	for _, id := range ids {
+		o, err := m.Retrieve(ctx, ds, id)
+		if err != nil {
+			return err
+		}
+
+		res.Objects = append(res.Objects, o)
+	}
+
+	return cmd.WriteResult(&res)
+}

--- a/govc/disk/register.go
+++ b/govc/disk/register.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type register struct {
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("disk.register", &register{})
+}
+
+func (cmd *register) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *register) Usage() string {
+	return "PATH [NAME]"
+}
+
+func (cmd *register) Description() string {
+	return `Register existing disk on DS.
+
+Examples:
+  govc disk.register disks/disk1.vmdk my-disk`
+}
+
+func (cmd *register) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := vslm.NewObjectManager(ds.Client())
+
+	path := ds.NewURL(f.Arg(0)).String()
+
+	obj, err := m.RegisterDisk(ctx, path, f.Arg(1))
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(obj.Config.Id.Id)
+
+	return nil
+}

--- a/govc/disk/rm.go
+++ b/govc/disk/rm.go
@@ -1,0 +1,69 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type rm struct {
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("disk.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Usage() string {
+	return "ID"
+}
+
+func (cmd *rm) Description() string {
+	return `Remove disk ID on DS.
+
+Examples:
+  govc disk.rm ID`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	id := f.Arg(0)
+	m := vslm.NewObjectManager(ds.Client())
+
+	task, err := m.Delete(ctx, ds, id)
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Deleting %s...", id))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}

--- a/govc/disk/snapshot/create.go
+++ b/govc/disk/snapshot/create.go
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type create struct {
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("disk.snapshot.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *create) Usage() string {
+	return "ID DESC"
+}
+
+func (cmd *create) Description() string {
+	return `Create snapshot of ID on DS.
+
+Examples:
+  govc disk.snapshot.create b9fe5f17-3b87-4a03-9739-09a82ddcc6b0 my-disk-snapshot`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := vslm.NewObjectManager(ds.Client())
+	id := f.Arg(0)
+
+	task, err := m.CreateSnapshot(ctx, ds, id, f.Arg(1))
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Snapshot %s...", id))
+
+	res, err := task.WaitForResult(ctx, logger)
+	logger.Wait()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(res.Result.(types.ID).Id)
+
+	return nil
+}

--- a/govc/disk/snapshot/ls.go
+++ b/govc/disk/snapshot/ls.go
@@ -1,0 +1,100 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type ls struct {
+	*flags.DatastoreFlag
+	long bool
+}
+
+func init() {
+	cli.Register("disk.snapshot.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing format")
+}
+
+func (cmd *ls) Usage() string {
+	return "ID"
+}
+
+func (cmd *ls) Description() string {
+	return `List snapshots for disk ID on DS.
+
+Examples:
+  govc snapshot.disk.ls -l 9b06a8b-d047-4d3c-b15b-43ea9608b1a6`
+}
+
+type lsResult struct {
+	Info *types.VStorageObjectSnapshotInfo
+	cmd  *ls
+}
+
+func (r *lsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for _, o := range r.Info.Snapshots {
+		_, _ = fmt.Fprintf(tw, "%s\t%s", o.Id.Id, o.Description)
+		if r.cmd.long {
+			created := o.CreateTime.Format(time.Stamp)
+			_, _ = fmt.Fprintf(tw, "\t%s", created)
+		}
+		_, _ = fmt.Fprintln(tw)
+	}
+
+	return tw.Flush()
+}
+
+func (r *lsResult) Dump() interface{} {
+	return r.Info
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := vslm.NewObjectManager(ds.Client())
+	info, err := m.RetrieveSnapshotInfo(ctx, ds, f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	res := lsResult{Info: info, cmd: cmd}
+
+	return cmd.WriteResult(&res)
+}

--- a/govc/disk/snapshot/rm.go
+++ b/govc/disk/snapshot/rm.go
@@ -1,0 +1,69 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type rm struct {
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("disk.snapshot.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Usage() string {
+	return "ID SID"
+}
+
+func (cmd *rm) Description() string {
+	return `Remove disk ID snapshot ID on DS.
+
+Examples:
+  govc disk.snapshot.rm ffe6a398-eb8e-4eaa-9118-e1f16b8b8e3c ecbca542-0a25-4127-a585-82e4047750d6`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	sid := f.Arg(1)
+	m := vslm.NewObjectManager(ds.Client())
+
+	task, err := m.DeleteSnapshot(ctx, ds, f.Arg(0), sid)
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("Deleting %s...", sid))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -35,6 +35,8 @@ import (
 	_ "github.com/vmware/govmomi/govc/device/scsi"
 	_ "github.com/vmware/govmomi/govc/device/serial"
 	_ "github.com/vmware/govmomi/govc/device/usb"
+	_ "github.com/vmware/govmomi/govc/disk"
+	_ "github.com/vmware/govmomi/govc/disk/snapshot"
 	_ "github.com/vmware/govmomi/govc/dvs"
 	_ "github.com/vmware/govmomi/govc/dvs/portgroup"
 	_ "github.com/vmware/govmomi/govc/env"

--- a/govc/test/disk.bats
+++ b/govc/test/disk.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "disk.ls" {
+  esx_env
+
+  run govc disk.ls
+  assert_success
+
+  run govc disk.ls enoent
+  assert_failure
+}
+
+@test "disk.create" {
+  esx_env
+
+  name=$(new_id)
+
+  run govc disk.create -size 10M "$name"
+  assert_success
+  id="${lines[1]}"
+
+  run govc disk.ls "$id"
+  assert_success
+
+  govc disk.ls -json "$id" | jq .
+
+  run govc disk.rm "$id"
+  assert_success
+
+  run govc disk.rm "$id"
+  assert_failure
+}
+
+@test "disk.register" {
+  esx_env
+
+  id=$(new_id)
+  vmdk="$id/$id.vmdk"
+
+  run govc datastore.mkdir "$id"
+  assert_success
+
+  # create with VirtualDiskManager
+  run govc datastore.disk.create -size 10M "$vmdk"
+  assert_success
+
+  run govc disk.register "$vmdk" "$id"
+  assert_success
+  id="$output"
+
+  run govc disk.register "$vmdk" "$id"
+  assert_failure
+
+  run govc disk.rm "$id"
+  assert_success
+
+  run govc disk.rm "$id"
+  assert_failure
+}
+
+@test "disk.snapshot" {
+  esx_env
+
+  name=$(new_id)
+
+  run govc disk.create -size 10M "$name"
+  assert_success
+  id="${lines[1]}"
+
+  run govc disk.snapshot.ls "$id"
+  assert_success
+
+  run govc disk.snapshot.create "$id"
+  assert_success
+  sid="${lines[1]}"
+
+  govc disk.snapshot.ls "$id" | grep "$sid"
+
+  govc disk.snapshot.ls -json "$id" | jq .
+
+  run govc disk.snapshot.rm "$id" "$sid"
+  assert_success
+
+  run govc disk.snapshot.rm "$id" "$sid"
+  assert_failure
+
+  run govc disk.rm "$id"
+  assert_success
+}

--- a/vslm/doc.go
+++ b/vslm/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package vslm provides access to the vSphere Storage Lifecycle Management service.
+*/
+package vslm

--- a/vslm/object_manager.go
+++ b/vslm/object_manager.go
@@ -1,0 +1,287 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vslm
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// ObjectManager wraps VStorageObjectManagerBase.
+type ObjectManager struct {
+	types.ManagedObjectReference
+	c    *vim25.Client
+	isVC bool
+}
+
+// NewObjectManager returns an ObjectManager referencing the VcenterVStorageObjectManager singleton when connected to vCenter or
+// the HostVStorageObjectManager singleton when connected to an ESX host.  The optional ref param can be used to specify a ESX
+// host instead, when connected to vCenter.
+func NewObjectManager(client *vim25.Client, ref ...types.ManagedObjectReference) *ObjectManager {
+	mref := *client.ServiceContent.VStorageObjectManager
+
+	if len(ref) == 1 {
+		mref = ref[0]
+	}
+
+	m := ObjectManager{
+		ManagedObjectReference: mref,
+		c:                      client,
+		isVC:                   mref.Type == "VcenterVStorageObjectManager",
+	}
+
+	return &m
+}
+
+func (m ObjectManager) CreateDisk(ctx context.Context, spec types.VslmCreateSpec) (*object.Task, error) {
+	req := types.CreateDisk_Task{
+		This: m.Reference(),
+		Spec: spec,
+	}
+
+	if m.isVC {
+		res, err := methods.CreateDisk_Task(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return object.NewTask(m.c, res.Returnval), nil
+	}
+
+	res, err := methods.HostCreateDisk_Task(ctx, m.c, (*types.HostCreateDisk_Task)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(m.c, res.Returnval), nil
+}
+
+func (m ObjectManager) Rename(ctx context.Context, ds mo.Reference, id, name string) error {
+	req := types.RenameVStorageObject{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+		Id:        types.ID{Id: id},
+		Name:      name,
+	}
+
+	if m.isVC {
+		_, err := methods.RenameVStorageObject(ctx, m.c, &req)
+		return err
+	}
+
+	_, err := methods.HostRenameVStorageObject(ctx, m.c, (*types.HostRenameVStorageObject)(&req))
+	return err
+}
+
+func (m ObjectManager) Delete(ctx context.Context, ds mo.Reference, id string) (*object.Task, error) {
+	req := types.DeleteVStorageObject_Task{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+		Id:        types.ID{Id: id},
+	}
+
+	if m.isVC {
+		res, err := methods.DeleteVStorageObject_Task(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return object.NewTask(m.c, res.Returnval), nil
+	}
+
+	res, err := methods.HostDeleteVStorageObject_Task(ctx, m.c, (*types.HostDeleteVStorageObject_Task)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(m.c, res.Returnval), nil
+}
+
+func (m ObjectManager) Retrieve(ctx context.Context, ds mo.Reference, id string) (*types.VStorageObject, error) {
+	req := types.RetrieveVStorageObject{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+		Id:        types.ID{Id: id},
+	}
+
+	if m.isVC {
+		res, err := methods.RetrieveVStorageObject(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return &res.Returnval, nil
+	}
+
+	res, err := methods.HostRetrieveVStorageObject(ctx, m.c, (*types.HostRetrieveVStorageObject)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (m ObjectManager) List(ctx context.Context, ds mo.Reference) ([]types.ID, error) {
+	req := types.ListVStorageObject{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+	}
+
+	if m.isVC {
+		res, err := methods.ListVStorageObject(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return res.Returnval, nil
+	}
+
+	res, err := methods.HostListVStorageObject(ctx, m.c, (*types.HostListVStorageObject)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m ObjectManager) RegisterDisk(ctx context.Context, path, name string) (*types.VStorageObject, error) {
+	req := types.RegisterDisk{
+		This: m.Reference(),
+		Path: path,
+		Name: name,
+	}
+
+	if m.isVC {
+		res, err := methods.RegisterDisk(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return &res.Returnval, nil
+	}
+
+	res, err := methods.HostRegisterDisk(ctx, m.c, (*types.HostRegisterDisk)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
+func (m ObjectManager) Clone(ctx context.Context, ds mo.Reference, id string, spec types.VslmCloneSpec) (*object.Task, error) {
+	req := types.CloneVStorageObject_Task{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+		Id:        types.ID{Id: id},
+		Spec:      spec,
+	}
+
+	if m.isVC {
+		res, err := methods.CloneVStorageObject_Task(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return object.NewTask(m.c, res.Returnval), nil
+	}
+
+	res, err := methods.HostCloneVStorageObject_Task(ctx, m.c, (*types.HostCloneVStorageObject_Task)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(m.c, res.Returnval), nil
+}
+
+func (m ObjectManager) CreateSnapshot(ctx context.Context, ds mo.Reference, id, desc string) (*object.Task, error) {
+	req := types.VStorageObjectCreateSnapshot_Task{
+		This:        m.Reference(),
+		Id:          types.ID{Id: id},
+		Description: desc,
+		Datastore:   ds.Reference(),
+	}
+
+	if m.isVC {
+		res, err := methods.VStorageObjectCreateSnapshot_Task(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return object.NewTask(m.c, res.Returnval), nil
+	}
+
+	res, err := methods.HostVStorageObjectCreateSnapshot_Task(ctx, m.c, (*types.HostVStorageObjectCreateSnapshot_Task)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(m.c, res.Returnval), nil
+}
+
+func (m ObjectManager) DeleteSnapshot(ctx context.Context, ds mo.Reference, id, sid string) (*object.Task, error) {
+	req := types.DeleteSnapshot_Task{
+		This:       m.Reference(),
+		Datastore:  ds.Reference(),
+		Id:         types.ID{Id: id},
+		SnapshotId: types.ID{Id: sid},
+	}
+
+	if m.isVC {
+		res, err := methods.DeleteSnapshot_Task(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return object.NewTask(m.c, res.Returnval), nil
+	}
+
+	res, err := methods.HostVStorageObjectDeleteSnapshot_Task(ctx, m.c, (*types.HostVStorageObjectDeleteSnapshot_Task)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(m.c, res.Returnval), nil
+}
+
+func (m ObjectManager) RetrieveSnapshotInfo(ctx context.Context, ds mo.Reference, id string) (*types.VStorageObjectSnapshotInfo, error) {
+	req := types.RetrieveSnapshotInfo{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+		Id:        types.ID{Id: id},
+	}
+
+	if m.isVC {
+		res, err := methods.RetrieveSnapshotInfo(ctx, m.c, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return &res.Returnval, nil
+	}
+
+	res, err := methods.HostVStorageObjectRetrieveSnapshotInfo(ctx, m.c, (*types.HostVStorageObjectRetrieveSnapshotInfo)(&req))
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}


### PR DESCRIPTION
- vslm.ObjectManager provides a higher level API for First Class Disk methods

- New govc disk.* and disk.snapshot.* commands manage FCDs and their snapshots

Fixes #1238