### PR TITLE
vcsim: Press any key to exit

### DIFF
--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -66,6 +66,7 @@ func main() {
 	listen := flag.String("l", "127.0.0.1:8989", "Listen address for vcsim")
 	tunnel := flag.Int("tunnel", -1, "SDK tunnel port")
 	flag.BoolVar(&simulator.Trace, "trace", simulator.Trace, "Trace SOAP to stderr")
+	stdinExit := flag.Bool("stdinexit", false, "Press any key to exit")
 
 	flag.IntVar(&model.DelayConfig.Delay, "delay", model.DelayConfig.Delay, "Method response delay across all methods")
 	methodDelayP := flag.String("method-delay", "", "Delay per method on the form 'method1:delay1,method2:delay2...'")
@@ -199,6 +200,13 @@ func main() {
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	if *stdinExit {
+		fmt.Fprintf(out, "Press any key to exit")
+		go func() {
+			os.Stdin.Read(make([]byte, 1))
+			sig <- syscall.SIGTERM
+		}()
+	}
 
 	<-sig
 


### PR DESCRIPTION
Currently, vcsim only stops when it receives SIGTERM or SIGINT signals.
This pull request adds the feature "press any key to exit", when the flag `stdinexit` is provided.

### Use-case
I'm using vcsim for unit/integration tests in C# (VMware.VIM)
```cs
var process = Process.Start(new ProcessStartInfo {
  FileName = "vcsim",
  UseShellExecute = false,
  RedirectStandardOutput = true,
  RedirectStandardError = true,
  RedirectStandardInput = true,
});
process.Kill();

process.StandardInput.Close();
process.WaitForExit();
```
After vcsim is used for testing, the process must be halted.

Killing the process results in remaining temporary files.
Unfortunately, dotnet has no build in functionality to signal a process (SIGTERM).
https://stackoverflow.com/a/15281070/5537074
https://github.com/dotnet/corefx/issues/1838


However, closing the standard input is trivial.
That's why I'm requesting a feature that vcsim exits when the standard input is closed.
I'm already using this solution myself, but I liked to share it.