### PR TITLE
vcsim: automatically set Context.Caller

### DIFF
--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -466,8 +466,6 @@ func (c *registerVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 }
 
 func (f *Folder) RegisterVMTask(ctx *Context, c *types.RegisterVM_Task) soap.HasFault {
-	ctx.Caller = &f.Self
-
 	return &methods.RegisterVM_TaskBody{
 		Res: &types.RegisterVM_TaskResponse{
 			Returnval: NewTask(&registerVM{f, ctx, c}).Run(),

--- a/simulator/object.go
+++ b/simulator/object.go
@@ -24,7 +24,6 @@ import (
 )
 
 func SetCustomValue(ctx *Context, req *types.SetCustomValue) soap.HasFault {
-	ctx.Caller = &req.This
 	body := &methods.SetCustomValueBody{}
 
 	cfm := Map.CustomFieldsManager()

--- a/simulator/resource_pool.go
+++ b/simulator/resource_pool.go
@@ -204,7 +204,6 @@ func (p *ResourcePool) ImportVApp(ctx *Context, req *types.ImportVApp) soap.HasF
 		folder = ctx.Map.Get(*req.Folder).(*Folder)
 	}
 
-	ctx.Caller = &p.Self
 	res := folder.CreateVMTask(ctx, &types.CreateVM_Task{
 		This:   folder.Self,
 		Config: spec.ConfigSpec,
@@ -331,7 +330,6 @@ func (p *ResourcePool) CreateVApp(req *types.CreateVApp) soap.HasFault {
 }
 
 func (a *VirtualApp) CreateChildVMTask(ctx *Context, req *types.CreateChildVM_Task) soap.HasFault {
-	ctx.Caller = &a.Self
 	body := &methods.CreateChildVM_TaskBody{}
 
 	folder := Map.Get(*a.ParentFolder).(*Folder)

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -128,6 +128,7 @@ func Fault(msg string, fault types.BaseMethodFault) *soap.Fault {
 func (s *Service) call(ctx *Context, method *Method) soap.HasFault {
 	handler := ctx.Map.Get(method.This)
 	session := ctx.Session
+	ctx.Caller = &method.This
 
 	if session == nil {
 		switch method.Name {

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1459,7 +1459,6 @@ func (vm *VirtualMachine) UnregisterVM(ctx *Context, c *types.UnregisterVM) soap
 }
 
 func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soap.HasFault {
-	ctx.Caller = &vm.Self
 	folder := Map.Get(req.Folder).(*Folder)
 	host := Map.Get(*vm.Runtime.Host).(*HostSystem)
 	event := vm.event()


### PR DESCRIPTION
The Context.Caller field avoids deadlocks when using Registry.WithLock,
it should always be set to the current method invocation's "This" reference.