### PR TITLE
Add v4 option to VirtualMachine.WaitForIP

### DIFF
--- a/govc/vm/ip.go
+++ b/govc/vm/ip.go
@@ -163,7 +163,7 @@ func (cmd *ip) Run(ctx context.Context, f *flag.FlagSet) error {
 				}
 				return strings.Join(ips, ","), nil
 			}
-			return vm.WaitForIP(deadline)
+			return vm.WaitForIP(deadline, cmd.v4)
 		}
 	}
 

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -221,7 +221,9 @@ func (v VirtualMachine) RefreshStorageInfo(ctx context.Context) error {
 	return err
 }
 
-func (v VirtualMachine) WaitForIP(ctx context.Context) (string, error) {
+// WaitForIP waits for the VM guest.ipAddress property to report an IP address.
+// Waits for an IPv4 address if the v4 param is true.
+func (v VirtualMachine) WaitForIP(ctx context.Context, v4 ...bool) (string, error) {
 	var ip string
 
 	p := property.DefaultCollector(v.c)
@@ -238,6 +240,11 @@ func (v VirtualMachine) WaitForIP(ctx context.Context) (string, error) {
 			}
 
 			ip = c.Val.(string)
+			if len(v4) == 1 && v4[0] {
+				if net.ParseIP(ip).To4() == nil {
+					return false
+				}
+			}
 			return true
 		}
 

--- a/object/vm_guest_test.go
+++ b/object/vm_guest_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestVirtualMachineWaitForIP(t *testing.T) {
+	m := simulator.VPX()
+	err := m.Run(func(ctx context.Context, c *vim25.Client) error {
+		vm, err := find.NewFinder(c).VirtualMachine(ctx, "DC0_H0_VM0")
+		if err != nil {
+			return err
+		}
+
+		obj := simulator.Map.Get(vm.Reference()).(*simulator.VirtualMachine)
+		obj.Guest.IpAddress = "fe80::250:56ff:fe97:2458"
+
+		ip, err := vm.WaitForIP(ctx)
+		if err != nil {
+			return err
+		}
+
+		if net.ParseIP(ip).To4() != nil {
+			t.Errorf("expected v6 ip, but %q is v4", ip)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			wg.Done()
+			ip, err = vm.WaitForIP(ctx, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wg.Done()
+		}()
+		wg.Wait()
+
+		wg.Add(1)
+		simulator.Map.WithLock(obj.Reference(), func() {
+			simulator.Map.Update(obj, []types.PropertyChange{
+				{Name: "guest.ipAddress", Val: "10.0.0.1"},
+			})
+		})
+		wg.Wait()
+		if net.ParseIP(ip).To4() == nil {
+			t.Errorf("expected v4 ip, but %q is v6", ip)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Parity with WaitForNetIP's v4 option and govc's vm.ip -v4 w/o -a or -n flags.

Fixes #1259