### PR TITLE
Default to running against vcsim in examples

### DIFF
--- a/examples/virtualmachines/main.go
+++ b/examples/virtualmachines/main.go
@@ -24,45 +24,39 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/vmware/govmomi/examples"
 	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 )
 
 func main() {
-	ctx := context.Background()
+	examples.Run(func(ctx context.Context, c *vim25.Client) error {
+		// Create view of VirtualMachine objects
+		m := view.NewManager(c)
 
-	// Connect and login to ESX or vCenter
-	c, err := examples.NewClient(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
+		v, err := m.CreateContainerView(ctx, c.ServiceContent.RootFolder, []string{"VirtualMachine"}, true)
+		if err != nil {
+			return err
+		}
 
-	defer c.Logout(ctx)
+		defer v.Destroy(ctx)
 
-	// Create view of VirtualMachine objects
-	m := view.NewManager(c.Client)
+		// Retrieve summary property for all machines
+		// Reference: http://pubs.vmware.com/vsphere-60/topic/com.vmware.wssdk.apiref.doc/vim.VirtualMachine.html
+		var vms []mo.VirtualMachine
+		err = v.Retrieve(ctx, []string{"VirtualMachine"}, []string{"summary"}, &vms)
+		if err != nil {
+			return err
+		}
 
-	v, err := m.CreateContainerView(ctx, c.ServiceContent.RootFolder, []string{"VirtualMachine"}, true)
-	if err != nil {
-		log.Fatal(err)
-	}
+		// Print summary per vm (see also: govc/vm/info.go)
 
-	defer v.Destroy(ctx)
+		for _, vm := range vms {
+			fmt.Printf("%s: %s\n", vm.Summary.Config.Name, vm.Summary.Config.GuestFullName)
+		}
 
-	// Retrieve summary property for all machines
-	// Reference: http://pubs.vmware.com/vsphere-60/topic/com.vmware.wssdk.apiref.doc/vim.VirtualMachine.html
-	var vms []mo.VirtualMachine
-	err = v.Retrieve(ctx, []string{"VirtualMachine"}, []string{"summary"}, &vms)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Print summary per vm (see also: govc/vm/info.go)
-
-	for _, vm := range vms {
-		fmt.Printf("%s: %s\n", vm.Summary.Config.Name, vm.Summary.Config.GuestFullName)
-	}
+		return nil
+	})
 }


### PR DESCRIPTION
- Add simulator.Model.Do method, generally useful outside of examples

- Add examples.Run method, which defaults to running the example against vcsim