### PR TITLE
Add various govmomi client examples

### DIFF
--- a/event/example_test.go
+++ b/event/example_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/event"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func ExampleManager_Events() {
+	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+		m := event.NewManager(c)
+
+		vm, err := find.NewFinder(c).VirtualMachine(ctx, "DC0_H0_VM0")
+		if err != nil {
+			return err
+		}
+
+		objs := []types.ManagedObjectReference{vm.Reference()}
+
+		return m.Events(ctx, objs, 10, false, false, func(ref types.ManagedObjectReference, events []types.BaseEvent) error {
+			event.Sort(events)
+			for _, event := range events {
+				fmt.Printf("%T\n", event)
+			}
+			return nil
+		})
+	})
+	// Output:
+	// *types.VmBeingCreatedEvent
+	// *types.VmInstanceUuidAssignedEvent
+	// *types.VmUuidAssignedEvent
+	// *types.VmCreatedEvent
+	// *types.VmStartingEvent
+	// *types.VmPoweredOnEvent
+}

--- a/find/finder.go
+++ b/find/finder.go
@@ -38,14 +38,24 @@ type Finder struct {
 	folders *object.DatacenterFolders
 }
 
-func NewFinder(client *vim25.Client, all bool) *Finder {
+func NewFinder(client *vim25.Client, all ...bool) *Finder {
+	props := false
+	if len(all) == 1 {
+		props = all[0]
+	}
+
 	f := &Finder{
 		client: client,
 		si:     object.NewSearchIndex(client),
 		r: recurser{
 			Collector: property.DefaultCollector(client),
-			All:       all,
+			All:       props,
 		},
+	}
+
+	if len(all) == 0 {
+		// attempt to avoid SetDatacenter() requirement
+		f.dc, _ = f.DefaultDatacenter(context.Background())
 	}
 
 	return f

--- a/object/example_test.go
+++ b/object/example_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func ExampleVirtualMachine_HostSystem() {
+	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+		vm, err := find.NewFinder(c).VirtualMachine(ctx, "DC0_H0_VM0")
+		if err != nil {
+			return err
+		}
+
+		host, err := vm.HostSystem(ctx)
+		if err != nil {
+			return err
+		}
+
+		name, err := host.ObjectName(ctx)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(name)
+
+		return nil
+	})
+	// Output: DC0_H0
+}
+
+func ExampleVirtualMachine_Clone() {
+	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+		finder := find.NewFinder(c)
+		dc, err := finder.Datacenter(ctx, "DC0")
+		if err != nil {
+			return err
+		}
+
+		finder.SetDatacenter(dc)
+
+		vm, err := finder.VirtualMachine(ctx, "DC0_H0_VM0")
+		if err != nil {
+			return err
+		}
+
+		folders, err := dc.Folders(ctx)
+		if err != nil {
+			return err
+		}
+
+		spec := types.VirtualMachineCloneSpec{
+			PowerOn: false,
+		}
+
+		task, err := vm.Clone(ctx, folders.VmFolder, "example-clone", spec)
+		if err != nil {
+			return err
+		}
+
+		info, err := task.WaitForResult(ctx)
+		if err != nil {
+			return err
+		}
+
+		clone := object.NewVirtualMachine(c, info.Result.(types.ManagedObjectReference))
+		name, err := clone.ObjectName(ctx)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(name)
+
+		return nil
+	})
+	// Output: example-clone
+}
+
+func ExampleCommon_Destroy() {
+	model := simulator.VPX()
+	model.Datastore = 2
+
+	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+		// Change to "LocalDS_0" will cause ResourceInUse error,
+		// as simulator VMs created by the VPX model use "LocalDS_0".
+		ds, err := find.NewFinder(c).Datastore(ctx, "LocalDS_1")
+		if err != nil {
+			return err
+		}
+
+		task, err := ds.Destroy(ctx)
+		if err != nil {
+			return err
+		}
+
+		if err = task.Wait(ctx); err != nil {
+			return err
+		}
+
+		fmt.Println("destroyed", ds.InventoryPath)
+		return nil
+	}, model)
+	// Output: destroyed /DC0/datastore/LocalDS_1
+}

--- a/object/task.go
+++ b/object/task.go
@@ -48,9 +48,13 @@ func (t *Task) Wait(ctx context.Context) error {
 	return err
 }
 
