### PR TITLE
Set the InventoryPath of the folder object in DefaultFolder

### DIFF
--- a/find/finder.go
+++ b/find/finder.go
@@ -917,11 +917,10 @@ func (f *Finder) DefaultFolder(ctx context.Context) (*object.Folder, error) {
 	folder := object.NewFolder(f.client, ref.Reference())
 
 	// Set the InventoryPath of the newly created folder object
-	e, err := f.Element(ctx, folder.Reference())
-	if err != nil {
-		return nil, err
-	}
-	folder.SetInventoryPath(e.Path)
+	// The default foler becomes the datacenter's "vm" folder.
+	// The "vm" folder always exists for a datacenter. It cannot be
+	// removed or replaced
+	folder.SetInventoryPath(path.Join(f.dc.InventoryPath, "vm"))
 
 	return folder, nil
 }

--- a/find/finder.go
+++ b/find/finder.go
@@ -916,6 +916,13 @@ func (f *Finder) DefaultFolder(ctx context.Context) (*object.Folder, error) {
 	}
 	folder := object.NewFolder(f.client, ref.Reference())
 
+	// Set the InventoryPath of the newly created folder object
+	e, err := f.Element(ctx, folder.Reference())
+	if err != nil {
+		return nil, err
+	}
+	folder.SetInventoryPath(e.Path)
+
 	return folder, nil
 }
 


### PR DESCRIPTION
The `DefaultFolder` is called in `FolderOrDefault` function which is expected to return a folder object of the default folder if the given path the empty.

The `DefaultFolder` object after creating the folder object needs to set the InventoryPath.

This PR fixes the above-mentioned issue.