### PR TITLE
CNS go bindings

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -1,0 +1,145 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cns
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/cns/methods"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+)
+
+// Namespace and Path constants
+const (
+	Namespace = "vsan"
+	Path      = "/vsanHealth"
+)
+
+var (
+	CnsVolumeManagerInstance = vimtypes.ManagedObjectReference{
+		Type:  "CnsVolumeManager",
+		Value: "cns-volume-manager",
+	}
+)
+
+type Client struct {
+	vim25Client   *vim25.Client
+	serviceClient *soap.Client
+}
+
+// NewClient creates a new CNS client
+func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
+	sc := c.Client.NewServiceClient(Path, Namespace)
+	return &Client{c, sc}, nil
+}
+
+// CreateVolume calls the CNS create API.
+func (c *Client) CreateVolume(ctx context.Context, createSpecList []cnstypes.CnsVolumeCreateSpec) (*object.Task, error) {
+	req := cnstypes.CnsCreateVolume{
+		This:        CnsVolumeManagerInstance,
+		CreateSpecs: createSpecList,
+	}
+	res, err := methods.CnsCreateVolume(ctx, c.serviceClient, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(c.vim25Client, res.Returnval), nil
+}
+
+// UpdateVolumeMetadata calls the CNS CnsUpdateVolumeMetadata API with UpdateSpecs specified in the argument
+func (c *Client) UpdateVolumeMetadata(ctx context.Context, updateSpecList []cnstypes.CnsVolumeMetadataUpdateSpec) (*object.Task, error) {
+	req := cnstypes.CnsUpdateVolumeMetadata{
+		This:        CnsVolumeManagerInstance,
+		UpdateSpecs: updateSpecList,
+	}
+	res, err := methods.CnsUpdateVolumeMetadata(ctx, c.serviceClient, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(c.vim25Client, res.Returnval), nil
+}
+
+// DeleteVolume calls the CNS delete API.
+func (c *Client) DeleteVolume(ctx context.Context, volumeIDList []cnstypes.CnsVolumeId, deleteDisk bool) (*object.Task, error) {
+	req := cnstypes.CnsDeleteVolume{
+		This:       CnsVolumeManagerInstance,
+		VolumeIds:  volumeIDList,
+		DeleteDisk: deleteDisk,
+	}
+	res, err := methods.CnsDeleteVolume(ctx, c.serviceClient, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(c.vim25Client, res.Returnval), nil
+}
+
+// AttachVolume calls the CNS Attach API.
+func (c *Client) AttachVolume(ctx context.Context, attachSpecList []cnstypes.CnsVolumeAttachDetachSpec) (*object.Task, error) {
+	req := cnstypes.CnsAttachVolume{
+		This:        CnsVolumeManagerInstance,
+		AttachSpecs: attachSpecList,
+	}
+	res, err := methods.CnsAttachVolume(ctx, c.serviceClient, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(c.vim25Client, res.Returnval), nil
+}
+
+// DetachVolume calls the CNS Detach API.
+func (c *Client) DetachVolume(ctx context.Context, detachSpecList []cnstypes.CnsVolumeAttachDetachSpec) (*object.Task, error) {
+	req := cnstypes.CnsDetachVolume{
+		This:        CnsVolumeManagerInstance,
+		DetachSpecs: detachSpecList,
+	}
+	res, err := methods.CnsDetachVolume(ctx, c.serviceClient, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(c.vim25Client, res.Returnval), nil
+}
+
+// QueryVolume calls the CNS QueryVolume API.
+func (c *Client) QueryVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
+	req := cnstypes.CnsQueryVolume{
+		This:   CnsVolumeManagerInstance,
+		Filter: queryFilter,
+	}
+	res, err := methods.CnsQueryVolume(ctx, c.serviceClient, &req)
+	if err != nil {
+		return nil, err
+	}
+	return &res.Returnval, nil
+}
+
+// QueryVolume calls the CNS QueryAllVolume API.
+func (c *Client) QueryAllVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter, querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+	req := cnstypes.CnsQueryAllVolume{
+		This:      CnsVolumeManagerInstance,
+		Filter:    queryFilter,
+		Selection: querySelection,
+	}
+	res, err := methods.CnsQueryAllVolume(ctx, c.serviceClient, &req)
+	if err != nil {
+		return nil, err
+	}
+	return &res.Returnval, nil
+}

--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -1,0 +1,351 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cns
+
+import (
+	"context"
+	"os"
+
+	"github.com/vmware/govmomi/object"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/vim25/soap"
+
+	"testing"
+
+	"github.com/vmware/govmomi"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	vim25types "github.com/vmware/govmomi/vim25/types"
+)
+
+func TestClient(t *testing.T) {
+	url := os.Getenv("CNS_VC_URL")
+	datacenter := os.Getenv("CNS_DATACENTER")
+	datastore := os.Getenv("CNS_DATASTORE")
+	if url == "" || datacenter == "" || datastore == "" {
+		t.Skipf("CNS_VC_URL or CNS_DATACENTER or CNS_DATASTORE is not set")
+		t.SkipNow()
+	}
+	u, err := soap.ParseURL(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	c, err := govmomi.NewClient(ctx, u, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cnsClient, err := NewClient(ctx, c.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	finder := find.NewFinder(cnsClient.vim25Client, false)
+	dc, err := finder.Datacenter(ctx, datacenter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finder.SetDatacenter(dc)
+	ds, err := finder.Datastore(ctx, datastore)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var dsList []vim25types.ManagedObjectReference
+	dsList = append(dsList, ds.Reference())
+
+	// Test CreateVolume API
+	var cnsVolumeCreateSpecList []cnstypes.CnsVolumeCreateSpec
+	cnsVolumeCreateSpec := cnstypes.CnsVolumeCreateSpec{
+		Name:       "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
+		VolumeType: string(cnstypes.CnsVolumeTypeBlock),
+		Datastores: dsList,
+		Metadata: cnstypes.CnsVolumeMetadata{
+			ContainerCluster: cnstypes.CnsContainerCluster{
+				ClusterType: string(cnstypes.CnsClusterTypeKubernetes),
+				ClusterId:   "demo-cluster-id",
+				VSphereUser: "Administrator@vsphere.local",
+			},
+		},
+		BackingObjectDetails: &cnstypes.CnsBackingObjectDetails{
+			CapacityInMb: 5120,
+		},
+	}
+	cnsVolumeCreateSpecList = append(cnsVolumeCreateSpecList, cnsVolumeCreateSpec)
+	t.Logf("Creating volume using the spec: %+v", cnsVolumeCreateSpec)
+	createTask, err := cnsClient.CreateVolume(ctx, cnsVolumeCreateSpecList)
+	if err != nil {
+		t.Errorf("Failed to create volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	createTaskInfo, err := GetTaskInfo(ctx, createTask)
+	if err != nil {
+		t.Errorf("Failed to create volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	createTaskResult, err := GetTaskResult(ctx, createTaskInfo)
+	if err != nil {
+		t.Errorf("Failed to create volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	if createTaskResult == nil {
+		t.Fatalf("Empty create task results")
+		t.FailNow()
+	}
+	createVolumeOperationRes := createTaskResult.GetCnsVolumeOperationResult()
+	if createVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to create volume: fault=%+v", createVolumeOperationRes.Fault)
+	}
+	volumeId := createVolumeOperationRes.VolumeId.Id
+	t.Logf("Volume created sucessfully. volumeId: %s", volumeId)
+
+	// Test QueryVolume API
+	var queryFilter cnstypes.CnsQueryFilter
+	var volumeIDList []cnstypes.CnsVolumeId
+	volumeIDList = append(volumeIDList, cnstypes.CnsVolumeId{Id: volumeId})
+	queryFilter.VolumeIds = volumeIDList
+	t.Logf("Calling QueryVolume using queryFilter: %+v", queryFilter)
+	queryResult, err := cnsClient.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Errorf("Failed to query volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	t.Logf("Sucessfully Queried Volumes. queryResult: %+v", queryResult)
+
+	// Test UpdateVolumeMetadata
+	var updateSpecList []cnstypes.CnsVolumeMetadataUpdateSpec
+
+	var metadataList []cnstypes.BaseCnsEntityMetadata
+	newLabels := []vim25types.KeyValue{
+		{
+			Key:   "testLabel",
+			Value: "testValue",
+		},
+	}
+	metadata := &cnstypes.CnsKubernetesEntityMetadata{
+		CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+			DynamicData: vim25types.DynamicData{},
+			EntityName:  "PV NAME",
+			Labels:      newLabels,
+			Delete:      false,
+		},
+		EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+		Namespace:  "",
+	}
+	metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(metadata))
+	cnsVolumeMetadataUpdateSpec := cnstypes.CnsVolumeMetadataUpdateSpec{
+		VolumeId: cnstypes.CnsVolumeId{Id: volumeId},
+		Metadata: cnstypes.CnsVolumeMetadata{
+			DynamicData: vim25types.DynamicData{},
+			ContainerCluster: cnstypes.CnsContainerCluster{
+				ClusterType: string(cnstypes.CnsClusterTypeKubernetes),
+				ClusterId:   "demo-cluster-id",
+				VSphereUser: "Administrator@vsphere.local",
+			},
+			EntityMetadata: metadataList,
+		},
+	}
+	t.Logf("Updating volume using the spec: %+v", cnsVolumeMetadataUpdateSpec)
+	updateSpecList = append(updateSpecList, cnsVolumeMetadataUpdateSpec)
+	updateTask, err := cnsClient.UpdateVolumeMetadata(ctx, updateSpecList)
+	if err != nil {
+		t.Errorf("Failed to update volume metadata. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	updateTaskInfo, err := GetTaskInfo(ctx, updateTask)
+	if err != nil {
+		t.Errorf("Failed to update volume metadata. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	updateTaskResult, err := GetTaskResult(ctx, updateTaskInfo)
+	if err != nil {
+		t.Errorf("Failed to update volume metadata. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	if updateTaskResult == nil {
+		t.Fatalf("Empty update task results")
+		t.FailNow()
+	}
+	updateVolumeOperationRes := updateTaskResult.GetCnsVolumeOperationResult()
+	if updateVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to update volume metadata: fault=%+v", updateVolumeOperationRes.Fault)
+	} else {
+		t.Logf("Sucessfully updated volume metadata")
+	}
+
+	// Test QueryAll
+	querySelection := cnstypes.CnsQuerySelection{
+		Names: []string{
+			string(cnstypes.CnsQuerySelectionName_VOLUME_NAME),
+			string(cnstypes.CnsQuerySelectionName_VOLUME_TYPE),
+			string(cnstypes.CnsQuerySelectionName_BACKING_OBJECT_DETAILS),
+			string(cnstypes.CnsQuerySelectionName_COMPLIANCE_STATUS),
+			string(cnstypes.CnsQuerySelectionName_DATASTORE_ACCESSIBILITY_STATUS),
+		},
+	}
+	queryResult, err = cnsClient.QueryAllVolume(ctx, cnstypes.CnsQueryFilter{}, querySelection)
+	if err != nil {
+		t.Errorf("Failed to query all volumes. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	t.Logf("Sucessfully Queried all Volumes. queryResult: %+v", queryResult)
+
+	// Create a VM to test Attach Volume API.
+	virtualMachineConfigSpec := vim25types.VirtualMachineConfigSpec{
+		Name: "test-node-vm",
+		Files: &vim25types.VirtualMachineFileInfo{
+			VmPathName: "[" + datastore + "]",
+		},
+		NumCPUs:  1,
+		MemoryMB: 4,
+		DeviceChange: []vim25types.BaseVirtualDeviceConfigSpec{
+			&vim25types.VirtualDeviceConfigSpec{
+				Operation: vim25types.VirtualDeviceConfigSpecOperationAdd,
+				Device: &vim25types.ParaVirtualSCSIController{
+					VirtualSCSIController: vim25types.VirtualSCSIController{
+						SharedBus: vim25types.VirtualSCSISharingNoSharing,
+						VirtualController: vim25types.VirtualController{
+							BusNumber: 0,
+							VirtualDevice: vim25types.VirtualDevice{
+								Key: 1000,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	defaultFolder, err := finder.DefaultFolder(ctx)
+	defaultResourcePool, err := finder.DefaultResourcePool(ctx)
+	task, err := defaultFolder.CreateVM(ctx, virtualMachineConfigSpec, defaultResourcePool, nil)
+	if err != nil {
+		t.Errorf("Failed to create VM. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+
+	vmTaskInfo, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		t.Errorf("Error occurred while waiting for create VM task result. err: %+v", err)
+		t.Fatal(err)
+	}
+
+	vmRef := vmTaskInfo.Result.(object.Reference)
+	t.Logf("Node VM created sucessfully. vmRef: %+v", vmRef.Reference())
+
+	nodeVM := object.NewVirtualMachine(cnsClient.vim25Client, vmRef.Reference())
+	defer nodeVM.Destroy(ctx)
+
+	// Test AttachVolume API
+	var cnsVolumeAttachSpecList []cnstypes.CnsVolumeAttachDetachSpec
+	cnsVolumeAttachSpec := cnstypes.CnsVolumeAttachDetachSpec{
+		VolumeId: cnstypes.CnsVolumeId{
+			Id: volumeId,
+		},
+		Vm: nodeVM.Reference(),
+	}
+	cnsVolumeAttachSpecList = append(cnsVolumeAttachSpecList, cnsVolumeAttachSpec)
+	t.Logf("Attaching volume using the spec: %+v", cnsVolumeAttachSpec)
+	attachTask, err := cnsClient.AttachVolume(ctx, cnsVolumeAttachSpecList)
+	if err != nil {
+		t.Errorf("Failed to attach volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	attachTaskInfo, err := GetTaskInfo(ctx, attachTask)
+	if err != nil {
+		t.Errorf("Failed to attach volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	attachTaskResult, err := GetTaskResult(ctx, attachTaskInfo)
+	if err != nil {
+		t.Errorf("Failed to attach volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	if attachTaskResult == nil {
+		t.Fatalf("Empty attach task results")
+		t.FailNow()
+	}
+	attachVolumeOperationRes := attachTaskResult.GetCnsVolumeOperationResult()
+	if attachVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to attach volume: fault=%+v", attachVolumeOperationRes.Fault)
+	}
+	diskUUID := attachVolumeOperationRes.VolumeId.Id
+	t.Logf("Volume attached sucessfully. Disk UUID: %s", diskUUID)
+
+	// Test DetachVolume API
+	var cnsVolumeDetachSpecList []cnstypes.CnsVolumeAttachDetachSpec
+	cnsVolumeDetachSpec := cnstypes.CnsVolumeAttachDetachSpec{
+		VolumeId: cnstypes.CnsVolumeId{
+			Id: volumeId,
+		},
+		Vm: nodeVM.Reference(),
+	}
+	cnsVolumeDetachSpecList = append(cnsVolumeDetachSpecList, cnsVolumeDetachSpec)
+	t.Logf("Detaching volume using the spec: %+v", cnsVolumeDetachSpec)
+	detachTask, err := cnsClient.DetachVolume(ctx, cnsVolumeDetachSpecList)
+	if err != nil {
+		t.Errorf("Failed to detach volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	detachTaskInfo, err := GetTaskInfo(ctx, detachTask)
+	if err != nil {
+		t.Errorf("Failed to detach volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	detachTaskResult, err := GetTaskResult(ctx, detachTaskInfo)
+	if err != nil {
+		t.Errorf("Failed to detach volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	if detachTaskResult == nil {
+		t.Fatalf("Empty detach task results")
+		t.FailNow()
+	}
+	detachVolumeOperationRes := detachTaskResult.GetCnsVolumeOperationResult()
+	if detachVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to detach volume: fault=%+v", detachVolumeOperationRes.Fault)
+	}
+	t.Logf("Volume detached sucessfully")
+
+	// Test DeleteVolume API
+	t.Logf("Deleting volume: %+v", volumeIDList)
+	deleteTask, err := cnsClient.DeleteVolume(ctx, volumeIDList, true)
+	if err != nil {
+		t.Errorf("Failed to delete volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	deleteTaskInfo, err := GetTaskInfo(ctx, deleteTask)
+	if err != nil {
+		t.Errorf("Failed to delete volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	deleteTaskResult, err := GetTaskResult(ctx, deleteTaskInfo)
+	if err != nil {
+		t.Errorf("Failed to detach volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	if deleteTaskResult == nil {
+		t.Fatalf("Empty delete task results")
+		t.FailNow()
+	}
+	deleteVolumeOperationRes := deleteTaskResult.GetCnsVolumeOperationResult()
+	if deleteVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to delete volume: fault=%+v", deleteVolumeOperationRes.Fault)
+	}
+	t.Logf("Volume deleted sucessfully")
+}

--- a/cns/cns_util.go
+++ b/cns/cns_util.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cns
+
+import (
+	"context"
+	"errors"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/object"
+	vim25types "github.com/vmware/govmomi/vim25/types"
+)
+
+// version and namespace constants for task client
+const (
+	// ClientVersion "6.9.0" is mapped to 'vsan.version.version11'
+	// This need to be changed if later VMODL version is bumped
+	taskClientVersion   = "6.9.0"
+	taskClientNamespace = "urn:vsan"
+)
+
+// GetTaskInfo gets the task info given a task
+func GetTaskInfo(ctx context.Context, task *object.Task) (*vim25types.TaskInfo, error) {
+	task.Client().Version = taskClientVersion
+	task.Client().Namespace = taskClientNamespace
+	taskInfo, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return taskInfo, nil
+}
+
+// GetTaskResult gets the task result given a task info
+func GetTaskResult(ctx context.Context, taskInfo *vim25types.TaskInfo) (cnstypes.BaseCnsVolumeOperationResult, error) {
+	if taskInfo == nil {
+		return nil, errors.New("TaskInfo is empty")
+	}
+	volumeOperationBatchResult := taskInfo.Result.(cnstypes.CnsVolumeOperationBatchResult)
+	if &volumeOperationBatchResult == nil ||
+		volumeOperationBatchResult.VolumeResults == nil ||
+		len(volumeOperationBatchResult.VolumeResults) == 0 {
+		return nil, errors.New("Cannot get VolumeOperationResult")
+	}
+	return volumeOperationBatchResult.VolumeResults[0], nil
+}

--- a/cns/methods/methods.go
+++ b/cns/methods/methods.go
@@ -1,0 +1,164 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package methods
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type CnsCreateVolumeBody struct {
+	Req    *types.CnsCreateVolume         `xml:"urn:vsan CnsCreateVolume,omitempty"`
+	Res    *types.CnsCreateVolumeResponse `xml:"urn:vsan CnsCreateVolumeResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsCreateVolumeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsCreateVolume(ctx context.Context, r soap.RoundTripper, req *types.CnsCreateVolume) (*types.CnsCreateVolumeResponse, error) {
+	var reqBody, resBody CnsCreateVolumeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CnsUpdateVolumeBody struct {
+	Req    *types.CnsUpdateVolumeMetadata         `xml:"urn:vsan CnsUpdateVolumeMetadata,omitempty"`
+	Res    *types.CnsUpdateVolumeMetadataResponse `xml:"urn:vsan CnsUpdateVolumeMetadataResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsUpdateVolumeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsUpdateVolumeMetadata(ctx context.Context, r soap.RoundTripper, req *types.CnsUpdateVolumeMetadata) (*types.CnsUpdateVolumeMetadataResponse, error) {
+	var reqBody, resBody CnsUpdateVolumeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CnsDeleteVolumeBody struct {
+	Req    *types.CnsDeleteVolume         `xml:"urn:vsan CnsDeleteVolume,omitempty"`
+	Res    *types.CnsDeleteVolumeResponse `xml:"urn:vsan CnsDeleteVolumeResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsDeleteVolumeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsDeleteVolume(ctx context.Context, r soap.RoundTripper, req *types.CnsDeleteVolume) (*types.CnsDeleteVolumeResponse, error) {
+	var reqBody, resBody CnsDeleteVolumeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CnsAttachVolumeBody struct {
+	Req    *types.CnsAttachVolume         `xml:"urn:vsan CnsAttachVolume,omitempty"`
+	Res    *types.CnsAttachVolumeResponse `xml:"urn:vsan CnsAttachVolumeResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsAttachVolumeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsAttachVolume(ctx context.Context, r soap.RoundTripper, req *types.CnsAttachVolume) (*types.CnsAttachVolumeResponse, error) {
+	var reqBody, resBody CnsAttachVolumeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CnsDetachVolumeBody struct {
+	Req    *types.CnsDetachVolume         `xml:"urn:vsan CnsDetachVolume,omitempty"`
+	Res    *types.CnsDetachVolumeResponse `xml:"urn:vsan CnsDetachVolumeResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsDetachVolumeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsDetachVolume(ctx context.Context, r soap.RoundTripper, req *types.CnsDetachVolume) (*types.CnsDetachVolumeResponse, error) {
+	var reqBody, resBody CnsDetachVolumeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CnsQueryVolumeBody struct {
+	Req    *types.CnsQueryVolume         `xml:"urn:vsan CnsQueryVolume,omitempty"`
+	Res    *types.CnsQueryVolumeResponse `xml:"urn:vsan CnsQueryVolumeResponse,omitempty"`
+	Fault_ *soap.Fault                   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsQueryVolumeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsQueryVolume(ctx context.Context, r soap.RoundTripper, req *types.CnsQueryVolume) (*types.CnsQueryVolumeResponse, error) {
+	var reqBody, resBody CnsQueryVolumeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CnsQueryAllVolumeBody struct {
+	Req    *types.CnsQueryAllVolume         `xml:"urn:vsan CnsQueryAllVolume,omitempty"`
+	Res    *types.CnsQueryAllVolumeResponse `xml:"urn:vsan CnsQueryAllVolumeResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsQueryAllVolumeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsQueryAllVolume(ctx context.Context, r soap.RoundTripper, req *types.CnsQueryAllVolume) (*types.CnsQueryAllVolumeResponse, error) {
+	var reqBody, resBody CnsQueryAllVolumeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/cns/mo/mo.go
+++ b/cns/mo/mo.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mo
+
+import (
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type CnsVolumeManager struct {
+	Self types.ManagedObjectReference
+}
+
+func (m CnsVolumeManager) Reference() types.ManagedObjectReference {
+	return m.Self
+}

--- a/cns/simulator/simulator.go
+++ b/cns/simulator/simulator.go
@@ -1,0 +1,335 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/google/uuid"
+	"github.com/vmware/govmomi/cns"
+	"github.com/vmware/govmomi/cns/methods"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/soap"
+	vim25types "github.com/vmware/govmomi/vim25/types"
+)
+
+func New() *simulator.Registry {
+	r := simulator.NewRegistry()
+	r.Namespace = cns.Namespace
+	r.Path = cns.Path
+
+	r.Put(&CnsVolumeManager{
+		ManagedObjectReference: cns.CnsVolumeManagerInstance,
+		volumes:                make(map[vim25types.ManagedObjectReference]map[cnstypes.CnsVolumeId]*cnstypes.CnsVolume),
+		attachments:            make(map[cnstypes.CnsVolumeId]vim25types.ManagedObjectReference),
+	})
+
+	return r
+}
+
+type CnsVolumeManager struct {
+	vim25types.ManagedObjectReference
+	volumes     map[vim25types.ManagedObjectReference]map[cnstypes.CnsVolumeId]*cnstypes.CnsVolume
+	attachments map[cnstypes.CnsVolumeId]vim25types.ManagedObjectReference
+}
+
+const simulatorDiskUUID = "6000c298595bf4575739e9105b2c0c2d"
+
+func (m *CnsVolumeManager) CnsCreateVolume(ctx context.Context, req *cnstypes.CnsCreateVolume) soap.HasFault {
+	task := simulator.CreateTask(m, "CnsCreateVolume", func(*simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
+		if len(req.CreateSpecs) == 0 {
+			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsVolumeCreateSpec"}
+		}
+
+		operationResult := []cnstypes.BaseCnsVolumeOperationResult{}
+		for _, createSpec := range req.CreateSpecs {
+			staticProvisionedSpec, ok := interface{}(createSpec.BackingObjectDetails).(*cnstypes.CnsBlockBackingDetails)
+			if ok && staticProvisionedSpec.BackingDiskId != "" {
+				datastore := simulator.Map.Any("Datastore").(*simulator.Datastore)
+				volumes, ok := m.volumes[datastore.Self]
+				if !ok {
+					volumes = make(map[cnstypes.CnsVolumeId]*cnstypes.CnsVolume)
+					m.volumes[datastore.Self] = volumes
+				}
+				newVolume := &cnstypes.CnsVolume{
+					VolumeId: cnstypes.CnsVolumeId{
+						Id: interface{}(createSpec.BackingObjectDetails).(*cnstypes.CnsBlockBackingDetails).BackingDiskId,
+					},
+					Name:                         createSpec.Name,
+					VolumeType:                   createSpec.VolumeType,
+					DatastoreUrl:                 datastore.Info.GetDatastoreInfo().Url,
+					Metadata:                     createSpec.Metadata,
+					BackingObjectDetails:         *createSpec.BackingObjectDetails.GetCnsBackingObjectDetails(),
+					ComplianceStatus:             "Simulator Compliance Status",
+					DatastoreAccessibilityStatus: "Simulator Datastore Accessibility Status",
+				}
+
+				volumes[newVolume.VolumeId] = newVolume
+				operationResult = append(operationResult, &cnstypes.CnsVolumeOperationResult{
+					VolumeId: newVolume.VolumeId,
+				})
+
+			} else {
+				for _, datastoreRef := range createSpec.Datastores {
+					datastore := simulator.Map.Get(datastoreRef).(*simulator.Datastore)
+
+					volumes, ok := m.volumes[datastore.Self]
+					if !ok {
+						volumes = make(map[cnstypes.CnsVolumeId]*cnstypes.CnsVolume)
+						m.volumes[datastore.Self] = volumes
+
+					}
+
+					var policyId string
+					if createSpec.Profile != nil && createSpec.Profile[0] != nil &&
+						reflect.TypeOf(createSpec.Profile[0]) == reflect.TypeOf(&vim25types.VirtualMachineDefinedProfileSpec{}) {
+						policyId = interface{}(createSpec.Profile[0]).(*vim25types.VirtualMachineDefinedProfileSpec).ProfileId
+					}
+
+					newVolume := &cnstypes.CnsVolume{
+						VolumeId: cnstypes.CnsVolumeId{
+							Id: uuid.New().String(),
+						},
+						Name:                         createSpec.Name,
+						VolumeType:                   createSpec.VolumeType,
+						DatastoreUrl:                 datastore.Info.GetDatastoreInfo().Url,
+						Metadata:                     createSpec.Metadata,
+						BackingObjectDetails:         *createSpec.BackingObjectDetails.GetCnsBackingObjectDetails(),
+						ComplianceStatus:             "Simulator Compliance Status",
+						DatastoreAccessibilityStatus: "Simulator Datastore Accessibility Status",
+						StoragePolicyId:              policyId,
+					}
+
+					volumes[newVolume.VolumeId] = newVolume
+					operationResult = append(operationResult, &cnstypes.CnsVolumeOperationResult{
+						VolumeId: newVolume.VolumeId,
+					})
+				}
+			}
+		}
+
+		return &cnstypes.CnsVolumeOperationBatchResult{
+			VolumeResults: operationResult,
+		}, nil
+	})
+
+	return &methods.CnsCreateVolumeBody{
+		Res: &cnstypes.CnsCreateVolumeResponse{
+			Returnval: task.Run(),
+		},
+	}
+}
+
+// CnsQueryVolume simulates the query volumes implementation for CNSQuery API
+func (m *CnsVolumeManager) CnsQueryVolume(ctx context.Context, req *cnstypes.CnsQueryVolume) soap.HasFault {
+	retVolumes := []cnstypes.CnsVolume{}
+	reqVolumeIds := make(map[string]bool)
+	isQueryFilter := false
+
+	if req.Filter.VolumeIds != nil {
+		isQueryFilter = true
+	}
+	// Create map of requested volume Ids in query request
+	for _, volumeID := range req.Filter.VolumeIds {
+		reqVolumeIds[volumeID.Id] = true
+	}
+
+	for _, dsVolumes := range m.volumes {
+		for _, volume := range dsVolumes {
+			if isQueryFilter {
+				if _, ok := reqVolumeIds[volume.VolumeId.Id]; ok {
+					retVolumes = append(retVolumes, *volume)
+				}
+			} else {
+				retVolumes = append(retVolumes, *volume)
+			}
+		}
+	}
+
+	return &methods.CnsQueryVolumeBody{
+		Res: &cnstypes.CnsQueryVolumeResponse{
+			Returnval: cnstypes.CnsQueryResult{
+				Volumes: retVolumes,
+				Cursor:  cnstypes.CnsCursor{},
+			},
+		},
+	}
+}
+
+// CnsQueryAllVolume simulates the query volumes implementation for CNSQueryAll API
+func (m *CnsVolumeManager) CnsQueryAllVolume(ctx context.Context, req *cnstypes.CnsQueryAllVolume) soap.HasFault {
+	retVolumes := []cnstypes.CnsVolume{}
+	reqVolumeIds := make(map[string]bool)
+	isQueryFilter := false
+
+	if req.Filter.VolumeIds != nil {
+		isQueryFilter = true
+	}
+	// Create map of requested volume Ids in query request
+	for _, volumeID := range req.Filter.VolumeIds {
+		reqVolumeIds[volumeID.Id] = true
+	}
+
+	for _, dsVolumes := range m.volumes {
+		for _, volume := range dsVolumes {
+			if isQueryFilter {
+				if _, ok := reqVolumeIds[volume.VolumeId.Id]; ok {
+					retVolumes = append(retVolumes, *volume)
+				}
+			} else {
+				retVolumes = append(retVolumes, *volume)
+			}
+		}
+	}
+
+	return &methods.CnsQueryAllVolumeBody{
+		Res: &cnstypes.CnsQueryAllVolumeResponse{
+			Returnval: cnstypes.CnsQueryResult{
+				Volumes: retVolumes,
+				Cursor:  cnstypes.CnsCursor{},
+			},
+		},
+	}
+}
+
+func (m *CnsVolumeManager) CnsDeleteVolume(ctx context.Context, req *cnstypes.CnsDeleteVolume) soap.HasFault {
+	task := simulator.CreateTask(m, "CnsDeleteVolume", func(*simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
+		operationResult := []cnstypes.BaseCnsVolumeOperationResult{}
+		for _, volumeId := range req.VolumeIds {
+			for ds, dsVolumes := range m.volumes {
+				volume := dsVolumes[volumeId]
+				if volume != nil {
+					delete(m.volumes[ds], volumeId)
+					operationResult = append(operationResult, &cnstypes.CnsVolumeOperationResult{
+						VolumeId: volumeId,
+					})
+
+				}
+			}
+		}
+		return &cnstypes.CnsVolumeOperationBatchResult{
+			VolumeResults: operationResult,
+		}, nil
+	})
+
+	return &methods.CnsDeleteVolumeBody{
+		Res: &cnstypes.CnsDeleteVolumeResponse{
+			Returnval: task.Run(),
+		},
+	}
+}
+
+// CnsUpdateVolumeMetadata simulates UpdateVolumeMetadata call for simulated vc
+func (m *CnsVolumeManager) CnsUpdateVolumeMetadata(ctx context.Context, req *cnstypes.CnsUpdateVolumeMetadata) soap.HasFault {
+	task := simulator.CreateTask(m, "CnsUpdateVolumeMetadata", func(*simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
+		if len(req.UpdateSpecs) == 0 {
+			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsUpdateVolumeMetadataSpec"}
+		}
+		operationResult := []cnstypes.BaseCnsVolumeOperationResult{}
+		for _, updateSpecs := range req.UpdateSpecs {
+			for _, dsVolumes := range m.volumes {
+				for id, volume := range dsVolumes {
+					if id.Id == updateSpecs.VolumeId.Id {
+						volume.Metadata.EntityMetadata = updateSpecs.Metadata.EntityMetadata
+						operationResult = append(operationResult, &cnstypes.CnsVolumeOperationResult{
+							VolumeId: volume.VolumeId,
+						})
+						break
+					}
+				}
+			}
+
+		}
+		return &cnstypes.CnsVolumeOperationBatchResult{
+			VolumeResults: operationResult,
+		}, nil
+	})
+	return &methods.CnsUpdateVolumeBody{
+		Res: &cnstypes.CnsUpdateVolumeMetadataResponse{
+			Returnval: task.Run(),
+		},
+	}
+}
+
+// CnsAttachVolume simulates AttachVolume call for simulated vc
+func (m *CnsVolumeManager) CnsAttachVolume(ctx context.Context, req *cnstypes.CnsAttachVolume) soap.HasFault {
+	task := simulator.CreateTask(m, "CnsAttachVolume", func(task *simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
+		if len(req.AttachSpecs) == 0 {
+			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsAttachVolumeSpec"}
+		}
+		operationResult := []cnstypes.BaseCnsVolumeOperationResult{}
+		for _, attachSpec := range req.AttachSpecs {
+			node := simulator.Map.Get(attachSpec.Vm).(*simulator.VirtualMachine)
+			if _, ok := m.attachments[attachSpec.VolumeId]; !ok {
+				m.attachments[attachSpec.VolumeId] = node.Self
+			} else {
+				return nil, &vim25types.ResourceInUse{
+					Name: attachSpec.VolumeId.Id,
+				}
+			}
+			operationResult = append(operationResult, &cnstypes.CnsVolumeAttachResult{
+				CnsVolumeOperationResult: cnstypes.CnsVolumeOperationResult{
+					VolumeId: attachSpec.VolumeId,
+				},
+				DiskUUID: simulatorDiskUUID,
+			})
+		}
+
+		return &cnstypes.CnsVolumeOperationBatchResult{
+			VolumeResults: operationResult,
+		}, nil
+	})
+
+	return &methods.CnsAttachVolumeBody{
+		Res: &cnstypes.CnsAttachVolumeResponse{
+			Returnval: task.Run(),
+		},
+	}
+}
+
+// CnsDetachVolume simulates DetachVolume call for simulated vc
+func (m *CnsVolumeManager) CnsDetachVolume(ctx context.Context, req *cnstypes.CnsDetachVolume) soap.HasFault {
+	task := simulator.CreateTask(m, "CnsDetachVolume", func(*simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
+		if len(req.DetachSpecs) == 0 {
+			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsDetachVolumeSpec"}
+		}
+		operationResult := []cnstypes.BaseCnsVolumeOperationResult{}
+		for _, detachSpec := range req.DetachSpecs {
+			if _, ok := m.attachments[detachSpec.VolumeId]; ok {
+				delete(m.attachments, detachSpec.VolumeId)
+				operationResult = append(operationResult, &cnstypes.CnsVolumeOperationResult{
+					VolumeId: detachSpec.VolumeId,
+				})
+			} else {
+				return nil, &vim25types.InvalidArgument{
+					InvalidProperty: detachSpec.VolumeId.Id,
+				}
+			}
+		}
+
+		return &cnstypes.CnsVolumeOperationBatchResult{
+			VolumeResults: operationResult,
+		}, nil
+	})
+	return &methods.CnsDetachVolumeBody{
+		Res: &cnstypes.CnsDetachVolumeResponse{
+			Returnval: task.Run(),
+		},
+	}
+}

--- a/cns/simulator/simulator_test.go
+++ b/cns/simulator/simulator_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/cns"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/simulator"
+	vim25types "github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	testLabel = "testLabel"
+	testValue = "testValue"
+)
+
+func TestSimulator(t *testing.T) {
+	ctx := context.Background()
+
+	model := simulator.VPX()
+	defer model.Remove()
+
+	var err error
+
+	if err = model.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	model.Service.RegisterSDK(New())
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cnsClient, err := cns.NewClient(ctx, c.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Query
+	queryFilter := cnstypes.CnsQueryFilter{}
+	queryResult, err := cnsClient.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	existingNumDisks := len(queryResult.Volumes)
+
+	// Get a simulator DS
+	datastore := simulator.Map.Any("Datastore").(*simulator.Datastore)
+
+	// Create
+	createSpecList := []cnstypes.CnsVolumeCreateSpec{
+		{
+			Name:       "test",
+			VolumeType: "TestVolumeType",
+			Datastores: []vim25types.ManagedObjectReference{
+				datastore.Self,
+			},
+			BackingObjectDetails: &cnstypes.CnsBackingObjectDetails{
+				CapacityInMb: 1024,
+			},
+			Profile: []vim25types.BaseVirtualMachineProfileSpec{
+				&vim25types.VirtualMachineDefinedProfileSpec{
+					ProfileId: uuid.New().String(),
+				},
+			},
+		},
+	}
+	createTask, err := cnsClient.CreateVolume(ctx, createSpecList)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createTaskInfo, err := cns.GetTaskInfo(ctx, createTask)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createTaskResult, err := cns.GetTaskResult(ctx, createTaskInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if createTaskResult == nil {
+		t.Fatalf("Empty create task results")
+	}
+	createVolumeOperationRes := createTaskResult.GetCnsVolumeOperationResult()
+	if createVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to create volume: fault=%+v", createVolumeOperationRes.Fault)
+	}
+	volumeId := createVolumeOperationRes.VolumeId.Id
+
+	// Attach
+	nodeVM := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	attachSpecList := []cnstypes.CnsVolumeAttachDetachSpec{
+		{
+			VolumeId: createVolumeOperationRes.VolumeId,
+			Vm:       nodeVM.Self,
+		},
+	}
+	attachTask, err := cnsClient.AttachVolume(ctx, attachSpecList)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attachTaskInfo, err := cns.GetTaskInfo(ctx, attachTask)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attachTaskResult, err := cns.GetTaskResult(ctx, attachTaskInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attachTaskResult == nil {
+		t.Fatalf("Empty attach task results")
+	}
+
+	attachVolumeOperationRes := attachTaskResult.GetCnsVolumeOperationResult()
+	if attachVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to attach: fault=%+v", attachVolumeOperationRes.Fault)
+	}
+
+	// Detach
+	detachVolumeList := []cnstypes.CnsVolumeAttachDetachSpec{
+		{
+			VolumeId: createVolumeOperationRes.VolumeId,
+		},
+	}
+	detachTask, err := cnsClient.DetachVolume(ctx, detachVolumeList)
+
+	detachTaskInfo, err := cns.GetTaskInfo(ctx, detachTask)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	detachTaskResult, err := cns.GetTaskResult(ctx, detachTaskInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detachTaskResult == nil {
+		t.Fatalf("Empty detach task results")
+	}
+
+	detachVolumeOperationRes := detachTaskResult.GetCnsVolumeOperationResult()
+	if detachVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to detach volume: fault=%+v", detachVolumeOperationRes.Fault)
+	}
+
+	// Query
+	queryFilter = cnstypes.CnsQueryFilter{}
+	queryResult, err = cnsClient.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(queryResult.Volumes) != existingNumDisks+1 {
+		t.Fatal("Number of volumes mismatches after creating a single volume")
+	}
+
+	// QueryAll
+	queryFilter = cnstypes.CnsQueryFilter{}
+	querySelection := cnstypes.CnsQuerySelection{}
+	queryResult, err = cnsClient.QueryAllVolume(ctx, queryFilter, querySelection)
+
+	if len(queryResult.Volumes) != existingNumDisks+1 {
+		t.Fatal("Number of volumes mismatches after creating a single volume")
+	}
+
+	// Update
+	var metadataList []cnstypes.BaseCnsEntityMetadata
+	newLabels := []vim25types.KeyValue{
+		{
+			Key:   testLabel,
+			Value: testValue,
+		},
+	}
+	metadata := &cnstypes.CnsKubernetesEntityMetadata{
+
+		CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+			DynamicData: vim25types.DynamicData{},
+			EntityName:  queryResult.Volumes[0].Name,
+			Labels:      newLabels,
+			Delete:      false,
+		},
+		EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+		Namespace:  "",
+	}
+	metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(metadata))
+	updateSpecList := []cnstypes.CnsVolumeMetadataUpdateSpec{
+		{
+			DynamicData: vim25types.DynamicData{},
+			VolumeId:    createVolumeOperationRes.VolumeId,
+			Metadata: cnstypes.CnsVolumeMetadata{
+				DynamicData:      vim25types.DynamicData{},
+				ContainerCluster: queryResult.Volumes[0].Metadata.ContainerCluster,
+				EntityMetadata:   metadataList,
+			},
+		},
+	}
+	updateTask, err := cnsClient.UpdateVolumeMetadata(ctx, updateSpecList)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updateTaskInfo, err := cns.GetTaskInfo(ctx, updateTask)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updateTaskResult, err := cns.GetTaskResult(ctx, updateTaskInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updateTaskResult == nil {
+		t.Fatalf("Empty create task results")
+	}
+
+	updateVolumeOperationRes := updateTaskResult.GetCnsVolumeOperationResult()
+	if updateVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to create volume: fault=%+v", updateVolumeOperationRes.Fault)
+	}
+
+	// Delete
+	deleteVolumeList := []cnstypes.CnsVolumeId{
+		{
+			Id: volumeId,
+		},
+	}
+	deleteTask, err := cnsClient.DeleteVolume(ctx, deleteVolumeList, true)
+
+	deleteTaskInfo, err := cns.GetTaskInfo(ctx, deleteTask)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deleteTaskResult, err := cns.GetTaskResult(ctx, deleteTaskInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleteTaskResult == nil {
+		t.Fatalf("Empty delete task results")
+	}
+
+	deleteVolumeOperationRes := deleteTaskResult.GetCnsVolumeOperationResult()
+	if deleteVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to delete volume: fault=%+v", deleteVolumeOperationRes.Fault)
+	}
+
+	queryFilter = cnstypes.CnsQueryFilter{}
+	queryResult, err = cnsClient.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Fatalf("Failed to query volume with QueryFilter: err=%+v", err)
+	}
+	if len(queryResult.Volumes) != existingNumDisks {
+		t.Fatal("Number of volumes mismatches after deleting a single volume")
+	}
+
+}

--- a/cns/types/enum.go
+++ b/cns/types/enum.go
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"reflect"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type CnsVolumeType string
+
+const (
+	CnsVolumeTypeBlock = CnsVolumeType("BLOCK")
+)
+
+func init() {
+	types.Add("CnsVolumeType", reflect.TypeOf((*CnsVolumeType)(nil)).Elem())
+}
+
+type QuerySelectionNameType string
+
+const (
+	QuerySelectionNameTypeVolumeType             = QuerySelectionNameType("VOLUME_TYPE")
+	QuerySelectionNameTypeVolumeName             = QuerySelectionNameType("VOLUME_NAME")
+	QuerySelectionNameTypeBackingObjectDetails   = QuerySelectionNameType("BACKING_OBJECT_DETAILS")
+	QuerySelectionNameTypeComplianceStatus       = QuerySelectionNameType("COMPLIANCE_STATUS")
+	QuerySelectionNameTypeDataStoreAccessibility = QuerySelectionNameType("DATASTORE_ACCESSIBILITY_STATUS")
+)
+
+func init() {
+	types.Add("QuerySelectionNameType", reflect.TypeOf((*QuerySelectionNameType)(nil)).Elem())
+}
+
+type CnsClusterType string
+
+const (
+	CnsClusterTypeKubernetes = CnsClusterType("KUBERNETES")
+)
+
+func init() {
+	types.Add("CnsClusterType", reflect.TypeOf((*CnsClusterType)(nil)).Elem())
+}
+
+type CnsKubernetesEntityType string
+
+const (
+	CnsKubernetesEntityTypePVC = CnsKubernetesEntityType("PERSISTENT_VOLUME_CLAIM")
+	CnsKubernetesEntityTypePV  = CnsKubernetesEntityType("PERSISTENT_VOLUME")
+	CnsKubernetesEntityTypePOD = CnsKubernetesEntityType("POD")
+)
+
+type CnsQuerySelectionNameType string
+
+const (
+	CnsQuerySelectionName_VOLUME_NAME                    = CnsQuerySelectionNameType("VOLUME_NAME")
+	CnsQuerySelectionName_VOLUME_TYPE                    = CnsQuerySelectionNameType("VOLUME_TYPE")
+	CnsQuerySelectionName_BACKING_OBJECT_DETAILS         = CnsQuerySelectionNameType("BACKING_OBJECT_DETAILS")
+	CnsQuerySelectionName_COMPLIANCE_STATUS              = CnsQuerySelectionNameType("COMPLIANCE_STATUS")
+	CnsQuerySelectionName_DATASTORE_ACCESSIBILITY_STATUS = CnsQuerySelectionNameType("DATASTORE_ACCESSIBILITY_STATUS")
+)
+
+func init() {
+	types.Add("CnsKubernetesEntityType", reflect.TypeOf((*CnsKubernetesEntityType)(nil)).Elem())
+}

--- a/cns/types/if.go
+++ b/cns/types/if.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"reflect"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func (b *CnsFault) GetCnsFault() *CnsFault {
+	return b
+}
+
+type BaseCnsFault interface {
+	GetCnsFault() *CnsFault
+}
+
+func init() {
+	types.Add("BaseCnsFault", reflect.TypeOf((*CnsFault)(nil)).Elem())
+}
+
+func (b *CnsBackingObjectDetails) GetCnsBackingObjectDetails() *CnsBackingObjectDetails { return b }
+
+type BaseCnsBackingObjectDetails interface {
+	GetCnsBackingObjectDetails() *CnsBackingObjectDetails
+}
+
+func init() {
+	types.Add("BaseCnsBackingObjectDetails", reflect.TypeOf((*CnsBackingObjectDetails)(nil)).Elem())
+}
+
+func (b *CnsEntityMetadata) GetCnsEntityMetadata() *CnsEntityMetadata { return b }
+
+type BaseCnsEntityMetadata interface {
+	GetCnsEntityMetadata() *CnsEntityMetadata
+}
+
+func init() {
+	types.Add("BaseCnsEntityMetadata", reflect.TypeOf((*CnsEntityMetadata)(nil)).Elem())
+}
+
+func (b *CnsVolumeOperationResult) GetCnsVolumeOperationResult() *CnsVolumeOperationResult { return b }
+
+type BaseCnsVolumeOperationResult interface {
+	GetCnsVolumeOperationResult() *CnsVolumeOperationResult
+}
+
+func init() {
+	types.Add("BaseCnsVolumeOperationResult", reflect.TypeOf((*CnsVolumeOperationResult)(nil)).Elem())
+}

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -1,0 +1,382 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"reflect"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type CnsCreateVolumeRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	CreateSpecs []CnsVolumeCreateSpec        `xml:"createSpecs,omitempty"`
+}
+
+func init() {
+	types.Add("CnsCreateVolumeRequestType", reflect.TypeOf((*CnsCreateVolumeRequestType)(nil)).Elem())
+}
+
+type CnsCreateVolume CnsCreateVolumeRequestType
+
+func init() {
+	types.Add("CnsCreateVolume", reflect.TypeOf((*CnsCreateVolume)(nil)).Elem())
+}
+
+type CnsCreateVolumeResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type CnsEntityMetadata struct {
+	types.DynamicData
+
+	EntityName string           `xml:"entityName"`
+	Labels     []types.KeyValue `xml:"labels,omitempty"`
+	Delete     bool             `xml:"delete,omitempty"`
+}
+
+func init() {
+	types.Add("CnsEntityMetadata", reflect.TypeOf((*CnsEntityMetadata)(nil)).Elem())
+}
+
+type CnsKubernetesEntityMetadata struct {
+	CnsEntityMetadata
+
+	EntityType string `xml:"entityType"`
+	Namespace  string `xml:"namespace,omitempty"`
+}
+
+func init() {
+	types.Add("CnsKubernetesEntityMetadata", reflect.TypeOf((*CnsKubernetesEntityMetadata)(nil)).Elem())
+}
+
+type CnsVolumeMetadata struct {
+	types.DynamicData
+
+	ContainerCluster CnsContainerCluster     `xml:"containerCluster"`
+	EntityMetadata   []BaseCnsEntityMetadata `xml:"entityMetadata,typeattr,omitempty"`
+}
+
+func init() {
+	types.Add("CnsVolumeMetadata", reflect.TypeOf((*CnsVolumeMetadata)(nil)).Elem())
+}
+
+type CnsVolumeCreateSpec struct {
+	types.DynamicData
+	Name                 string                                `xml:"name"`
+	VolumeType           string                                `xml:"volumeType"`
+	Datastores           []types.ManagedObjectReference        `xml:"datastores,omitempty"`
+	Metadata             CnsVolumeMetadata                     `xml:"metadata,omitempty"`
+	BackingObjectDetails BaseCnsBackingObjectDetails           `xml:"backingObjectDetails,typeattr"`
+	Profile              []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
+}
+
+func init() {
+	types.Add("CnsVolumeCreateSpec", reflect.TypeOf((*CnsVolumeCreateSpec)(nil)).Elem())
+}
+
+type CnsUpdateVolumeMetadataRequestType struct {
+	This        types.ManagedObjectReference  `xml:"_this"`
+	UpdateSpecs []CnsVolumeMetadataUpdateSpec `xml:"updateSpecs,omitempty"`
+}
+
+func init() {
+	types.Add("CnsUpdateVolumeMetadataRequestType", reflect.TypeOf((*CnsUpdateVolumeMetadataRequestType)(nil)).Elem())
+}
+
+type CnsUpdateVolumeMetadata CnsUpdateVolumeMetadataRequestType
+
+func init() {
+	types.Add("CnsUpdateVolumeMetadata", reflect.TypeOf((*CnsUpdateVolumeMetadata)(nil)).Elem())
+}
+
+type CnsUpdateVolumeMetadataResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type CnsVolumeMetadataUpdateSpec struct {
+	types.DynamicData
+
+	VolumeId CnsVolumeId       `xml:"volumeId"`
+	Metadata CnsVolumeMetadata `xml:"metadata,omitempty"`
+}
+
+func init() {
+	types.Add("CnsVolumeMetadataUpdateSpec", reflect.TypeOf((*CnsVolumeMetadataUpdateSpec)(nil)).Elem())
+}
+
+type CnsDeleteVolumeRequestType struct {
+	This       types.ManagedObjectReference `xml:"_this"`
+	VolumeIds  []CnsVolumeId                `xml:"volumeIds"`
+	DeleteDisk bool                         `xml:"deleteDisk"`
+}
+
+func init() {
+	types.Add("CnsDeleteVolumeRequestType", reflect.TypeOf((*CnsDeleteVolumeRequestType)(nil)).Elem())
+}
+
+type CnsDeleteVolume CnsDeleteVolumeRequestType
+
+func init() {
+	types.Add("CnsDeleteVolume", reflect.TypeOf((*CnsDeleteVolume)(nil)).Elem())
+}
+
+type CnsDeleteVolumeResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type CnsAttachVolumeRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	AttachSpecs []CnsVolumeAttachDetachSpec  `xml:"attachSpecs,omitempty"`
+}
+
+func init() {
+	types.Add("CnsAttachVolumeRequestType", reflect.TypeOf((*CnsAttachVolumeRequestType)(nil)).Elem())
+}
+
+type CnsAttachVolume CnsAttachVolumeRequestType
+
+func init() {
+	types.Add("CnsAttachVolume", reflect.TypeOf((*CnsAttachVolume)(nil)).Elem())
+}
+
+type CnsAttachVolumeResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type CnsDetachVolumeRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	DetachSpecs []CnsVolumeAttachDetachSpec  `xml:"detachSpecs,omitempty"`
+}
+
+func init() {
+	types.Add("CnsDetachVolumeRequestType", reflect.TypeOf((*CnsDetachVolumeRequestType)(nil)).Elem())
+}
+
+type CnsDetachVolume CnsDetachVolumeRequestType
+
+func init() {
+	types.Add("CnsDetachVolume", reflect.TypeOf((*CnsDetachVolume)(nil)).Elem())
+}
+
+type CnsDetachVolumeResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type CnsVolumeAttachDetachSpec struct {
+	types.DynamicData
+
+	VolumeId CnsVolumeId                  `xml:"volumeId"`
+	Vm       types.ManagedObjectReference `xml:"vm"`
+}
+
+func init() {
+	types.Add("CnsVolumeAttachDetachSpec", reflect.TypeOf((*CnsVolumeAttachDetachSpec)(nil)).Elem())
+}
+
+type CnsQueryVolume CnsQueryVolumeRequestType
+
+func init() {
+	types.Add("CnsQueryVolume", reflect.TypeOf((*CnsQueryVolume)(nil)).Elem())
+}
+
+type CnsQueryVolumeRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	Filter CnsQueryFilter               `xml:"filter"`
+}
+
+func init() {
+	types.Add("CnsQueryVolumeRequestType", reflect.TypeOf((*CnsQueryVolumeRequestType)(nil)).Elem())
+}
+
+type CnsQueryVolumeResponse struct {
+	Returnval CnsQueryResult `xml:"returnval"`
+}
+
+type CnsQueryAllVolume CnsQueryAllVolumeRequestType
+
+func init() {
+	types.Add("CnsQueryAllVolume", reflect.TypeOf((*CnsQueryAllVolume)(nil)).Elem())
+}
+
+type CnsQueryAllVolumeRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	Filter    CnsQueryFilter               `xml:"filter"`
+	Selection CnsQuerySelection            `xml:"selection"`
+}
+
+func init() {
+	types.Add("CnsQueryAllVolumeRequestType", reflect.TypeOf((*CnsQueryVolumeRequestType)(nil)).Elem())
+}
+
+type CnsQueryAllVolumeResponse struct {
+	Returnval CnsQueryResult `xml:"returnval"`
+}
+
+type CnsContainerCluster struct {
+	types.DynamicData
+
+	ClusterType string `xml:"clusterType"`
+	ClusterId   string `xml:"clusterId"`
+	VSphereUser string `xml:"vSphereUser"`
+}
+
+func init() {
+	types.Add("CnsContainerCluster", reflect.TypeOf((*CnsContainerCluster)(nil)).Elem())
+}
+
+type CnsVolume struct {
+	types.DynamicData
+
+	VolumeId                     CnsVolumeId             `xml:"volumeId"`
+	Name                         string                  `xml:"name,omitempty"`
+	VolumeType                   string                  `xml:"volumeType,omitempty"`
+	DatastoreUrl                 string                  `xml:"datastoreUrl,omitempty"`
+	Metadata                     CnsVolumeMetadata       `xml:"metadata,omitempty"`
+	BackingObjectDetails         CnsBackingObjectDetails `xml:"backingObjectDetails,omitempty"`
+	ComplianceStatus             string                  `xml:"complianceStatus,omitempty"`
+	DatastoreAccessibilityStatus string                  `xml:"datastoreAccessibilityStatus,omitempty"`
+	StoragePolicyId              string                  `xml:"storagePolicyId,omitempty"`
+}
+
+func init() {
+	types.Add("CnsVolume", reflect.TypeOf((*CnsVolume)(nil)).Elem())
+}
+
+type CnsVolumeOperationResult struct {
+	types.DynamicData
+
+	VolumeId CnsVolumeId `xml:"volumeId,omitempty"`
+	Fault    *CnsFault   `xml:"fault,omitempty"`
+}
+
+func init() {
+	types.Add("CnsVolumeOperationResult", reflect.TypeOf((*CnsVolumeOperationResult)(nil)).Elem())
+}
+
+type CnsVolumeOperationBatchResult struct {
+	types.DynamicData
+
+	VolumeResults []BaseCnsVolumeOperationResult `xml:"volumeResults,omitempty,typeattr"`
+}
+
+func init() {
+	types.Add("CnsVolumeOperationBatchResult", reflect.TypeOf((*CnsVolumeOperationBatchResult)(nil)).Elem())
+}
+
+type CnsVolumeCreateResult struct {
+	CnsVolumeOperationResult
+	Name string `xml:"name,omitempty"`
+}
+
+func init() {
+	types.Add("CnsVolumeCreateResult", reflect.TypeOf((*CnsVolumeCreateResult)(nil)).Elem())
+}
+
+type CnsVolumeAttachResult struct {
+	CnsVolumeOperationResult
+
+	DiskUUID string `xml:"diskUUID,omitempty"`
+}
+
+func init() {
+	types.Add("CnsVolumeAttachResult", reflect.TypeOf((*CnsVolumeAttachResult)(nil)).Elem())
+}
+
+type CnsVolumeId struct {
+	types.DynamicData
+
+	Id string `xml:"id"`
+}
+
+func init() {
+	types.Add("CnsVolumeId", reflect.TypeOf((*CnsVolumeId)(nil)).Elem())
+}
+
+type CnsBackingObjectDetails struct {
+	types.DynamicData
+
+	CapacityInMb int64 `xml:"capacityInMb,omitempty"`
+}
+
+func init() {
+	types.Add("CnsBackingObjectDetails", reflect.TypeOf((*CnsBackingObjectDetails)(nil)).Elem())
+}
+
+type CnsBlockBackingDetails struct {
+	CnsBackingObjectDetails
+
+	BackingDiskId string `xml:"backingDiskId,omitempty"`
+}
+
+func init() {
+	types.Add("CnsBlockBackingDetails", reflect.TypeOf((*CnsBlockBackingDetails)(nil)).Elem())
+}
+
+type CnsQueryFilter struct {
+	types.DynamicData
+
+	VolumeIds           []CnsVolumeId                  `xml:"volumeIds,omitempty"`
+	Names               []string                       `xml:"names,omitempty"`
+	ContainerClusterIds []string                       `xml:"containerClusterIds,omitempty"`
+	StoragePolicyId     string                         `xml:"storagePolicyId,omitempty"`
+	Datastores          []types.ManagedObjectReference `xml:"datastores,omitempty"`
+	Labels              []types.KeyValue               `xml:"labels,omitempty"`
+	Cursor              *CnsCursor                     `xml:"cursor,omitempty"`
+}
+
+func init() {
+	types.Add("CnsQueryFilter", reflect.TypeOf((*CnsQueryFilter)(nil)).Elem())
+}
+
+type CnsQuerySelection struct {
+	types.DynamicData
+
+	Names []string `xml:"names,omitempty"`
+}
+
+type CnsQueryResult struct {
+	types.DynamicData
+
+	Volumes []CnsVolume `xml:"volumes,omitempty"`
+	Cursor  CnsCursor   `xml:"cursor"`
+}
+
+func init() {
+	types.Add("CnsQueryResult", reflect.TypeOf((*CnsQueryResult)(nil)).Elem())
+}
+
+type CnsCursor struct {
+	types.DynamicData
+
+	Offset       int64 `xml:"offset"`
+	Limit        int64 `xml:"limit"`
+	TotalRecords int64 `xml:"totalRecords,omitempty"`
+}
+
+func init() {
+	types.Add("CnsCursor", reflect.TypeOf((*CnsCursor)(nil)).Elem())
+}
+
+type CnsFault struct {
+	Fault            *types.BaseMethodFault `xml:"fault,typeattr"`
+	LocalizedMessage string                 `xml:"localizedMessage,omitempty"`
+}
+
+func init() {
+	types.Add("CnsFault", reflect.TypeOf((*CnsFault)(nil)).Elem())
+}


### PR DESCRIPTION
This PR is adding go bindings for [CNS APIs](https://vdc-download.vmware.com/vmwb-repository/dcr-public/8ed923df-bad4-49b3-b677-45bca5326e85/d2d90bb6-d1b3-4266-8ce5-443680187a9a/vim.cns.VolumeManager.html) added in vsan 67u3 release.


Fixes: https://github.com/vmware/govmomi/issues/1571


Testing

```
$ pwd
../govmomi/cns


$ export CNS_VC_URL='https://Administrator@vsphere.local:Admin!23@10.160.90.22/sdk'
$ export CNS_DATACENTER='datacenter'
$ export CNS_DATASTORE='cluster1-vsanDatastore'

$ go test -v
=== RUN   TestClient
--- PASS: TestClient (25.02s)
    client_test.go:91: Creating volume using the spec: {DynamicData:{} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0 VolumeType:BLOCK Datastores:[Datastore:datastore-99] Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType:KUBERNETES ClusterId:demo-cluster-id VSphereUser:Administrator@vsphere.local} EntityMetadata:[]} BackingObjectDetails:0xc0000c19c0 Profile:[]}
    client_test.go:116: Volume created sucessfully. volumeId: 6969cd78-95b7-4fdf-be62-5c68047f90a5
    client_test.go:123: Calling QueryVolume using queryFilter: {DynamicData:{} VolumeIds:[{DynamicData:{} Id:6969cd78-95b7-4fdf-be62-5c68047f90a5}] Names:[] ContainerClusterIds:[] StoragePolicyId: Datastores:[] Labels:[] Cursor:<nil>}
    client_test.go:129: Sucessfully Queried Volumes. queryResult: &{DynamicData:{} Volumes:[{DynamicData:{} VolumeId:{DynamicData:{} Id:6969cd78-95b7-4fdf-be62-5c68047f90a5} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0 VolumeType:BLOCK DatastoreUrl:ds:///vmfs/volumes/vsan:520ae2de776a586c-567dd7d8a80fb5d2/ Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType:KUBERNETES ClusterId:demo-cluster-id VSphereUser:Administrator@vsphere.local} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:5120} ComplianceStatus:compliant DatastoreAccessibilityStatus:accessible StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad}] Cursor:{DynamicData:{} Offset:1 Limit:100 TotalRecords:1}}
    client_test.go:164: Updating volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:6969cd78-95b7-4fdf-be62-5c68047f90a5} Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType:KUBERNETES ClusterId:demo-cluster-id VSphereUser:Administrator@vsphere.local} EntityMetadata:[0xc0002222d0]}}
    client_test.go:189: Sucessfully updated volume metadata
    client_test.go:207: Sucessfully Queried all Volumes. queryResult: &{DynamicData:{} Volumes:[{DynamicData:{} VolumeId:{DynamicData:{} Id:d0a979ca-91d9-41d5-91dd-84dac0b18625} Name:pvc-c8ee0ec5-b805-11e9-80aa-005056a04307 VolumeType:BLOCK DatastoreUrl: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser:} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:-1} ComplianceStatus: DatastoreAccessibilityStatus: StoragePolicyId:} {DynamicData:{} VolumeId:{DynamicData:{} Id:6969cd78-95b7-4fdf-be62-5c68047f90a5} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0 VolumeType:BLOCK DatastoreUrl: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser:} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:5120} ComplianceStatus:compliant DatastoreAccessibilityStatus:accessible StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad}] Cursor:{DynamicData:{} Offset:2 Limit:0 TotalRecords:2}}
    client_test.go:249: Node VM created sucessfully. vmRef: VirtualMachine:vm-198
    client_test.go:263: Attaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:6969cd78-95b7-4fdf-be62-5c68047f90a5} Vm:VirtualMachine:vm-198}
    client_test.go:288: Volume attached sucessfully. Disk UUID: 6969cd78-95b7-4fdf-be62-5c68047f90a5
    client_test.go:299: Detaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:6969cd78-95b7-4fdf-be62-5c68047f90a5} Vm:VirtualMachine:vm-198}
    client_test.go:323: Volume detached sucessfully
    client_test.go:326: Deleting volume: [{DynamicData:{} Id:6969cd78-95b7-4fdf-be62-5c68047f90a5}]
    client_test.go:350: Volume deleted sucessfully
PASS
ok  	github.com/vmware/govmomi/cns	25.143s

```
