### PR TITLE
vapi: return info with current session query

### DIFF
--- a/vapi/rest/client.go
+++ b/vapi/rest/client.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/vmware/govmomi/vapi/internal"
 	"github.com/vmware/govmomi/vim25"
@@ -34,6 +35,13 @@ import (
 // Client extends soap.Client to support JSON encoding, while inheriting security features, debug tracing and session persistence.
 type Client struct {
 	*soap.Client
+}
+
+// Session information
+type Session struct {
+	User         string    `json:"user"`
+	Created      time.Time `json:"created_time"`
+	LastAccessed time.Time `json:"last_accessed_time"`
 }
 
 // LocalizableMessage represents a localizable error
@@ -64,6 +72,14 @@ func (c *Client) WithSigner(ctx context.Context, s Signer) context.Context {
 	return context.WithValue(ctx, signerContext{}, s)
 }
 
+type statusError struct {
+	res *http.Response
+}
+
+func (e *statusError) Error() string {
+	return fmt.Sprintf("%s %s: %s", e.res.Request.Method, e.res.Request.URL, e.res.Status)
+}
+
 // Do sends the http.Request, decoding resBody if provided.
 func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{}) error {
 	switch req.Method {
@@ -90,7 +106,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 			}
 			return fmt.Errorf("%s: %s", res.Status, bytes.TrimSpace(detail))
 		default:
-			return fmt.Errorf("%s %s: %s", req.Method, req.URL, res.Status)
+			return &statusError{res}
 		}
 
 		if resBody == nil {
@@ -129,10 +145,21 @@ func (c *Client) LoginByToken(ctx context.Context) error {
 	return c.Login(ctx, nil)
 }
 
-// Get returns an error if the current session is invalid.
-func (c *Client) Get(ctx context.Context) error {
+// Session returns the user's current session.
+// Nil is returned if the session is not authenticated.
+func (c *Client) Session(ctx context.Context) (*Session, error) {
+	var s Session
 	req := internal.URL(c, internal.SessionPath).WithAction("get").Request(http.MethodPost)
-	return c.Do(ctx, req, nil)
+	err := c.Do(ctx, req, &s)
+	if err != nil {
+		if e, ok := err.(*statusError); ok {
+			if e.res.StatusCode == http.StatusUnauthorized {
+				return nil, nil
+			}
+		}
+		return nil, err
+	}
+	return &s, nil
 }
 
 // Logout deletes the current session.

--- a/vapi/rest/client_test.go
+++ b/vapi/rest/client_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25"
+
+	_ "github.com/vmware/govmomi/vapi/simulator"
+)
+
+func TestSession(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		c := rest.NewClient(vc)
+
+		session, err := c.Session(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if session != nil {
+			t.Fatal("expected nil session")
+		}
+
+		err = c.Login(ctx, simulator.DefaultLogin)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		session, err = c.Session(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if session == nil {
+			t.Fatal("expected non-nil session")
+		}
+	})
+}


### PR DESCRIPTION
Rename Client.Get to Client.Session and return the session info.
A nil Session is returned when not authenticated.  This allows callers
to disambiguate between http.StatusUnauthorized and other errors,
as the soap session.Manager.UserSession method does.