### PR TITLE
Add Content Library synchronization support

### DIFF
--- a/govc/library/sync.go
+++ b/govc/library/sync.go
@@ -1,0 +1,175 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/library/finder"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/vcenter"
+)
+
+type sync struct {
+	*flags.FolderFlag
+	*flags.ResourcePoolFlag
+
+	vmtx string
+}
+
+func init() {
+	cli.Register("library.sync", &sync{})
+}
+
+func (cmd *sync) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.vmtx, "vmtx", "", "Sync subscribed library to local library as VM Templates")
+}
+
+func (cmd *sync) Process(ctx context.Context) error {
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.ResourcePoolFlag.Process(ctx)
+}
+
+func (cmd *sync) Description() string {
+	return `Sync library NAME or ITEM.
+
+Examples:
+  govc library.sync subscribed-library
+  govc library.sync subscribed-library/item
+  govc library.sync -vmtx local-library subscribed-library # convert subscribed OVFs to local VMTX`
+}
+
+func (cmd *sync) Usage() string {
+	return "NAME|ITEM"
+}
+
+func (cmd *sync) syncVMTX(ctx context.Context, m *library.Manager, src library.Library, dst library.Library, items ...library.Item) error {
+	if cmd.vmtx == "" {
+		return nil
+	}
+
+	pool, err := cmd.ResourcePool()
+	if err != nil {
+		return err
+	}
+
+	folder, err := cmd.Folder()
+	if err != nil {
+		return err
+	}
+
+	l := vcenter.TemplateLibrary{
+		Source:      src,
+		Destination: dst,
+		Placement: vcenter.Target{
+			FolderID:       folder.Reference().Value,
+			ResourcePoolID: pool.Reference().Value,
+		},
+		Include: func(item library.Item, current *library.Item) bool {
+			fmt.Printf("Syncing /%s/%s to /%s/%s...", src.Name, item.Name, dst.Name, item.Name)
+			if current == nil {
+				fmt.Println()
+				return true
+			}
+			fmt.Println("already exists.")
+			return false
+		},
+	}
+
+	return vcenter.NewManager(m.Client).SyncTemplateLibrary(ctx, l, items...)
+}
+
+func (cmd *sync) shouldSync(l library.Library) bool {
+	if cmd.vmtx == "" {
+		return true
+
+	}
+	// Allow library.sync -vmtx of LOCAL or SUBSCRIBED library
+	return l.Type == "SUBSCRIBED"
+}
+
+func (cmd *sync) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+	path := f.Arg(0)
+
+	return cmd.FolderFlag.WithRestClient(ctx, func(c *rest.Client) error {
+		m := library.NewManager(c)
+		finder := finder.NewFinder(m)
+
+		var local library.Library
+		if cmd.vmtx != "" {
+			res, err := finder.Find(ctx, cmd.vmtx)
+			if err != nil {
+				return err
+			}
+			if len(res) != 1 {
+				return ErrMultiMatch{Type: "library", Key: "name", Val: cmd.vmtx, Count: len(res)}
+			}
+			l, ok := res[0].GetResult().(library.Library)
+			if !ok {
+				return fmt.Errorf("%q is a %T", res[0].GetPath(), l)
+			}
+			local = l
+		}
+
+		res, err := finder.Find(ctx, path)
+		if err != nil {
+			return err
+		}
+
+		if len(res) != 1 {
+			return ErrMultiMatch{Type: "library", Key: "name", Val: path, Count: len(res)}
+		}
+
+		fmt.Printf("Syncing %s...\n", res[0].GetPath())
+
+		switch t := res[0].GetResult().(type) {
+		case library.Library:
+			if cmd.shouldSync(t) {
+				if err = m.SyncLibrary(ctx, &t); err != nil {
+					return err
+				}
+			}
+			return cmd.syncVMTX(ctx, m, t, local)
+		case library.Item:
+			lib := res[0].GetParent().GetResult().(library.Library)
+			if cmd.shouldSync(lib) {
+				if err = m.SyncLibraryItem(ctx, &t, false); err != nil {
+					return err
+				}
+			}
+			return cmd.syncVMTX(ctx, m, lib, local, t)
+		default:
+			return fmt.Errorf("%q is a %T", res[0].GetPath(), t)
+		}
+	})
+}

