### PR TITLE
Allow pointer values in mo.ApplyPropertyChange

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1026,7 +1026,7 @@ func (vm *VirtualMachine) RelocateVMTask(req *types.RelocateVM_Task) soap.HasFau
 			pool := Map.Get(*ref).(*ResourcePool)
 			Map.RemoveReference(pool, &pool.Vm, *ref)
 
-			changes = append(changes, types.PropertyChange{Name: "resourcePool", Val: *ref})
+			changes = append(changes, types.PropertyChange{Name: "resourcePool", Val: ref})
 		}
 
 		if ref := req.Spec.Host; ref != nil {
@@ -1034,8 +1034,8 @@ func (vm *VirtualMachine) RelocateVMTask(req *types.RelocateVM_Task) soap.HasFau
 			Map.RemoveReference(host, &host.Vm, *ref)
 
 			changes = append(changes,
-				types.PropertyChange{Name: "runtime.host", Val: *ref},
-				types.PropertyChange{Name: "summary.runtime.host", Val: *ref},
+				types.PropertyChange{Name: "runtime.host", Val: ref},
+				types.PropertyChange{Name: "summary.runtime.host", Val: ref},
 			)
 		}
 

--- a/vim25/mo/type_info.go
+++ b/vim25/mo/type_info.go
@@ -218,6 +218,9 @@ func assignValue(val reflect.Value, fi []int, pv reflect.Value) {
 			} else {
 				panic(fmt.Sprintf("type %s doesn't implement %s", pt.Name(), rt.Name()))
 			}
+		} else if rt.Kind() == reflect.Struct && pt.Kind() == reflect.Ptr {
+			pv = pv.Elem()
+			pt = pv.Type()
 		}
 
 		if pt.AssignableTo(rt) {

--- a/vim25/mo/type_info_test.go
+++ b/vim25/mo/type_info_test.go
@@ -19,12 +19,26 @@ package mo
 import (
 	"reflect"
 	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 func TestLoadAll(*testing.T) {
 	for _, typ := range t {
 		newTypeInfo(typ)
 	}
+}
+
+func TestApplyPropertyChange(t *testing.T) {
+	changes := []types.PropertyChange{
+		{Name: "snapshot.currentSnapshot", Val: nil},
+		{Name: "snapshot.currentSnapshot", Val: types.ManagedObjectReference{}},
+		{Name: "snapshot.currentSnapshot", Val: &types.ManagedObjectReference{}},
+	}
+	var vm VirtualMachine
+	vm.Self = types.ManagedObjectReference{Type: "VirtualMachine"}
+	vm.Snapshot = new(types.VirtualMachineSnapshotInfo)
+	ApplyPropertyChange(vm, changes)
 }
 
 // The virtual machine managed object has about 500 nested properties.


### PR DESCRIPTION
The code was originally written for client side SOAP -> Go inflation,
where struct types were never considered pointers on the wire.
Now that we are using this method in-memory via simulator.Registry.Update,
it is possible to use pointer values.