### PR TITLE
add GetInventoryPath to NetworkReference interface

### DIFF
--- a/object/distributed_virtual_portgroup.go
+++ b/object/distributed_virtual_portgroup.go
@@ -36,6 +36,10 @@ func NewDistributedVirtualPortgroup(c *vim25.Client, ref types.ManagedObjectRefe
 	}
 }
 
+func (p DistributedVirtualPortgroup) GetInventoryPath() string {
+	return p.InventoryPath
+}
+
 // EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this DistributedVirtualPortgroup
 func (p DistributedVirtualPortgroup) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
 	var dvp mo.DistributedVirtualPortgroup

--- a/object/distributed_virtual_switch.go
+++ b/object/distributed_virtual_switch.go
@@ -34,6 +34,10 @@ func NewDistributedVirtualSwitch(c *vim25.Client, ref types.ManagedObjectReferen
 	}
 }
 
+func (s DistributedVirtualSwitch) GetInventoryPath() string {
+	return s.InventoryPath
+}
+
 func (s DistributedVirtualSwitch) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
 	return nil, ErrNotSupported // TODO: just to satisfy NetworkReference interface for the finder
 }

--- a/object/network.go
+++ b/object/network.go
@@ -34,6 +34,10 @@ func NewNetwork(c *vim25.Client, ref types.ManagedObjectReference) *Network {
 	}
 }
 
+func (n Network) GetInventoryPath() string {
+	return n.InventoryPath
+}
+
 // EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this Network
 func (n Network) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
 	var e mo.Network

--- a/object/network_reference.go
+++ b/object/network_reference.go
@@ -26,6 +26,6 @@ import (
 // which can be used as the backing for a VirtualEthernetCard.
 type NetworkReference interface {
 	Reference
-
+	GetInventoryPath() string
 	EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error)
 }

--- a/object/opaque_network.go
+++ b/object/opaque_network.go
@@ -35,6 +35,10 @@ func NewOpaqueNetwork(c *vim25.Client, ref types.ManagedObjectReference) *Opaque
 	}
 }
 
+func (n OpaqueNetwork) GetInventoryPath() string {
+	return n.InventoryPath
+}
+
 // EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this Network
 func (n OpaqueNetwork) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
 	var net mo.OpaqueNetwork

--- a/object/vmware_distributed_virtual_switch.go
+++ b/object/vmware_distributed_virtual_switch.go
@@ -19,3 +19,7 @@ package object
 type VmwareDistributedVirtualSwitch struct {
 	DistributedVirtualSwitch
 }
+
+func (s VmwareDistributedVirtualSwitch) GetInventoryPath() string {
+	return s.InventoryPath
+}


### PR DESCRIPTION
When using NetworkList from Finder a list of interfaces is returned meaning you'd need to make a similar looking switch to type caste back to the proper type which is a bit annoying if you're just trying to get InventoryPath. Adding a helper method to NetworkReference to grab and return it.