### PR TITLE
Fix port signature in REST endpoint token auth

### DIFF
--- a/sts/signer.go
+++ b/sts/signer.go
@@ -265,8 +265,11 @@ func (s *Signer) SignRequest(req *http.Request) error {
 		}
 		bhash := sha256.New().Sum(body)
 
-		// Port in the signature must be that of the reverse proxy port, vCenter's default is port 80
-		port := "80" // TODO: get from lookup service
+		port := req.URL.Port()
+		if port == "" {
+			port = "80" // Default port for the "Host" header on the server side
+		}
+
 		var buf bytes.Buffer
 		msg := []string{
 			nonce,


### PR DESCRIPTION
When http.Request.URL.Port is not set on the client side, is also omitted from the request "Host" header.
In this case, on the server side, the default port value used in the message signature is "80".
This change fixes the case when URL.Port is explicitly set, which is then included in the "Host" header.