### PR TITLE
Fix staticcheck issues value of `XXX` is never used

### DIFF
--- a/govc/library/item/upload.go
+++ b/govc/library/item/upload.go
@@ -91,6 +91,9 @@ func (cmd *upload) Run(ctx context.Context, f *flag.FlagSet) error {
 		defer file.Close()
 
 		fileInfo, err := file.Stat()
+		if err != nil {
+			return err
+		}
 		size := fileInfo.Size()
 
 		hash := md5.New()

--- a/govc/library/ova.go
+++ b/govc/library/ova.go
@@ -127,7 +127,14 @@ func (of *OVAFile) Close() error {
 // getOVAFileInfo opens an OVA, finds the file entry, and returns both the size and md5 checksum
 func getOVAFileInfo(ovafile string, filename string) (int64, string, error) {
 	of, err := NewOVAFile(ovafile)
+	if err != nil {
+		return 0, "", err
+	}
+
 	hdr, err := of.Find(filename)
+	if err != nil {
+		return 0, "", err
+	}
 
 	hash := md5.New()
 	_, err = io.Copy(hash, of)
@@ -169,6 +176,9 @@ func uploadFile(ctx context.Context, m *library.Manager, sessionID string, ovafi
 
 	// Setup to point to the OVA file to be transferred
 	_, err = of.Find(filename)
+	if err != nil {
+		return err
+	}
 
 	req, err := http.NewRequest("PUT", addFileInfo.UploadEndpoint.URI, of)
 	if err != nil {
@@ -201,7 +211,11 @@ func (cmd *ova) Run(ctx context.Context, f *flag.FlagSet) error {
 		if err != nil {
 			return err
 		}
+
 		hdr, err := o.Next()
+		if err != nil {
+			return err
+		}
 
 		// Per the OVA spec, the first file must be the .ovf file.
 		if !strings.HasSuffix(hdr.Name, ".ovf") {

--- a/govc/vcenter/deploy.go
+++ b/govc/vcenter/deploy.go
@@ -78,7 +78,11 @@ func getOVFItemID(ctx context.Context, c *rest.Client, libname string, ovfname s
 	if err != nil {
 		return "", err
 	}
+
 	res, err := m.GetLibraryItems(ctx, library.ID)
+	if err != nil {
+		return "", err
+	}
 
 	for _, r := range res {
 		if r.Name == ovfname || r.ID == ovfname {
@@ -134,6 +138,10 @@ func (cmd *deploy) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		filterResponse, err := m.FilterLibraryItem(ctx, ovfItemID, filter)
+		if err != nil {
+			return err
+		}
+
 		fmt.Printf("Found OVA for deployment: %s\n", filterResponse.Name)
 
 		deploy := vcenter.Deploy{

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -263,7 +263,7 @@ func (v VirtualMachine) WaitForNetIP(ctx context.Context, v4 bool, device ...str
 	p := property.DefaultCollector(v.c)
 
 	// Wait for all NICs to have a MacAddress, which may not be generated yet.
-	err := property.Wait(ctx, p, v.Reference(), []string{"config.hardware.device"}, func(pc []types.PropertyChange) bool {
+	_ = property.Wait(ctx, p, v.Reference(), []string{"config.hardware.device"}, func(pc []types.PropertyChange) bool {
 		for _, c := range pc {
 			if c.Op != types.PropertyChangeOpAssign {
 				continue
@@ -296,7 +296,7 @@ func (v VirtualMachine) WaitForNetIP(ctx context.Context, v4 bool, device ...str
 		}
 	}
 
-	err = property.Wait(ctx, p, v.Reference(), []string{"guest.net"}, func(pc []types.PropertyChange) bool {
+	err := property.Wait(ctx, p, v.Reference(), []string{"guest.net"}, func(pc []types.PropertyChange) bool {
 		for _, c := range pc {
 			if c.Op != types.PropertyChangeOpAssign {
 				continue

--- a/toolbox/command_test.go
+++ b/toolbox/command_test.go
@@ -164,7 +164,6 @@ func TestVixRelayedCommandHandler(t *testing.T) {
 	// header.UserCredentialType not set
 	header.OpCode = vix.CommandStartProgram
 	request := new(vix.StartProgramRequest)
-	buf := marshal(request)
 	reply, _ = cmd.Dispatch(marshal())
 	rc = vixRC(reply)
 	if rc != vix.AuthenticationFail {
@@ -181,7 +180,7 @@ func TestVixRelayedCommandHandler(t *testing.T) {
 	header.CredentialLength = uint32(len(creds))
 
 	// ProgramPath not set
-	buf = append(marshal(request), creds...)
+	buf := append(marshal(request), creds...)
 	reply, _ = cmd.Dispatch(buf)
 	rc = vixRC(reply)
 	if rc != vix.FileNotFound {


### PR DESCRIPTION
Hi @dougm,

I fixed here some trivial staticcheck issues related with never used variables.

See,
```
$ golangci-lint run --skip-dirs '^vim25/xml/*' --disable-all --enable=staticcheck
```