### PR TITLE
Debug Update to Add a Password Scrubber and stdout style LogType

### DIFF
--- a/govc/README.md
+++ b/govc/README.md
@@ -133,6 +133,29 @@ to set defaults:
 
 ## Troubleshooting
 
+### Debug Flag
+There is a `-debug` flag which you can use to debug the calls made to the vSphere API and there are some environment
+variables you can use to configure how it works. If you turn on the `-debug` flag the default behavior is to put the
+output in `~/.govmomi/debug/<run timestamp>`. In that directory will be four (4) files per API call.
+
+```
+1-0001.req.headers #headers from the request sent to the API
+1-0001.req.xml #body content from request sent to the API
+1-0001.res.headers #headers from the response from the API
+1-0001.res.xml #body from the respnse from the API
+```
+
+In that filename the `0001` represents the an incremented call order and will increment for each time the SOAP client
+makes an API call. 
+
+To configure the debug output you can use two environment variables.
+* `GOVC_DEBUG_PATH`: defaults to ~/.govmomi/debug
+* `GOVC_DEBUG_PATH_RUN`: defaults to timestamp of the run
+
+#### stdout debug
+If you prefer debug output to be sent to stdout and seen while the command is running you can override the file behavior
+by setting the debug path to a dash: `export GOVC_DEBUG_PATH=-`
+
 ### Environment variables
 
 If you're using environment variables to set `GOVC_URL`, verify the values are set as expected:

--- a/govc/flags/debug.go
+++ b/govc/flags/debug.go
@@ -68,7 +68,11 @@ func (flag *DebugFlag) Process(ctx context.Context) error {
 	return flag.ProcessOnce(func() error {
 		// Base path for storing debug logs.
 		r := os.Getenv("GOVC_DEBUG_PATH")
-		if r == "" {
+		switch r {
+		case "-":
+			debug.SetProvider(&debug.LogProvider{})
+			return nil
+		case "":
 			r = home
 		}
 		r = filepath.Join(r, "debug")

--- a/vim25/debug/debug.go
+++ b/vim25/debug/debug.go
@@ -18,8 +18,7 @@ package debug
 
 import (
 	"io"
-	"os"
-	"path"
+	"regexp"
 )
 
 // Provider specified the interface types must implement to be used as a
@@ -31,6 +30,7 @@ type Provider interface {
 }
 
 var currentProvider Provider = nil
+var scrubPassword = regexp.MustCompile(`<password>(.*)</password>`)
 
 func SetProvider(p Provider) {
 	if currentProvider != nil {
@@ -54,28 +54,9 @@ func Flush() {
 	currentProvider.Flush()
 }
 
-// FileProvider implements a debugging provider that creates a real file for
-// every call to NewFile. It maintains a list of all files that it creates,
-// such that it can close them when its Flush function is called.
-type FileProvider struct {
-	Path string
+func Scrub(in []byte) []byte {
+	out := string(in)
+	out = scrubPassword.ReplaceAllString(out, `<password>********</password>`)
 
-	files []*os.File
-}
-
-func (fp *FileProvider) NewFile(p string) io.WriteCloser {
-	f, err := os.Create(path.Join(fp.Path, p))
-	if err != nil {
-		panic(err)
-	}
-
-	fp.files = append(fp.files, f)
-
-	return f
-}
-
-func (fp *FileProvider) Flush() {
-	for _, f := range fp.files {
-		f.Close()
-	}
+	return []byte(out)
 }

--- a/vim25/debug/file.go
+++ b/vim25/debug/file.go
@@ -1,0 +1,68 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"io"
+	"os"
+	"path"
+)
+
+// FileProvider implements a debugging provider that creates a real file for
+// every call to NewFile. It maintains a list of all files that it creates,
+// such that it can close them when its Flush function is called.
+type FileProvider struct {
+	Path  string
+	files []*os.File
+}
+
+func (fp *FileProvider) NewFile(p string) io.WriteCloser {
+	f, err := os.Create(path.Join(fp.Path, p))
+	if err != nil {
+		panic(err)
+	}
+
+	fp.files = append(fp.files, f)
+
+	return NewFileWriterCloser(f, p)
+}
+
+func (fp *FileProvider) Flush() {
+	for _, f := range fp.files {
+		f.Close()
+	}
+}
+
+type FileWriterCloser struct {
+	f *os.File
+	p string
+}
+
+func NewFileWriterCloser(f *os.File, p string) *FileWriterCloser {
+	return &FileWriterCloser{
+		f,
+		p,
+	}
+}
+
+func (fwc *FileWriterCloser) Write(p []byte) (n int, err error) {
+	return fwc.f.Write(Scrub(p))
+}
+
+func (fwc *FileWriterCloser) Close() error {
+	return fwc.f.Close()
+}

--- a/vim25/debug/log.go
+++ b/vim25/debug/log.go
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"io"
+	"log"
+)
+
+type LogWriterCloser struct {
+}
+
+func NewLogWriterCloser() *LogWriterCloser {
+	return &LogWriterCloser{}
+}
+
+func (lwc *LogWriterCloser) Write(p []byte) (n int, err error) {
+	log.Print(string(Scrub(p)))
+	return len(p), nil
+}
+
+func (lwc *LogWriterCloser) Close() error {
+	return nil
+}
+
+type LogProvider struct {
+}
+
+func (s *LogProvider) NewFile(p string) io.WriteCloser {
+	log.Print(p)
+	return NewLogWriterCloser()
+}
+
+func (s *LogProvider) Flush() {
+}


### PR DESCRIPTION
Most important part of this PR is the Scrub method added to the debug output to remove your password from the logs. To do this I just wrote a wrapper CloseWrite for FileType and to debug easier I wrote a LogType so decided to include it in the PR.

LogType uses go's log package and fakes a write/close to pass to the TeeReader and instead run a `log.Print()` on the contents which are normally written to file. This will show debug in your console while the command is running. @dougm would love your feedback as output is a bit messy but I didn't want to rock the boat too hard and kept some of file output like filename etc.

I additionally added a -debug to default to the stdout LogType method if no GOVC_DEBUG_PATH is not set so you don't magically write some log files without the govc user knowing (which happened to me)