### PR TITLE
Update tags.ls and tags.info to Support Tags with Same Name

### DIFF
--- a/govc/tags/info.go
+++ b/govc/tags/info.go
@@ -109,7 +109,6 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 			for i := range src {
 				if src[i].Name == arg || src[i].ID == arg {
 					res = append(res, src[i])
-					break
 				}
 			}
 			if len(res) == 0 {


### PR DESCRIPTION
You can have two tags with the same name in vsphere only in different category. This updates tags.ls to send back the Category name so it makes more sense why there are two tags with the same name and removes the break in tags.info which made info only return 1 result and makes it work more like if you pass an empty string to tags.info which shows the info for all the tags in the system.

Example
```➜  govc git:(govc-tags) ✗ ./govc-dev tags.ls
New Tag      Luthers Tag Category
Luthers Tag  Luthers Tag Category
New Tag      asdf
```

Before my change
```
➜  govc git:(govc-tags) ✗ ./govc-dev tags.info "New Tag"
Name:           New Tag
  ID:           urn:vmomi:InventoryServiceTag:ee4de041-48d8-4709-b5a5-d08add628c75:GLOBAL
  Description:
  Category:     Luthers Tag Category
  UsedBy: []
```
After my change
```
➜  govc git:(govc-tags) ✗ ./govc-dev tags.info "New Tag"
Name:           New Tag
  ID:           urn:vmomi:InventoryServiceTag:ee4de041-48d8-4709-b5a5-d08add628c75:GLOBAL
  Description:
  Category:     Luthers Tag Category
  UsedBy: []
Name:           New Tag
  ID:           urn:vmomi:InventoryServiceTag:172f10de-dcb4-425e-8af4-e8d9ece240d6:GLOBAL
  Description:
  Category:     asdf
  UsedBy: []```