### PR TITLE
Add error check for deferred functions

### DIFF
--- a/event/processor.go
+++ b/event/processor.go
@@ -115,7 +115,9 @@ func (p *eventProcessor) run(ctx context.Context, tail bool) error {
 		return err
 	}
 
-	defer list.Destroy(context.Background())
+	defer func() {
+		_ = list.Destroy(context.Background())
+	}()
 
 	ref := list.Reference()
 	filter := new(property.WaitFilter).Add(ref, collectors[0].Type, props, list.TraversalSpec())

--- a/govc/datacenter/info.go
+++ b/govc/datacenter/info.go
@@ -180,7 +180,9 @@ func (r *infoResult) Write(w io.Writer) error {
 			return err
 		}
 
-		defer v.Destroy(r.ctx)
+		defer func() {
+			_ = v.Destroy(r.ctx)
+		}()
 
 		totalVms := 0
 		for _, vm := range vms {

--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -25,6 +25,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -592,7 +593,11 @@ func (flag *ClientFlag) WithRestClient(ctx context.Context, f func(*rest.Client)
 		}
 	}
 
-	defer c.Logout(ctx)
+	defer func() {
+		if err := c.Logout(ctx); err != nil {
+			log.Printf("user logout error: %v", err)
+		}
+	}()
 
 	return f(c)
 }

--- a/govc/flags/cluster.go
+++ b/govc/flags/cluster.go
@@ -133,7 +133,10 @@ func (f *ClusterFlag) objectMap(ctx context.Context, kind string, names []string
 	if err != nil {
 		return nil, err
 	}
-	defer v.Destroy(ctx)
+
+	defer func() {
+		_ = v.Destroy(ctx)
+	}()
 
 	var entities []mo.ManagedEntity
 

--- a/govc/object/collect.go
+++ b/govc/object/collect.go
@@ -356,7 +356,9 @@ func (cmd *collect) Run(ctx context.Context, f *flag.FlagSet) error {
 				return cerr
 			}
 
-			defer v.Destroy(ctx)
+			defer func() {
+				_ = v.Destroy(ctx)
+			}()
 
 			for _, kind := range cmd.kind {
 				filter.Add(v.Reference(), kind, props, v.TraversalSpec())

--- a/govc/object/find.go
+++ b/govc/object/find.go
@@ -322,7 +322,9 @@ func (cmd *find) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	defer v.Destroy(ctx)
+	defer func() {
+		_ = v.Destroy(ctx)
+	}()
 
 	objs, err := v.Find(ctx, cmd.kind, filter)
 	if err != nil {

--- a/govc/sso/user/create.go
+++ b/govc/sso/user/create.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"flag"
+	"log"
 	"os"
 
 	"github.com/vmware/govmomi/govc/cli"
@@ -73,7 +74,12 @@ func withClient(ctx context.Context, cmd *flags.ClientFlag, f func(*ssoadmin.Cli
 	if err = c.Login(c.WithHeader(ctx, header)); err != nil {
 		return err
 	}
-	defer c.Logout(ctx)
+
+	defer func() {
+		if err := c.Logout(ctx); err != nil {
+			log.Printf("user logout error: %v", err)
+		}
+	}()
 
 	return f(c)
 }

--- a/govc/task/recent.go
+++ b/govc/task/recent.go
@@ -148,7 +148,9 @@ func (cmd *recent) Run(ctx context.Context, f *flag.FlagSet) error {
 		return nil
 	}
 
-	defer v.Destroy(context.Background())
+	defer func() {
+		_ = v.Destroy(context.Background())
+	}()
 
 	v.Follow = cmd.follow
 

--- a/property/wait.go
+++ b/property/wait.go
@@ -89,7 +89,9 @@ func WaitForUpdates(ctx context.Context, c *Collector, filter *WaitFilter, f fun
 
 	// Attempt to destroy the collector using the background context, as the
 	// specified context may have timed out or have been canceled.
-	defer p.Destroy(context.Background())
+	defer func() {
+		_ = p.Destroy(context.Background())
+	}()
 
 	err = p.CreateFilter(ctx, filter.CreateFilter)
 	if err != nil {

--- a/simulator/event_manager_test.go
+++ b/simulator/event_manager_test.go
@@ -149,7 +149,12 @@ func TestEventManagerRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer vc.Logout(ctx)
+
+	defer func() {
+		if err := vc.Logout(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	spec := types.EventFilterSpec{}
 	c, err := event.NewManager(vc.Client).CreateCollectorForEvents(ctx, spec)

--- a/sts/client_test.go
+++ b/sts/client_test.go
@@ -62,7 +62,11 @@ func solutionUserCreate(ctx context.Context, info *url.Userinfo, sts *Client) er
 		return err
 	}
 
-	defer admin.Logout(ctx)
+	defer func() {
+		if err := admin.Logout(ctx); err != nil {
+			log.Printf("user logout error: %v", err)
+		}
+	}()
 
 	id := types.PrincipalId{
 		Name:   "govmomi-test",


### PR DESCRIPTION
Hi @dougm,

I fixed here some errcheck issues. PTAL, the log types could be others than **Fatal**. See,
```
$ golangci-lint run --skip-dirs '^vim25/xml/*' --disable-all --enable=errcheck
```