### PR TITLE
Fix deadlock for keep alive handlers that attempt log in

### DIFF
--- a/session/keep_alive.go
+++ b/session/keep_alive.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015,2019 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -110,16 +110,20 @@ func (k *keepAlive) stop() {
 }
 
 func (k *keepAlive) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
+	// Stop ticker on logout.
+	switch req.(type) {
+	case *methods.LogoutBody:
+		k.stop()
+	}
+
 	err := k.roundTripper.RoundTrip(ctx, req, res)
 	if err != nil {
 		return err
 	}
-	// Start ticker on login, stop ticker on logout.
+	// Start ticker on login.
 	switch req.(type) {
 	case *methods.LoginBody, *methods.LoginExtensionByCertificateBody, *methods.LoginByTokenBody:
 		k.start()
-	case *methods.LogoutBody:
-		k.stop()
 	}
 
 	return nil


### PR DESCRIPTION
Over the last couple of months we have seen test time outs in a project
using govmomi at a frequency of a few failures a week. The reason for
those timeouts lies in a deadlock in the govmomi code driving the keep
alive handler.
In particular, after we sent a Login request we start a timer issuing
keep alive callbacks. Similarly, after issuing a Logout request we stop
this timer.
Every so often we attempt a logout and while in the process of doing so
the timer gets a tick and attempts to log in. Because we wait for all
keep alive handlers to return and do so with a lock held that is also
acquired as part of the timer start that is performed as part of the
login, we deadlock.
To fix this issue this change moves the logic to stop the keep alive
timer before the actual logout call, effectively preventing such a
scenario from occurring.