### PR TITLE
govc: fix datacenter.info against nested folders

### DIFF
--- a/govc/datacenter/info.go
+++ b/govc/datacenter/info.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"path"
 	"text/tabwriter"
 
 	"github.com/vmware/govmomi/find"
@@ -154,17 +153,12 @@ func (r *infoResult) Write(w io.Writer) error {
 		fmt.Fprintf(tw, "Name:\t%s\n", dc.Name)
 		fmt.Fprintf(tw, "  Path:\t%s\n", o.InventoryPath)
 
-		folders, err := o.Folders(r.ctx)
-		if err != nil {
-			return err
-		}
-
 		r.finder.SetDatacenter(o)
 
-		hosts, _ := r.finder.HostSystemList(r.ctx, path.Join(folders.HostFolder.InventoryPath, "*"))
+		hosts, _ := r.finder.HostSystemList(r.ctx, "*")
 		fmt.Fprintf(tw, "  Hosts:\t%d\n", len(hosts))
 
-		clusters, _ := r.finder.ClusterComputeResourceList(r.ctx, path.Join(folders.HostFolder.InventoryPath, "*"))
+		clusters, _ := r.finder.ClusterComputeResourceList(r.ctx, "*")
 		fmt.Fprintf(tw, "  Clusters:\t%d\n", len(clusters))
 
 		manager := view.NewManager(r.client)

--- a/govc/test/datacenter.bats
+++ b/govc/test/datacenter.bats
@@ -16,6 +16,23 @@ load test_helper
   assert_failure
 }
 
+@test "datacenter.info with folders" {
+  vcsim_start -cluster 3 -folder 1
+
+  info=$(govc datacenter.info DC0)
+
+  hosts=$(govc find -type h | wc -l)
+  clusters=$(govc find -type c | wc -l)
+  vms=$(govc find -type m | wc -l)
+  datastores=$(govc find -type s | wc -l)
+
+
+  assert_equal "$hosts" "$(grep Hosts: <<<"$info" | awk '{print $2}')"
+  assert_equal "$clusters" "$(grep Clusters: <<<"$info" | awk '{print $2}')"
+  assert_equal "$vms" "$(grep "Virtual Machines": <<<"$info" | awk '{print $3}')"
+  assert_equal "$datastores" "$(grep Datastores: <<<"$info" | awk '{print $2}')"
+}
+
 @test "datacenter.create" {
   vcsim_env
   unset GOVC_DATACENTER


### PR DESCRIPTION
With nested folders, the cluster and host count was 0.

Issue #1173 fix the VM count in this case, but clusters and hosts count did not include folders.