### PR TITLE
govc: avoid env for -cluster placement flag

### DIFF
--- a/govc/flags/cluster.go
+++ b/govc/flags/cluster.go
@@ -64,6 +64,16 @@ func (f *ClusterFlag) Register(ctx context.Context, fs *flag.FlagSet) {
 	})
 }
 
+// RegisterPlacement registers the -cluster flag without using GOVC_CLUSTER env as the default value,
+// usage is specific to VM placement.
+func (f *ClusterFlag) RegisterPlacement(ctx context.Context, fs *flag.FlagSet) {
+	f.RegisterOnce(func() {
+		f.DatacenterFlag.Register(ctx, fs)
+
+		fs.StringVar(&f.Name, "cluster", "", "Use cluster for VM placement via DRS")
+	})
+}
+
 func (f *ClusterFlag) Process(ctx context.Context) error {
 	return f.ProcessOnce(func() error {
 		if err := f.DatacenterFlag.Process(ctx); err != nil {

--- a/govc/vm/clone.go
+++ b/govc/vm/clone.go
@@ -74,7 +74,7 @@ func (cmd *clone) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.ClientFlag.Register(ctx, f)
 
 	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
-	cmd.ClusterFlag.Register(ctx, f)
+	cmd.ClusterFlag.RegisterPlacement(ctx, f)
 
 	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
 	cmd.DatacenterFlag.Register(ctx, f)

--- a/govc/vm/create.go
+++ b/govc/vm/create.go
@@ -95,7 +95,7 @@ func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.ClientFlag.Register(ctx, f)
 
 	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
-	cmd.ClusterFlag.Register(ctx, f)
+	cmd.ClusterFlag.RegisterPlacement(ctx, f)
 
 	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
 	cmd.DatacenterFlag.Register(ctx, f)


### PR DESCRIPTION
PR #1589 added the '-cluster' flag to vm.clone and vm.create commands.
However, the GOVC_CLUSTER env var should not be used as a default.

Fixes #1712