### PR TITLE
added IsTemplate vm helper

### DIFF
--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	PropRuntimePowerState = "summary.runtime.powerState"
+	PropConfigTemplate    = "summary.config.template"
 )
 
 type VirtualMachine struct {
@@ -54,6 +55,17 @@ func (v VirtualMachine) PowerState(ctx context.Context) (types.VirtualMachinePow
 	}
 
 	return o.Summary.Runtime.PowerState, nil
+}
+
+func (v VirtualMachine) IsTemplate(ctx context.Context) (bool, error) {
+	var o mo.VirtualMachine
+
+	err := v.Properties(ctx, v.Reference(), []string{PropConfigTemplate}, &o)
+	if err != nil {
+		return false, err
+	}
+
+	return o.Summary.Config.Template, nil
 }
 
 func (v VirtualMachine) PowerOn(ctx context.Context) (*Task, error) {


### PR DESCRIPTION
Added an IsTemplate helper method to help when using finder to help split VMs if you only need Templates. Makes this possible instead of having to use a Retrieve or something heavier that fills out VirtualMachine.Config:

```
vms, err := finder.VirtualMachineList(ctx, "*")
if err != nil {
    return nil, err
}

var templates []string
for _, vm := range vms {
    if isTemplate, err := vm.IsTemplate(ctx); err == nil && isTemplate {
        templates = append(data, vm.InventoryPath)
    }
}

```
