### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:       false
 
 # Set the version of Go.
 language:       go
-go:             1.11
+go:             1.12
 
 # Always set the project's Go import path to ensure that forked
 # builds get cloned to the correct location.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Use the newer Travis-CI build templates based on the
-# Debian Linux distribution "Trusty" release.
+# Ubuntu Linux distribution "Xenial Xerus" release.
 os:             linux
-dist:           trusty
+dist:           xenial
 
 # Disable sudo for all builds by default. This ensures all jobs use
 # Travis-CI's containerized build environment unless specified otherwise.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: test
+GO                      ?= go
+pkgs                    = $(shell $(GO) list ./... | grep -v 'github.com/vmware/govmomi/vim25/xml')
 
 all: check test
 
@@ -6,23 +7,24 @@ check: goimports govet
 
 goimports:
 	@echo checking go imports...
-	@command -v goimports >/dev/null 2>&1 || go get golang.org/x/tools/cmd/goimports
+	@command -v goimports >/dev/null 2>&1 || $(GO) get golang.org/x/tools/cmd/goimports
 	@! goimports -d . 2>&1 | egrep -v '^$$'
 
 govet:
 	@echo checking go vet...
-	@go tool vet -structtags=false -methods=false $$(find . -mindepth 1 -maxdepth 1 -type d -not -name vendor)
+	@$(GO) vet -structtag=false -methods=false $(pkgs)
 
 install:
 	$(MAKE) -C govc install
 	$(MAKE) -C vcsim install
 
 go-test:
-	GORACE=history_size=5 go test -timeout 5m -count 1 -race -v $(TEST_OPTS) ./...
+	GORACE=history_size=5 $(GO) test -timeout 5m -count 1 -race -v $(TEST_OPTS) ./...
 
 govc-test: install
 	(cd govc/test && ./vendor/github.com/sstephenson/bats/libexec/bats -t .)
 
+.PHONY: test
 test: go-test govc-test
 
 doc: install


### PR DESCRIPTION
Hi @dougm,

I updated Travis CI configuration from Ubuntu "Trusty Tahr" (14.04 LTS) to "Xenial Xerus" (16.04 LTS). See the EOL information [here](https://wiki.ubuntu.com/Releases).
BTW, I upgraded the golang version from 1.11 to 1.12 in a separate commit, so I you don't agree, I can drop it.