-func (t *Task) WaitForResult(ctx context.Context, s progress.Sinker) (*types.TaskInfo, error) {
+func (t *Task) WaitForResult(ctx context.Context, s ...progress.Sinker) (*types.TaskInfo, error) {
+	var pr progress.Sinker
+	if len(s) == 1 {
+		pr = s[0]
+	}
 	p := property.DefaultCollector(t.c)
-	return task.Wait(ctx, t.Reference(), p, s)
+	return task.Wait(ctx, t.Reference(), p, pr)
 }
 
 func (t *Task) Cancel(ctx context.Context) error {

--- a/property/example_test.go
+++ b/property/example_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package property_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+// Example to retrieve properties from a single object
+func ExampleCollector_RetrieveOne() {
+	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+		pc := property.DefaultCollector(c)
+
+		obj, err := find.NewFinder(c).VirtualMachine(ctx, "DC0_H0_VM0")
+		if err != nil {
+			return err
+		}
+
+		var vm mo.VirtualMachine
+		err = pc.RetrieveOne(ctx, obj.Reference(), []string{"config.version"}, &vm)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("hardware version %s", vm.Config.Version)
+		return nil
+	})
+	// Output: hardware version vmx-13
+}

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -543,3 +543,19 @@ func (m *Model) Run(f func(context.Context, *vim25.Client) error) error {
 
 	return f(ctx, c.Client)
 }
+
+// Example calls Model.Run for each model and will panic if f returns an error.
+// If no model is specified, the VPX Model is used by default.
+func Example(f func(context.Context, *vim25.Client) error, model ...*Model) {
+	m := model
+	if len(m) == 0 {
+		m = []*Model{VPX()}
+	}
+
+	for i := range m {
+		err := m[i].Run(f)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/view/example_test.go
+++ b/view/example_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+// Create a view of all hosts in the inventory, printing host names that belong to a cluster and excluding standalone hosts.
+func ExampleContainerView_Retrieve() {
+	model := simulator.VPX()
+	model.Datacenter = 2
+
+	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+		m := view.NewManager(c)
+		kind := []string{"HostSystem"}
+
+		v, err := m.CreateContainerView(ctx, c.ServiceContent.RootFolder, kind, true)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		var hosts []mo.HostSystem
+		var names []string
+
+		err = v.Retrieve(ctx, kind, []string{"summary.config.name", "parent"}, &hosts)
+		if err != nil {
+			return err
+		}
+
+		for _, host := range hosts {
+			if host.Parent.Type != "ClusterComputeResource" {
+				continue
+			}
+			names = append(names, host.Summary.Config.Name)
+		}
+
+		sort.Strings(names)
+		fmt.Println(names)
+
+		return v.Destroy(ctx)
+	}, model)
+	// Output: [DC0_C0_H0 DC0_C0_H1 DC0_C0_H2 DC1_C0_H0 DC1_C0_H1 DC1_C0_H2]
+}
+
+// Create a view of all VMs in the inventory, printing VM names that end with "_VM1".
+func ExampleContainerView_RetrieveWithFilter() {
+	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+		m := view.NewManager(c)
+		kind := []string{"VirtualMachine"}
+
+		v, err := m.CreateContainerView(ctx, c.ServiceContent.RootFolder, kind, true)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		var vms []mo.VirtualMachine
+		var names []string
+
+		err = v.RetrieveWithFilter(ctx, kind, []string{"name"}, &vms, property.Filter{"name": "*_VM1"})
+		if err != nil {
+			return err
+		}
+
+		for _, vm := range vms {
+			names = append(names, vm.Name)
+		}
+
+		sort.Strings(names)
+		fmt.Println(names)
+
+		return v.Destroy(ctx)
+	})
+	// Output: [DC0_C0_RP0_VM1 DC0_H0_VM1]
+}


### PR DESCRIPTION
Using Go's example style for these tests rather than main functions in the examples/ directory.
These examples will be included in godoc, tested by 'go test' and only run against vcsim.

- Add simulator.Example function to make examples more concise

- Make finder.NewFinder 'all' param optional.  If not specified, also attempts default DC lookup

- Make task.WaitForResult progress param optional

- Add vcsim Datastore.Destroy_Task impl

Fixes #1497
Fixes #1495
Fixes #1478
Fixes #1451
Fixes #1443