### PR TITLE
govc: field.set can now add a missing field

### DIFF
--- a/govc/fields/set.go
+++ b/govc/fields/set.go
@@ -19,6 +19,7 @@ package fields
 import (
 	"context"
 	"flag"
+	"strings"
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
@@ -27,6 +28,8 @@ import (
 
 type set struct {
 	*flags.DatacenterFlag
+	add  bool
+	kind string
 }
 
 func init() {
@@ -36,6 +39,14 @@ func init() {
 func (cmd *set) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
 	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.kind, "type", "", "Managed object type on which to add "+
+		"the field if it does not exist. This flag is ignored unless -add=true")
+	f.BoolVar(&cmd.add, "add", false, "Adds the field if it does not exist. "+
+		"Use the -type flag to specify the managed object type to which the "+
+		"field is added. Using -add and omitting -kind causes a new, global "+
+		"field to be created if a field with the provided name does not "+
+		"already exist.")
 }
 
 func (cmd *set) Process(ctx context.Context) error {
@@ -47,6 +58,15 @@ func (cmd *set) Process(ctx context.Context) error {
 
 func (cmd *set) Usage() string {
 	return "KEY VALUE PATH..."
+}
+
+func (cmd *set) Description() string {
+	return `Set custom field values for PATH.
+
+Examples:
+  govc fields.set my-field-name field-value vm/my-vm
+  govc fields.set -add my-new-global-field-name field-value vm/my-vm
+  govc fields.set -add -type VirtualMachine my-new-vm-field-name field-value vm/my-vm`
 }
 
 func (cmd *set) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -68,7 +88,17 @@ func (cmd *set) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	key, err := m.FindKey(ctx, args[0])
 	if err != nil {
-		return err
+		if !(cmd.add && strings.Contains(err.Error(), "key name not found")) {
+			return err
+		}
+		// Add the missing field.
+		def, err := m.Add(ctx, args[0], cmd.kind, nil, nil)
+		if err != nil {
+			return err
+		}
+		// Assign the new field's key to the "key" var used below when
+		// setting the key/value pair on the provided list of objects.
+		key = def.Key
 	}
 
 	val := args[1]


### PR DESCRIPTION
This patch adds support to the `fields.set` command for adding new fields when setting the value of a field that does not yet exist. For example, this is what happens when attempting to set a field that does not exist:

```shell
$ govc fields.set my-field my-value OBJECT_PATH
govc: key name not found
```

Using the new `-add` flag, the field will be created upon attempting to set the field's value:

```shell
$ govc fields.set -add my-field my-value OBJECT_PATH
$ govc fields.ls OBJECT_PATH
205  my-field
```

The new `-type` flag also allows users to specify to which managed object type to add new fields when setting them. If no type is specified then a global field is created (see above example). The following example adds a field to just the `VirtualMachine` type:

```shell
$ govc fields.set -add -type VirtualMachine my-vm-field my-vm-value OBJECT_PATH
$ govc fields.ls OBJECT_PATH
205  my-field
206  my-vm-field
```
