### PR TITLE
vcsim: simplify container vm arguments input

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -229,6 +229,10 @@ load test_helper
   run govc vm.change -vm $vm -e RUN.container="[\"-v\", \"$PWD:/usr/share/nginx/html:ro\", \"nginx\"]"
   assert_success
 
+  # test bash -c args parsing
+  run govc vm.change -vm $vm -e RUN.container="-v '$PWD:/usr/share/nginx/html:ro' nginx"
+  assert_success
+
   run govc vm.power -on $vm
   assert_success
 

--- a/simulator/container.go
+++ b/simulator/container.go
@@ -26,6 +26,16 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+var (
+	shell = "/bin/sh"
+)
+
+func init() {
+	if sh, err := exec.LookPath("bash"); err != nil {
+		shell = sh
+	}
+}
+
 // container provides methods to manage a container within a simulator VM lifecycle.
 type container struct {
 	id string
@@ -111,8 +121,8 @@ func (c *container) start(vm *VirtualMachine) {
 		return
 	}
 
-	args = append([]string{"run", "-d", "--name", vm.Name}, args...)
-	cmd := exec.Command("docker", args...)
+	args = append([]string{"docker", "run", "-d", "--name", vm.Name}, args...)
+	cmd := exec.Command(shell, "-c", strings.Join(args, " "))
 	out, err := cmd.Output()
 	if err != nil {
 		log.Printf("%s %s: %s", vm.Name, cmd.Args, err)

--- a/simulator/feature_test.go
+++ b/simulator/feature_test.go
@@ -105,7 +105,7 @@ func Example_runContainer() {
 			log.Fatal(err)
 		}
 
-		args := fmt.Sprintf(`["-v", "%s:/usr/share/nginx/html:ro", "nginx"]`, dir) // json encoded args
+		args := fmt.Sprintf("-v '%s:/usr/share/nginx/html:ro' nginx", dir)
 
 		spec := types.VirtualMachineConfigSpec{
 			Name: "nginx",


### PR DESCRIPTION
Rather than require users to supply a json encoded argument list,
let sh|bash do the work of parsing.