### PR TITLE
vslm: Fix to throw errors on tasks that are completed with error state

### DIFF
--- a/vslm/global_object_manager.go
+++ b/vslm/global_object_manager.go
@@ -18,6 +18,7 @@ package vslm
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/vmware/govmomi/object"
@@ -92,6 +93,8 @@ func (this *Task) WaitNonDefault(ctx context.Context, timeoutNS time.Duration, s
 					waitIntervalNS = maxIntervalNS
 				}
 			}
+		} else if info.State == types.VslmTaskInfoStateError {
+			return nil, errors.New(info.Error.LocalizedMessage)
 		} else {
 			break
 		}


### PR DESCRIPTION
In the current code base, govmomi/vslm does not throw any errors even if API tasks are completed with error state, which would be confusing to govmomi client. Make the fix to throw errors as expected.