### PR TITLE
Add support for the cis session get method

### DIFF
--- a/vapi/rest/client.go
+++ b/vapi/rest/client.go
@@ -129,6 +129,12 @@ func (c *Client) LoginByToken(ctx context.Context) error {
 	return c.Login(ctx, nil)
 }
 
+// Get returns an error if the current session is invalid.
+func (c *Client) Get(ctx context.Context) error {
+	req := internal.URL(c, internal.SessionPath).WithAction("get").Request(http.MethodPost)
+	return c.Do(ctx, req, nil)
+}
+
 // Logout deletes the current session.
 func (c *Client) Logout(ctx context.Context) error {
 	req := internal.URL(c, internal.SessionPath).Request(http.MethodDelete)

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -156,7 +156,7 @@ func New(u *url.URL, settings []vim.BaseOptionValue) (string, http.Handler) {
 }
 
 func (s *handler) isAuthorized(r *http.Request) bool {
-	if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, internal.SessionPath) {
+	if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, internal.SessionPath) && s.action(r) == "" {
 		return true
 	}
 	id := r.Header.Get(internal.SessionCookieName)
@@ -320,6 +320,14 @@ func (s *handler) session(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodPost:
+		if s.action(r) != "" {
+			if _, ok := s.Session[id]; ok {
+				s.ok(w)
+			} else {
+				w.WriteHeader(http.StatusUnauthorized)
+			}
+			return
+		}
 		user, ok := s.hasAuthorization(r)
 		if !ok {
 			w.WriteHeader(http.StatusUnauthorized)


### PR DESCRIPTION
Added support for the [get method](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/1cd28284-3b72-4885-9e31-d1c6d9e26686/71ef7304-a6c9-43b3-a3cd-868b2c236c81/doc/operations/com/vmware/cis/session.get-operation.html) on the cis session endpoint to both the REST client and the simulator.

