### PR TITLE
vcsim: update VM configureDevices method to change VM properties with UpdateObject

### DIFF
--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -275,6 +275,7 @@ func hostsWithDatastore(hosts []types.ManagedObjectReference, path string) []typ
 func (c *createVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	vm, err := NewVirtualMachine(c.Folder.Self, &c.req.Config)
 	if err != nil {
+		c.Folder.removeChild(vm)
 		return nil, err
 	}
 
@@ -312,10 +313,9 @@ func (c *createVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 
 	err = vm.create(&c.req.Config, c.register)
 	if err != nil {
+		c.Folder.removeChild(vm)
 		return nil, err
 	}
-
-	c.Folder.putChild(vm)
 
 	host := Map.Get(*vm.Runtime.Host).(*HostSystem)
 	Map.AppendReference(host, &host.Vm, vm.Self)

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -48,12 +48,14 @@ func NewVirtualMachine(parent types.ManagedObjectReference, spec *types.VirtualM
 	vm := &VirtualMachine{}
 	vm.Parent = &parent
 
+	Map.Get(parent).(*Folder).putChild(vm)
+
 	if spec.Name == "" {
-		return nil, &types.InvalidVmConfig{Property: "configSpec.name"}
+		return vm, &types.InvalidVmConfig{Property: "configSpec.name"}
 	}
 
 	if spec.Files == nil || spec.Files.VmPathName == "" {
-		return nil, &types.InvalidVmConfig{Property: "configSpec.files.vmPathName"}
+		return vm, &types.InvalidVmConfig{Property: "configSpec.files.vmPathName"}
 	}
 
 	rspec := types.DefaultResourceConfigSpec()
@@ -104,7 +106,7 @@ func NewVirtualMachine(parent types.ManagedObjectReference, spec *types.VirtualM
 
 	err := vm.configure(&defaults)
 	if err != nil {
-		return nil, err
+		return vm, err
 	}
 
 	vm.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOff


### PR DESCRIPTION
VM is now added to registry during `NewVirtualMachine` call. `folder.putChild(...)` is called at the start of the function so it always completes, if VM creation fails - it is up to callers to cleanup (`folder.removeChild`). This might be confusing as caller needs to know that VM is added to folder inside and it's up to him to catch a fault and cleanup. This is done to be safer - if cleanup was up to `NewVirtualMachine` it would need to catch all errors (and cleanup then) - any error not caught would result it no cleanup.

Fixes #1288