### PR TITLE
Move to cs.identity service type for sts endpoint

### DIFF
--- a/govc/emacs/govc.el
+++ b/govc/emacs/govc.el
@@ -449,7 +449,7 @@ Also fixes the case where user contains an '@'."
           (progn (setf (url-host url) (govc-table-column-value "IP address"))
                  (setf (url-target url) (govc-table-column-value "Name"))
                  ;; default url-user to Administrator@$domain when connecting to a vCenter VM
-                 (let ((sts (ignore-errors (govc "sso.service.ls" "-t" "sso:sts" "-U" "-u" (url-host url)))))
+                 (let ((sts (ignore-errors (govc "sso.service.ls" "-t" "cs.identity" "-P" "wsTrust" "-U" "-u" (url-host url)))))
                    (if sts (setf (url-user url) (concat "Administrator@" (file-name-nondirectory (car sts))))))))
         (setf (url-filename url) "") ; erase query string
         (if (string-empty-p (url-user url))

--- a/govc/sso/service/ls.go
+++ b/govc/sso/service/ls.go
@@ -69,9 +69,9 @@ func (cmd *ls) Description() string {
 Examples:
   govc sso.service.ls
   govc sso.service.ls -t vcenterserver -P vmomi
-  govc sso.service.ls -t sso:sts
-  govc sso.service.ls -t sso:sts -U
-  govc sso.service.ls -t sso:sts -json | jq -r .[].ServiceEndpoints[].Url`
+  govc sso.service.ls -t cs.identity
+  govc sso.service.ls -t cs.identity -P wsTrust -U
+  govc sso.service.ls -t cs.identity -json | jq -r .[].ServiceEndpoints[].Url`
 }
 
 func (cmd *ls) Process(ctx context.Context) error {

--- a/govc/test/sso.bats
+++ b/govc/test/sso.bats
@@ -24,12 +24,12 @@ load test_helper
 
   [ -z "$(govc sso.service.ls -t enoent)" ]
 
-  run govc sso.service.ls -t sso:sts -U
+  run govc sso.service.ls -t cs.identity -U
   assert_success "$sts"
 
-  govc sso.service.ls -t sso:sts | grep com.vmware.cis | grep -v https:
-  govc sso.service.ls -t sso:sts -l | grep https:
-  govc sso.service.ls -p com.vmware.cis -t sso:sts -P wsTrust -T com.vmware.cis.cs.identity.sso -l | grep wsTrust
+  govc sso.service.ls -t cs.identity | grep com.vmware.cis | grep -v https:
+  govc sso.service.ls -t cs.identity -l | grep https:
+  govc sso.service.ls -p com.vmware.cis -t cs.identity -P wsTrust -T com.vmware.cis.cs.identity.sso -l | grep wsTrust
   govc sso.service.ls -P vmomi | grep vcenterserver | grep -v https:
   govc sso.service.ls -P vmomi -l | grep https:
 }

--- a/lookup/simulator/registration_info.go
+++ b/lookup/simulator/registration_info.go
@@ -72,7 +72,7 @@ func registrationInfo() []types.LookupServiceRegistrationInfo {
 				OwnerId: admin,
 				ServiceType: types.LookupServiceRegistrationServiceType{
 					Product: "com.vmware.cis",
-					Type:    "sso:sts",
+					Type:    "cs.identity",
 				},
 			},
 			ServiceId: siteID + ":" + uuid.New().String(),

--- a/lookup/simulator/simulator_test.go
+++ b/lookup/simulator/simulator_test.go
@@ -82,7 +82,7 @@ func TestClient(t *testing.T) {
 		},
 		&types.LookupServiceRegistrationFilter{
 			ServiceType: &types.LookupServiceRegistrationServiceType{
-				Type: "sso:sts",
+				Type: "cs.identity",
 			},
 		},
 		&types.LookupServiceRegistrationFilter{

--- a/sts/client.go
+++ b/sts/client.go
@@ -48,7 +48,7 @@ func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
 	filter := &types.LookupServiceRegistrationFilter{
 		ServiceType: &types.LookupServiceRegistrationServiceType{
 			Product: "com.vmware.cis",
-			Type:    "sso:sts",
+			Type:    "cs.identity",
 		},
 		EndpointType: &types.LookupServiceRegistrationEndpointType{
 			Protocol: "wsTrust",


### PR DESCRIPTION
The "sso:sts" service type is obsolete, update to "cs.identity".