### PR TITLE
Ensure that extraConfig from clone spec is added to VM being cloned

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1461,7 +1461,7 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 			Files: &types.VirtualMachineFileInfo{
 				VmPathName: strings.Replace(vm.Config.Files.VmPathName, vm.Name, req.Name, -1),
 			},
-			ExtraConfig: req.Spec.Config.ExtraConfig,			
+			ExtraConfig: req.Spec.Config.ExtraConfig,
 		}
 
 		defaultDevices := object.VirtualDeviceList(esx.VirtualDevice)

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1461,6 +1461,7 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 			Files: &types.VirtualMachineFileInfo{
 				VmPathName: strings.Replace(vm.Config.Files.VmPathName, vm.Name, req.Name, -1),
 			},
+			ExtraConfig: req.Spec.Config.ExtraConfig,			
 		}
 
 		defaultDevices := object.VirtualDeviceList(esx.VirtualDevice)

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1461,7 +1461,9 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 			Files: &types.VirtualMachineFileInfo{
 				VmPathName: strings.Replace(vm.Config.Files.VmPathName, vm.Name, req.Name, -1),
 			},
-			ExtraConfig: req.Spec.Config.ExtraConfig,
+		}
+		if req.Spec.Config != nil {
+			config.ExtraConfig = req.Spec.Config.ExtraConfig
 		}
 
 		defaultDevices := object.VirtualDeviceList(esx.VirtualDevice)


### PR DESCRIPTION
Given that vcsim creates a VirtualMachineConfigSpec from a VirtualMachineCloneSpec, it needs to manually copy over fields that are important. By adding this line, it ensures that extraConfig from the clone spec is added to the extraConfig in the vm being cloned