### PR TITLE
Content library: support library ID in Finder

### DIFF
--- a/govc/library/deploy.go
+++ b/govc/library/deploy.go
@@ -104,7 +104,7 @@ func (cmd *deploy) Run(ctx context.Context, f *flag.FlagSet) error {
 			return err
 		}
 		if len(res) != 1 {
-			return fmt.Errorf("%q matches %d items", path, len(res))
+			return ErrMultiMatch{Type: "library", Key: "name", Val: f.Arg(0), Count: len(res)}
 		}
 		item, ok := res[0].GetResult().(library.Item)
 		if !ok {

--- a/govc/library/errors.go
+++ b/govc/library/errors.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import "fmt"
+
+// ErrMultiMatch is an error returned when a query returns more than one result.
+type ErrMultiMatch struct {
+	// Type is the type of object being queried.
+	Type string
+
+	// Key is the key used to perform the query.
+	Key string
+
+	// Val is the value used to perform the query.
+	Val string
+
+	// Count is the number of objects returned.
+	Count int
+}
+
+// Error returns the error string.
+func (e ErrMultiMatch) Error() string {
+	return e.String()
+}
+
+// String returns the same value as Error().
+func (e ErrMultiMatch) String() string {
+	return fmt.Sprintf("%q=%q matches %d items, %q id must be specified", e.Key, e.Val, e.Count, e.Type)
+}

--- a/govc/library/export.go
+++ b/govc/library/export.go
@@ -92,7 +92,7 @@ func (cmd *export) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		if len(res) != 1 {
-			return fmt.Errorf("%q matches %d items", f.Arg(0), len(res))
+			return ErrMultiMatch{Type: "library", Key: "name", Val: f.Arg(0), Count: len(res)}
 		}
 
 		switch t := res[0].GetResult().(type) {

--- a/govc/library/import.go
+++ b/govc/library/import.go
@@ -73,6 +73,7 @@ Examples:
   govc library.import library_name file.ova
   govc library.import library_name file.ovf
   govc library.import library_name file.iso
+  govc library.import library_id file.iso # Use library id if multiple libraries have the same name
   govc library.import library_name/item_name file.ova # update existing item
   govc library.import library_name http://example.com/file.ovf # download and push to vCenter
   govc library.import -pull library_name http://example.com/file.ova # direct pull from vCenter`
@@ -149,7 +150,7 @@ func (cmd *item) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		if len(res) != 1 {
-			return fmt.Errorf("%q matches %d items", f.Arg(0), len(res))
+			return ErrMultiMatch{Type: "library", Key: "name", Val: f.Arg(0), Count: len(res)}
 		}
 
 		switch t := res[0].GetResult().(type) {

--- a/govc/library/rm.go
+++ b/govc/library/rm.go
@@ -51,6 +51,7 @@ func (cmd *rm) Description() string {
 
 Examples:
   govc library.rm /library_name
+  govc library.rm library_id # Use library id if multiple libraries have the same name
   govc library.rm /library_name/item_name`
 }
 
@@ -64,7 +65,7 @@ func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		if len(res) != 1 {
-			return fmt.Errorf("%q matches %d items", f.Arg(0), len(res))
+			return ErrMultiMatch{Type: "library", Key: "name", Val: f.Arg(0), Count: len(res)}
 		}
 
 		switch t := res[0].GetResult().(type) {

--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -234,3 +234,35 @@ EOF
   assert_matches "Subscription:"
   assert_matches "$url"
 }
+
+@test "library.findbyid" {
+  vcsim_env
+
+  run govc library.create my-content
+  assert_success
+  id="$output"
+
+  run govc library.create my-content
+  assert_success
+
+  run govc library.import my-content library.bats
+  assert_failure # "my-content" matches 2 items
+
+  run govc library.import "$id" library.bats
+  assert_success # using id to find library
+
+  n=$(govc library.info my-content | grep -c Name:)
+  [ "$n" == 2 ]
+
+  n=$(govc library.info "$id" | grep -c Name:)
+  [ "$n" == 1 ]
+
+  run govc library.rm my-content
+  assert_failure # "my-content" matches 2 items
+
+  run govc library.rm "$id"
+  assert_success
+
+  n=$(govc library.info my-content | grep -c Name:)
+  [ "$n" == 1 ]
+}

--- a/vapi/library/finder/finder.go
+++ b/vapi/library/finder/finder.go
@@ -206,6 +206,12 @@ func (f *Finder) findLibraries(
 			}
 			result = append(result, findResult{result: *lib})
 		}
+		if len(result) == 0 {
+			lib, err := f.M.GetLibraryByID(ctx, token)
+			if err == nil {
+				result = append(result, findResult{result: *lib})
+			}
+		}
 		return result, nil
 	}
 


### PR DESCRIPTION
vCenter supports libraries with the same name, so we need to support
use of library ID instead of name for methods that require a single library.

Fixes #1581