### PR TITLE
Avoid empty principal in HoK token request

### DIFF
--- a/sts/signer.go
+++ b/sts/signer.go
@@ -143,7 +143,7 @@ func (s *Signer) Sign(env soap.Envelope) ([]byte, error) {
 			}
 		}
 		// When requesting HoK token for interactive user, request will have both priv. key and username/password.
-		if s.user != nil {
+		if s.user.Username() != "" {
 			header.UsernameToken = &internal.UsernameToken{
 				Username: s.user.Username(),
 			}


### PR DESCRIPTION
Commit d296a5f added support HoK tokens with Interactive Users.
But if s.user is non-nil (in the case of govc session.login -issue), the Issue
request includes an empty principal, resulting in:

  govc: ns0:RequestFailed: Empty principal name is not allowed