### PR TITLE
vcsim: add setCustomValue support

### DIFF
--- a/object/common.go
+++ b/object/common.go
@@ -130,3 +130,14 @@ func (c Common) Rename(ctx context.Context, name string) (*Task, error) {
 
 	return NewTask(c.c, res.Returnval), nil
 }
+
+func (c Common) SetCustomVal(ctx context.Context, key string, value string) error {
+	req := types.SetCustomValue{
+		This:   c.Reference(),
+		Key:    key,
+		Value:  value,
+	}
+
+	_, err := methods.SetCustomValue(ctx, c.c, &req)
+	return err
+}

--- a/simulator/custom_fields_manager.go
+++ b/simulator/custom_fields_manager.go
@@ -36,7 +36,70 @@ func NewCustomFieldsManager(ref types.ManagedObjectReference) object.Reference {
 	return m
 }
 
-func (c *CustomFieldsManager) find(key int32) (int, *types.CustomFieldDef) {
+// Iterates through all entities of passed field type;
+// Removes found field from their custom field properties.
+func entitiesFieldRemove(field types.CustomFieldDef) {
+	entities := Map.All(field.ManagedObjectType)
+	for _, e := range entities {
+		entity := e.Entity()
+		Map.WithLock(entity, func() {
+			aFields := entity.AvailableField
+			for i, aField := range aFields {
+				if aField.Key == field.Key {
+					entity.AvailableField = append(aFields[:i], aFields[i+1:]...)
+					break
+				}
+			}
+
+			values := e.Entity().Value
+			for i, value := range values {
+				if value.(*types.CustomFieldStringValue).Key == field.Key {
+					entity.Value = append(values[:i], values[i+1:]...)
+					break
+				}
+			}
+
+			cValues := e.Entity().CustomValue
+			for i, cValue := range cValues {
+				if cValue.(*types.CustomFieldStringValue).Key == field.Key {
+					entity.CustomValue = append(cValues[:i], cValues[i+1:]...)
+					break
+				}
+			}
+		})
+	}
+}
+
+// Iterates through all entities of passed field type;
+// Renames found field in entity's AvailableField property.
+func entitiesFieldRename(field types.CustomFieldDef) {
+	entities := Map.All(field.ManagedObjectType)
+	for _, e := range entities {
+		entity := e.Entity()
+		Map.WithLock(entity, func() {
+			aFields := entity.AvailableField
+			for i, aField := range aFields {
+				if aField.Key == field.Key {
+					aFields[i].Name = field.Name
+					break
+				}
+			}
+		})
+	}
+}
+
+func (c *CustomFieldsManager) findByNameType(name, moType string) (int, *types.CustomFieldDef) {
+	for i, field := range c.Field {
+		if ((field.ManagedObjectType == "" || field.ManagedObjectType == moType || moType == "") &&
+			field.Name == name) {
+			return i, &c.Field[i]
+		}
+	}
+
+	return -1, nil
+}
+
+func (c *CustomFieldsManager) findByKey(key int32) (int, *types.CustomFieldDef) {
 	for i, field := range c.Field {
 		if field.Key == key {
 			return i, &c.Field[i]
@@ -49,6 +112,15 @@ func (c *CustomFieldsManager) find(key int32) (int, *types.CustomFieldDef) {
 func (c *CustomFieldsManager) AddCustomFieldDef(req *types.AddCustomFieldDef) soap.HasFault {
 	body := &methods.AddCustomFieldDefBody{}
 
+	_, field := c.findByNameType(req.Name, req.MoType)
+	if field != nil {
+		body.Fault_ = Fault("", &types.DuplicateName{
+			Name:   req.Name,
+			Object: c.Reference(),
+		})
+		return body
+	}
+
 	def := types.CustomFieldDef{
 		Key:                     c.nextKey,
 		Name:                    req.Name,
@@ -56,6 +128,14 @@ func (c *CustomFieldsManager) AddCustomFieldDef(req *types.AddCustomFieldDef) so
 		Type:                    req.MoType,
 		FieldDefPrivileges:      req.FieldDefPolicy,
 		FieldInstancePrivileges: req.FieldPolicy,
+	}
+
+	entities := Map.All(req.MoType)
+	for _, e := range entities {
+		entity := e.Entity()
+		Map.WithLock(entity, func() {
+			entity.AvailableField = append(entity.AvailableField, def)
+		})
 	}
 
 	c.Field = append(c.Field, def)
@@ -70,11 +150,13 @@ func (c *CustomFieldsManager) AddCustomFieldDef(req *types.AddCustomFieldDef) so
 func (c *CustomFieldsManager) RemoveCustomFieldDef(req *types.RemoveCustomFieldDef) soap.HasFault {
 	body := &methods.RemoveCustomFieldDefBody{}
 
-	i, field := c.find(req.Key)
+	i, field := c.findByKey(req.Key)
 	if field == nil {
 		body.Fault_ = Fault("", &types.NotFound{})
 		return body
 	}
+
+	entitiesFieldRemove(*field)
 
 	c.Field = append(c.Field[:i], c.Field[i+1:]...)
 
@@ -85,13 +167,15 @@ func (c *CustomFieldsManager) RemoveCustomFieldDef(req *types.RemoveCustomFieldD
 func (c *CustomFieldsManager) RenameCustomFieldDef(req *types.RenameCustomFieldDef) soap.HasFault {
 	body := &methods.RenameCustomFieldDefBody{}
 
-	_, field := c.find(req.Key)
+	_, field := c.findByKey(req.Key)
 	if field == nil {
 		body.Fault_ = Fault("", &types.NotFound{})
 		return body
 	}
 
 	field.Name = req.Name
+
+	entitiesFieldRename(*field)
 
 	body.Res = &types.RenameCustomFieldDefResponse{}
 	return body
@@ -100,12 +184,15 @@ func (c *CustomFieldsManager) RenameCustomFieldDef(req *types.RenameCustomFieldD
 func (c *CustomFieldsManager) SetField(req *types.SetField) soap.HasFault {
 	body := &methods.SetFieldBody{}
 
+	newValue := &types.CustomFieldStringValue{
+		CustomFieldValue: types.CustomFieldValue{Key: req.Key},
+		Value:            req.Value,
+	}
+
 	entity := Map.Get(req.Entity).(mo.Entity).Entity()
 	Map.WithLock(entity, func() {
-		entity.CustomValue = append(entity.CustomValue, &types.CustomFieldStringValue{
-			CustomFieldValue: types.CustomFieldValue{Key: req.Key},
-			Value:            req.Value,
-		})
+		entity.CustomValue = append(entity.CustomValue, newValue)
+		entity.Value = append(entity.Value, newValue)
 	})
 
 	body.Res = &types.SetFieldResponse{}

--- a/simulator/object.go
+++ b/simulator/object.go
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func SetCustomValue(e mo.Entity, req *types.SetCustomValue) soap.HasFault {
+	body := &methods.SetCustomValueBody{}
+
+	cfm := Map.CustomFieldsManager()
+
+	_, field := cfm.findByNameType(req.Key, req.This.Type)
+	if field == nil {
+		body.Fault_ = Fault("", &types.InvalidArgument{InvalidProperty: "key"})
+		return body
+	}
+
+	entity := Map.Get(req.This).(mo.Entity).Entity()
+	// Temporarily unlock this object for SetField to use
+	mu := Map.locker(entity)
+	mu.Unlock()
+	res := cfm.SetField(&types.SetField{
+		This:   cfm.Reference(),
+		Entity: req.This,
+		Key:    field.Key,
+		Value:  req.Value,
+	})
+	mu.Lock()
+
+	if res.Fault() != nil {
+		body.Fault_ = res.Fault()
+		return body
+	}
+
+	body.Res = &types.SetCustomValueResponse{}
+	return body
+}

--- a/simulator/object_test.go
+++ b/simulator/object_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestObjectCustomFields(t *testing.T) {
+	ctx := context.Background()
+
+	m := VPX()
+	defer m.Remove()
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfm, err := object.GetCustomFieldsManager(c.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vm  := Map.Any("VirtualMachine").(*VirtualMachine)
+	vmm := object.NewVirtualMachine(c.Client, vm.Reference())
+
+	fieldName  := "testField"
+	fieldValue := "12345"
+
+	// Test that field is not created
+	err = vmm.SetCustomVal(ctx, fieldName, fieldValue)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	if len(vm.AvailableField) != 0 {
+		t.Fatalf("vm.AvailableField length expected 0, got %d", len(vm.AvailableField))
+	}
+
+	// Create field
+	field, err := cfm.Add(ctx, fieldName, vm.Reference().Type, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(vm.AvailableField) != 1 {
+		t.Fatalf("len(vm.AvailableField) expected 1, got %d", len(vm.AvailableField))
+	}
+
+	if vm.AvailableField[0].Key != field.Key {
+		t.Fatalf("vm.AvailableField[0].Key expected %d, got %d", field.Key, vm.AvailableField[0].Key)
+	}
+	if vm.AvailableField[0].Name != field.Name {
+		t.Fatalf("vm.AvailableField[0].Name expected %s, got %s", field.Name, vm.AvailableField[0].Name)
+	}
+	if vm.AvailableField[0].Type != field.Type {
+		t.Fatalf("vm.AvailableField[0].Type expected %s, got %s", field.Type, vm.AvailableField[0].Type)
+	}
+	if vm.AvailableField[0].ManagedObjectType != field.ManagedObjectType {
+		t.Fatalf("vm.AvailableField[0].ManagedObjectType expected %s, got %s",
+		field.ManagedObjectType, vm.AvailableField[0].ManagedObjectType)
+	}
+	if vm.AvailableField[0].FieldDefPrivileges != field.FieldDefPrivileges {
+		t.Fatalf("vm.AvailableField[0].FieldDefPrivileges expected %s, got %s",
+		field.FieldDefPrivileges, vm.AvailableField[0].FieldDefPrivileges)
+	}
+	if vm.AvailableField[0].FieldInstancePrivileges != field.FieldInstancePrivileges {
+		t.Fatalf("vm.AvailableField[0].FieldInstancePrivileges expected %s, got %s",
+		field.FieldInstancePrivileges, vm.AvailableField[0].FieldInstancePrivileges)
+	}
+
+	// Test that field with duplicate name can't be created
+	_, err = cfm.Add(ctx, fieldName, vm.Reference().Type, nil, nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	// Create second field
+	_, err = cfm.Add(ctx, fieldName+"2", vm.Reference().Type, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(vm.AvailableField) != 2 {
+		t.Fatalf("len(vm.AvailableField) expected 2, got %d", len(vm.AvailableField))
+	}
+
+	// Set field
+	err = vmm.SetCustomVal(ctx, fieldName, fieldValue)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(vm.CustomValue) != 1 {
+		t.Fatalf("len(vm.CustomValue) expected 1, got %d", len(vm.CustomValue))
+	}
+
+	if len(vm.Value) != 1 {
+		t.Fatalf("len(vm.Value) expected 1, got %d", len(vm.Value))
+	}
+
+	if vm.CustomValue[0].(*types.CustomFieldStringValue).Key != field.Key {
+		t.Fatalf("vm.CustomValue[0].Key expected %d, got %d",
+			field.Key, vm.CustomValue[0].(*types.CustomFieldStringValue).Key)
+	}
+	if vm.CustomValue[0].(*types.CustomFieldStringValue).Value != fieldValue {
+		t.Fatalf("vm.CustomValue[0].Value expected %s, got %s",
+			fieldValue, vm.CustomValue[0].(*types.CustomFieldStringValue).Value)
+	}
+
+	if vm.Value[0].(*types.CustomFieldStringValue).Key != field.Key {
+		t.Fatalf("vm.Value[0].Key expected %d, got %d",
+			field.Key, vm.Value[0].(*types.CustomFieldStringValue).Key)
+	}
+	if vm.Value[0].(*types.CustomFieldStringValue).Value != fieldValue {
+		t.Fatalf("vm.Value[0].Value expected %s, got %s",
+			fieldValue, vm.Value[0].(*types.CustomFieldStringValue).Value)
+	}
+
+	// Rename field
+	newName := field.Name+"_renamed"
+	err = cfm.Rename(ctx, field.Key, newName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vm.AvailableField[0].Name != newName {
+		t.Fatalf("vm.AvailableField[0].Name expected %s, got %s", newName, vm.AvailableField[0].Name)
+	}
+
+	// Remove field
+	err = cfm.Remove(ctx, field.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(vm.AvailableField) != 1 {
+		t.Fatalf("len(vm.AvailableField) expected 1, got %d", len(vm.AvailableField))
+	}
+
+	if len(vm.CustomValue) != 0 {
+		t.Fatalf("len(vm.CustomValue) expected 0, got %d", len(vm.CustomValue))
+	}
+
+	if len(vm.Value) != 0 {
+		t.Fatalf("len(vm.Value) expected 0, got %d", len(vm.Value))
+	}
+
+	// Test that remaining field key is different from removed field
+	if vm.AvailableField[0].Key == field.Key {
+		t.Fatalf("vm.AvailableField[0].Key expected to not be equal %d", field.Key)
+	}
+
+	// Remove remaining field
+	err = cfm.Remove(ctx, vm.AvailableField[0].Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(vm.AvailableField) != 0 {
+		t.Fatalf("len(vm.AvailableField) expected 0, got %d", len(vm.AvailableField))
+	}
+}

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -177,6 +177,24 @@ func (r *Registry) Any(kind string) mo.Entity {
 	return nil
 }
 
+// All returns all entities of type specified by kind.
+// If kind is empty - all entities will be returned.
+func (r *Registry) All(kind string) []mo.Entity {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	var entities []mo.Entity
+	for ref, val := range r.objects {
+		if kind == "" || ref.Type == kind {
+			if e, ok := val.(mo.Entity); ok {
+				entities = append(entities, e)
+			}
+		}
+	}
+
+	return entities
+}
+
 // applyHandlers calls the given func for each r.handlers
 func (r *Registry) applyHandlers(f func(o RegisterObject)) {
 	r.m.Lock()
@@ -441,6 +459,11 @@ func (r *Registry) SessionManager() *SessionManager {
 // OptionManager returns the OptionManager singleton
 func (r *Registry) OptionManager() *OptionManager {
 	return r.Get(r.content().Setting.Reference()).(*OptionManager)
+}
+
+// CustomFieldsManager returns CustomFieldsManager singleton
+func (r *Registry) CustomFieldsManager() *CustomFieldsManager {
+	return r.Get(r.content().CustomFieldsManager.Reference()).(*CustomFieldsManager)
 }
 
 func (r *Registry) MarshalJSON() ([]byte, error) {

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -150,7 +150,8 @@ func (s *Service) call(ctx *Context, method *Method) soap.HasFault {
 		return &serverFaultBody{Reason: Fault(msg, fault)}
 	}
 
-	name := method.Name
+	// Lowercase methods can't be accessed outside their package
+	name := strings.Title(method.Name)
 
 	if strings.HasSuffix(name, vTaskSuffix) {
 		// Make golint happy renaming "Foo_Task" -> "FooTask"

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -858,6 +858,10 @@ func (vm *VirtualMachine) DestroyTask(ctx *Context, req *types.Destroy_Task) soa
 	}
 }
 
+func (vm *VirtualMachine) SetCustomValue(req *types.SetCustomValue) soap.HasFault {
+	return SetCustomValue(vm, req)
+}
+
 func (vm *VirtualMachine) UnregisterVM(ctx *Context, c *types.UnregisterVM) soap.HasFault {
 	r := &methods.UnregisterVMBody{}
 


### PR DESCRIPTION
Implements `setCustomValue` method for Entities.
First commit only implements it for simulator's `VirtualMachine`, but can be added to other objects as well like so:
```
func (vm *VirtualMachine) SetCustomValue(req *types.SetCustomValue) soap.HasFault {
	return SetCustomValue(vm, req)
}
```
I based this on `RenameTask` method which is currently only added to simulator's `Folder`.

Fixes #1264 