### PR TITLE
tags API: add methods for association of multiple tags/objects

### DIFF
--- a/govc/test/tags.bats
+++ b/govc/test/tags.bats
@@ -128,6 +128,7 @@ load test_helper
 
   run govc tags.attached.ls "$tag_name"
   assert_success
+  [ ${#lines[@]} -eq 1 ]
 
   result=$(govc tags.attached.ls -r "$object")
   assert_matches "$result" "$tag_name"

--- a/vapi/tags/tag_association.go
+++ b/vapi/tags/tag_association.go
@@ -18,6 +18,7 @@ package tags
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -102,4 +103,143 @@ func (c *Manager) ListAttachedObjects(ctx context.Context, tagID string) ([]mo.R
 		refs[i] = res[i]
 	}
 	return refs, nil
+}
+
+// AttachedObjects is the response type used by ListAttachedObjectsOnTags.
+type AttachedObjects struct {
+	TagID     string         `json:"tag_id"`
+	Tag       *Tag           `json:"tag,omitempty"`
+	ObjectIDs []mo.Reference `json:"object_ids"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (t *AttachedObjects) UnmarshalJSON(b []byte) error {
+	var o struct {
+		TagID     string                      `json:"tag_id"`
+		ObjectIDs []internal.AssociatedObject `json:"object_ids"`
+	}
+	err := json.Unmarshal(b, &o)
+	if err != nil {
+		return err
+	}
+
+	t.TagID = o.TagID
+	t.ObjectIDs = make([]mo.Reference, len(o.ObjectIDs))
+	for i := range o.ObjectIDs {
+		t.ObjectIDs[i] = o.ObjectIDs[i]
+	}
+
+	return nil
+}
+
+// ListAttachedObjectsOnTags fetches the array of attached objects for the given tag IDs.
+func (c *Manager) ListAttachedObjectsOnTags(ctx context.Context, tagID []string) ([]AttachedObjects, error) {
+	var ids []string
+	for i := range tagID {
+		id, err := c.tagID(ctx, tagID[i])
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+
+	spec := struct {
+		TagIDs []string `json:"tag_ids"`
+	}{ids}
+
+	url := internal.URL(c, internal.AssociationPath).WithAction("list-attached-objects-on-tags")
+	var res []AttachedObjects
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// GetAttachedObjectsOnTags combines ListAttachedObjectsOnTags and populates each Tag field.
+func (c *Manager) GetAttachedObjectsOnTags(ctx context.Context, tagID []string) ([]AttachedObjects, error) {
+	objs, err := c.ListAttachedObjectsOnTags(ctx, tagID)
+	if err != nil {
+		return nil, fmt.Errorf("list attached objects %s: %s", tagID, err)
+	}
+
+	tags := make(map[string]*Tag)
+
+	for i := range objs {
+		var err error
+		id := objs[i].TagID
+		tag, ok := tags[id]
+		if !ok {
+			tag, err = c.GetTag(ctx, id)
+			if err != nil {
+				return nil, fmt.Errorf("get tag %s: %s", id, err)
+			}
+			objs[i].Tag = tag
+		}
+	}
+
+	return objs, nil
+}
+
+// AttachedTags is the response type used by ListAttachedTagsOnObjects.
+type AttachedTags struct {
+	ObjectID mo.Reference `json:"object_id"`
+	TagIDs   []string     `json:"tag_ids"`
+	Tags     []Tag        `json:"tags,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (t *AttachedTags) UnmarshalJSON(b []byte) error {
+	var o struct {
+		ObjectID internal.AssociatedObject `json:"object_id"`
+		TagIDs   []string                  `json:"tag_ids"`
+	}
+	err := json.Unmarshal(b, &o)
+	if err != nil {
+		return err
+	}
+
+	t.ObjectID = o.ObjectID
+	t.TagIDs = o.TagIDs
+
+	return nil
+}
+
+// ListAttachedTagsOnObjects fetches the array of attached tag IDs for the given object IDs.
+func (c *Manager) ListAttachedTagsOnObjects(ctx context.Context, objectID []mo.Reference) ([]AttachedTags, error) {
+	var ids []internal.AssociatedObject
+	for i := range objectID {
+		ids = append(ids, internal.AssociatedObject(objectID[i].Reference()))
+	}
+
+	spec := struct {
+		ObjectIDs []internal.AssociatedObject `json:"object_ids"`
+	}{ids}
+
+	url := internal.URL(c, internal.AssociationPath).WithAction("list-attached-tags-on-objects")
+	var res []AttachedTags
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// GetAttachedTagsOnObjects calls ListAttachedTagsOnObjects and populates each Tags field.
+func (c *Manager) GetAttachedTagsOnObjects(ctx context.Context, objectID []mo.Reference) ([]AttachedTags, error) {
+	objs, err := c.ListAttachedTagsOnObjects(ctx, objectID)
+	if err != nil {
+		return nil, fmt.Errorf("list attached tags %s: %s", objectID, err)
+	}
+
+	tags := make(map[string]*Tag)
+
+	for i := range objs {
+		for _, id := range objs[i].TagIDs {
+			var err error
+			tag, ok := tags[id]
+			if !ok {
+				tag, err = c.GetTag(ctx, id)
+				if err != nil {
+					return nil, fmt.Errorf("get tag %s: %s", id, err)
+				}
+				tags[id] = tag
+			}
+			objs[i].Tags = append(objs[i].Tags, *tag)
+		}
+	}
+
+	return objs, nil
 }


### PR DESCRIPTION
Add support for multiple tags/objects and '-l' flag to govc tags.attached.ls command

Fixes #1429