### PR TITLE
Move to cs.identity service type for sso admin endpoint

### DIFF
--- a/ssoadmin/client.go
+++ b/ssoadmin/client.go
@@ -65,7 +65,7 @@ func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
 	filter := &ltypes.LookupServiceRegistrationFilter{
 		ServiceType: &ltypes.LookupServiceRegistrationServiceType{
 			Product: "com.vmware.cis",
-			Type:    "sso:admin",
+			Type:    "cs.identity",
 		},
 		EndpointType: &ltypes.LookupServiceRegistrationEndpointType{
 			Protocol: "vmomi",


### PR DESCRIPTION
The "sso:admin" service type is obsolete, update to "cs.identity".