### PR TITLE
Fix hostsystem ManagementIPs call

### DIFF
--- a/object/host_system.go
+++ b/object/host_system.go
@@ -83,14 +83,21 @@ func (h HostSystem) ManagementIPs(ctx context.Context) ([]net.IP, error) {
 
 	var ips []net.IP
 	for _, nc := range mh.Config.VirtualNicManagerInfo.NetConfig {
-		if nc.NicType == "management" && len(nc.CandidateVnic) > 0 {
-			ip := net.ParseIP(nc.CandidateVnic[0].Spec.Ip.IpAddress)
-			if ip != nil {
-				ips = append(ips, ip)
+		if nc.NicType != string(types.HostVirtualNicManagerNicTypeManagement) {
+			continue
+		}
+		for ix := range nc.CandidateVnic {
+			for _, selectedVnicKey := range nc.SelectedVnic {
+				if nc.CandidateVnic[ix].Key != selectedVnicKey {
+					continue
+				}
+				ip := net.ParseIP(nc.CandidateVnic[ix].Spec.Ip.IpAddress)
+				if ip != nil {
+					ips = append(ips, ip)
+				}
 			}
 		}
 	}
-
 	return ips, nil
 }
 

--- a/object/host_system_test.go
+++ b/object/host_system_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object_test
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+)
+
+func TestHostSystemManagementIPs(t *testing.T) {
+	m := simulator.ESX()
+	m.Run(func(ctx context.Context, c *vim25.Client) error {
+		finder := find.NewFinder(c, false)
+		dc, err := finder.DefaultDatacenter(ctx)
+		if err != nil {
+			log.Fatalf("Failed to get default DC")
+		}
+		finder.SetDatacenter(dc)
+
+		host, err := finder.DefaultHostSystem(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ips, err := host.ManagementIPs(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ips) != 1 {
+			t.Fatalf("no mgmt ip found")
+		}
+		if ips[0].String() != "127.0.0.1" {
+			t.Fatalf("Expected management ip %s, got %s", "127.0.0.1", ips[0].String())
+		}
+		return nil
+	})
+}

--- a/simulator/esx/host_config_info.go
+++ b/simulator/esx/host_config_info.go
@@ -545,6 +545,30 @@ var HostConfigInfo = types.HostConfigInfo{
 				MultiSelectAllowed: true,
 				CandidateVnic: []types.HostVirtualNic{
 					{
+						Device:    "vmk1",
+						Key:       "management.key-vim.host.VirtualNic-vmk1",
+						Portgroup: "",
+						Spec: types.HostVirtualNicSpec{
+							Ip: &types.HostIpConfig{
+								Dhcp:       true,
+								IpAddress:  "192.168.0.1",
+								SubnetMask: "255.0.0.0",
+								IpV6Config: (*types.HostIpConfigIpV6AddressConfiguration)(nil),
+							},
+							Mac:                    "00:0c:29:81:d8:00",
+							DistributedVirtualPort: (*types.DistributedVirtualSwitchPortConnection)(nil),
+							Portgroup:              "Management Network",
+							Mtu:                    1500,
+							TsoEnabled:             types.NewBool(true),
+							NetStackInstanceKey:    "defaultTcpipStack",
+							OpaqueNetwork:          (*types.HostVirtualNicOpaqueNetworkSpec)(nil),
+							ExternalId:             "",
+							PinnedPnic:             "",
+							IpRouteSpec:            (*types.HostVirtualNicIpRouteSpec)(nil),
+						},
+						Port: "",
+					},
+					{
 						Device:    "vmk0",
 						Key:       "management.key-vim.host.VirtualNic-vmk0",
 						Portgroup: "Management Network",


### PR DESCRIPTION
Currently hostsystem ManagementIPs chooses 1st CandidateVnic in
hosts Config.VirtualNicManagerInfo.NetConfig property as the mgmt ip.
This is not correct. This changes switches to using  SelectedVnic
property for a management nicType instead.

Testing Done: Added a unittest.
Used govc to upload file to datastore and verified that IP chosen
was based on SelectedVnic property.