### PR TITLE
Makefiles for govc/vcsim; updates  govc/build.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ govet:
 	@go tool vet -structtags=false -methods=false $$(find . -mindepth 1 -maxdepth 1 -type d -not -name vendor)
 
 install:
-	go install -v github.com/vmware/govmomi/govc
-	go install -v github.com/vmware/govmomi/vcsim
+	$(MAKE) -C govc install
+	$(MAKE) -C vcsim install
 
 go-test:
 	GORACE=history_size=5 go test -timeout 5m -count 1 -race -v $(TEST_OPTS) ./...

--- a/govc/Makefile
+++ b/govc/Makefile
@@ -1,0 +1,2 @@
+PROGRAM ?= govc
+include ../program.mk

--- a/program.mk
+++ b/program.mk
@@ -1,0 +1,48 @@
+ifneq (,$(strip $(GOOS)))
+ifeq (,$(strip $(GOARCH)))
+GOARCH := $(shell go env | grep GOARCH | awk -F= '{print $$2}' | tr -d '"')
+endif
+endif
+
+ifneq (,$(strip $(GOARCH)))
+ifeq (,$(strip $(GOOS)))
+GOOS := $(shell go env | grep GOOS | awk -F= '{print $$2}' | tr -d '"')
+endif
+endif
+
+ifeq (2,$(words $(GOOS) $(GOARCH)))
+PROGRAM := $(PROGRAM)_$(GOOS)_$(GOARCH)
+endif
+
+ifeq (windows,$(GOOS))
+PROGRAM := $(PROGRAM).exe
+endif
+
+all: $(PROGRAM)
+
+TAGS += netgo
+ifeq (,$(strip $(findstring -w,$(LDFLAGS))))
+LDFLAGS += -w
+endif
+BUILD_ARGS := -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -v
+
+$(PROGRAM):
+	CGO_ENABLED=0 go build -a $(BUILD_ARGS) -o $@
+
+install:
+	CGO_ENABLED=0 go install $(BUILD_ARGS)
+
+ifneq (,$(strip $(BUILD_OS)))
+ifneq (,$(strip $(BUILD_ARCH)))
+GOOS_GOARCH_TARGETS := $(foreach a,$(BUILD_ARCH),$(patsubst %,%_$a,$(BUILD_OS)))
+XBUILD := $(addprefix $(PROGRAM)_,$(GOOS_GOARCH_TARGETS))
+$(XBUILD):
+	GOOS=$(word 2,$(subst _, ,$@)) GOARCH=$(word 3,$(subst _, ,$@)) $(MAKE) --output-sync=target
+build-all: $(XBUILD)
+endif
+endif
+
+clean:
+	@rm -f $(PROGRAM) $(XBUILD)
+
+.PHONY: build-all install clean

--- a/vcsim/Makefile
+++ b/vcsim/Makefile
@@ -1,0 +1,2 @@
+PROGRAM ?= vcsim
+include ../program.mk


### PR DESCRIPTION
This patch introduces Makefiles for the two programs `govc` and `vcsim`. Each `Makefile` supports cross-compilation as well as sane defaults. The build script for `govc` has been updated to depend on the `govc`'s `Makefile` to keep things simple.

This PR also changes the default build behavior for `govc` (and introduces it to `vcsim`) so that both programs are compiled as static binaries with no host dependencies.

cc @dougm 