### PR TITLE
Fix json request tracing

### DIFF
--- a/scripts/debug-xmlformat.sh
+++ b/scripts/debug-xmlformat.sh
@@ -12,6 +12,10 @@ jqformat() {
   jq .
 }
 
+xmlformat() {
+  xmlstarlet fo
+}
+
 for file in *.req.{xml,json}; do
     ext=${file##*.}
     base=$(basename "$file" ".req.$ext")

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -482,8 +482,9 @@ func (c *Client) Do(ctx context.Context, req *http.Request, f func(*http.Respons
 		req.Header.Set(`User-Agent`, c.UserAgent)
 	}
 
+	ext := ""
 	if d.enabled() {
-		d.debugRequest(req)
+		ext = d.debugRequest(req)
 	}
 
 	tstart := time.Now()
@@ -507,7 +508,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, f func(*http.Respons
 	defer res.Body.Close()
 
 	if d.enabled() {
-		d.debugResponse(res)
+		d.debugResponse(res, ext)
 	}
 
 	return f(res)

--- a/vim25/soap/debug.go
+++ b/vim25/soap/debug.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -71,16 +70,17 @@ func (d *debugRoundTrip) newFile(suffix string) io.WriteCloser {
 }
 
 func (d *debugRoundTrip) ext(h http.Header) string {
+	const json = "application/json"
 	ext := "xml"
-	if strings.Contains(h.Get("Content-Type"), "/json") {
+	if h.Get("Accept") == json || h.Get("Content-Type") == json {
 		ext = "json"
 	}
 	return ext
 }
 
-func (d *debugRoundTrip) debugRequest(req *http.Request) {
+func (d *debugRoundTrip) debugRequest(req *http.Request) string {
 	if d == nil {
-		return
+		return ""
 	}
 
 	// Capture headers
@@ -89,15 +89,18 @@ func (d *debugRoundTrip) debugRequest(req *http.Request) {
 	wc.Write(b)
 	wc.Close()
 
+	ext := d.ext(req.Header)
 	// Capture body
-	wc = d.newFile("req." + d.ext(req.Header))
+	wc = d.newFile("req." + ext)
 	req.Body = newTeeReader(req.Body, wc)
 
 	// Delay closing until marked done
 	d.cs = append(d.cs, wc)
+
+	return ext
 }
 
-func (d *debugRoundTrip) debugResponse(res *http.Response) {
+func (d *debugRoundTrip) debugResponse(res *http.Response, ext string) {
 	if d == nil {
 		return
 	}
@@ -109,7 +112,7 @@ func (d *debugRoundTrip) debugResponse(res *http.Response) {
 	wc.Close()
 
 	// Capture body
-	wc = d.newFile("res." + d.ext(res.Header))
+	wc = d.newFile("res." + ext)
 	res.Body = newTeeReader(res.Body, wc)
 
 	// Delay closing until marked done


### PR DESCRIPTION
Not all responses from json requests include a Content-Type header.
Use the request extension to determine the response extension.