### PR TITLE
examples: fix flag parsing

### DIFF
--- a/examples/examples.go
+++ b/examples/examples.go
@@ -103,8 +103,6 @@ func processOverride(u *url.URL) {
 
 // NewClient creates a govmomi.Client for use in the examples
 func NewClient(ctx context.Context) (*govmomi.Client, error) {
-	flag.Parse()
-
 	// Parse URL from string
 	u, err := soap.ParseURL(*urlFlag)
 	if err != nil {
@@ -121,6 +119,8 @@ func NewClient(ctx context.Context) (*govmomi.Client, error) {
 // Run calls f with Client create from the -url flag if provided,
 // otherwise runs the example against vcsim.
 func Run(f func(context.Context, *vim25.Client) error) {
+	flag.Parse()
+
 	var err error
 	if *urlFlag == "" {
 		err = simulator.VPX().Run(f)

--- a/examples/perfmanager/main.go
+++ b/examples/perfmanager/main.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 
 	"github.com/vmware/govmomi/examples"
@@ -30,6 +31,8 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
 )
+
+var interval = flag.Int("i", 20, "Interval ID")
 
 func main() {
 	examples.Run(func(ctx context.Context, c *vim25.Client) error {
@@ -66,7 +69,7 @@ func main() {
 		spec := types.PerfQuerySpec{
 			MaxSample:  1,
 			MetricId:   []types.PerfMetricId{{Instance: "*"}},
-			IntervalId: 300,
+			IntervalId: int32(*interval),
 		}
 
 		// Query metrics


### PR DESCRIPTION
The move to running examples against vcsim by default broke flag parsing.
The following works again to run examples against a real vCenter:

 go run . -url $GOVC_URL

- Add -i flag to examples/perfmanager

Fixes #1565