### PR TITLE
Avoid possible deadlock in KeepAliveHandler

### DIFF
--- a/session/keep_alive.go
+++ b/session/keep_alive.go
@@ -80,17 +80,18 @@ func (k *keepAlive) start() {
 	k.notifyWaitGroup.Add(1)
 
 	go func() {
-		defer k.notifyWaitGroup.Done()
-
 		for t := time.NewTimer(k.idleTime); ; {
 			select {
 			case <-k.notifyStop:
+				k.notifyWaitGroup.Done()
 				return
 			case <-k.notifyRequest:
 				t.Reset(k.idleTime)
 			case <-t.C:
 				if err := k.keepAlive(k.roundTripper); err != nil {
+					k.notifyWaitGroup.Done()
 					k.stop()
+					return
 				}
 				t = time.NewTimer(k.idleTime)
 			}

--- a/session/keep_alive_test.go
+++ b/session/keep_alive_test.go
@@ -225,6 +225,9 @@ func TestKeepAliveHandler(t *testing.T) {
 	if err := m1.Login(context.Background(), u1.User); err != nil {
 		t.Error(err)
 	}
+	defer m1.Logout(context.Background())
+	defer m2.Logout(context.Background())
+
 	if err := m2.Login(context.Background(), u2.User); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
The call to stop() triggered by a handler error would cause a deadlock.
Avoid the use of deferring notifyWaitGroup.Done(), instead calling it explicitly
on both return paths.

Note that the deadlock was not seen within the test until adding the defered
calls to Logout()
