### PR TITLE
vcsim: update VM device add operation

### DIFF
--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -618,9 +618,11 @@ func TestCreateVmWithDevices(t *testing.T) {
 			},
 		},
 	}
+	devices = append(devices, ide, cdrom, scsi)
 	devices.AssignController(disk, scsi.(*types.VirtualLsiLogicController))
+	devices = append(devices, disk)
 	devices.AssignController(disk2, scsi.(*types.VirtualLsiLogicController))
-	devices = append(devices, ide, cdrom, scsi, disk, disk2)
+	devices = append(devices, disk2)
 	create, _ := devices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
 
 	spec := types.VirtualMachineConfigSpec{


### PR DESCRIPTION
* Changed VM device keys to be generated when are negative or zero (instead of only when negative)
* Changed VM device keys to always check for uniqueness
* Do not allow adding device with duplicate Key and ControllerKey = 0 (these are considered base controllers are can't be added after VM is created)
* Device configuration is considered invalid if there exists the same type device with the same UnitNumber
* Updated CloneVMTask to not clone default devices
* Updated CloneVMTask to clone disks (changing required parameters) instead of adding new ones

Fixes #1281, #1292 