### PR TITLE
VSLM: fixed the missing param in the QueryChangedDiskArea API impl

### DIFF
--- a/vslm/global_object_manager.go
+++ b/vslm/global_object_manager.go
@@ -537,6 +537,7 @@ func (this *GlobalObjectManager) QueryChangedDiskAreas(ctx context.Context, id v
 		Id:          id,
 		SnapshotId:  snapshotId,
 		StartOffset: startOffset,
+		ChangeId:    changeId,
 	}
 
 	res, err := methods.VslmQueryChangedDiskAreas(ctx, this.c, &req)


### PR DESCRIPTION
The param `changeId` is missing in constructing the VslmQueryChangedDiskAreas struct in the implementation of QueryChangedDiskArea Go API. Fixed it in this PR.