### PR TITLE
Pass vm.Config.Uuid into the "VM" container via an env var

### DIFF
--- a/simulator/container.go
+++ b/simulator/container.go
@@ -132,6 +132,7 @@ func (c *container) start(vm *VirtualMachine) {
 	}
 
 	run := append([]string{"docker", "run", "-d", "--name", vm.Name}, env...)
+	run = append(run, "--env", "VMX_CONFIG_UUID="+vm.Config.Uuid)
 	args = append(run, args...)
 	cmd := exec.Command(shell, "-c", strings.Join(args, " "))
 	out, err := cmd.Output()


### PR DESCRIPTION
E.g. for passing it through to a Kubernetes cloud-provider.
The var is VMX_CONFIG_UUID.