### PR TITLE
govc: add device name match support to device.ls and device.remove

### DIFF
--- a/govc/device/info.go
+++ b/govc/device/info.go
@@ -80,7 +80,7 @@ Examples:
   govc device.info -vm $name -json ethernet-0 | jq -r .Devices[].MacAddress`
 }
 
-func (cmd *info) match(p string, devices object.VirtualDeviceList) object.VirtualDeviceList {
+func match(p string, devices object.VirtualDeviceList) object.VirtualDeviceList {
 	var matches object.VirtualDeviceList
 	match := func(name string) bool {
 		matched, _ := path.Match(p, name)
@@ -138,7 +138,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 		res.Devices = toInfoList(devices)
 	} else {
 		for _, name := range f.Args() {
-			matches := cmd.match(name, devices)
+			matches := match(name, devices)
 			if len(matches) == 0 {
 				return fmt.Errorf("device '%s' not found", name)
 			}

--- a/govc/device/ls.go
+++ b/govc/device/ls.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
 )
 
 type ls struct {
@@ -55,7 +56,8 @@ func (cmd *ls) Description() string {
 	return `List devices for VM.
 
 Examples:
-  govc device.ls -vm $name`
+  govc device.ls -vm $name
+  govc device.ls -vm $name disk-*`
 }
 
 func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -71,6 +73,18 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 	devices, err := vm.Device(ctx)
 	if err != nil {
 		return err
+	}
+
+	if f.NArg() != 0 {
+		var matches object.VirtualDeviceList
+		for _, name := range f.Args() {
+			device := match(name, devices)
+			if len(device) == 0 {
+				return fmt.Errorf("device '%s' not found", name)
+			}
+			matches = append(matches, device...)
+		}
+		devices = matches
 	}
 
 	if cmd.boot {

--- a/govc/device/remove.go
+++ b/govc/device/remove.go
@@ -56,7 +56,8 @@ func (cmd *remove) Description() string {
 
 Examples:
   govc device.remove -vm $name cdrom-3000
-  govc device.remove -vm $name -keep disk-1000`
+  govc device.remove -vm $name disk-1000
+  govc device.remove -vm $name -keep disk-*`
 }
 
 func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -75,12 +76,12 @@ func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	for _, name := range f.Args() {
-		device := devices.Find(name)
-		if device == nil {
+		device := match(name, devices)
+		if len(device) == 0 {
 			return fmt.Errorf("device '%s' not found", name)
 		}
 
-		if err = vm.RemoveDevice(ctx, cmd.keepFiles, device); err != nil {
+		if err = vm.RemoveDevice(ctx, cmd.keepFiles, device...); err != nil {
 			return err
 		}
 	}

--- a/govc/test/device.bats
+++ b/govc/test/device.bats
@@ -317,3 +317,35 @@ load test_helper
   run govc vm.unregister "$vm"
   assert_success
 }
+
+@test "device.match" {
+  vcsim_env
+
+  vm=DC0_H0_VM0
+
+  run govc device.ls -vm $vm enoent-*
+  assert_failure
+
+  run govc device.info -vm $vm enoent-*
+  assert_failure
+
+  run govc device.info -vm $vm disk-*
+  assert_success
+
+  run govc vm.disk.create -vm $vm -name $vm/disk2.vmdk -size 10M
+  assert_success
+
+  run govc device.ls -vm $vm disk-*
+  assert_success
+
+  [ ${#lines[@]} -eq 2 ]
+
+  run govc device.remove -vm $vm enoent-*
+  assert_failure
+
+  run govc device.remove -vm $vm disk-*
+  assert_success
+
+  run govc device.ls -vm $vm disk-*
+  assert_failure
+}

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -727,8 +727,12 @@ func (vm *VirtualMachine) configureDevices(spec *types.VirtualMachineConfigSpec)
 				// after VM is created (returns success but device is not added).
 				continue
 			} else if device.UnitNumber != nil && devices.SelectByType(dspec.Device).Select(func(d types.BaseVirtualDevice) bool {
-				if d.GetVirtualDevice().UnitNumber != nil {
-					return *d.GetVirtualDevice().UnitNumber == *device.UnitNumber
+				base := d.GetVirtualDevice()
+				if base.UnitNumber != nil {
+					if base.ControllerKey != device.ControllerKey {
+						return false
+					}
+					return *base.UnitNumber == *device.UnitNumber
 				}
 				return false
 			}) != nil {

--- a/toolbox/guest_info.go
+++ b/toolbox/guest_info.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/davecgh/go-xdr/xdr2"
+	xdr "github.com/davecgh/go-xdr/xdr2"
 )
 
 // Defs from: open-vm-tools/lib/guestRpc/nicinfo.x


### PR DESCRIPTION
The device.info command already supports name matching, extend to the ls and remove commands.