### PR TITLE
Fix description of vm.keystrokes

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -4498,7 +4498,7 @@ Examples:
   govc vm.keystrokes -vm $vm -c 0x15 	# writes an 'r' to the console
   govc vm.keystrokes -vm $vm -r 1376263 # writes an 'r' to the console
   govc vm.keystrokes -vm $vm -c 0x28 	# presses ENTER on the console
-  govc vm.keystrokes -vm $vm -c 0x4c -la true -lc true 	# sends CTRL+ALT+DEL to console
+  govc vm.keystrokes -vm $vm -c 0x4c -la=true -lc=true 	# sends CTRL+ALT+DEL to console
 
 Options:
   -c=                    USB HID Code (hex)

--- a/govc/vm/keystrokes.go
+++ b/govc/vm/keystrokes.go
@@ -181,7 +181,7 @@ Examples:
   govc vm.keystrokes -vm $vm -c 0x15 	# writes an 'r' to the console
   govc vm.keystrokes -vm $vm -r 1376263 # writes an 'r' to the console
   govc vm.keystrokes -vm $vm -c 0x28 	# presses ENTER on the console
-  govc vm.keystrokes -vm $vm -c 0x4c -la true -lc true 	# sends CTRL+ALT+DEL to console`
+  govc vm.keystrokes -vm $vm -c 0x4c -la=true -lc=true 	# sends CTRL+ALT+DEL to console`
 }
 
 func (cmd *keystrokes) Process(ctx context.Context) error {


### PR DESCRIPTION
as mentionned in https://github.com/vmware/govmomi/issues/1621

```-la true -rc true```  will silently parse la as true and rc as false.

Not sure what is wrong with the flag parsing, but fixing at least the example in the description.