### PR TITLE
vcsim: allow '.' in vm name

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -101,3 +101,13 @@ load test_helper
   run govc object.collect -s $vm config.uuid
   assert_success "$uuid"
 }
+
+@test "vcsim vm.create" {
+  vcsim_env
+
+  run govc vm.create foo.yakity
+  assert_success
+
+  run govc vm.create bar.yakity
+  assert_success
+}

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -348,8 +348,8 @@ func (vm *VirtualMachine) createFile(spec string, name string, register bool) (*
 	file := path.Join(ds.Info.GetDatastoreInfo().Url, p.Path)
 
 	if name != "" {
-		if path.Ext(file) != "" {
-			file = path.Dir(file)
+		if path.Ext(p.Path) == ".vmx" {
+			file = path.Dir(file) // vm.Config.Files.VmPathName can be a directory or full path to .vmx
 		}
 
 		file = path.Join(file, name)


### PR DESCRIPTION
vm.Config.Files.VmPathName can be a directory or full path to .vmx,
but the logic to support it assumed the .vmx case for any non-empty path.Ext
This prevented having a '.' in the vm directory name.