### PR TITLE
Add OVF properties to library deploy

### DIFF
--- a/govc/library/deploy.go
+++ b/govc/library/deploy.go
@@ -167,7 +167,7 @@ func (cmd *deploy) Run(ctx context.Context, f *flag.FlagSet) error {
 		var properties []vcenter.Property
 		for _, prop := range cmd.Options.PropertyMapping {
 			properties = append(properties, vcenter.Property{
-				ID: prop.Key,
+				ID:    prop.Key,
 				Value: prop.Value,
 			})
 		}

--- a/govc/library/deploy.go
+++ b/govc/library/deploy.go
@@ -164,6 +164,14 @@ func (cmd *deploy) Run(ctx context.Context, f *flag.FlagSet) error {
 			})
 		}
 
+		var properties []vcenter.Property
+		for _, prop := range cmd.Options.PropertyMapping {
+			properties = append(properties, vcenter.Property{
+				ID: prop.Key,
+				Value: prop.Value,
+			})
+		}
+
 		dsID := ""
 		if ds != nil {
 			dsID = ds.Reference().Value
@@ -186,6 +194,12 @@ func (cmd *deploy) Run(ctx context.Context, f *flag.FlagSet) error {
 							Class:       vcenter.ClassOvfParams,
 							Type:        vcenter.TypeDeploymentOptionParams,
 							SelectedKey: cmd.Options.Deployment,
+						},
+						{
+							Class:       vcenter.ClassPropertyParams,
+							Type:        vcenter.TypePropertyParams,
+							SelectedKey: cmd.Options.Deployment,
+							Properties:  properties,
 						},
 					},
 					NetworkMappings:     networks,

--- a/vapi/vcenter/vcenter_ovf.go
+++ b/vapi/vcenter/vcenter_ovf.go
@@ -61,6 +61,7 @@ type AdditionalParams struct {
 
 const (
 	ClassOvfParams             = "com.vmware.vcenter.ovf.ovf_params"
+	ClassPropertyParams        = "com.vmware.vcenter.ovf.property_params"
 	TypeDeploymentOptionParams = "DeploymentOptionParams"
 	TypeExtraConfigParams      = "ExtraConfigParams"
 	TypeExtraConfigs           = "ExtraConfigs"


### PR DESCRIPTION
This addresses issue #1718 so you can deploy an OVA from the content library _and_ specify properties typically required to deploy an OVA.

We're using this to deploy nsx-unified-appliance-2.5.0.0.0.14663978 from our local content library.