### PR TITLE
Fix codespell issues

### DIFF
--- a/govc/test/pool.bats
+++ b/govc/test/pool.bats
@@ -208,7 +208,7 @@ load test_helper
   result=$(govc ls "host/*/Resources/govc-test-*" | wc -l)
   [ $result -eq 1 ]
 
-  # delete childs
+  # delete children
   run govc pool.destroy -children $path
   assert_success
 

--- a/govc/vm/info.go
+++ b/govc/vm/info.go
@@ -180,7 +180,8 @@ type infoResult struct {
 // collectReferences builds a unique set of MORs to the set of VirtualMachines,
 // so we can collect properties in a single call for each reference type {host,datastore,network}.
 func (r *infoResult) collectReferences(pc *property.Collector, ctx context.Context) error {
-	r.entities = make(map[types.ManagedObjectReference]string) // MOR -> Name map
+	// MOR -> Name map
+	r.entities = make(map[types.ManagedObjectReference]string)
 
 	var host []mo.HostSystem
 	var network []mo.Network

--- a/govc/vm/vnc.go
+++ b/govc/vm/vnc.go
@@ -50,12 +50,12 @@ func (i *intRange) Set(s string) error {
 
 	low, err := strconv.Atoi(m[1])
 	if err != nil {
-		return fmt.Errorf("could't convert to integer: %v", err)
+		return fmt.Errorf("couldn't convert to integer: %v", err)
 	}
 
 	high, err := strconv.Atoi(m[2])
 	if err != nil {
-		return fmt.Errorf("could't convert to integer: %v", err)
+		return fmt.Errorf("couldn't convert to integer: %v", err)
 	}
 
 	if low > high {

--- a/nfc/lease_updater.go
+++ b/nfc/lease_updater.go
@@ -57,8 +57,8 @@ func (o FileItem) File() types.OvfFile {
 }
 
 type LeaseUpdater struct {
-	pos   int64 // Number of bytes (keep first to ensure 64 bit aligment)
-	total int64 // Total number of bytes (keep first to ensure 64 bit aligment)
+	pos   int64 // Number of bytes (keep first to ensure 64 bit alignment)
+	total int64 // Total number of bytes (keep first to ensure 64 bit alignment)
 
 	lease *Lease
 

--- a/pbm/client_test.go
+++ b/pbm/client_test.go
@@ -93,7 +93,8 @@ func TestClient(t *testing.T) {
 	sort.Strings(qids)
 	sort.Strings(cids)
 
-	// Check whether ids retreived from QueryProfile and RetrieveContent are identical.
+	// Check whether ids retrieved from QueryProfile and RetrieveContent
+	// are identical.
 	if !reflect.DeepEqual(qids, cids) {
 		t.Error("ids mismatch")
 	}

--- a/pbm/simulator/simulator_test.go
+++ b/pbm/simulator/simulator_test.go
@@ -97,7 +97,7 @@ func TestSimulator(t *testing.T) {
 	sort.Strings(qids)
 	sort.Strings(cids)
 
-	// Check whether ids retreived from QueryProfile and RetrieveContent are identical.
+	// Check whether ids retrieved from QueryProfile and RetrieveContent are identical.
 	if !reflect.DeepEqual(qids, cids) {
 		t.Error("ids mismatch")
 	}

--- a/scripts/vcsa/create-vcsa-vm.sh
+++ b/scripts/vcsa/create-vcsa-vm.sh
@@ -107,7 +107,7 @@ opts+=(
 )
 
 if [ "$product" = "ws" ] ; then
-  # workstation does not suport NFC
+  # workstation does not support NFC
   dir=$(govc datastore.info -json | jq -r .Datastores[0].Info.Url)
 
   ovftool --name="$name" --acceptAllEulas "$ova" "$dir"

--- a/simulator/esx/task_manager.go
+++ b/simulator/esx/task_manager.go
@@ -9735,7 +9735,7 @@ var Description = types.TaskDescription{
 		&types.ElementDescription{
 			Description: types.Description{
 				Label:   "Retrieve Managed Method Executer",
-				Summary: "Retrieves a referemce to Managed Method Executer",
+				Summary: "Retrieves a reference to Managed Method Executer",
 			},
 			Key: "HostSystem.retrieveManagedMethodExecuter",
 		},
@@ -9819,7 +9819,7 @@ var Description = types.TaskDescription{
 		&types.ElementDescription{
 			Description: types.Description{
 				Label:   "Query feature capabilities for vSphere Distributed Switch specification",
-				Summary: "Queries feature capabilites available for a given vSphere Distributed Switch specification",
+				Summary: "Queries feature capabilities available for a given vSphere Distributed Switch specification",
 			},
 			Key: "dvs.DistributedVirtualSwitchManager.queryFeatureCapability",
 		},

--- a/simulator/license_manager_test.go
+++ b/simulator/license_manager_test.go
@@ -157,7 +157,7 @@ func TestAddRemoveLicense(t *testing.T) {
 	}
 
 	if len(info.Labels) != len(labels) {
-		t.Fatalf("expect len(info.Labels) eqaul to %d; got %d",
+		t.Fatalf("expect len(info.Labels) equal to %d; got %d",
 			len(labels), len(info.Labels))
 	}
 
@@ -181,7 +181,7 @@ func TestAddRemoveLicense(t *testing.T) {
 	}
 
 	if len(la[1].Labels) != len(labels) {
-		t.Fatalf("expect len(info.Labels) eqaul to %d; got %d",
+		t.Fatalf("expect len(info.Labels) equal to %d; got %d",
 			len(labels), len(la[1].Labels))
 	}
 

--- a/simulator/performance_manager_test.go
+++ b/simulator/performance_manager_test.go
@@ -277,7 +277,7 @@ func testPerfQuery(ctx context.Context, m *Model, e mo.Entity, interval int32) e
 		return err
 	}
 	if len(result) == 0 {
-		return errors.New("Emtpy result set")
+		return errors.New("Empty result set")
 	}
 	ms, err := p.ToMetricSeries(ctx, result)
 	if err != nil {

--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -521,7 +521,7 @@ func TestWaitForUpdatesOneUpdateCalculation(t *testing.T) {
 			set := res.Returnval
 			if set == nil {
 				// Retry if the result came back empty
-				// Thats a normal case when MaxWaitSeconds is set to 0.
+				// That's a normal case when MaxWaitSeconds is set to 0.
 				// It means we have no updates for now
 				time.Sleep(500 * time.Millisecond)
 				continue

--- a/simulator/vpx/performance_manager.go
+++ b/simulator/vpx/performance_manager.go
@@ -4436,7 +4436,7 @@ var PerfCounter = []types.PerfCounterInfo{
 		NameInfo: &types.ElementDescription{
 			Description: types.Description{
 				Label:   "Net Throughput Contention",
-				Summary: "The aggregate network droppped packets for the host",
+				Summary: "The aggregate network dropped packets for the host",
 			},
 			Key: "throughput.contention",
 		},
@@ -7277,7 +7277,7 @@ var PerfCounter = []types.PerfCounterInfo{
 		Key: 251,
 		NameInfo: &types.ElementDescription{
 			Description: types.Description{
-				Label:   "VXLAN Nework Found Matched ARP Entry Throughput",
+				Label:   "VXLAN Network Found Matched ARP Entry Throughput",
 				Summary: "Count of transmitted packets that found matched ARP entry for this network",
 			},
 			Key: "throughput.vds.arpFound",
@@ -10728,7 +10728,7 @@ var PerfCounter = []types.PerfCounterInfo{
 		Key: 370,
 		NameInfo: &types.ElementDescription{
 			Description: types.Description{
-				Label:   "VXLAN Nework Found Matched ARP Entry Throughput",
+				Label:   "VXLAN Network Found Matched ARP Entry Throughput",
 				Summary: "Count of transmitted packets that found matched ARP entry for this network",
 			},
 			Key: "throughput.vds.arpFound",

--- a/simulator/vpx/task_manager.go
+++ b/simulator/vpx/task_manager.go
@@ -1055,7 +1055,7 @@ var Description = types.TaskDescription{
 		&types.ElementDescription{
 			Description: types.Description{
 				Label:   "Query feature capabilities for vSphere Distributed Switch specification",
-				Summary: "Queries feature capabilites available for a given vSphere Distributed Switch specification",
+				Summary: "Queries feature capabilities available for a given vSphere Distributed Switch specification",
 			},
 			Key: "dvs.DistributedVirtualSwitchManager.queryFeatureCapability",
 		},
@@ -7040,7 +7040,7 @@ var Description = types.TaskDescription{
 		&types.ElementDescription{
 			Description: types.Description{
 				Label:   "Retrieve Managed Method Executer",
-				Summary: "Retrieves a referemce to Managed Method Executer",
+				Summary: "Retrieves a reference to Managed Method Executer",
 			},
 			Key: "HostSystem.retrieveManagedMethodExecuter",
 		},
@@ -10876,7 +10876,7 @@ var Description = types.TaskDescription{
 		&types.ElementDescription{
 			Description: types.Description{
 				Label:   "Convert to a stretched cluster",
-				Summary: "Convert the given configuration to a streched cluster",
+				Summary: "Convert the given configuration to a stretched cluster",
 			},
 			Key: "com.vmware.vsan.stretchedcluster.tasks.convert2stretchedcluster",
 		},
@@ -10988,14 +10988,14 @@ var Description = types.TaskDescription{
 		&types.ElementDescription{
 			Description: types.Description{
 				Label:   "Detect Update Manager Guest Agent",
-				Summary: "Detect Update Manager Guest Agent installataion on Linux VMs",
+				Summary: "Detect Update Manager Guest Agent installation on Linux VMs",
 			},
 			Key: "com.vmware.vcIntegrity.DetectLinuxGATask",
 		},
 		&types.ElementDescription{
 			Description: types.Description{
 				Label:   "Cancel detecting Update Manager GuestAgent",
-				Summary: "Cancel detecting Update Manager GuestAgent installataion on Linux VMs",
+				Summary: "Cancel detecting Update Manager GuestAgent installation on Linux VMs",
 			},
 			Key: "com.vmware.vcIntegrity.CancelDetectLinuxGATask",
 		},

--- a/task/wait.go
+++ b/task/wait.go
@@ -68,7 +68,7 @@ func (t *taskCallback) fn(pc []types.PropertyChange) bool {
 		t.info = &ti
 	}
 
-	// t.info could be nil if pc can't satify the rules above
+	// t.info could be nil if pc can't satisfy the rules above
 	if t.info == nil {
 		return false
 	}

--- a/toolbox/hgfs/protocol_test.go
+++ b/toolbox/hgfs/protocol_test.go
@@ -29,7 +29,7 @@ func TestProtocolEncoding(t *testing.T) {
 		packetSize = ps
 	}()
 
-	// a few structs have pading of some sort, leave PacketSize as-is for now with these tests
+	// a few structs have padding of some sort, leave PacketSize as-is for now with these tests
 	packetSize = func(r *Packet) uint32 {
 		return r.PacketSize
 	}

--- a/vim25/client.go
+++ b/vim25/client.go
@@ -54,7 +54,7 @@ type Client struct {
 	RoundTripper soap.RoundTripper
 }
 
-// NewClient creates and returns a new client wirh the ServiceContent field
+// NewClient creates and returns a new client with the ServiceContent field
 // filled in.
 func NewClient(ctx context.Context, rt soap.RoundTripper) (*Client, error) {
 	c := Client{

--- a/vim25/mo/type_info.go
+++ b/vim25/mo/type_info.go
@@ -157,7 +157,7 @@ func (t *typeInfo) build(typ reflect.Type, fn string, fi []int) {
 
 var nilValue reflect.Value
 
-// assignValue assignes a value 'pv' to the struct pointed to by 'val', given a
+// assignValue assigns a value 'pv' to the struct pointed to by 'val', given a
 // slice of field indices. It recurses into the struct until it finds the field
 // specified by the indices. It creates new values for pointer types where
 // needed.

--- a/vim25/soap/client_test.go
+++ b/vim25/soap/client_test.go
@@ -62,7 +62,7 @@ func TestInvalidRootCAPath(t *testing.T) {
 	err := setCAsOnClient("fixtures/there-is-no-such-file")
 
 	if _, ok := err.(*os.PathError); !ok {
-		t.Fatalf("os.PathError should have occured: %#v", err)
+		t.Fatalf("os.PathError should have occurred: %#v", err)
 	}
 }
 
@@ -70,7 +70,7 @@ func TestValidRootCAs(t *testing.T) {
 	err := setCAsOnClient("fixtures/valid-cert.pem")
 
 	if err != nil {
-		t.Fatalf("Err should not have occured: %#v", err)
+		t.Fatalf("Err should not have occurred: %#v", err)
 	}
 }
 


### PR DESCRIPTION
Hi @dougm,

This fixes some spelling issues found by [codespell](https://github.com/codespell-project/codespell).

See,
```
$ codespell --skip="./.git/*,./vim25/xml*,./vendor*" --ignore-words-list="cas,compres,mor,te,uint"
```

Are you interested in running this at the CI? If you agree, I can send you a PR configuring this at CircleCI as TravisCI does not support mixing **golang** and **python**. See this simple implementation [here](https://github.com/prometheus/node_exporter/blob/master/.circleci/config.yml#L24).

