### PR TITLE
vm.keystrokes -s (Allow spaces)

### DIFF
--- a/govc/vm/keystrokes.go
+++ b/govc/vm/keystrokes.go
@@ -106,6 +106,7 @@ var hidCharacterMap = map[string]hidKey{
 	"*": {0x25, true},
 	"(": {0x26, true},
 	")": {0x27, true},
+	" ": {0x2c, false},
 	"-": {0x2d, false},
 	"_": {0x2d, true},
 	"=": {0x2e, false},


### PR DESCRIPTION
govc vm.keystrokes -vm=demo123 -s=“Space would be nice”
govc: invalid Character   in String: Space would be nice

Add 0x2c