### PR TITLE
govc: default to simple esxcli format when hints fields is empty

### DIFF
--- a/govc/host/esxcli/esxcli.go
+++ b/govc/host/esxcli/esxcli.go
@@ -142,7 +142,10 @@ func (cmd *esxcli) formatSimple(w io.Writer, res *Response) {
 
 func (cmd *esxcli) formatTable(w io.Writer, res *Response) {
 	fields := res.Info.Hints.Fields()
-
+	if len(fields) == 0 {
+		cmd.formatSimple(w, res)
+		return
+	}
 	tw := tabwriter.NewWriter(w, len(fields), 0, 2, ' ', 0)
 
 	var hr []string


### PR DESCRIPTION
Fixes #1739