### PR TITLE
vcsim: fix host uuid

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -132,8 +132,14 @@ load test_helper
   run govc object.collect -s vm/DC0_H0_VM0 config.uuid config.instanceUuid
   assert_success "$(printf "265104de-1472-547c-b873-6dc7883fb6cb\nb4689bed-97f0-5bcd-8a4c-07477cc8f06f")"
 
+  dups=$(govc object.collect -s -type m / config.uuid | sort | uniq -d | wc -l)
+  [ "$dups" = "0" ]
+
   run govc object.collect -s host/DC0_H0/DC0_H0 summary.hardware.uuid
-  assert_success 081cb246-2225-56d3-836b-8b26da9041ea
+  assert_success dcf7fb3c-4a1c-5a05-b730-5e09f3704e2f
+
+  dups=$(govc object.collect -s -type m / summary.hardware.uuid | sort | uniq -d | wc -l)
+  [ "$dups" = "0" ]
 
   run govc vm.create foo.yakity
   assert_success

--- a/simulator/cluster_compute_resource.go
+++ b/simulator/cluster_compute_resource.go
@@ -51,13 +51,7 @@ func (add *addHost) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	}
 
 	host := NewHostSystem(esx.HostSystem)
-	host.Summary.Config.Name = spec.HostName
-	host.Name = host.Summary.Config.Name
-	if add.req.AsConnected {
-		host.Runtime.ConnectionState = types.HostSystemConnectionStateConnected
-	} else {
-		host.Runtime.ConnectionState = types.HostSystemConnectionStateDisconnected
-	}
+	host.configure(spec, add.req.AsConnected)
 
 	cr := add.ClusterComputeResource
 	Map.PutEntity(cr, Map.NewEntity(host))


### PR DESCRIPTION
All hosts had the same uuid after #1473 was merged.
The SearchIndex test would randomly pass/fail due to this.