### PR TITLE
Replace LoadRetrievePropertiesResponse with LoadObjectContent

### DIFF
--- a/property/collector.go
+++ b/property/collector.go
@@ -179,7 +179,7 @@ func (p *Collector) Retrieve(ctx context.Context, objs []types.ManagedObjectRefe
 		return nil
 	}
 
-	return mo.LoadRetrievePropertiesResponse(res, dst)
+	return mo.LoadObjectContent(res.Returnval, dst)
 }
 
 // RetrieveWithFilter populates dst as Retrieve does, but only for entities matching the given filter.

--- a/view/container_view.go
+++ b/view/container_view.go
@@ -89,7 +89,7 @@ func (v ContainerView) Retrieve(ctx context.Context, kind []string, ps []string,
 		return nil
 	}
 
-	return mo.LoadRetrievePropertiesResponse(res, dst)
+	return mo.LoadObjectContent(res.Returnval, dst)
 }
 
 // RetrieveWithFilter populates dst as Retrieve does, but only for entities matching the given filter.

--- a/vim25/mo/retrieve.go
+++ b/vim25/mo/retrieve.go
@@ -81,9 +81,9 @@ func ApplyPropertyChange(obj Reference, changes []types.PropertyChange) {
 	}
 }
 
-// LoadRetrievePropertiesResponse converts the response of a call to
-// RetrieveProperties to one or more managed objects.
-func LoadRetrievePropertiesResponse(res *types.RetrievePropertiesResponse, dst interface{}) error {
+// LoadObjectContent converts the response of a call to
+// RetrieveProperties{Ex} to one or more managed objects.
+func LoadObjectContent(content []types.ObjectContent, dst interface{}) error {
 	rt := reflect.TypeOf(dst)
 	if rt == nil || rt.Kind() != reflect.Ptr {
 		panic("need pointer")
@@ -104,7 +104,7 @@ func LoadRetrievePropertiesResponse(res *types.RetrievePropertiesResponse, dst i
 	}
 
 	if isSlice {
-		for _, p := range res.Returnval {
+		for _, p := range content {
 			v, err := ObjectContentToType(p)
 			if err != nil {
 				return err
@@ -123,10 +123,10 @@ func LoadRetrievePropertiesResponse(res *types.RetrievePropertiesResponse, dst i
 			rv.Set(reflect.Append(rv, reflect.ValueOf(v)))
 		}
 	} else {
-		switch len(res.Returnval) {
+		switch len(content) {
 		case 0:
 		case 1:
-			v, err := ObjectContentToType(res.Returnval[0])
+			v, err := ObjectContentToType(content[0])
 			if err != nil {
 				return err
 			}
@@ -160,7 +160,7 @@ func RetrievePropertiesForRequest(ctx context.Context, r soap.RoundTripper, req 
 		return err
 	}
 
-	return LoadRetrievePropertiesResponse(res, dst)
+	return LoadObjectContent(res.Returnval, dst)
 }
 
 // RetrieveProperties retrieves the properties of the managed object specified

--- a/vim25/mo/retrieve_test.go
+++ b/vim25/mo/retrieve_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/vmware/govmomi/vim25/xml"
 )
 
-func load(name string) *types.RetrievePropertiesResponse {
+func load(name string) []types.ObjectContent {
 	f, err := os.Open(name)
 	if err != nil {
 		panic(err)
@@ -41,13 +41,13 @@ func load(name string) *types.RetrievePropertiesResponse {
 		panic(err)
 	}
 
-	return &b
+	return b.Returnval
 }
 
 func TestNotAuthenticatedFault(t *testing.T) {
 	var s SessionManager
 
-	err := LoadRetrievePropertiesResponse(load("fixtures/not_authenticated_fault.xml"), &s)
+	err := LoadObjectContent(load("fixtures/not_authenticated_fault.xml"), &s)
 	if !soap.IsVimFault(err) {
 		t.Errorf("Expected IsVimFault")
 	}
@@ -61,7 +61,7 @@ func TestNotAuthenticatedFault(t *testing.T) {
 func TestNestedProperty(t *testing.T) {
 	var vm VirtualMachine
 
-	err := LoadRetrievePropertiesResponse(load("fixtures/nested_property.xml"), &vm)
+	err := LoadObjectContent(load("fixtures/nested_property.xml"), &vm)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %s", err)
 	}
@@ -91,7 +91,7 @@ func TestNestedProperty(t *testing.T) {
 func TestPointerProperty(t *testing.T) {
 	var vm VirtualMachine
 
-	err := LoadRetrievePropertiesResponse(load("fixtures/pointer_property.xml"), &vm)
+	err := LoadObjectContent(load("fixtures/pointer_property.xml"), &vm)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %s", err)
 	}
@@ -110,7 +110,7 @@ func TestEmbeddedTypeProperty(t *testing.T) {
 	// panic: reflect.Set: value of type mo.ClusterComputeResource is not assignable to type mo.ComputeResource
 	var cr ComputeResource
 
-	err := LoadRetrievePropertiesResponse(load("fixtures/cluster_host_property.xml"), &cr)
+	err := LoadObjectContent(load("fixtures/cluster_host_property.xml"), &cr)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %s", err)
 	}
@@ -123,7 +123,7 @@ func TestEmbeddedTypeProperty(t *testing.T) {
 func TestEmbeddedTypePropertySlice(t *testing.T) {
 	var me []ManagedEntity
 
-	err := LoadRetrievePropertiesResponse(load("fixtures/hostsystem_list_name_property.xml"), &me)
+	err := LoadObjectContent(load("fixtures/hostsystem_list_name_property.xml"), &me)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %s", err)
 	}


### PR DESCRIPTION
Change the method signature to []types.ObjectContent which can be used
not just with RetrieveProperties(), but also RetrievePropertiesEx() and ContinueRetrievePropertiesEx()