### PR TITLE
govc: fix vm.change against templates

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -826,6 +826,9 @@ load test_helper
   run govc vm.create -on=true "$id"
   assert_success
 
+  run govc vm.change -vm "$id" -e testing=123
+  assert_success
+
   run govc vm.markastemplate "$id"
   assert_failure
 
@@ -833,6 +836,12 @@ load test_helper
   assert_success
 
   run govc vm.markastemplate "$id"
+  assert_success
+
+  run govc vm.change -vm "$id" -e testing=456
+  assert_failure # template reconfigure only allows name and annotation change
+
+  run govc vm.change -vm "$id" -annotation testing123
   assert_success
 
   run govc vm.power -on "$id"

--- a/govc/vm/change.go
+++ b/govc/vm/change.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/vmware/govmomi/govc/cli"
@@ -137,6 +138,9 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	setAllocation(&cmd.CpuAllocation)
 	setAllocation(&cmd.MemoryAllocation)
+	if reflect.DeepEqual(cmd.Tools, new(types.ToolsConfigInfo)) {
+		cmd.Tools = nil // no flags set, avoid sending <tools/> in the request
+	}
 
 	task, err := vm.Reconfigure(ctx, cmd.VirtualMachineConfigSpec)
 	if err != nil {


### PR DESCRIPTION
When a VM is marked as a template, only the name and annotation can be changed.
However, the vm.change command was sending an empty "<tools></tools>" field in the request,
causing vCenter to respond with a NotSupported fault.

Updates vcsim to behave as vCenter does in this case.

Fixes #1430