--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -293,6 +293,18 @@ EOF
   assert_success
   assert_matches "Subscription:"
   assert_matches "$url"
+
+  run govc library.import my-content "$GOVC_IMAGES/ttylinux-latest.ova"
+  assert_success # TODO: this should fail, but allow until vcsim supports publishing
+
+  run govc library.sync my-content
+  assert_success
+
+  run govc library.create my-content-vmtx
+  assert_success
+
+  run govc library.sync -vmtx my-content-vmtx my-content
+  assert_success
 }
 
 @test "library.findbyid" {

--- a/vapi/internal/internal.go
+++ b/vapi/internal/internal.go
@@ -37,8 +37,10 @@ const (
 	LibraryItemDownloadSessionFile = "/com/vmware/content/library/item/downloadsession/file"
 	LocalLibraryPath               = "/com/vmware/content/local-library"
 	SubscribedLibraryPath          = "/com/vmware/content/subscribed-library"
+	SubscribedLibraryItem          = "/com/vmware/content/library/subscribed-item"
 	VCenterOVFLibraryItem          = "/com/vmware/vcenter/ovf/library-item"
 	VCenterVMTXLibraryItem         = "/vcenter/vm-template/library-items"
+	VCenterVM                      = "/vcenter/vm"
 	SessionCookieName              = "vmware-api-session-id"
 )
 

--- a/vapi/library/library.go
+++ b/vapi/library/library.go
@@ -40,6 +40,7 @@ type Library struct {
 	Description      string            `json:"description,omitempty"`
 	ID               string            `json:"id,omitempty"`
 	LastModifiedTime *time.Time        `json:"last_modified_time,omitempty"`
+	LastSyncTime     *time.Time        `json:"last_sync_time,omitempty"`
 	Name             string            `json:"name,omitempty"`
 	Storage          []StorageBackings `json:"storage_backings,omitempty"`
 	Type             string            `json:"type,omitempty"`
@@ -136,6 +137,13 @@ func (c *Manager) CreateLibrary(ctx context.Context, library Library) (string, e
 	url := c.Resource(path)
 	var res string
 	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// SyncLibrary syncs a subscribed library.
+func (c *Manager) SyncLibrary(ctx context.Context, library *Library) error {
+	path := internal.SubscribedLibraryPath
+	url := c.Resource(path).WithID(library.ID).WithAction("sync")
+	return c.Do(ctx, url.Request(http.MethodPost), nil)
 }
 
 // DeleteLibrary deletes an existing library.

--- a/vapi/library/library_item.go
+++ b/vapi/library/library_item.go
@@ -88,6 +88,15 @@ func (c *Manager) CreateLibraryItem(ctx context.Context, item Item) (string, err
 	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
 }
 
+// SyncLibraryItem syncs a subscribed library item
+func (c *Manager) SyncLibraryItem(ctx context.Context, item *Item, force bool) error {
+	body := struct {
+		Force bool `json:"force_sync_content"`
+	}{force}
+	url := c.Resource(internal.SubscribedLibraryItem).WithID(item.ID).WithAction("sync")
+	return c.Do(ctx, url.Request(http.MethodPost, body), nil)
+}
+
 // DeleteLibraryItem deletes an existing library item.
 func (c *Manager) DeleteLibraryItem(ctx context.Context, item *Item) error {
 	url := c.Resource(internal.LibraryItemPath).WithID(item.ID)


### PR DESCRIPTION
- vAPI: add sync client APIs

- vAPI: add helpers to sync subscribed library OVF items to local library VMTX items

- vcsim: support sync APIs

- govc: add library.sync command