### PR TITLE
Set stable vSAN client version

### DIFF
--- a/cns/cns_util.go
+++ b/cns/cns_util.go
@@ -27,9 +27,8 @@ import (
 
 // version and namespace constants for task client
 const (
-	// ClientVersion "6.9.0" is mapped to 'vsan.version.version11'
-	// This need to be changed if later VMODL version is bumped
-	taskClientVersion   = "6.9.0"
+	// ClientVersion "vSAN 6.7U3" is the stable version for vSphere 6.7u3 release
+	taskClientVersion   = "vSAN 6.7U3"
 	taskClientNamespace = "urn:vsan"
 )
 


### PR DESCRIPTION
Version `6.9.0` is not the stable vSAN Client Version we should use.

As per `sdk/vsanServiceVersions.xml` - `vSAN 6.7U3` is the right stable version we should be using.

![Screen Shot 2019-10-10 at 12 16 10 PM](https://user-images.githubusercontent.com/22985595/66599308-c584af00-eb57-11e9-97a4-b6c1bff82c05.png)


Testing
-------
Executed test on vSphere 67u3 release to confirm APIs are returning correct task result containing objects with vsan namespace.

```
$ pwd
/Users/divyenp/go/src/github.com/vmware/govmomi/cns

$ export CNS_VC_URL='https://Administrator@vsphere.local:Admin!23@10.160.68.110'
$ export CNS_DATACENTER="datacenter"
$ export CNS_DATASTORE="vsanDatastore"

$ go test -v
=== RUN   TestClient
--- PASS: TestClient (21.79s)
    client_test.go:91: Creating volume using the spec: {DynamicData:{} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0 VolumeType:BLOCK Datastores:[Datastore:datastore-39] Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType:KUBERNETES ClusterId:demo-cluster-id VSphereUser:Administrator@vsphere.local} EntityMetadata:[]} BackingObjectDetails:0xc0002fcec0 Profile:[]}
    client_test.go:116: Volume created sucessfully. volumeId: 5903c972-e827-4d73-a8b4-ff3d8439091b
    client_test.go:123: Calling QueryVolume using queryFilter: {DynamicData:{} VolumeIds:[{DynamicData:{} Id:5903c972-e827-4d73-a8b4-ff3d8439091b}] Names:[] ContainerClusterIds:[] StoragePolicyId: Datastores:[] Labels:[] Cursor:<nil>}
    client_test.go:129: Sucessfully Queried Volumes. queryResult: &{DynamicData:{} Volumes:[{DynamicData:{} VolumeId:{DynamicData:{} Id:5903c972-e827-4d73-a8b4-ff3d8439091b} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0 VolumeType:BLOCK DatastoreUrl:ds:///vmfs/volumes/vsan:528721c1051556d4-7340e66a7e27768f/ Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType:KUBERNETES ClusterId:demo-cluster-id VSphereUser:Administrator@vsphere.local} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:5120} ComplianceStatus:compliant DatastoreAccessibilityStatus:accessible StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad}] Cursor:{DynamicData:{} Offset:1 Limit:100 TotalRecords:1}}
    client_test.go:164: Updating volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:5903c972-e827-4d73-a8b4-ff3d8439091b} Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType:KUBERNETES ClusterId:demo-cluster-id VSphereUser:Administrator@vsphere.local} EntityMetadata:[0xc000326230]}}
    client_test.go:189: Sucessfully updated volume metadata
    client_test.go:207: Sucessfully Queried all Volumes. queryResult: &{DynamicData:{} Volumes:[{DynamicData:{} VolumeId:{DynamicData:{} Id:e83b5902-3e51-4e26-b48f-4aa07e8ebe7e} Name:vspherepv-vcbwv VolumeType:BLOCK DatastoreUrl: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser:} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:-1} ComplianceStatus: DatastoreAccessibilityStatus: StoragePolicyId:} {DynamicData:{} VolumeId:{DynamicData:{} Id:c3f522e3-81ad-4ce2-a6e4-1b7fd3a9d8fa} Name:vspherepv-29vhz VolumeType:BLOCK DatastoreUrl: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser:} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:-1} ComplianceStatus: DatastoreAccessibilityStatus: StoragePolicyId:} {DynamicData:{} VolumeId:{DynamicData:{} Id:ee29980e-0433-45f3-b599-3751e8850695} Name:pvc-42e5295e-ea21-11e9-881f-0050568dddbf VolumeType:BLOCK DatastoreUrl: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser:} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:2048} ComplianceStatus:compliant DatastoreAccessibilityStatus:accessible StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad} {DynamicData:{} VolumeId:{DynamicData:{} Id:aa7a23de-69e4-40eb-9d7a-214467a47e2b} Name:vspherepv-dzdsn VolumeType:BLOCK DatastoreUrl: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser:} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:-1} ComplianceStatus: DatastoreAccessibilityStatus: StoragePolicyId:} {DynamicData:{} VolumeId:{DynamicData:{} Id:91e88baa-9e4f-4f25-b48f-bae7a514a4a4} Name:pvc-2d2ce1da-ea21-11e9-881f-0050568dddbf VolumeType:BLOCK DatastoreUrl: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser:} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:2048} ComplianceStatus:compliant DatastoreAccessibilityStatus:accessible StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad} {DynamicData:{} VolumeId:{DynamicData:{} Id:80691b44-53d5-4cf6-b56b-f10ed745276c} Name:testvolume VolumeType:BLOCK DatastoreUrl: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser:} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:1024} ComplianceStatus:compliant DatastoreAccessibilityStatus:accessible StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad} {DynamicData:{} VolumeId:{DynamicData:{} Id:69e2452a-0f83-4119-a185-275b57ee7a46} Name:pvc-1d70a7ba-ea21-11e9-881f-0050568dddbf VolumeType:BLOCK DatastoreUrl: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser:} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:2048} ComplianceStatus:compliant DatastoreAccessibilityStatus:accessible StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad} {DynamicData:{} VolumeId:{DynamicData:{} Id:a762141d-d078-4c9f-9736-5696cbce7872} Name:pvc-3cd9ffd5-ea21-11e9-881f-0050568dddbf VolumeType:BLOCK DatastoreUrl: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser:} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:2048} ComplianceStatus:compliant DatastoreAccessibilityStatus:accessible StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad} {DynamicData:{} VolumeId:{DynamicData:{} Id:5903c972-e827-4d73-a8b4-ff3d8439091b} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0 VolumeType:BLOCK DatastoreUrl: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser:} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:5120} ComplianceStatus:compliant DatastoreAccessibilityStatus:accessible StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad} {DynamicData:{} VolumeId:{DynamicData:{} Id:5635cc49-7bc2-459d-96b6-7b86c861ef74} Name:pvc-3469531f-ea21-11e9-881f-0050568dddbf VolumeType:BLOCK DatastoreUrl: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser:} EntityMetadata:[]} BackingObjectDetails:{DynamicData:{} CapacityInMb:2048} ComplianceStatus:compliant DatastoreAccessibilityStatus:accessible StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad}] Cursor:{DynamicData:{} Offset:10 Limit:0 TotalRecords:10}}
    client_test.go:249: Node VM created sucessfully. vmRef: VirtualMachine:vm-59
    client_test.go:263: Attaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:5903c972-e827-4d73-a8b4-ff3d8439091b} Vm:VirtualMachine:vm-59}
    client_test.go:288: Volume attached sucessfully. Disk UUID: 5903c972-e827-4d73-a8b4-ff3d8439091b
    client_test.go:299: Detaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:5903c972-e827-4d73-a8b4-ff3d8439091b} Vm:VirtualMachine:vm-59}
    client_test.go:323: Volume detached sucessfully
    client_test.go:326: Deleting volume: [{DynamicData:{} Id:5903c972-e827-4d73-a8b4-ff3d8439091b}]
    client_test.go:350: Volume deleted sucessfully
PASS
ok  	github.com/vmware/govmomi/cns	22.385s
```