### PR TITLE
vcsim: avoid panic when event template is not defined

### DIFF
--- a/simulator/esx/event_manager.go
+++ b/simulator/esx/event_manager.go
@@ -78,6 +78,12 @@ var EventInfo = []types.EventDescriptionEventDetail{
 		FullFormat:  "Host {{.Host.Name}} in {{.Datacenter.Name}} has exited maintenance mode",
 	},
 	{
+		Key:         "HostRemovedEvent",
+		Description: "Host removed",
+		FullFormat:  "Removed host {{.Host.Name}} in {{.Datacenter.Name}}",
+		Category:    "info",
+	},
+	{
 		Key:         "VmSuspendedEvent",
 		Description: "VM suspended",
 		Category:    "info",

--- a/simulator/event_manager.go
+++ b/simulator/event_manager.go
@@ -138,11 +138,13 @@ func (m *EventManager) formatMessage(event types.BaseEvent) {
 		}
 	}
 
-	var buf bytes.Buffer
-	if err := t.Execute(&buf, event); err != nil {
-		log.Print(err)
+	if t != nil {
+		var buf bytes.Buffer
+		if err := t.Execute(&buf, event); err != nil {
+			log.Print(err)
+		}
+		e.FullFormattedMessage = buf.String()
 	}
-	e.FullFormattedMessage = buf.String()
 
 	if logEvents {
 		log.Printf("[%s] %s", id, e.FullFormattedMessage)

--- a/simulator/event_manager_test.go
+++ b/simulator/event_manager_test.go
@@ -18,6 +18,7 @@ package simulator
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/vmware/govmomi"
@@ -113,6 +114,19 @@ func TestEventManagerVPX(t *testing.T) {
 		if test.expect != n {
 			t.Errorf("%d: expected %d events, got: %d", i, test.expect, n)
 		}
+	}
+
+	// Test that we don't panic if event ID is not defined in esx.EventInfo
+	type TestHostRemovedEvent struct {
+		types.HostEvent
+	}
+	var hre TestHostRemovedEvent
+	kind := reflect.TypeOf(hre)
+	types.Add(kind.Name(), kind)
+
+	err = e.PostEvent(ctx, &hre, types.TaskInfo{})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
EventManager.formatMessage would panic if an event type was not defined in esx.EventInfo,
now simply leaves FullFormattedMessage as-is in that case.

Add HostRemovedEvent to esx.EventInfo and emit from the HostSystem.Destroy_Task method.