### PR TITLE
build: Refactored Travis-CI to use containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,95 @@
-sudo: required
+# Use the newer Travis-CI build templates based on the
+# Debian Linux distribution "Trusty" release.
+os:             linux
+dist:           trusty
 
-language: go
+# Disable sudo for all builds by default. This ensures all jobs use
+# Travis-CI's containerized build environment unless specified otherwise.
+# The container builds have *much* shorter queue times than the VM-based
+# build environment on which the sudo builds depend.
+sudo:           false
+services:       false
 
-go:
-   - '1.11'
+# Set the version of Go.
+language:       go
+go:             1.11
+
+# Always set the project's Go import path to ensure that forked
+# builds get cloned to the correct location.
 go_import_path: github.com/vmware/govmomi
 
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y xmlstarlet
-  - make vendor
-
-script:
-  - make check test
-  - GOOS=windows make install
-
-after_success:
-  - test -n "$TRAVIS_TAG" && docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-
-deploy:
-- provider: script
-  skip_cleanup: true
-  script: curl -sL http://git.io/goreleaser | bash
-  on:
-    tags: true
-    condition: $TRAVIS_OS_NAME = linux
-    go: '1.11'
-
+# Ensure all the jobs know where the temp directory is.
 env:
-  global:
-    - TMPDIR=/tmp
+  global: TMPDIR=/tmp
+
+jobs:
+  include:
+
+    # The "lint" stage runs the various linters against the project.
+    - &lint-stage
+      stage:         lint
+      env:           LINTER=govet
+      install:       true
+      script:        make "${LINTER}"
+
+    - <<:            *lint-stage
+      env:           LINTER=goimports
+
+    # The "build" stage verifies the program can be built against the 
+    # various GOOS and GOARCH combinations found in the Go releaser
+    # config file, ".goreleaser.yml".
+    - &build-stage
+      stage:         build
+      env:           GOOS=linux GOARCH=amd64
+      install:       true
+      script:        make install
+
+    - <<:            *build-stage
+      env:           GOOS=linux   GOARCH=386
+
+    - <<:            *build-stage
+      env:           GOOS=darwin  GOARCH=amd64
+    - <<:            *build-stage
+      env:           GOOS=darwin  GOARCH=386
+
+    - <<:            *build-stage
+      env:           GOOS=freebsd GOARCH=amd64
+    - <<:            *build-stage
+      env:           GOOS=freebsd GOARCH=386
+
+    - <<:            *build-stage
+      env:           GOOS=windows GOARCH=amd64
+    - <<:            *build-stage
+      env:           GOOS=windows GOARCH=386
+
+    # The test stage executes the test target.
+    - stage:         test
+      install:       true
+      script:        make test
+
+    # The deploy stage deploys the build artifacts using goreleaser.
+    #
+    # This stage will only be activated when there is an annotated tag present
+    # or when the text "/ci-deploy" is present in the commit message. However,
+    # the "deploy" phase of the build will still only be executed on non-PR
+    # builds as that restriction is baked into Travis-CI.
+    #
+    # Finally, this stage requires the Travis-CI VM infrastructure in order to
+    # leverage Docker. This will increase the amount of time the jobs sit
+    # in the queue, waiting to be built. However, it's a necessity as Travis-CI
+    # only allows the use of Docker with VM builds.
+    - stage:         deploy
+      if:            tag IS present OR commit_message =~ /\/ci-deploy/
+      sudo:          required
+      services:      docker
+      install:       true
+      script:        make install
+      after_success: docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+      deploy:
+      - provider:     script
+        skip_cleanup: true
+        script:       curl -sL http://git.io/goreleaser | bash
+      addons:
+        apt:
+          update:     true
+          packages:   xmlstarlet

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ check: goimports govet
 
 goimports:
 	@echo checking go imports...
-	@go get golang.org/x/tools/cmd/goimports
+	@command -v goimports >/dev/null 2>&1 || go get golang.org/x/tools/cmd/goimports
 	@! goimports -d . 2>&1 | egrep -v '^$$'
 
 govet:


### PR DESCRIPTION
This patch refactors the Travis-CI builds to use containers when possible. This will shorten the build queue times dramatically. Only when deploying build artifacts for tagged releases will Travis-CI require the VM infrastructure.

The phrase `/ci-deploy` may also be added to the commit message in order to activate the deploy stage for non-release builds.

Please see this [forked build](https://travis-ci.com/akutz/govmomi/builds/91010365) for an example of the new config in action. This PR's [build](https://travis-ci.org/vmware/govmomi/builds/453784582) also demonstrates the new config, but this link will change every time the PR is updated.