### PR TITLE
Fix object.collect with moref argument

### DIFF
--- a/govc/object/collect.go
+++ b/govc/object/collect.go
@@ -333,7 +333,9 @@ func (cmd *collect) Run(ctx context.Context, f *flag.FlagSet) error {
 		default:
 			ref, err = cmd.ManagedObject(ctx, arg)
 			if err != nil {
-				return err
+				if !ref.FromString(arg) {
+					return err
+				}
 			}
 		}
 

--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -77,7 +77,7 @@ load test_helper
 }
 
 @test "object.collect" {
-  esx_env
+  vcsim_env
 
   run govc object.collect
   assert_success
@@ -124,12 +124,12 @@ load test_helper
   assert_success
 
   # test against slice of interface
-  perfman=$(govc object.collect -s - content.perfManager)
-  result=$(govc object.collect -s "$perfman" description.counterType)
+  setting=$(govc object.collect -s - content.setting)
+  result=$(govc object.collect -s "$setting" setting)
   assert_equal "..." "$result"
 
   # test against an interface field
-  run govc object.collect '/ha-datacenter/network/VM Network' summary
+  run govc object.collect 'network/VM Network' summary
   assert_success
 }
 


### PR DESCRIPTION
Commit c35a532 added validation for ManagedEntity types, but this breaks
morefs for types that don't extend ManagedEntity - such as mo.*Manager types.