### PR TITLE
vcsim: avoid zero IP address in GOVC_URL output

### DIFF
--- a/govc/test/test_helper.bash
+++ b/govc/test/test_helper.bash
@@ -50,6 +50,7 @@ vcsim_start() {
 
 vcsim_stop() {
   kill "$GOVC_SIM_PID"
+  wait "$GOVC_SIM_PID"
   rm -f "$GOVC_SIM_ENV"
   unset GOVC_SIM_PID
 }

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -242,3 +242,22 @@ load test_helper
   run govc vm.destroy $vm
   assert_success
 }
+
+@test "vcsim listen" {
+  vcsim_start -dc 0
+  url=$(govc option.ls vcsim.server.url)
+  [[ "$url" == *"https://127.0.0.1:"* ]]
+  vcsim_stop
+
+  vcsim_start -dc 0 -httptest.serve 0.0.0.0:0
+  url=$(govc option.ls vcsim.server.url)
+  [[ "$url" != *"https://127.0.0.1:"* ]]
+  [[ "$url" != *"https://[::]:"* ]]
+  vcsim_stop
+
+  vcsim_start -dc 0 -l :0 -httptest.serve ""
+  url=$(govc option.ls vcsim.server.url)
+  [[ "$url" != *"https://127.0.0.1:"* ]]
+  [[ "$url" != *"https://[::]:"* ]]
+  vcsim_stop
+}

--- a/vcsim/README.md
+++ b/vcsim/README.md
@@ -88,9 +88,9 @@ The default vcsim listen address is `127.0.0.1:8989`.  Use the `-httptest.serve`
 
 
 ``` shell
-vcsim -httptest.serve=10.118.69.224:8989 # specific address
+vcsim -l 10.118.69.224:8989 # specific address
 
-vcsim -httptest.serve=:8989 # any address
+vcsim -l :8989 # any address
 ```
 
 When given a port value of '0', an unused port will be chosen.  You can then source the GOVC_URL from another
@@ -101,7 +101,7 @@ govc_sim_env=$TMPDIR/vcsim-$(uuidgen)
 
 mkfifo $govc_sim_env
 
-vcsim -httptest.serve=127.0.0.1:0 -E $govc_sim_env &
+vcsim -l 127.0.0.1:0 -E $govc_sim_env &
 
 eval "$(cat $govc_sim_env)"
 

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -63,6 +63,7 @@ func main() {
 	cert := flag.String("tlscert", "", "Path to TLS certificate file")
 	key := flag.String("tlskey", "", "Path to TLS key file")
 	env := flag.String("E", "-", "Output vcsim variables to the given fifo or stdout")
+	listen := flag.String("l", "127.0.0.1:8989", "Listen address for vcsim")
 	tunnel := flag.Int("tunnel", -1, "SDK tunnel port")
 	flag.BoolVar(&simulator.Trace, "trace", simulator.Trace, "Trace SOAP to stderr")
 
@@ -110,12 +111,13 @@ func main() {
 	}
 
 	f := flag.Lookup("httptest.serve")
-	listen := f.Value.String()
-	if listen == "" {
-		listen = "127.0.0.1:8989"
-		_ = f.Value.Set(listen)
+	serve := f.Value.String()
+	if serve == "" {
+		_ = f.Value.Set(*listen) // propagate -l unless -httptest.serve is specified
+	} else {
+		*listen = serve // propagate to updateHostTemplate call below
 	}
-	if err = updateHostTemplate(listen); err != nil {
+	if err = updateHostTemplate(*listen); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
If the '-httptest.serve' flag is specified without an address,
the default GOVC_URL output will be unusable.  Attempt to replace
with a valid IPv4 address.

- Add vcsim '-l' flag as an alias for '-httptest.serve'

- Fix vcsim_stop race; need to wait for process to exit