### PR TITLE
Add Juju to projects using govmomi

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Refer to the [CHANGELOG](CHANGELOG.md) for version to version changes.
 
 * [Open Storage](https://github.com/libopenstorage/openstorage/tree/master/pkg/storageops/vsphere)
 
+* [Juju](https://github.com/juju/juju)
+
 ## Related projects
 
 * [rbvmomi](https://github.com/vmware/rbvmomi)


### PR DESCRIPTION
This commit adds the Juju project to the list of users. Juju by Canonical has been using govmomi since at least 2017.