### PR TITLE
Check whether there's a NIC before updating guest.ipAddress

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -281,12 +281,14 @@ func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 
 		switch key {
 		case "guest.ipAddress":
-			ip := val.Value.(string)
-			vm.Guest.Net[0].IpAddress = []string{ip}
-			changes = append(changes,
-				types.PropertyChange{Name: "summary." + key, Val: ip},
-				types.PropertyChange{Name: "guest.net", Val: vm.Guest.Net},
-			)
+			if len(vm.Guest.Net) > 0 {
+				ip := val.Value.(string)
+				vm.Guest.Net[0].IpAddress = []string{ip}
+				changes = append(changes,
+					types.PropertyChange{Name: "summary." + key, Val: ip},
+					types.PropertyChange{Name: "guest.net", Val: vm.Guest.Net},
+				)
+			}
 		case "guest.hostName":
 			changes = append(changes,
 				types.PropertyChange{Name: "summary." + key, Val: val.Value},


### PR DESCRIPTION
If you want to update ipAddress in ExtraConfig in a VirtualMachine without a NIC, it crashes. Better to have the operation be a no-op if there's no NIC.