### PR TITLE
Generate pointer type for ResourceReductionToToleratePercent

### DIFF
--- a/gen/vim_wsdl.rb
+++ b/gen/vim_wsdl.rb
@@ -206,7 +206,7 @@ class Simple
 
   def pointer_type?
     ["UnitNumber"].include?(var_name) or
-      optional? && ["OwnerId", "GroupId", "MaxWaitSeconds", "Reservation", "Limit", "OverheadLimit"].include?(var_name)
+      optional? && ["OwnerId", "GroupId", "MaxWaitSeconds", "Reservation", "Limit", "OverheadLimit", "ResourceReductionToToleratePercent"].include?(var_name)
   end
 
   def var_type

--- a/gen/vim_wsdl.rb
+++ b/gen/vim_wsdl.rb
@@ -230,7 +230,6 @@ class Simple
       when "int"
         if pointer_type?
           prefix += "*"
-          self.need_omitempty = false
         end
         t = "int32"
       when "boolean"

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -8231,7 +8231,7 @@ func init() {
 type ClusterDasAdmissionControlPolicy struct {
 	DynamicData
 
-	ResourceReductionToToleratePercent int32 `xml:"resourceReductionToToleratePercent,omitempty"`
+	ResourceReductionToToleratePercent *int32 `xml:"resourceReductionToToleratePercent"`
 }
 
 func init() {

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -5931,7 +5931,7 @@ type AttachDiskRequestType struct {
 	DiskId        ID                     `xml:"diskId"`
 	Datastore     ManagedObjectReference `xml:"datastore"`
 	ControllerKey int32                  `xml:"controllerKey,omitempty"`
-	UnitNumber    *int32                 `xml:"unitNumber"`
+	UnitNumber    *int32                 `xml:"unitNumber,omitempty"`
 }
 
 func init() {
@@ -8231,7 +8231,7 @@ func init() {
 type ClusterDasAdmissionControlPolicy struct {
 	DynamicData
 
-	ResourceReductionToToleratePercent *int32 `xml:"resourceReductionToToleratePercent"`
+	ResourceReductionToToleratePercent *int32 `xml:"resourceReductionToToleratePercent,omitempty"`
 }
 
 func init() {
@@ -12167,7 +12167,7 @@ type DVSMacLearningPolicy struct {
 
 	Enabled              bool   `xml:"enabled"`
 	AllowUnicastFlooding *bool  `xml:"allowUnicastFlooding"`
-	Limit                *int32 `xml:"limit"`
+	Limit                *int32 `xml:"limit,omitempty"`
 	LimitPolicy          string `xml:"limitPolicy,omitempty"`
 }
 
@@ -19507,8 +19507,8 @@ func init() {
 type GuestPosixFileAttributes struct {
 	GuestFileAttributes
 
-	OwnerId     *int32 `xml:"ownerId"`
-	GroupId     *int32 `xml:"groupId"`
+	OwnerId     *int32 `xml:"ownerId,omitempty"`
+	GroupId     *int32 `xml:"groupId,omitempty"`
 	Permissions int64  `xml:"permissions,omitempty"`
 }
 
@@ -23831,7 +23831,7 @@ type HostPlacedVirtualNicIdentifier struct {
 
 	Vm          ManagedObjectReference `xml:"vm"`
 	VnicKey     string                 `xml:"vnicKey"`
-	Reservation *int32                 `xml:"reservation"`
+	Reservation *int32                 `xml:"reservation,omitempty"`
 }
 
 func init() {
@@ -29196,7 +29196,7 @@ type LimitExceeded struct {
 	VimFault
 
 	Property string `xml:"property,omitempty"`
-	Limit    *int32 `xml:"limit"`
+	Limit    *int32 `xml:"limit,omitempty"`
 }
 
 func init() {
@@ -29364,7 +29364,7 @@ func init() {
 
 type ListKeysRequestType struct {
 	This  ManagedObjectReference `xml:"_this"`
-	Limit *int32                 `xml:"limit"`
+	Limit *int32                 `xml:"limit,omitempty"`
 }
 
 func init() {
@@ -29383,7 +29383,7 @@ func init() {
 
 type ListKmipServersRequestType struct {
 	This  ManagedObjectReference `xml:"_this"`
-	Limit *int32                 `xml:"limit"`
+	Limit *int32                 `xml:"limit,omitempty"`
 }
 
 func init() {
@@ -31231,7 +31231,7 @@ func init() {
 type NamespaceLimitReached struct {
 	VimFault
 
-	Limit *int32 `xml:"limit"`
+	Limit *int32 `xml:"limit,omitempty"`
 }
 
 func init() {
@@ -38418,7 +38418,7 @@ func init() {
 type QueryVsanObjectUuidsByFilterRequestType struct {
 	This    ManagedObjectReference `xml:"_this"`
 	Uuids   []string               `xml:"uuids,omitempty"`
-	Limit   *int32                 `xml:"limit"`
+	Limit   *int32                 `xml:"limit,omitempty"`
 	Version int32                  `xml:"version,omitempty"`
 }
 
@@ -44554,7 +44554,7 @@ type StorageIOAllocationInfo struct {
 
 	Limit       *int64      `xml:"limit"`
 	Shares      *SharesInfo `xml:"shares,omitempty"`
-	Reservation *int32      `xml:"reservation"`
+	Reservation *int32      `xml:"reservation,omitempty"`
 }
 
 func init() {
@@ -49627,7 +49627,7 @@ type VirtualDevice struct {
 	Connectable   *VirtualDeviceConnectInfo    `xml:"connectable,omitempty"`
 	SlotInfo      BaseVirtualDeviceBusSlotInfo `xml:"slotInfo,omitempty,typeattr"`
 	ControllerKey int32                        `xml:"controllerKey,omitempty"`
-	UnitNumber    *int32                       `xml:"unitNumber"`
+	UnitNumber    *int32                       `xml:"unitNumber,omitempty"`
 }
 
 func init() {
@@ -55758,7 +55758,7 @@ type WaitForUpdatesResponse struct {
 type WaitOptions struct {
 	DynamicData
 
-	MaxWaitSeconds   *int32 `xml:"maxWaitSeconds"`
+	MaxWaitSeconds   *int32 `xml:"maxWaitSeconds,omitempty"`
 	MaxObjectUpdates int32  `xml:"maxObjectUpdates,omitempty"`
 }
 

--- a/vslm/types/types.go
+++ b/vslm/types/types.go
@@ -116,7 +116,7 @@ type VslmAttachDiskRequestType struct {
 	Id            types.ID                     `xml:"id"`
 	Vm            types.ManagedObjectReference `xml:"vm"`
 	ControllerKey int32                        `xml:"controllerKey,omitempty"`
-	UnitNumber    *int32                       `xml:"unitNumber"`
+	UnitNumber    *int32                       `xml:"unitNumber,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
Another field optional in the wsdl, but with Go's "omitempty" semantics prevents a value of '0'.

Fixes #1686