### PR TITLE
vcsim: add endpoint registration mechanism

### DIFF
--- a/lookup/client_test.go
+++ b/lookup/client_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/simulator/vpx"
-	sts "github.com/vmware/govmomi/sts/simulator"
 )
 
 func TestClient(t *testing.T) {
@@ -35,8 +34,6 @@ func TestClient(t *testing.T) {
 
 	ts := s.NewServer()
 	defer ts.Close()
-
-	_, _ = sts.New(ts.URL, vpx.Setting) // rewrite sts.uri
 
 	ctx := context.Background()
 

--- a/lookup/simulator/simulator.go
+++ b/lookup/simulator/simulator.go
@@ -32,6 +32,14 @@ var content = types.LookupServiceContent{
 	L10n:                         vim.ManagedObjectReference{Type: "LookupL10n", Value: "l10n"},
 }
 
+func init() {
+	simulator.RegisterEndpoint(func(s *simulator.Service, r *simulator.Registry) {
+		if r.IsVPX() {
+			s.RegisterSDK(New())
+		}
+	})
+}
+
 func New() *simulator.Registry {
 	r := simulator.NewRegistry()
 	r.Namespace = lookup.Namespace

--- a/lookup/simulator/simulator_test.go
+++ b/lookup/simulator/simulator_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/vmware/govmomi/lookup"
 	"github.com/vmware/govmomi/lookup/types"
 	"github.com/vmware/govmomi/simulator"
-	"github.com/vmware/govmomi/simulator/vpx"
-	sts "github.com/vmware/govmomi/sts/simulator"
 )
 
 func TestClient(t *testing.T) {
@@ -44,8 +42,6 @@ func TestClient(t *testing.T) {
 	defer s.Close()
 
 	model.Service.RegisterSDK(New())
-
-	_, _ = sts.New(s.URL, vpx.Setting) // rewrite sts.uri
 
 	vc, err := govmomi.NewClient(ctx, s.URL, true)
 	if err != nil {

--- a/pbm/simulator/simulator.go
+++ b/pbm/simulator/simulator.go
@@ -42,6 +42,14 @@ var content = types.PbmServiceInstanceContent{
 	ReplicationManager:        &vim.ManagedObjectReference{Type: "PbmReplicationManager", Value: "ReplicationManager"},
 }
 
+func init() {
+	simulator.RegisterEndpoint(func(s *simulator.Service, r *simulator.Registry) {
+		if r.IsVPX() {
+			s.RegisterSDK(New())
+		}
+	})
+}
+
 func New() *simulator.Registry {
 	r := simulator.NewRegistry()
 	r.Namespace = pbm.Namespace

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -97,7 +97,7 @@ type Model struct {
 	Pod int
 
 	// Delay configurations
-	DelayConfig DelayConfig
+	DelayConfig DelayConfig `json:"-"`
 
 	// total number of inventory objects, set by Count()
 	total int
@@ -530,6 +530,8 @@ func (m *Model) Run(f func(context.Context, *vim25.Client) error) error {
 	if err != nil {
 		return err
 	}
+
+	m.Service.RegisterEndpoints = true
 
 	s := m.Service.NewServer()
 	defer s.Close()

--- a/simulator/session_manager.go
+++ b/simulator/session_manager.go
@@ -81,7 +81,7 @@ func (s *SessionManager) validLogin(ctx *Context, req *types.Login) bool {
 		return false
 	}
 	user := ctx.svc.Listen.User
-	if user == nil {
+	if user == nil || user == DefaultLogin {
 		return req.UserName != "" && req.Password != ""
 	}
 	pass, _ := user.Password()

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -40,6 +40,7 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/nfc"
 	"github.com/vmware/govmomi/ovf"
+	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vapi/internal"
 	"github.com/vmware/govmomi/vapi/library"
 	"github.com/vmware/govmomi/vapi/rest"
@@ -90,6 +91,15 @@ type handler struct {
 	Library     map[string]content
 	Update      map[string]update
 	Download    map[string]download
+}
+
+func init() {
+	simulator.RegisterEndpoint(func(s *simulator.Service, r *simulator.Registry) {
+		if r.IsVPX() {
+			path, handler := New(s.Listen, r.OptionManager().Setting)
+			s.Handle(path, handler)
+		}
+	})
 }
 
 // New creates a vAPI simulator.

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -33,15 +33,16 @@ import (
 	"syscall"
 
 	"github.com/google/uuid"
-	lookup "github.com/vmware/govmomi/lookup/simulator"
-	pbm "github.com/vmware/govmomi/pbm/simulator"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/simulator/esx"
-	"github.com/vmware/govmomi/simulator/vpx"
-	sts "github.com/vmware/govmomi/sts/simulator"
-	vapi "github.com/vmware/govmomi/vapi/simulator"
 	"github.com/vmware/govmomi/vim25/types"
+
+	// Register vcsim optional endpoints
+	_ "github.com/vmware/govmomi/lookup/simulator"
+	_ "github.com/vmware/govmomi/pbm/simulator"
+	_ "github.com/vmware/govmomi/sts/simulator"
+	_ "github.com/vmware/govmomi/vapi/simulator"
 )
 
 func main() {
@@ -147,6 +148,7 @@ func main() {
 		log.Fatal(err)
 	}
 
+	model.Service.RegisterEndpoints = true
 	model.Service.Listen = u
 	if *isTLS {
 		model.Service.TLS = new(tls.Config)
@@ -181,22 +183,6 @@ func main() {
 		if err := s.StartTunnel(); err != nil {
 			log.Fatal(err)
 		}
-	}
-
-	if !*isESX {
-		// STS simulator
-		path, handler := sts.New(s.URL, vpx.Setting)
-		model.Service.Handle(path, handler)
-
-		// vAPI simulator
-		path, handler = vapi.New(s.URL, vpx.Setting)
-		model.Service.Handle(path, handler)
-
-		// Lookup Service simulator
-		model.Service.RegisterSDK(lookup.New())
-
-		// PBM simulator
-		model.Service.RegisterSDK(pbm.New())
 	}
 
 	fmt.Fprintf(out, "export GOVC_URL=%s GOVC_SIM_PID=%d\n", s.URL, os.Getpid())


### PR DESCRIPTION
Simplify endpoint registration for vapi, lookup, sts, etc.

This feature cannot be enabled by default as it would break existing
tests that currently make these calls directly.  However, both vcsim/main
and Model.Run can take advantage of it.

URL rewriting moved from the sts endpoint to the main simulator, this avoids
the previous dependency of lookup on sts.
