### PR TITLE
vcsim: datastore.upload now creates missing directories in destination path

### DIFF
--- a/simulator/datastore_test.go
+++ b/simulator/datastore_test.go
@@ -361,6 +361,12 @@ func TestDatastoreHTTP(t *testing.T) {
 		// PUT path is directory = fail
 		upload("", true, "PUT")
 
+		// POST parent does not exist = ok
+		upload("foobar/"+dst, false, "POST")
+
+		// PUT parent does not exist = ok
+		upload("barfoo/"+dst, false, "PUT")
+
 		// mkdir parent does not exist = fail
 		mkdir("foo/bar", true, false)
 

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -486,6 +486,9 @@ func (s *Service) ServeDatastore(w http.ResponseWriter, r *http.Request) {
 		// File does not exist, fallthrough to create via PUT logic
 		fallthrough
 	case "PUT":
+		dir := path.Dir(p)
+		_ = os.MkdirAll(dir, 0700)
+
 		f, err := os.Create(p)
 		if err != nil {
 			log.Printf("failed to %s '%s': %s", r.Method, p, err)


### PR DESCRIPTION
fixes #1332