### PR TITLE
Fixed 64-bit aligment issues with atomic counters

### DIFF
--- a/nfc/lease_updater.go
+++ b/nfc/lease_updater.go
@@ -57,10 +57,10 @@ func (o FileItem) File() types.OvfFile {
 }
 
 type LeaseUpdater struct {
-	lease *Lease
+	pos   int64 // Number of bytes (keep first to ensure 64 bit aligment)
+	total int64 // Total number of bytes (keep first to ensure 64 bit aligment)
 
-	pos   int64 // Number of bytes
-	total int64 // Total number of bytes
+	lease *Lease
 
 	done chan struct{} // When lease updater should stop
 

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -57,11 +57,11 @@ type RegisterObject interface {
 
 // Registry manages a map of mo.Reference objects
 type Registry struct {
+	counter  int64 // Keep first to ensure 64-bit alignment
 	m        sync.Mutex
 	objects  map[types.ManagedObjectReference]mo.Reference
 	handlers map[types.ManagedObjectReference]RegisterObject
 	locks    map[types.ManagedObjectReference]sync.Locker
-	counter  int64
 
 	Namespace string
 	Path      string

--- a/toolbox/process.go
+++ b/toolbox/process.go
@@ -94,13 +94,14 @@ type ProcessIO struct {
 
 // ProcessState is the toolbox representation of the GuestProcessInfo type
 type ProcessState struct {
-	Name      string
-	Args      string
-	Owner     string
-	Pid       int64
-	ExitCode  int32
-	StartTime int64
-	EndTime   int64
+	StartTime int64 // (keep first to ensure 64-bit alignment)
+	EndTime   int64 // (keep first to ensure 64-bit alignment)
+
+	Name     string
+	Args     string
+	Owner    string
+	Pid      int64
+	ExitCode int32
 
 	IO *ProcessIO
 }
@@ -472,7 +473,7 @@ func NewProcessFunc(run func(ctx context.Context, args string) error) *Process {
 
 // ProcessFuncIO is the Context key to access optional ProcessIO
 var ProcessFuncIO = struct {
-	key int
+	key int64
 }{vix.CommandMagicWord}
 
 func (f *processFunc) start(p *Process, r *vix.StartProgramRequest) (int64, error) {

--- a/vim25/progress/reader.go
+++ b/vim25/progress/reader.go
@@ -26,11 +26,11 @@ import (
 )
 
 type readerReport struct {
-	t time.Time
+	pos  int64   // Keep first to ensure 64-bit alignment
+	size int64   // Keep first to ensure 64-bit alignment
+	bps  *uint64 // Keep first to ensure 64-bit alignment
 
-	pos  int64
-	size int64
-	bps  *uint64
+	t time.Time
 
 	err error
 }


### PR DESCRIPTION
Atomic 64-bit counters in structs must be on an even 64-bit boundary, or a panic will occur. See #1330 for details.

Addressed the issue by moving all atomic 64-bit counters to the beginning of their structs, which guarantees that they will fall on a 64-bit boundary.