### PR TITLE
vcsim: DefaultDatastoreID is optional in library deploy

### DIFF
--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -209,7 +209,10 @@ EOF
   assert_success
   assert_matches DC0_DVPG0
 
-  run govc vm.destroy ttylinux ttylinux2
+  run env GOVC_DATASTORE="" govc library.deploy "my-content/$TTYLINUX_NAME" ttylinux3 # datastore is not required
+  assert_success
+
+  run govc vm.destroy ttylinux ttylinux2 ttylinux3
   assert_success
 
   item_id=$(govc library.info -json "/my-content/$TTYLINUX_NAME" | jq -r .[].id)

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -1339,6 +1339,16 @@ func (s *handler) libraryDeploy(lib *library.Library, item *item, deploy vcenter
 		}
 	}
 
+	if ds.Value == "" {
+		// Datastore is optional in the deploy spec, but not in OvfManager.CreateImportSpec
+		refs, err = v.Find(ctx, []string{"Datastore"}, nil)
+		if err != nil {
+			return nil, err
+		}
+		// TODO: consider StorageProfileID
+		ds = refs[0]
+	}
+
 	cisp := types.OvfCreateImportSpecParams{
 		DiskProvisioning: deploy.DeploymentSpec.StorageProvisioning,
 		EntityName:       deploy.DeploymentSpec.Name,


### PR DESCRIPTION
- Avoid panic in vcsim if DefaultDatastoreID is not specified

- Change library.deploy -ds flag to optional

- Add library.deploy -profile flag

Fixes #1588