### PR TITLE
Add support to reconcile FCD datastore inventory

### DIFF
--- a/object/datastore.go
+++ b/object/datastore.go
@@ -70,7 +70,7 @@ func NewDatastore(c *vim25.Client, ref types.ManagedObjectReference) *Datastore 
 func (d Datastore) Path(path string) string {
 	var p DatastorePath
 	if p.FromString(path) {
-		return path // already in "[datastore] path" format
+		return p.String() // already in "[datastore] path" format
 	}
 
 	return (&DatastorePath{

--- a/vslm/object_manager.go
+++ b/vslm/object_manager.go
@@ -407,3 +407,16 @@ func (m ObjectManager) ListAttachedTags(ctx context.Context, id string) ([]types
 	}
 	return res.Returnval, nil
 }
+
+func (m ObjectManager) ReconcileDatastoreInventory(ctx context.Context, ds mo.Reference) (*object.Task, error) {
+	req := &types.ReconcileDatastoreInventory_Task{
+		This:      m.Reference(),
+		Datastore: ds.Reference(),
+	}
+
+	res, err := methods.ReconcileDatastoreInventory_Task(ctx, m.c, req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(m.c, res.Returnval), nil
+}


### PR DESCRIPTION
Rather than hide NotFound errors (as 18cb914 did), the disk.ls -R
option can be used to reconcile the FCD datastore inventory.
This will remove FCD objects from inventory whos datastore backing
file no longer exists.

- Add disk.ls '-L' option to print the file path instead of name