### PR TITLE
Fix a race in NewServer().

### DIFF
--- a/lookup/simulator/registration_info.go
+++ b/lookup/simulator/registration_info.go
@@ -33,6 +33,7 @@ var (
 func registrationInfo() []types.LookupServiceRegistrationInfo {
 	vc := simulator.Map.Get(vim25.ServiceInstance).(*simulator.ServiceInstance)
 	setting := simulator.Map.OptionManager().Setting
+	sm := simulator.Map.SessionManager()
 	opts := make(map[string]string, len(setting))
 
 	for _, o := range setting {
@@ -42,7 +43,10 @@ func registrationInfo() []types.LookupServiceRegistrationInfo {
 		}
 	}
 
-	trust := []string{opts["vcsim.server.cert"]}
+	trust := []string{""}
+	if sm.TLSCert != nil {
+		trust[0] = sm.TLSCert()
+	}
 	sdk := opts["vcsim.server.url"] + vim25.Path
 	admin := opts["config.vpxd.sso.default.admin"]
 	owner := opts["config.vpxd.sso.solutionUser.name"]

--- a/simulator/session_manager.go
+++ b/simulator/session_manager.go
@@ -36,6 +36,7 @@ type SessionManager struct {
 	mo.SessionManager
 
 	ServiceHostName string
+	TLSCert         func() string
 
 	sessions map[string]Session
 }


### PR DESCRIPTION
It's important to do all global configuration before starting the server. Otherwise, a request could access settings while they're being configured.