### PR TITLE
govcsim: Set datastore status as normal

### DIFF
--- a/simulator/host_datastore_system.go
+++ b/simulator/host_datastore_system.go
@@ -108,6 +108,7 @@ func (dss *HostDatastoreSystem) CreateLocalDatastore(c *types.CreateLocalDatasto
 	}
 
 	ds.Summary.Type = string(types.HostFileSystemVolumeFileSystemTypeOTHER)
+	ds.Summary.MaintenanceMode = string(types.DatastoreSummaryMaintenanceModeStateNormal)
 
 	if err := dss.add(ds); err != nil {
 		r.Fault_ = err
@@ -154,6 +155,7 @@ func (dss *HostDatastoreSystem) CreateNasDatastore(c *types.CreateNasDatastore) 
 	}
 
 	ds.Summary.Type = c.Spec.Type
+	ds.Summary.MaintenanceMode = string(types.DatastoreSummaryMaintenanceModeStateNormal)
 
 	if err := dss.add(ds); err != nil {
 		r.Fault_ = err


### PR DESCRIPTION
While creating datastore maintenance mode is set to None.
Fix add string value 'normal' as the value of datastore maintenance mode.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>