### PR TITLE
vcsim: fix SearchDatastore task info entity

### DIFF
--- a/simulator/datastore_test.go
+++ b/simulator/datastore_test.go
@@ -292,6 +292,9 @@ func TestDatastoreHTTP(t *testing.T) {
 				}
 				return nil
 			}
+			if info.Entity.Type != "Datastore" {
+				t.Fatal(info.Entity.Type)
+			}
 
 			return info.Result.(types.HostDatastoreBrowserSearchResults).File
 		}
@@ -319,6 +322,9 @@ func TestDatastoreHTTP(t *testing.T) {
 					}
 				}
 				return nil
+			}
+			if info.Entity.Type != "Datastore" {
+				t.Fatal(info.Entity.Type)
 			}
 
 			return info.Result.(types.ArrayOfHostDatastoreBrowserSearchResults).HostDatastoreBrowserSearchResults

--- a/simulator/host_datastore_browser.go
+++ b/simulator/host_datastore_browser.go
@@ -187,7 +187,7 @@ func (s *searchDatastore) search(ds *types.ManagedObjectReference, folder string
 	return nil
 }
 
-func (s *searchDatastore) Run(Task *Task) (types.AnyType, types.BaseMethodFault) {
+func (s *searchDatastore) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	p, fault := parseDatastorePath(s.DatastorePath)
 	if fault != nil {
 		return nil, fault
@@ -199,6 +199,8 @@ func (s *searchDatastore) Run(Task *Task) (types.AnyType, types.BaseMethodFault)
 	}
 
 	ds := ref.(*Datastore)
+	task.Info.Entity = &ds.Self // TODO: CreateTask() should require mo.Entity, rather than mo.Reference
+	task.Info.EntityName = ds.Name
 
 	dir := path.Join(ds.Info.GetDatastoreInfo().Url, p.Path)
 


### PR DESCRIPTION
Task.Info.Entity must be of type ManagedEntity, in this case should the Datastore
rather than the HostDatastoreBrowser.

Fixes #1353