### PR TITLE
vcsim: use TLS in simulator.Run

### DIFF
--- a/simulator/example_test.go
+++ b/simulator/example_test.go
@@ -93,9 +93,9 @@ func ExampleVPX() {
 	// Output: VirtualCenter with 4 hosts
 }
 
-// Run simplifies startup/cleanup of a simulator instance
+// Run simplifies startup/cleanup of a simulator instance for example or testing purposes.
 func ExampleModel_Run() {
-	simulator.VPX().Run(func(ctx context.Context, c *vim25.Client) error {
+	err := simulator.VPX().Run(func(ctx context.Context, c *vim25.Client) error {
 		// Client has connected and logged in to a new simulator instance.
 		// Server.Close and Model.Remove are called when this func returns.
 		s, err := session.NewManager(c).UserSession(ctx)
@@ -104,6 +104,23 @@ func ExampleModel_Run() {
 		}
 		fmt.Print(s.UserName)
 		return nil
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Output: user
+}
+
+// Test simplifies startup/cleanup of a simulator instance for testing purposes.
+func ExampleTest() {
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		// Client has connected and logged in to a new simulator instance.
+		// Server.Close and Model.Remove are called when this func returns.
+		s, err := session.NewManager(c).UserSession(ctx)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Print(s.UserName)
 	})
 	// Output: user
 }

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -18,6 +18,7 @@ package simulator
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -531,6 +532,7 @@ func (m *Model) Run(f func(context.Context, *vim25.Client) error) error {
 		return err
 	}
 
+	m.Service.TLS = new(tls.Config)
 	m.Service.RegisterEndpoints = true
 
 	s := m.Service.NewServer()


### PR DESCRIPTION
Clients using soap.ParseURL for example are expecting https by default.

- Add simulator.Test example