### PR TITLE
Fix tls config in soap.NewServiceClient

### DIFF
--- a/govc/test/tags.bats
+++ b/govc/test/tags.bats
@@ -60,6 +60,12 @@ load test_helper
   run govc tags.ls
   assert_success # no tags defined yet
 
+  run govc tags.ls -k=false
+  assert_failure
+
+  run govc tags.ls -k=false -tls-ca-certs <(govc about.cert -show)
+  assert_success
+
   run govc tags.info
   assert_success # no tags defined yet
 

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -173,6 +173,7 @@ func (c *Client) NewServiceClient(path string, namespace string) *Client {
 
 	client := NewClient(u, c.k)
 	client.Namespace = "urn:" + namespace
+	client.Transport.(*http.Transport).TLSClientConfig = c.Transport.(*http.Transport).TLSClientConfig
 	if cert := c.Certificate(); cert != nil {
 		client.SetCertificate(*cert)
 	}


### PR DESCRIPTION
Use the same transport when creating a service client to preserve options
such as TLSClientConfig.