### PR TITLE
Fix 502 on WaitForIP with retry

### DIFF
--- a/property/collector.go
+++ b/property/collector.go
@@ -47,6 +47,12 @@ func DefaultCollector(c *vim25.Client) *Collector {
 	return &p
 }
 
+// SetRoundTripper returns a Collector with a custom RountTripper
+func (p Collector) SetRoundTripper(r soap.RoundTripper) *Collector {
+	p.roundTripper = r
+	return &p
+}
+
 func (p Collector) Reference() types.ManagedObjectReference {
 	return p.reference
 }


### PR DESCRIPTION
Implement a simple retry on WaitForIP, as I always get "502 Proxy error" on the first try on vSphere 6.5.

Here the requests from my error :
```
==> centos-8.0-x86_64-server: Waiting for IP...
2019/12/18 10:10:13 REQ: <Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/"><Body><CreateFilter xmlns="urn:vim25"><_this type="PropertyCollector">session[527c8b84-b5ac-4877-30f9-afb55b975aaf]52f587bd-a995-089a-92b0-f5cc137d58cb</_this><spec><propSet><type>VirtualMachine</type><pathSet>guest.ipAddress</pathSet></propSet><objectSet><obj type="VirtualMachine">vm-144</obj></objectSet></spec><partialUpdates>false</partialUpdates></CreateFilter></Body></Envelope>
2019/12/18 10:10:13 RES: 200
2019/12/18 10:10:13 REQ: <Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/"><Body><WaitForUpdatesEx xmlns="urn:vim25"><_this type="PropertyCollector">session[527c8b84-b5ac-4877-30f9-afb55b975aaf]52f587bd-a995-089a-92b0-f5cc137d58cb</_this></WaitForUpdatesEx></Body></Envelope>
2019/12/18 10:10:13 RES: 200
2019/12/18 10:10:13 REQ: <Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/"><Body><WaitForUpdatesEx xmlns="urn:vim25"><_this type="PropertyCollector">session[527c8b84-b5ac-4877-30f9-afb55b975aaf]52f587bd-a995-089a-92b0-f5cc137d58cb</_this><version>1</version></WaitForUpdatesEx></Body></Envelope>
2019/12/18 10:15:13 RES: 502
2019/12/18 10:15:13 REQ: <Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/"><Body><DestroyPropertyCollector xmlns="urn:vim25"><_this type="PropertyCollector">session[527c8b84-b5ac-4877-30f9-afb55b975aaf]52f587bd-a995-089a-92b0-f5cc137d58cb</_this></DestroyPropertyCollector></Body></Envelope>
2019/12/18 10:15:13 RES: 200
2019/12/18 10:15:16 REQ: <Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/"><Body><CreatePropertyCollector xmlns="urn:vim25"><_this type="PropertyCollector">propertyCollector</_this></CreatePropertyCollector></Body></Envelope>
2019/12/18 10:15:16 RES: 200
2019/12/18 10:15:16 REQ: <Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/"><Body><CreateFilter xmlns="urn:vim25"><_this type="PropertyCollector">session[527c8b84-b5ac-4877-30f9-afb55b975aaf]52520ddd-6ddc-7ef2-6130-3fc2cba4446b</_this><spec><propSet><type>VirtualMachine</type><pathSet>guest.ipAddress</pathSet></propSet><objectSet><obj type="VirtualMachine">vm-144</obj></objectSet></spec><partialUpdates>false</partialUpdates></CreateFilter></Body></Envelope>
2019/12/18 10:15:16 RES: 200
```

I think it's related to that issue : https://github.com/jetbrains-infra/packer-builder-vsphere/issues/211
That Packer plugin is using govmomi.

The retry is a simple, on error try 3 time max, with 3 seconds sleep each time.