### PR TITLE
Fix for govc/build.sh wrong dir

### DIFF
--- a/govc/build.sh
+++ b/govc/build.sh
@@ -8,8 +8,9 @@ git_version=$(git describe --dirty)
   exit 1
 fi
 
+PROGRAM_NAME=govc
 PROJECT_PKG="github.com/vmware/govmomi"
-PROGRAM_PKG="${PROJECT_PKG}/$(basename "$(dirname "${0}")")"
+PROGRAM_PKG="${PROJECT_PKG}/${PROGRAM_NAME}"
 
 export LDFLAGS="-w -X ${PROGRAM_PKG}/version.gitVersion=${git_version}"
 export BUILD_OS="${BUILD_OS:-darwin linux windows freebsd}"


### PR DESCRIPTION
This patch fixes the issue described in the comment at https://github.com/vmware/govmomi/pull/1370#issuecomment-461294868.