### PR TITLE
[doc] add an example for cpu and memory hotplug

### DIFF
--- a/govc/vm/change.go
+++ b/govc/vm/change.go
@@ -107,6 +107,8 @@ To add ExtraConfig variables that can read within the guest, use the 'guestinfo.
 Examples:
   govc vm.change -vm $vm -mem.reservation 2048
   govc vm.change -vm $vm -e smc.present=TRUE -e ich7m.present=TRUE
+  # Enable both cpu and memory hotplug on a guest:
+  govc vm.change -vm $vm -e vcpu.hotadd=true -e mem.hotadd=true
   govc vm.change -vm $vm -e guestinfo.vmname $vm
   # Read the variable set above inside the guest:
   vmware-rpctool "info-get guestinfo.vmname"`


### PR DESCRIPTION
As per #1271, i've added an example to document how to enable cpu and memory hotplug on a vm using govc.