### PR TITLE
Remove nested progress.Tee usage

### DIFF
--- a/nfc/lease.go
+++ b/nfc/lease.go
@@ -27,7 +27,6 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/progress"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
@@ -208,8 +207,6 @@ func (l *Lease) StartUpdater(ctx context.Context, info *LeaseInfo) *LeaseUpdater
 func (l *Lease) Upload(ctx context.Context, item FileItem, f io.Reader, opts soap.Upload) error {
 	if opts.Progress == nil {
 		opts.Progress = item
-	} else {
-		opts.Progress = progress.Tee(item, opts.Progress)
 	}
 
 	// Non-disk files (such as .iso) use the PUT method.
@@ -230,8 +227,6 @@ func (l *Lease) Upload(ctx context.Context, item FileItem, f io.Reader, opts soa
 func (l *Lease) DownloadFile(ctx context.Context, file string, item FileItem, opts soap.Download) error {
 	if opts.Progress == nil {
 		opts.Progress = item
-	} else {
-		opts.Progress = progress.Tee(item, opts.Progress)
 	}
 
 	return l.c.DownloadFile(ctx, file, item.URL, &opts)


### PR DESCRIPTION
The call to progress.NewReader already creates a Tee.
This nesting caused prevented progress from exiting when an error occurs during import.vmdk upload.