### PR TITLE
Added SSL Thumbprint option to create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ require (
 	github.com/kr/text v0.1.0 // indirect
 	github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,3 @@ require (
 	github.com/kr/text v0.1.0 // indirect
 	github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728
 )
-
-go 1.13

--- a/govc/library/create.go
+++ b/govc/library/create.go
@@ -49,6 +49,7 @@ func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 	f.StringVar(&cmd.sub.SubscriptionURL, "sub", "", "Subscribe to library URL")
 	f.StringVar(&cmd.sub.UserName, "sub-username", "", "Subscription username")
 	f.StringVar(&cmd.sub.Password, "sub-password", "", "Subscription password")
+	f.StringVar(&cmd.sub.SslThumbprint, "ssl-thumbprint", "", "SSL Tumbprint")
 	f.BoolVar(cmd.sub.AutomaticSyncEnabled, "sub-autosync", true, "Automatic synchronization")
 	f.BoolVar(cmd.sub.OnDemand, "sub-ondemand", false, "Download content on demand")
 }

--- a/govc/library/create.go
+++ b/govc/library/create.go
@@ -49,7 +49,7 @@ func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 	f.StringVar(&cmd.sub.SubscriptionURL, "sub", "", "Subscribe to library URL")
 	f.StringVar(&cmd.sub.UserName, "sub-username", "", "Subscription username")
 	f.StringVar(&cmd.sub.Password, "sub-password", "", "Subscription password")
-	f.StringVar(&cmd.sub.SslThumbprint, "ssl-thumbprint", "", "SSL Tumbprint")
+	f.StringVar(&cmd.sub.SslThumbprint, "thumbprint", "", "SHA-1 thumbprint of the host's SSL certificate")
 	f.BoolVar(cmd.sub.AutomaticSyncEnabled, "sub-autosync", true, "Automatic synchronization")
 	f.BoolVar(cmd.sub.OnDemand, "sub-ondemand", false, "Download content on demand")
 }


### PR DESCRIPTION
Added SSL Thumbprint option to create library subscription.  Call was failing in both govc and postman without a valid SSL thumbprint present in the JSON