### PR TITLE
Fix pbm field type lookup

### DIFF
--- a/pbm/simulator/simulator.go
+++ b/pbm/simulator/simulator.go
@@ -17,7 +17,6 @@ limitations under the License.
 package simulator
 
 import (
-	"reflect"
 	"time"
 
 	"github.com/google/uuid"
@@ -60,10 +59,6 @@ func New() *simulator.Registry {
 	r.Put(&PlacementSolver{
 		ManagedObjectReference: content.PlacementSolver,
 	})
-
-	// TODO: vim25/xml typeToString() does not have an option to include namespace prefix.
-	// workaround by adding type without the prefix for now.
-	vim.Add("PbmCapabilityProfile", reflect.TypeOf((*types.PbmCapabilityProfile)(nil)).Elem())
 
 	return r
 }

--- a/pbm/simulator/simulator_test.go
+++ b/pbm/simulator/simulator_test.go
@@ -211,9 +211,19 @@ func TestSimulator(t *testing.T) {
 	t.Logf("VSAN Profile: %q successfully created", vsanProfileID.UniqueId)
 
 	// 6. Verify if profile created exists by issuing a RetrieveContent request.
-	_, err = pc.RetrieveContent(ctx, []types.PbmProfileId{*vsanProfileID})
+	profiles, err := pc.RetrieveContent(ctx, []types.PbmProfileId{*vsanProfileID})
 	if err != nil {
 		t.Fatal(err)
+	}
+	for _, profile := range profiles {
+		if cap, ok := profile.(*types.PbmCapabilityProfile); ok {
+			_, ok = cap.Constraints.(*types.PbmCapabilitySubProfileConstraints)
+			if !ok {
+				t.Errorf("cap=%T", cap.Constraints)
+			}
+		} else {
+			t.Errorf("profile=%T", profile)
+		}
 	}
 	t.Logf("Profile: %q exists on vCenter", vsanProfileID.UniqueId)
 


### PR DESCRIPTION
When fields are encoded with xsi type, vim25/xml typeToString() does not have an option to include namespace prefix.
Workaround this by re-trying the lookup with the namespace prefix.