### PR TITLE
vcsim: use VMX_ prefix for guestinfo env vars

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -263,7 +263,7 @@ load test_helper
   assert_success
 
   vm=DC0_C0_RP0_VM1
-  run govc vm.change -vm $vm -e RUN.container="busybox sh -c 'sleep \$GUESTINFO_SLEEP'" -e guestinfo.sleep=500
+  run govc vm.change -vm $vm -e RUN.container="busybox sh -c 'sleep \$VMX_GUESTINFO_SLEEP'" -e guestinfo.sleep=500
   assert_success
 
   run govc vm.power -on $vm

--- a/simulator/container.go
+++ b/simulator/container.go
@@ -119,12 +119,16 @@ func (c *container) start(vm *VirtualMachine) {
 		}
 		if strings.HasPrefix(val.Key, "guestinfo.") {
 			key := strings.Replace(strings.ToUpper(val.Key), ".", "_", -1)
-			env = append(env, "--env", fmt.Sprintf("%s=%s", key, val.Value.(string)))
+			env = append(env, "--env", fmt.Sprintf("VMX_%s=%s", key, val.Value.(string)))
 		}
 	}
 
 	if len(args) == 0 {
 		return
+	}
+	if len(env) != 0 {
+		// Configure env as the data access method for cloud-init-vmware-guestinfo
+		env = append(env, "--env", "VMX_GUESTINFO=true")
 	}
 
 	run := append([]string{"docker", "run", "-d", "--name", vm.Name}, env...)


### PR DESCRIPTION
Following the convention by vmware/cloud-init-vmware-guestinfo#22