### PR TITLE
Fix travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
     - <<:            *lint-stage
       env:           LINTER=goimports
 
-    # The "build" stage verifies the program can be built against the 
+    # The "build" stage verifies the program can be built against the
     # various GOOS and GOARCH combinations found in the Go releaser
     # config file, ".goreleaser.yml".
     - &build-stage
@@ -89,6 +89,9 @@ jobs:
       - provider:     script
         skip_cleanup: true
         script:       curl -sL http://git.io/goreleaser | bash
+        on:
+          tags: true
+          condition: $TRAVIS_OS_NAME = linux
       addons:
         apt:
           update:     true


### PR DESCRIPTION
The on tags section was removed in #1302

Causing deploy to fail:
 Skipping a deployment with the script provider because this branch is not permitted: v0.20.0
 https://travis-ci.org/vmware/govmomi/jobs/489881920#L648