### PR TITLE
govc: FCD workarounds

### DIFF
--- a/object/datastore.go
+++ b/object/datastore.go
@@ -68,6 +68,11 @@ func NewDatastore(c *vim25.Client, ref types.ManagedObjectReference) *Datastore 
 }
 
 func (d Datastore) Path(path string) string {
+	var p DatastorePath
+	if p.FromString(path) {
+		return path // already in "[datastore] path" format
+	}
+
 	return (&DatastorePath{
 		Datastore: d.Name(),
 		Path:      path,


### PR DESCRIPTION
- Workaround issue where List() returns IDs for disk deleted via VM destroy,
  which return a NotFound fault when Retrieve() is called.

- Change Datastore.Path helper to check if the given path is already in datastore URI format.
  This makes it simpler to query for path via disk.ls and attach via vm.create, vm.disk.attach, etc.