### PR TITLE
vcsim: update VM snapshot methods to change VM properties with UpdateObject

### DIFF
--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -29,20 +29,30 @@ type VirtualMachineSnapshot struct {
 
 func (v *VirtualMachineSnapshot) RemoveSnapshotTask(req *types.RemoveSnapshot_Task) soap.HasFault {
 	task := CreateTask(v, "removeSnapshot", func(t *Task) (types.AnyType, types.BaseMethodFault) {
+		var changes []types.PropertyChange
+
 		Map.Remove(req.This)
 
 		vm := Map.Get(v.Vm).(*VirtualMachine)
 		Map.WithLock(vm, func() {
 			if vm.Snapshot.CurrentSnapshot != nil && *vm.Snapshot.CurrentSnapshot == req.This {
-				parent := findParentSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This)
-				vm.Snapshot.CurrentSnapshot = parent
+				var parentSnapshot types.ManagedObjectReference
+				if parentRef := findParentSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This); parentRef != nil {
+					parentSnapshot = *parentRef
+				}
+				changes = append(changes, types.PropertyChange{Name: "snapshot.currentSnapshot", Val: parentSnapshot})
 			}
 
-			vm.Snapshot.RootSnapshotList = removeSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This, req.RemoveChildren)
+			rootSnapshots := removeSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This, req.RemoveChildren)
+			changes = append(changes, types.PropertyChange{Name: "snapshot.rootSnapshotList", Val: rootSnapshots})
 
-			if len(vm.Snapshot.RootSnapshotList) == 0 {
-				vm.Snapshot = nil
+			if len(rootSnapshots) == 0 {
+				changes = []types.PropertyChange{
+					{Name: "snapshot", Val: nil},
+				}
 			}
+
+			Map.Update(vm, changes)
 		})
 
 		return nil, nil
@@ -59,7 +69,11 @@ func (v *VirtualMachineSnapshot) RevertToSnapshotTask(req *types.RevertToSnapsho
 	task := CreateTask(v, "revertToSnapshot", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		vm := Map.Get(v.Vm).(*VirtualMachine)
 
-		Map.WithLock(vm, func() { vm.Snapshot.CurrentSnapshot = &v.Self })
+		Map.WithLock(vm, func() {
+			Map.Update(vm, []types.PropertyChange{
+				{Name: "snapshot.currentSnapshot", Val: v.Self},
+			})
+		})
 
 		return nil, nil
 	})

--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -36,11 +36,8 @@ func (v *VirtualMachineSnapshot) RemoveSnapshotTask(req *types.RemoveSnapshot_Ta
 		vm := Map.Get(v.Vm).(*VirtualMachine)
 		Map.WithLock(vm, func() {
 			if vm.Snapshot.CurrentSnapshot != nil && *vm.Snapshot.CurrentSnapshot == req.This {
-				var parentSnapshot types.ManagedObjectReference
-				if parentRef := findParentSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This); parentRef != nil {
-					parentSnapshot = *parentRef
-				}
-				changes = append(changes, types.PropertyChange{Name: "snapshot.currentSnapshot", Val: parentSnapshot})
+				parent := findParentSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This)
+				changes = append(changes, types.PropertyChange{Name: "snapshot.currentSnapshot", Val: parent})
 			}
 
 			rootSnapshots := removeSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This, req.RemoveChildren)


### PR DESCRIPTION
Updated VM Snapshot methods (Create, Remove, RemoveAll, Revert) to change VM properties with UpdateObject instead of setting directly.