### PR TITLE
Add a method to update ports on a distributed virtual switch

### DIFF
--- a/object/distributed_virtual_switch.go
+++ b/object/distributed_virtual_switch.go
@@ -82,3 +82,17 @@ func (s DistributedVirtualSwitch) FetchDVPorts(ctx context.Context, criteria *ty
 	}
 	return res.Returnval, nil
 }
+
+func (s DistributedVirtualSwitch) ReconfigureDVPort(ctx context.Context, spec []types.DVPortConfigSpec) (*Task, error) {
+	req := types.ReconfigureDVPort_Task{
+		This: s.Reference(),
+		Port: spec,
+	}
+
+	res, err := methods.ReconfigureDVPort_Task(ctx, s.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(s.Client(), res.Returnval), nil
+}


### PR DESCRIPTION
As we discussed in issue: https://github.com/vmware/govmomi/issues/1667

Open this PR to add a new method in order to provide a way for developers to update ports on a distributed virtual switch.