### PR TITLE
vcsim: implement RefreshStorageInfo method for virtual machine

### DIFF
--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -212,6 +212,15 @@ func (v VirtualMachine) Reconfigure(ctx context.Context, config types.VirtualMac
 	return NewTask(v.c, res.Returnval), nil
 }
 
+func (v VirtualMachine) RefreshStorageInfo(ctx context.Context) error {
+	req := types.RefreshStorageInfo{
+		This: v.Reference(),
+	}
+
+	_, err := methods.RefreshStorageInfo(ctx, v.c, &req)
+	return err
+}
+
 func (v VirtualMachine) WaitForIP(ctx context.Context) (string, error) {
 	var ip string
 

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -355,6 +355,8 @@ func (c *createVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 		},
 	)
 
+	vm.RefreshStorageInfo(c.ctx, nil)
+
 	return vm.Reference(), nil
 }
 

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"reflect"
 	"testing"
 
@@ -866,5 +867,245 @@ func TestVmMarkAsTemplate(t *testing.T) {
 	_, err = vm.PowerOn(ctx)
 	if err == nil {
 		t.Fatal("cannot PowerOn a template")
+	}
+}
+
+func TestVmRefreshStorageInfo(t *testing.T) {
+	ctx := context.Background()
+
+	m := ESX()
+	defer m.Remove()
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vm := object.NewVirtualMachine(c.Client, vmm.Reference())
+
+	// take snapshot
+	task, err := vm.CreateSnapshot(ctx, "root", "description", true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err := vm.FindSnapshot(ctx, "root")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check vm.Layout.Snapshot
+	found := false
+	for _, snapLayout := range vmm.Layout.Snapshot {
+		if snapLayout.Key == *snapshot {
+			found = true
+		}
+	}
+
+	if found == false {
+		t.Fatal("could not find new snapshot in vm.Layout.Snapshot")
+	}
+
+	// check vm.LayoutEx.Snapshot
+	found = false
+	for _, snapLayoutEx := range vmm.LayoutEx.Snapshot {
+		if snapLayoutEx.Key == *snapshot {
+			found = true
+		}
+	}
+
+	if found == false {
+		t.Fatal("could not find new snapshot in vm.LayoutEx.Snapshot")
+	}
+
+	// remove snapshot
+	task, err = vm.RemoveAllSnapshot(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(vmm.Layout.Snapshot) != 0 {
+		t.Fatal("expected vm.Layout.Snapshot to be empty")
+	}
+
+	if len(vmm.LayoutEx.Snapshot) != 0 {
+		t.Fatal("expected vm.LayoutEx.Snapshot to be empty")
+	}
+
+	device, err := vm.Device(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	disks := device.SelectByType((*types.VirtualDisk)(nil))
+	if len(disks) < 1 {
+		t.Fatal("expected VM to have at least 1 disk")
+	}
+
+	findDiskFile := func(vmdkName string) *types.VirtualMachineFileLayoutExFileInfo {
+		for _, dFile := range vmm.LayoutEx.File {
+			if dFile.Name == vmdkName {
+				return &dFile
+			}
+		}
+
+		return nil
+	}
+
+	findDsStorage := func(dsName string) *types.VirtualMachineUsageOnDatastore {
+		host := Map.Get(*vmm.Runtime.Host).(*HostSystem)
+		ds := Map.FindByName(dsName, host.Datastore).(*Datastore)
+
+		for _, dsUsage := range vmm.Storage.PerDatastoreUsage {
+			if dsUsage.Datastore == ds.Self {
+				return &dsUsage
+			}
+		}
+
+		return nil
+	}
+
+	for _, d := range disks {
+		disk := d.(*types.VirtualDisk)
+		info := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+		diskLayoutCount := len(vmm.Layout.Disk)
+		summaryStorageNew := vmm.Summary.Storage
+
+		p, fault := parseDatastorePath(info.FileName)
+		if fault != nil {
+			t.Fatalf("could not parse datastore path for disk file: %s", info.FileName)
+		}
+
+		storageNew := findDsStorage(p.Datastore)
+		if storageNew == nil {
+			t.Fatalf("could not find vm usage on datastore: %s", p.Datastore)
+		}
+
+		diskFile := findDiskFile(info.FileName)
+		if diskFile == nil {
+			t.Fatal("could not find disk file in vm.LayoutEx.File")
+		}
+
+		// remove disk
+		if err = vm.RemoveDevice(ctx, false, d); err != nil {
+			t.Error(err)
+		}
+
+		summaryStorageOld := summaryStorageNew
+		summaryStorageNew = vmm.Summary.Storage
+
+		storageOld := storageNew
+		storageNew = findDsStorage(p.Datastore)
+		if storageNew == nil {
+			t.Fatalf("could not find vm usage on datastore: %s", p.Datastore)
+		}
+
+		tests := []struct {
+			got      int64
+			expected int64
+		}{
+			{int64(len(vmm.Layout.Disk)), int64(diskLayoutCount - 1)},
+			{summaryStorageNew.Committed, summaryStorageOld.Committed - diskFile.Size},
+			{summaryStorageNew.Unshared, summaryStorageOld.Unshared - diskFile.Size},
+			{summaryStorageNew.Uncommitted, summaryStorageOld.Uncommitted - disk.CapacityInBytes + diskFile.Size},
+			{storageNew.Committed, storageOld.Committed - diskFile.Size},
+			{storageNew.Unshared, storageOld.Unshared - diskFile.Size},
+			{storageNew.Uncommitted, storageOld.Uncommitted - disk.CapacityInBytes + diskFile.Size},
+		}
+
+		for _, test := range tests {
+			if test.got != test.expected {
+				t.Errorf("expected %d, got %d", test.expected, test.got)
+			}
+		}
+
+		// add disk
+		disk.CapacityInBytes = 1000000000
+		if err = vm.AddDevice(ctx, d); err != nil {
+			t.Error(err)
+		}
+
+		summaryStorageOld = summaryStorageNew
+		summaryStorageNew = vmm.Summary.Storage
+
+		storageOld = storageNew
+		storageNew = findDsStorage(p.Datastore)
+		if storageNew == nil {
+			t.Fatalf("could not find vm usage on datastore: %s", p.Datastore)
+		}
+
+		diskFile = findDiskFile(info.FileName)
+		if diskFile == nil {
+			t.Fatal("could not find disk file in vm.LayoutEx.File")
+		}
+
+		tests = []struct {
+			got      int64
+			expected int64
+		}{
+			{int64(len(vmm.Layout.Disk)), int64(diskLayoutCount)},
+			{summaryStorageNew.Committed, summaryStorageOld.Committed + diskFile.Size},
+			{summaryStorageNew.Unshared, summaryStorageOld.Unshared + diskFile.Size},
+			{summaryStorageNew.Uncommitted, summaryStorageOld.Uncommitted + disk.CapacityInBytes - diskFile.Size},
+			{storageNew.Committed, storageOld.Committed + diskFile.Size},
+			{storageNew.Unshared, storageOld.Unshared + diskFile.Size},
+			{storageNew.Uncommitted, storageOld.Uncommitted + disk.CapacityInBytes - diskFile.Size},
+		}
+
+		for _, test := range tests {
+			if test.got != test.expected {
+				t.Errorf("expected %d, got %d", test.expected, test.got)
+			}
+		}
+	}
+
+	// manually create log file
+	fileLayoutExCount := len(vmm.LayoutEx.File)
+
+	p, fault := parseDatastorePath(vmm.Config.Files.LogDirectory)
+	if fault != nil {
+		t.Fatalf("could not parse datastore path: %s", vmm.Config.Files.LogDirectory)
+	}
+
+	f, fault := vmm.createFile(p.String(), "test.log", false)
+	if fault != nil {
+		t.Fatal("could not create log file")
+	}
+
+	if len(vmm.LayoutEx.File) != fileLayoutExCount {
+		t.Errorf("expected %d, got %d", fileLayoutExCount, len(vmm.LayoutEx.File))
+	}
+
+	vm.RefreshStorageInfo(ctx)
+
+	if len(vmm.LayoutEx.File) != fileLayoutExCount+1 {
+		t.Errorf("expected %d, got %d", fileLayoutExCount+1, len(vmm.LayoutEx.File))
+	}
+
+	_ = f.Close()
+	_ = os.Remove(f.Name())
+
+	vm.RefreshStorageInfo(ctx)
+
+	if len(vmm.LayoutEx.File) != fileLayoutExCount {
+		t.Errorf("expected %d, got %d", fileLayoutExCount, len(vmm.LayoutEx.File))
 	}
 }


### PR DESCRIPTION
This pull request implements `RefreshStorageInfo()` method for `VirtualMachine`.

`RefreshStorageInfo` method can be called explicitly to update `vm.Storage`, `vm.Summary.Storage` and `vm.LayoutEx` properties. This pull request also provides implicitly called methods for updating mentioned properties (also `vm.Layout`).

Notes:

- Taking `VirtualMachine` snapshot now also creates `.vmsn` file (snapshot data file; leaving `.vmem` - snapshot memory, implementation for later - it exists only when VM is powered on or suspended)
- Created 2 methods to manage snapshot files - `createSnapshotFiles` and `removeSnapshotFiles` these can be later extended to create delta disks
- Any file that belongs to `VirtualMachine` now can be found in `vm.LayoutEx.File`. The sizes of these files is used to calculate `vm.Storage` and `vm.Summary.Storage` values
- `RefreshStorageInfo` can be called implicitly to update the properties and will look through `vm.Config.Files` directories for any files that might belong to virtual machine (logs, screenshots, config files, etc.)
- Test covers cases such as: taking/removing snapshot, removing/adding disk, creating/removing file in datastore while checking `vm.Storage`, `vm.Summary.Storage`, `vm.Layout`, `vm.LayoutEx` properties. There are more test cases that could be covered (checking if snapshot has correct disk files chain `vm.LayoutEx.Snapshot.Disk`, if it's data keys are correct `vm.LayoutEx.Snapshot.DataKey` and `vm.LayoutEx.Snapshot.MemoryKey`, checking if `vm.LayoutEx.File` files can be found, etc. - not sure how much need there is.


fixes #1336