### PR TITLE
Fixed type bug in global_object_manager Task.QueryResult

### DIFF
--- a/vslm/global_object_manager.go
+++ b/vslm/global_object_manager.go
@@ -49,7 +49,7 @@ func (this *Task) QueryResult(ctx context.Context) (vim.AnyType, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &res.Returnval, nil
+	return res.Returnval, nil
 }
 
 func (this *Task) QueryInfo(ctx context.Context) (*types.VslmTaskInfo, error) {


### PR DESCRIPTION
interface {} is not * interface{} but the go compiler doesn't seem to mind