### PR TITLE
govc: add optional library.info details

### DIFF
--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -136,6 +136,16 @@ load test_helper
   run govc library.import -n ttylinux-live /my-content "$GOVC_IMAGES/$TTYLINUX_NAME.iso"
   assert_success
 
+  run govc library.info -l "/my-content/ttylinux-live/$TTYLINUX_NAME.iso"
+  assert_success
+
+  run govc library.info -L /my-content/ttylinux-live/
+  assert_success
+  assert_matches contentlib-
+  file="$output"
+  run govc datastore.ls "$file"
+  assert_matches "$TTYLINUX_NAME.iso"
+
   run govc library.ls "/my-content/ttylinux-live/*"
   assert_success
   assert_matches "$TTYLINUX_NAME.iso"


### PR DESCRIPTION
- The -l flag outputs Size and Item count for Libraries

- The -l flag outputs 'Datastore Path'

- The -L flag outputs only the Datastore Path
  Example use: Content Library iso file as VM cdrom backing

Fixes #1697