### PR TITLE
Support resignature of vmfs snapshots

### DIFF
--- a/object/host_datastore_system.go
+++ b/object/host_datastore_system.go
@@ -117,3 +117,19 @@ func (s HostDatastoreSystem) QueryVmfsDatastoreCreateOptions(ctx context.Context
 
 	return res.Returnval, nil
 }
+
+func (s HostDatastoreSystem) ResignatureUresolvedVmfsVolumes(ctx context.Context, devicePaths []string) (*Task, error) {
+	req := &types.ResignatureUnresolvedVmfsVolume_Task{
+		This: s.Reference(),
+		ResolutionSpec: types.HostUnresolvedVmfsResignatureSpec{
+			ExtentDevicePath: devicePaths,
+		},
+	}
+
+	res, err := methods.ResignatureUnresolvedVmfsVolume_Task(ctx, s.Client(), req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(s.c, res.Returnval), nil
+}

--- a/object/host_datastore_system.go
+++ b/object/host_datastore_system.go
@@ -118,7 +118,7 @@ func (s HostDatastoreSystem) QueryVmfsDatastoreCreateOptions(ctx context.Context
 	return res.Returnval, nil
 }
 
-func (s HostDatastoreSystem) ResignatureUresolvedVmfsVolumes(ctx context.Context, devicePaths []string) (*Task, error) {
+func (s HostDatastoreSystem) ResignatureUnresolvedVmfsVolumes(ctx context.Context, devicePaths []string) (*Task, error) {
 	req := &types.ResignatureUnresolvedVmfsVolume_Task{
 		This: s.Reference(),
 		ResolutionSpec: types.HostUnresolvedVmfsResignatureSpec{

--- a/object/host_datastore_system_test.go
+++ b/object/host_datastore_system_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi/simulator/esx"
+	"github.com/vmware/govmomi/test"
+)
+
+func TestHostDatastoreSystemResignatureUresolvedVmfsVolume(t *testing.T) {
+	c := test.NewAuthenticatedClient(t)
+	host := NewHostSystem(c, esx.HostSystem.Reference())
+
+	ctx := context.Background()
+
+	hds, err := host.ConfigManager().DatastoreSystem(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+	hss, err := host.ConfigManager().StorageSystem(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	paths, err := hss.QueryUnresolvedVmfsVolumes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(paths) == 0 {
+		t.Skip("No unresolved vmfs volumes found")
+	}
+
+	task, err := hds.ResignatureUresolvedVmfsVolumes(ctx, []string{paths[0].Extent[0].DevicePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	err = task.Wait(ctx);
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/object/host_datastore_system_test.go
+++ b/object/host_datastore_system_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/vmware/govmomi/test"
 )
 
-func TestHostDatastoreSystemResignatureUresolvedVmfsVolume(t *testing.T) {
+func TestHostDatastoreSystemResignatureUnresolvedVmfsVolume(t *testing.T) {
 	c := test.NewAuthenticatedClient(t)
 	host := NewHostSystem(c, esx.HostSystem.Reference())
 
@@ -48,7 +48,7 @@ func TestHostDatastoreSystemResignatureUresolvedVmfsVolume(t *testing.T) {
 		t.Skip("No unresolved vmfs volumes found")
 	}
 
-	task, err := hds.ResignatureUresolvedVmfsVolumes(ctx, []string{paths[0].Extent[0].DevicePath})
+	task, err := hds.ResignatureUnresolvedVmfsVolumes(ctx, []string{paths[0].Extent[0].DevicePath})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/object/host_datastore_system_test.go
+++ b/object/host_datastore_system_test.go
@@ -52,8 +52,8 @@ func TestHostDatastoreSystemResignatureUresolvedVmfsVolume(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	
-	err = task.Wait(ctx);
+
+	err = task.Wait(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/object/host_storage_system.go
+++ b/object/host_storage_system.go
@@ -184,3 +184,17 @@ func (s HostStorageSystem) QueryUnresolvedVmfsVolumes(ctx context.Context) ([]ty
 	}
 	return res.Returnval, nil
 }
+
+func (s HostStorageSystem) UnmountVmfsVolume(ctx context.Context, vmfsUuid string) (error) {
+	req := &types.UnmountVmfsVolume{
+		This:s.Reference(),
+		VmfsUuid: vmfsUuid,
+	}
+
+	_, err := methods.UnmountVmfsVolume(ctx, s.Client(), req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/object/host_storage_system.go
+++ b/object/host_storage_system.go
@@ -185,9 +185,9 @@ func (s HostStorageSystem) QueryUnresolvedVmfsVolumes(ctx context.Context) ([]ty
 	return res.Returnval, nil
 }
 
-func (s HostStorageSystem) UnmountVmfsVolume(ctx context.Context, vmfsUuid string) (error) {
+func (s HostStorageSystem) UnmountVmfsVolume(ctx context.Context, vmfsUuid string) error {
 	req := &types.UnmountVmfsVolume{
-		This:s.Reference(),
+		This:     s.Reference(),
 		VmfsUuid: vmfsUuid,
 	}
 

--- a/object/host_storage_system.go
+++ b/object/host_storage_system.go
@@ -172,3 +172,15 @@ func (s HostStorageSystem) AttachScsiLun(ctx context.Context, uuid string) error
 
 	return err
 }
+
+func (s HostStorageSystem) QueryUnresolvedVmfsVolumes(ctx context.Context) ([]types.HostUnresolvedVmfsVolume, error) {
+	req := &types.QueryUnresolvedVmfsVolume{
+		This: s.Reference(),
+	}
+
+	res, err := methods.QueryUnresolvedVmfsVolume(ctx, s.Client(), req)
+	if err != nil {
+		return nil, err
+	}
+	return res.Returnval, nil
+}


### PR DESCRIPTION
Added ability (and a test that skips unless there is an available snapshot) to resignature vmfs snapshots. Basically [this](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.storage.doc/GUID-EEFEB765-A41F-4B6D-917C-BB9ABB80FC80.html) flow