### PR TITLE
Tags support for First Class Disks

### DIFF
--- a/govc/disk/tags.go
+++ b/govc/disk/tags.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+)
+
+type tags struct {
+	*flags.ClientFlag
+	types.VslmTagEntry
+	attach bool
+}
+
+func init() {
+	cli.Register("disk.tags.attach", &tags{attach: true})
+	cli.Register("disk.tags.detach", &tags{attach: false})
+}
+
+func (cmd *tags) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.ParentCategoryName, "c", "", "Tag category")
+}
+
+func (cmd *tags) Usage() string {
+	return "NAME ID"
+}
+
+func (cmd *tags) name() string {
+	if cmd.attach {
+		return "attach"
+	}
+	return "detach"
+}
+
+func (cmd *tags) Description() string {
+	if cmd.attach {
+		return `Attach tag NAME to disk ID.
+
+Examples:
+  govc disk.tags.attach -c k8s-region k8s-region-us $id`
+	}
+
+	return `Detach tag NAME from disk ID.
+
+Examples:
+  govc disk.tags.detach -c k8s-region k8s-region-us $id`
+}
+
+func (cmd *tags) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := vslm.NewObjectManager(c)
+	cmd.TagName = f.Arg(0)
+	method := m.DetachTag
+	if cmd.attach {
+		method = m.AttachTag
+	}
+	return method(ctx, f.Arg(1), cmd.VslmTagEntry)
+}

--- a/govc/test/disk.bats
+++ b/govc/test/disk.bats
@@ -123,3 +123,46 @@ load test_helper
   run govc disk.rm "$id"
   assert_success
 }
+
+@test "disk.tags" {
+  vcsim_env
+
+  run govc tags.category.create region
+  assert_success
+
+  run govc tags.create -c region US-WEST
+  assert_success
+
+  name=$(new_id)
+
+  run govc disk.create -size 10M "$name"
+  assert_success
+  id="${lines[1]}"
+
+  run govc disk.ls "$id"
+  assert_success
+
+  run govc disk.ls -c region -t US-WEST
+  assert_success ""
+
+  govc disk.ls -T | grep -v US-WEST
+
+  run govc disk.tags.attach -c region US-WEST "$id"
+  assert_success
+
+  run govc disk.ls -c region -t US-WEST
+  assert_success
+  assert_matches "$id"
+
+  run govc disk.ls -T
+  assert_success
+  assert_matches US-WEST
+
+  run govc disk.tags.detach -c region enoent "$id"
+  assert_failure
+
+  run govc disk.tags.detach -c region US-WEST "$id"
+  assert_success
+
+  govc disk.ls -T | grep -v US-WEST
+}

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -65,6 +65,16 @@ type Registry struct {
 
 	Namespace string
 	Path      string
+
+	tagManager tagManager
+}
+
+// tagManager is an interface to simplify internal interaction with the vapi tag manager simulator.
+type tagManager interface {
+	AttachedObjects(types.VslmTagEntry) ([]types.ManagedObjectReference, types.BaseMethodFault)
+	AttachedTags(id types.ManagedObjectReference) ([]types.VslmTagEntry, types.BaseMethodFault)
+	AttachTag(types.ManagedObjectReference, types.VslmTagEntry) types.BaseMethodFault
+	DetachTag(types.ManagedObjectReference, types.VslmTagEntry) types.BaseMethodFault
 }
 
 // NewRegistry creates a new instances of Registry

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -312,6 +312,16 @@ func (s *Service) About(w http.ResponseWriter, r *http.Request) {
 	_ = enc.Encode(&about)
 }
 
+// Handle registers the handler for the given pattern with Service.ServeMux.
+func (s *Service) Handle(pattern string, handler http.Handler) {
+	s.ServeMux.Handle(pattern, handler)
+	// Not ideal, but avoids having to add yet another registration mechanism
+	// so we can optionally use vapi/simulator internally.
+	if m, ok := handler.(tagManager); ok {
+		s.sdk[vim25.Path].tagManager = m
+	}
+}
+
 // RegisterSDK adds an HTTP handler for the Registry's Path and Namespace.
 func (s *Service) RegisterSDK(r *Registry) {
 	if s.ServeMux == nil {

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -179,11 +179,11 @@ func main() {
 	if !*isESX {
 		// STS simulator
 		path, handler := sts.New(s.URL, vpx.Setting)
-		model.Service.ServeMux.Handle(path, handler)
+		model.Service.Handle(path, handler)
 
 		// vAPI simulator
 		path, handler = vapi.New(s.URL, vpx.Setting)
-		model.Service.ServeMux.Handle(path, handler)
+		model.Service.Handle(path, handler)
 
 		// Lookup Service simulator
 		model.Service.RegisterSDK(lookup.New())

--- a/vslm/object_manager.go
+++ b/vslm/object_manager.go
@@ -356,3 +356,54 @@ func (m ObjectManager) RetrieveSnapshotInfo(ctx context.Context, ds mo.Reference
 
 	return &res.Returnval, nil
 }
+
+func (m ObjectManager) AttachTag(ctx context.Context, id string, tag types.VslmTagEntry) error {
+	req := &types.AttachTagToVStorageObject{
+		This:     m.ManagedObjectReference,
+		Id:       types.ID{Id: id},
+		Category: tag.ParentCategoryName,
+		Tag:      tag.TagName,
+	}
+
+	_, err := methods.AttachTagToVStorageObject(ctx, m.c, req)
+	return err
+}
+
+func (m ObjectManager) DetachTag(ctx context.Context, id string, tag types.VslmTagEntry) error {
+	req := &types.DetachTagFromVStorageObject{
+		This:     m.ManagedObjectReference,
+		Id:       types.ID{Id: id},
+		Category: tag.ParentCategoryName,
+		Tag:      tag.TagName,
+	}
+
+	_, err := methods.DetachTagFromVStorageObject(ctx, m.c, req)
+	return err
+}
+
+func (m ObjectManager) ListAttachedObjects(ctx context.Context, category, tag string) ([]types.ID, error) {
+	req := &types.ListVStorageObjectsAttachedToTag{
+		This:     m.ManagedObjectReference,
+		Category: category,
+		Tag:      tag,
+	}
+
+	res, err := methods.ListVStorageObjectsAttachedToTag(ctx, m.c, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.Returnval, nil
+}
+
+func (m ObjectManager) ListAttachedTags(ctx context.Context, id string) ([]types.VslmTagEntry, error) {
+	req := &types.ListTagsAttachedToVStorageObject{
+		This: m.ManagedObjectReference,
+		Id:   types.ID{Id: id},
+	}
+
+	res, err := methods.ListTagsAttachedToVStorageObject(ctx, m.c, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.Returnval, nil
+}


### PR DESCRIPTION
- Add tag related methods to vslm.ObjectManager

- Add vcsim support for vslm.ObjectManager tag methods

- Add govc disk.ls -c and -t options to list tagged disks

- Add govc disk.ls -T option to list tags attached to disks

- Add govc disk.tags.attach and disk.tags.detach commands