### PR TITLE
vcsim: remove httptest.serve flag

### DIFF
--- a/govc/test/test_helper.bash
+++ b/govc/test/test_helper.bash
@@ -43,7 +43,7 @@ vcsim_start() {
     export GOVC_SIM_ENV
     mkfifo "$GOVC_SIM_ENV"
 
-    vcsim -httptest.serve=127.0.0.1:0 -E "$GOVC_SIM_ENV" "$@" &
+    vcsim -l 127.0.0.1:0 -E "$GOVC_SIM_ENV" "$@" &
 
     eval "$(cat "$GOVC_SIM_ENV")"
 }

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -62,7 +62,7 @@ load test_helper
   port=$(govc env -x GOVC_URL_PORT)
   vcsim_stop
 
-  vcsim_start -httptest.serve="$url" # reuse free port selection from above
+  vcsim_start -l "$url" # reuse free port selection from above
 
   run govc object.collect -s -type h host/DC0_H0 summary.config.port
   assert_success "$port"
@@ -71,7 +71,7 @@ load test_helper
 
   vcsim_stop
 
-  VCSIM_HOST_PORT_UNIQUE=true vcsim_start -httptest.serve="$url"
+  VCSIM_HOST_PORT_UNIQUE=true vcsim_start -l "$url"
 
   hosts=$(curl -sk "https://$url/debug/vars" | jq .vcsim.Model.Host)
   ports=$(govc object.collect -s -type h / summary.config.port | uniq -u | wc -l)
@@ -249,13 +249,7 @@ load test_helper
   [[ "$url" == *"https://127.0.0.1:"* ]]
   vcsim_stop
 
-  vcsim_start -dc 0 -httptest.serve 0.0.0.0:0
-  url=$(govc option.ls vcsim.server.url)
-  [[ "$url" != *"https://127.0.0.1:"* ]]
-  [[ "$url" != *"https://[::]:"* ]]
-  vcsim_stop
-
-  vcsim_start -dc 0 -l :0 -httptest.serve ""
+  vcsim_start -dc 0 -l 0.0.0.0:0
   url=$(govc option.ls vcsim.server.url)
   [[ "$url" != *"https://127.0.0.1:"* ]]
   [[ "$url" != *"https://[::]:"* ]]

--- a/vcsim/README.md
+++ b/vcsim/README.md
@@ -84,7 +84,7 @@ curl -sk https://user:pass@127.0.0.1:8989/about
 
 ## Listen address
 
-The default vcsim listen address is `127.0.0.1:8989`.  Use the `-httptest.serve` flag to listen on another address:
+The default vcsim listen address is `127.0.0.1:8989`.  Use the `-l` flag to listen on another address:
 
 
 ``` shell

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -110,16 +110,6 @@ func main() {
 		}
 	}
 
-	f := flag.Lookup("httptest.serve")
-	serve := f.Value.String()
-	if serve == "" {
-		err = f.Value.Set(*listen) // propagate -l unless -httptest.serve is specified
-		if err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		*listen = serve // propagate to updateHostTemplate call below
-	}
 	if err = updateHostTemplate(*listen); err != nil {
 		log.Fatal(err)
 	}
@@ -147,6 +137,7 @@ func main() {
 		log.Fatal(err)
 	}
 
+	model.Service.Listen = *listen
 	if *isTLS {
 		model.Service.TLS = new(tls.Config)
 		if *cert != "" {


### PR DESCRIPTION
The package was forked in PR #1400 due to issues with 1.12 and
the httptest.serve flag - this change drops the flag altogether.