### PR TITLE
vcsim: rename Example to Run

### DIFF
--- a/event/example_test.go
+++ b/event/example_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func ExampleManager_Events() {
-	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 		m := event.NewManager(c)
 
 		vm, err := find.NewFinder(c).VirtualMachine(ctx, "DC0_H0_VM0")

--- a/object/example_test.go
+++ b/object/example_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func ExampleResourcePool_Owner() {
-	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 		finder := find.NewFinder(c)
 
 		for _, name := range []string{"DC0_H0_VM0", "DC0_C0_RP0_VM0"} {
@@ -62,7 +62,7 @@ func ExampleResourcePool_Owner() {
 }
 
 func ExampleVirtualMachine_HostSystem() {
-	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 		vm, err := find.NewFinder(c).VirtualMachine(ctx, "DC0_H0_VM0")
 		if err != nil {
 			return err
@@ -86,7 +86,7 @@ func ExampleVirtualMachine_HostSystem() {
 }
 
 func ExampleVirtualMachine_Clone() {
-	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 		finder := find.NewFinder(c)
 		dc, err := finder.Datacenter(ctx, "DC0")
 		if err != nil {
@@ -133,7 +133,7 @@ func ExampleVirtualMachine_Clone() {
 }
 
 func ExampleVirtualMachine_Reconfigure() {
-	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 		vm, err := find.NewFinder(c).VirtualMachine(ctx, "DC0_H0_VM0")
 		if err != nil {
 			return err
@@ -168,7 +168,7 @@ func ExampleCommon_Destroy() {
 	model := simulator.VPX()
 	model.Datastore = 2
 
-	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 		// Change to "LocalDS_0" will cause ResourceInUse error,
 		// as simulator VMs created by the VPX model use "LocalDS_0".
 		ds, err := find.NewFinder(c).Datastore(ctx, "LocalDS_1")
@@ -192,7 +192,7 @@ func ExampleCommon_Destroy() {
 }
 
 func ExampleCustomFieldsManager_Set() {
-	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 		m, err := object.GetCustomFieldsManager(c)
 		if err != nil {
 			return err

--- a/performance/example_test.go
+++ b/performance/example_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func ExampleManager_ToMetricSeries() {
-	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 		// Get virtual machines references
 		m := view.NewManager(c)
 

--- a/property/example_test.go
+++ b/property/example_test.go
@@ -29,7 +29,7 @@ import (
 
 // Example to retrieve properties from a single object
 func ExampleCollector_RetrieveOne() {
-	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 		pc := property.DefaultCollector(c)
 
 		obj, err := find.NewFinder(c).VirtualMachine(ctx, "DC0_H0_VM0")

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -546,9 +546,9 @@ func (m *Model) Run(f func(context.Context, *vim25.Client) error) error {
 	return f(ctx, c.Client)
 }
 
-// Example calls Model.Run for each model and will panic if f returns an error.
+// Run calls Model.Run for each model and will panic if f returns an error.
 // If no model is specified, the VPX Model is used by default.
-func Example(f func(context.Context, *vim25.Client) error, model ...*Model) {
+func Run(f func(context.Context, *vim25.Client) error, model ...*Model) {
 	m := model
 	if len(m) == 0 {
 		m = []*Model{VPX()}
@@ -560,4 +560,12 @@ func Example(f func(context.Context, *vim25.Client) error, model ...*Model) {
 			panic(err)
 		}
 	}
+}
+
+// Test calls Run and expects the caller propagate any errors, via testing.T for example.
+func Test(f func(context.Context, *vim25.Client), model ...*Model) {
+	Run(func(ctx context.Context, c *vim25.Client) error {
+		f(ctx, c)
+		return nil
+	}, model...)
 }

--- a/view/example_test.go
+++ b/view/example_test.go
@@ -34,7 +34,7 @@ func ExampleContainerView_Retrieve() {
 	model := simulator.VPX()
 	model.Datacenter = 2
 
-	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 		m := view.NewManager(c)
 		kind := []string{"HostSystem"}
 
@@ -68,7 +68,7 @@ func ExampleContainerView_Retrieve() {
 
 // Create a view of all VMs in the inventory, printing VM names that end with "_VM1".
 func ExampleContainerView_RetrieveWithFilter() {
-	simulator.Example(func(ctx context.Context, c *vim25.Client) error {
+	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 		m := view.NewManager(c)
 		kind := []string{"VirtualMachine"}
 


### PR DESCRIPTION
The wrapper around Model.Run is useful outside of examples.

Add a new Model.Run Test wrapper intended for use in tests.