### PR TITLE
adding managed obj type to table

### DIFF
--- a/govc/fields/ls.go
+++ b/govc/fields/ls.go
@@ -30,6 +30,7 @@ import (
 
 type ls struct {
 	*flags.ClientFlag
+	kind string
 }
 
 func init() {
@@ -39,13 +40,16 @@ func init() {
 func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
 	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.kind, "type", "", "Filter by a Managed Object Type")
 }
 
 func (cmd *ls) Description() string {
 	return `List custom field definitions.
 
 Examples:
-  govc fields.ls`
+  govc fields.ls
+  govc fields.ls -type VirtualMachine`
 }
 
 func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -64,10 +68,12 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+	tw := tabwriter.NewWriter(os.Stdout, 3, 0, 2, ' ', 0)
 
 	for _, def := range field {
-		fmt.Fprintf(tw, "%d\t%s\n", def.Key, def.Name)
+		if cmd.kind == "" || cmd.kind == def.ManagedObjectType {
+			fmt.Fprintf(tw, "%d\t%s\t%s\n", def.Key, def.Name, def.ManagedObjectType)
+		}
 	}
 
 	return tw.Flush()


### PR DESCRIPTION
Since you can't assign every field to MO type I added the ManagedObjectType to the table output. Also added -t filter to limit the list to only certain Manage Object Types.

```
➜  govc git:(field-type) ./govc-dev fields.ls
1    AutoDeploy.MachineIdentity                                  HostSystem
203  asdffffff                                                   VirtualMachine
2    com.vmware.vcIntegrity.customField.scheduledTask.action     ScheduledTask
3    com.vmware.vcIntegrity.customField.scheduledTask.signature  ScheduledTask
4    com.vmware.vcIntegrity.customField.scheduledTask.target     ScheduledTask
➜  govc git:(field-type) ./govc-dev fields.ls -t VirtualMachine
203  asdffffff  VirtualMachine
➜  govc git:(field-type) ./govc-dev fields.ls -t ScheduledTask
2  com.vmware.vcIntegrity.customField.scheduledTask.action     ScheduledTask
3  com.vmware.vcIntegrity.customField.scheduledTask.signature  ScheduledTask
4  com.vmware.vcIntegrity.customField.scheduledTask.target     ScheduledTask
```