### PR TITLE
Report local Datastore back as type OTHER

### DIFF
--- a/simulator/host_datastore_system.go
+++ b/simulator/host_datastore_system.go
@@ -98,7 +98,7 @@ func (dss *HostDatastoreSystem) CreateLocalDatastore(c *types.CreateLocalDatasto
 		Path: c.Path,
 	}
 
-	ds.Summary.Type = "local"
+	ds.Summary.Type = string(types.HostFileSystemVolumeFileSystemTypeOTHER)
 
 	if err := dss.add(ds); err != nil {
 		r.Fault_ = err


### PR DESCRIPTION
Hi. This PR is addressing the issue reported in #1399 

- OTHER is a valid and compatible FileSystemType in vSphere Management Web SDK

Thanks and Cheers! :beers: 