### PR TITLE
Added the missing RetrieveSnapshotDetails API in VSLM

### DIFF
--- a/vslm/global_object_manager.go
+++ b/vslm/global_object_manager.go
@@ -530,6 +530,22 @@ func (this *GlobalObjectManager) Revert(ctx context.Context, id vim.ID, snapshot
 	return NewTask(this.c, res.Returnval), nil
 }
 
+func(this *GlobalObjectManager) RetrieveSnapshotDetails(ctx context.Context, id vim.ID, snapshotId vim.ID) (
+	*vim.VStorageObjectSnapshotDetails, error) {
+	req := types.VslmRetrieveSnapshotDetails{
+		This:        this.Reference(),
+		Id:          id,
+		SnapshotId:  snapshotId,
+	}
+
+	res, err := methods.VslmRetrieveSnapshotDetails(ctx, this.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}
+
 func (this *GlobalObjectManager) QueryChangedDiskAreas(ctx context.Context, id vim.ID, snapshotId vim.ID, startOffset int64,
 	changeId string) (*vim.DiskChangeInfo, error) {
 	req := types.VslmQueryChangedDiskAreas{

--- a/vslm/global_object_manager.go
+++ b/vslm/global_object_manager.go
@@ -530,12 +530,12 @@ func (this *GlobalObjectManager) Revert(ctx context.Context, id vim.ID, snapshot
 	return NewTask(this.c, res.Returnval), nil
 }
 
-func(this *GlobalObjectManager) RetrieveSnapshotDetails(ctx context.Context, id vim.ID, snapshotId vim.ID) (
+func (this *GlobalObjectManager) RetrieveSnapshotDetails(ctx context.Context, id vim.ID, snapshotId vim.ID) (
 	*vim.VStorageObjectSnapshotDetails, error) {
 	req := types.VslmRetrieveSnapshotDetails{
-		This:        this.Reference(),
-		Id:          id,
-		SnapshotId:  snapshotId,
+		This:       this.Reference(),
+		Id:         id,
+		SnapshotId: snapshotId,
 	}
 
 	res, err := methods.VslmRetrieveSnapshotDetails(ctx, this.c, &req)


### PR DESCRIPTION
The RetrieveSnapshotDetails API is necessary for the incremental backup of FCD or CNS block volume. Somehow, the API is not added initially.