### PR TITLE
govc: fixup usage suggestions

### DIFF
--- a/govc/cli/command.go
+++ b/govc/cli/command.go
@@ -45,21 +45,20 @@ type Command interface {
 }
 
 func generalHelp(w io.Writer, filter string) {
-	if filter == "" {
-		fmt.Fprintf(w, "Usage of %s:\n", os.Args[0])
-	} else {
-		fmt.Fprintf(w, "No command '%s' found, did you mean:\n", filter)
+	var cmds, matches []string
+	for name := range commands {
+		cmds = append(cmds, name)
+
+		if filter != "" && strings.Contains(name, filter) {
+			matches = append(matches, name)
+		}
 	}
 
-	var cmds []string
-	for name := range commands {
-		if filter == "" {
-			cmds = append(cmds, name)
-			continue
-		}
-		if strings.Contains(name, filter) {
-			cmds = append(cmds, name)
-		}
+	if len(matches) == 0 {
+		fmt.Fprintf(w, "Usage of %s:\n", os.Args[0])
+	} else {
+		fmt.Fprintf(w, "%s: command '%s' not found, did you mean:\n", os.Args[0], filter)
+		cmds = matches
 	}
 
 	sort.Strings(cmds)

--- a/govc/test/cli.bats
+++ b/govc/test/cli.bats
@@ -147,6 +147,7 @@ load test_helper
 
   run govc -h
   assert_success
+  assert_matches "Usage of govc:"
 
   run govc -enoent
   assert_failure
@@ -159,4 +160,12 @@ load test_helper
 
   run govc vm.create -enoent
   assert_failure
+
+  run govc nope
+  assert_failure
+  assert_matches "Usage of govc:"
+
+  run govc power
+  assert_failure
+  assert_matches "did you mean:"
 }


### PR DESCRIPTION
3e3d351 added usage suggestions, this follow up does:

- make 'govc -h' behave as it used to

- if there are no command suggestions, print the complete list of commands