### PR TITLE
Fix error check in session.Secret

### DIFF
--- a/session/manager.go
+++ b/session/manager.go
@@ -50,10 +50,10 @@ func Secret(value string) (string, error) {
 	}
 	contents, err := ioutil.ReadFile(value)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return value, nil
+		if os.IsPermission(err) {
+			return "", err
 		}
-		return "", err
+		return value, nil
 	}
 	return strings.TrimSpace(string(contents)), nil
 }


### PR DESCRIPTION
Windows may return an error other than those matching os.IsNotExist(),
such as ERROR_INVALID_NAME.  Use os.IsPermission() instead.

Fixes #1612