### PR TITLE
Add 2x blog posts about vcsim

### DIFF
--- a/vcsim/README.md
+++ b/vcsim/README.md
@@ -136,3 +136,9 @@ Sometimes, especially when debugging software, it can be useful to introduce del
 ## Related projects
 
 [LocalStack](https://github.com/localstack/localstack/blob/master/README.md#why-localstack)
+
+## Blog posts on vcsim
+
+* [Beginning vCenter Server simulation with Govcsim](https://opensourceforu.com/2017/10/vcenter-server-simulation-govcsim/) By Abhijeet Kasurde - October 3, 2017
+
+* [govcsim – Neat incubation project (vCenter Server & ESXi API based simulator)](https://www.virtuallyghetto.com/2017/04/govcsim-neat-incubation-project-vcenter-server-esxi-api-based-simulator.html) by [William Lam](https://twitter.com/lamw) - April 21, 2017


### PR DESCRIPTION
## Title

Add 2x blog posts about vcsim

## What 
- adds 2x blog posts to the README.md file of the vcsim
component to help new users get started and to improve SEO.

This is a documentation change which should have no impact on tests etc.

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>