### PR TITLE
govc: guest.run improvements

### DIFF
--- a/govc/cli/command.go
+++ b/govc/cli/command.go
@@ -179,7 +179,12 @@ error:
 		}
 		commandHelp(hw, args[0], cmd, fs)
 	} else {
-		fmt.Fprintf(os.Stderr, "%s: %s\n", os.Args[0], err)
+		if x, ok := err.(interface{ ExitCode() int }); ok {
+			// propagate exit code, e.g. from guest.run
+			rc = x.ExitCode()
+		} else {
+			fmt.Fprintf(os.Stderr, "%s: %s\n", os.Args[0], err)
+		}
 	}
 
 	_ = clientLogout(ctx, cmd)

--- a/govc/vm/guest/guest.go
+++ b/govc/vm/guest/guest.go
@@ -26,6 +26,8 @@ import (
 	"github.com/vmware/govmomi/guest"
 	"github.com/vmware/govmomi/guest/toolbox"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 type GuestFlag struct {
@@ -73,10 +75,26 @@ func (flag *GuestFlag) Toolbox() (*toolbox.Client, error) {
 		return nil, err
 	}
 
+	vm, err := flag.VirtualMachine()
+	if err != nil {
+		return nil, err
+	}
+
+	family := ""
+	var props mo.VirtualMachine
+	err = vm.Properties(context.Background(), vm.Reference(), []string{"guest.guestFamily"}, &props)
+	if err != nil {
+		return nil, err
+	}
+	if props.Guest != nil {
+		family = props.Guest.GuestFamily
+	}
+
 	return &toolbox.Client{
 		ProcessManager: pm,
 		FileManager:    fm,
 		Authentication: flag.Auth(),
+		GuestFamily:    types.VirtualMachineGuestOsFamily(family),
 	}, nil
 }
 

--- a/govc/vm/guest/run.go
+++ b/govc/vm/guest/run.go
@@ -110,6 +110,9 @@ func (cmd *run) do(c *http.Client, req *http.Request) error {
 }
 
 func (cmd *run) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
 	name := f.Arg(0)
 
 	tc, err := cmd.Toolbox()

--- a/govc/vm/guest/run.go
+++ b/govc/vm/guest/run.go
@@ -20,12 +20,8 @@ import (
 	"bytes"
 	"context"
 	"flag"
-	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/vmware/govmomi/govc/cli"
 )
@@ -33,11 +29,9 @@ import (
 type run struct {
 	*GuestFlag
 
-	data    string
-	verbose bool
-	toolbox bool
-	dir     string
-	vars    env
+	data string
+	dir  string
+	vars env
 }
 
 func init() {
@@ -48,18 +42,9 @@ func (cmd *run) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.GuestFlag, ctx = newGuestFlag(ctx)
 	cmd.GuestFlag.Register(ctx, f)
 
-	f.StringVar(&cmd.data, "d", "", "Input data")
-	f.BoolVar(&cmd.verbose, "v", false, "Verbose")
-	f.BoolVar(&cmd.toolbox, "T", false, "Use govmomi/toolbox process I/O")
+	f.StringVar(&cmd.data, "d", "", "Input data string. A value of '-' reads from OS stdin")
 	f.StringVar(&cmd.dir, "C", "", "The absolute path of the working directory for the program to start")
-	f.Var(&cmd.vars, "e", "Set environment variable or HTTP header")
-}
-
-func (cmd *run) Process(ctx context.Context) error {
-	if err := cmd.GuestFlag.Process(ctx); err != nil {
-		return err
-	}
-	return nil
+	f.Var(&cmd.vars, "e", "Set environment variables")
 }
 
 func (cmd *run) Usage() string {
@@ -69,44 +54,17 @@ func (cmd *run) Usage() string {
 func (cmd *run) Description() string {
 	return `Run program PATH in VM and display output.
 
-If the program PATH is an HTTP verb, the toolbox's http.RoundTripper will be used as the HTTP transport.
-HTTP commands depend on govmomi/toolbox running in the VM guest and do not work with standard VMware tools.
+The guest.run command starts a program in the VM with i/o redirected, waits for the process to exit and
+propagates the exit code to the govc process exit code.  Note that stdout and stderr are redirected by default,
+stdin is only redirected when the '-d' flag is specified.
 
 Examples:
-  govc guest.run -vm $name /usr/bin/kubectl get pods
-  govc guest.run -vm $name -d - /usr/bin/kubectl create -f - <svc.json
-  govc guest.run -vm $name /usr/bin/kubectl delete pod,service my-service
-  govc guest.run -vm $name GET http://localhost:8080/api/v1/nodes
-  govc guest.run -vm $name -e Content-Type:application/json -d - POST http://localhost:8080/api/v1/namespaces/default/pods <svc.json
-  govc guest.run -vm $name DELETE http://localhost:8080/api/v1/namespaces/default/services/my-service`
-}
-
-func (cmd *run) do(c *http.Client, req *http.Request) error {
-	for _, v := range cmd.vars {
-		h := strings.SplitN(v, ":", 2)
-		if len(h) != 2 {
-			return fmt.Errorf("invalid header: %q", v)
-		}
-
-		req.Header.Set(strings.TrimSpace(h[0]), strings.TrimSpace(h[1]))
-	}
-
-	res, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if cmd.verbose {
-		return res.Write(cmd.Out)
-	}
-
-	_, err = io.Copy(cmd.Out, res.Body)
-	if err != nil {
-		return err
-	}
-
-	err = res.Body.Close()
-	return err
+  govc guest.run -vm $name ifconfig
+  govc guest.run -vm $name ifconfig eth0
+  cal | govc guest.run -vm $name -d - cat
+  govc guest.run -vm $name -d "hello $USER" cat
+  govc guest.run -vm $name curl -s :invalid: || echo $? # exit code 6
+  govc guest.run -vm $name -e FOO=bar -e BIZ=baz -C /tmp env`
 }
 
 func (cmd *run) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -115,51 +73,27 @@ func (cmd *run) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 	name := f.Arg(0)
 
-	tc, err := cmd.Toolbox()
+	c, err := cmd.Toolbox()
 	if err != nil {
 		return err
 	}
 
-	hc := &http.Client{
-		Transport: tc,
+	ecmd := &exec.Cmd{
+		Path:   name,
+		Args:   f.Args()[1:],
+		Env:    cmd.vars,
+		Dir:    cmd.dir,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
 	}
 
-	switch name {
-	case "HEAD", "GET", "DELETE":
-		req, err := http.NewRequest(name, f.Arg(1), nil)
-		if err != nil {
-			return err
-		}
-
-		return cmd.do(hc, req)
-	case "POST", "PUT":
-		req, err := http.NewRequest(name, f.Arg(1), os.Stdin)
-		if err != nil {
-			return err
-		}
-
-		return cmd.do(hc, req)
+	switch cmd.data {
+	case "":
+	case "-":
+		ecmd.Stdin = os.Stdin
 	default:
-		ecmd := &exec.Cmd{
-			Path:   name,
-			Args:   f.Args()[1:],
-			Env:    cmd.vars,
-			Dir:    cmd.dir,
-			Stdout: os.Stdout,
-			Stderr: os.Stderr,
-		}
-
-		switch cmd.data {
-		case "":
-		case "-":
-			ecmd.Stdin = os.Stdin
-		default:
-			ecmd.Stdin = bytes.NewBuffer([]byte(cmd.data))
-		}
-
-		if cmd.toolbox {
-			return tc.RunToolbox(ctx, ecmd)
-		}
-		return tc.Run(ctx, ecmd)
+		ecmd.Stdin = bytes.NewBuffer([]byte(cmd.data))
 	}
+
+	return c.Run(ctx, ecmd)
 }

--- a/guest/toolbox/client.go
+++ b/guest/toolbox/client.go
@@ -17,13 +17,11 @@ limitations under the License.
 package toolbox
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"log"
-	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -41,195 +39,6 @@ type Client struct {
 	FileManager    *guest.FileManager
 	Authentication types.BaseGuestAuthentication
 	GuestFamily    types.VirtualMachineGuestOsFamily
-}
-
-// procReader retries InitiateFileTransferFromGuest calls if toolbox is still running the process.
-// See also: ProcessManager.Stat
-func (c *Client) procReader(ctx context.Context, src string) (*types.FileTransferInformation, error) {
-	for {
-		info, err := c.FileManager.InitiateFileTransferFromGuest(ctx, c.Authentication, src)
-		if err != nil {
-			if soap.IsSoapFault(err) {
-				if _, ok := soap.ToSoapFault(err).VimFault().(types.CannotAccessFile); ok {
-					// We're not waiting in between retries since ProcessManager.Stat
-					// has already waited.  In the case that this client was pointed at
-					// standard vmware-tools, the types.NotFound fault would have been
-					// returned since the file "/proc/$pid/stdout" does not exist - in
-					// which case, we won't retry at all.
-					continue
-				}
-			}
-
-			return nil, err
-		}
-
-		return info, err
-	}
-}
-
-// RoundTrip implements http.RoundTripper over vmx guest RPC.
-// This transport depends on govmomi/toolbox running in the VM guest and does not work with standard VMware tools.
-// Using this transport makes it is possible to connect to HTTP endpoints that are bound to the VM's loopback address.
-// Note that the toolbox's http.RoundTripper only supports the "http" scheme, "https" is not supported.
-func (c *Client) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.URL.Scheme != "http" {
-		return nil, fmt.Errorf("%q scheme not supported", req.URL.Scheme)
-	}
-
-	ctx := req.Context()
-
-	req.Header.Set("Connection", "close") // we need the server to close the connection after 1 request
-
-	spec := types.GuestProgramSpec{
-		ProgramPath: "http.RoundTrip",
-		Arguments:   req.URL.Host,
-	}
-
-	pid, err := c.ProcessManager.StartProgram(ctx, c.Authentication, &spec)
-	if err != nil {
-		return nil, err
-	}
-
-	dst := fmt.Sprintf("/proc/%d/stdin", pid)
-	src := fmt.Sprintf("/proc/%d/stdout", pid)
-
-	var buf bytes.Buffer
-	err = req.Write(&buf)
-	if err != nil {
-		return nil, err
-	}
-
-	attr := new(types.GuestPosixFileAttributes)
-	size := int64(buf.Len())
-
-	url, err := c.FileManager.InitiateFileTransferToGuest(ctx, c.Authentication, dst, attr, size, true)
-	if err != nil {
-		return nil, err
-	}
-
-	vc := c.ProcessManager.Client()
-
-	u, err := c.FileManager.TransferURL(ctx, url)
-	if err != nil {
-		return nil, err
-	}
-
-	p := soap.DefaultUpload
-	p.ContentLength = size
-
-	err = vc.Client.Upload(ctx, &buf, u, &p)
-	if err != nil {
-		return nil, err
-	}
-
-	info, err := c.procReader(ctx, src)
-	if err != nil {
-		return nil, err
-	}
-
-	u, err = c.FileManager.TransferURL(ctx, info.Url)
-	if err != nil {
-		return nil, err
-	}
-
-	f, _, err := vc.Client.Download(ctx, u, &soap.DefaultDownload)
-	if err != nil {
-		return nil, err
-	}
-
-	return http.ReadResponse(bufio.NewReader(f), req)
-}
-
-// Run implements exec.Cmd.Run over vmx guest RPC against govmomi/toolbox.
-func (c *Client) RunToolbox(ctx context.Context, cmd *exec.Cmd) error {
-	vc := c.ProcessManager.Client()
-
-	spec := types.GuestProgramSpec{
-		ProgramPath:      cmd.Path,
-		Arguments:        strings.Join(cmd.Args, " "),
-		EnvVariables:     cmd.Env,
-		WorkingDirectory: cmd.Dir,
-	}
-
-	pid, serr := c.ProcessManager.StartProgram(ctx, c.Authentication, &spec)
-	if serr != nil {
-		return serr
-	}
-
-	if cmd.Stdin != nil {
-		dst := fmt.Sprintf("/proc/%d/stdin", pid)
-
-		var buf bytes.Buffer
-		size, err := io.Copy(&buf, cmd.Stdin)
-		if err != nil {
-			return err
-		}
-
-		attr := new(types.GuestPosixFileAttributes)
-
-		url, err := c.FileManager.InitiateFileTransferToGuest(ctx, c.Authentication, dst, attr, size, true)
-		if err != nil {
-			return err
-		}
-
-		u, err := c.FileManager.TransferURL(ctx, url)
-		if err != nil {
-			return err
-		}
-
-		p := soap.DefaultUpload
-		p.ContentLength = size
-
-		err = vc.Client.Upload(ctx, &buf, u, &p)
-		if err != nil {
-			return err
-		}
-	}
-
-	names := []string{"out", "err"}
-
-	for i, w := range []io.Writer{cmd.Stdout, cmd.Stderr} {
-		if w == nil {
-			continue
-		}
-
-		src := fmt.Sprintf("/proc/%d/std%s", pid, names[i])
-
-		info, err := c.procReader(ctx, src)
-		if err != nil {
-			return err
-		}
-
-		u, err := c.FileManager.TransferURL(ctx, info.Url)
-		if err != nil {
-			return err
-		}
-
-		f, _, err := vc.Client.Download(ctx, u, &soap.DefaultDownload)
-		if err != nil {
-			return err
-		}
-
-		_, err = io.Copy(w, f)
-		_ = f.Close()
-		if err != nil {
-			return err
-		}
-	}
-
-	procs, err := c.ProcessManager.ListProcesses(ctx, c.Authentication, []int64{pid})
-	if err != nil {
-		return err
-	}
-
-	if len(procs) == 1 {
-		rc := procs[0].ExitCode
-		if rc != 0 {
-			return fmt.Errorf("%s: exit %d", cmd.Path, rc)
-		}
-	}
-
-	return nil
 }
 
 func (c *Client) rm(ctx context.Context, path string) {
@@ -371,7 +180,7 @@ func (c *Client) Run(ctx context.Context, cmd *exec.Cmd) error {
 			continue
 		}
 
-		info, err := c.procReader(ctx, out.path)
+		info, err := c.FileManager.InitiateFileTransferFromGuest(ctx, c.Authentication, out.path)
 		if err != nil {
 			return err
 		}

--- a/toolbox/toolbox-test.sh
+++ b/toolbox/toolbox-test.sh
@@ -228,12 +228,6 @@ if [ -n "$test" ] ; then
     test -n "$(govc guest.download /proc/$name -)"
   done
 
-  addr=$(govc guest.getenv TOOLBOX_ECHO_SERVER | cut -d= -f2)
-
-  echo "Testing http.RoundTrip via $addr..."
-  govc guest.run GET "$addr/$vm" | grep "$vm"
-  echo "$vm" | govc guest.run -e Content-Type:text/plain -d - POST "$addr" | grep "$vm"
-
   echo "Testing commands with IO..."
   # Note that we don't use a pipe here, as guest.ps transitions the vm to VM_STATE_GUEST_OPERATION,
   # which prevents guest.run from invoking guest operations.  By letting guest.ps complete before


### PR DESCRIPTION
- Propagate exit code to govc's exit code

- Default to cmd.exe /c on Windows (required for i/o redirection)

- Default to /bin/bash -c on Linux (convenience)

- Fix process exit polling

- Remove toolbox specific guest run implementation