### PR TITLE
Clarify System.Read privilege requirement for PortGroup backing

### DIFF
--- a/object/distributed_virtual_portgroup.go
+++ b/object/distributed_virtual_portgroup.go
@@ -50,9 +50,15 @@ func (p DistributedVirtualPortgroup) EthernetCardBackingInfo(ctx context.Context
 		return nil, err
 	}
 
+	// From the docs at https://code.vmware.com/apis/196/vsphere/doc/vim.dvs.DistributedVirtualPortgroup.ConfigInfo.html:
 	// "This property should always be set unless the user's setting does not have System.Read privilege on the object referred to by this property."
+	// Note that "the object" refers to the Switch, not the PortGroup.
 	if dvp.Config.DistributedVirtualSwitch == nil {
-		return nil, fmt.Errorf("no System.Read privilege on: %s.%s", p.Reference(), prop)
+		name := p.InventoryPath
+		if name == "" {
+			name = p.Reference().String()
+		}
+		return nil, fmt.Errorf("failed to create EthernetCardBackingInfo for %s: System.Read privilege required for %s", name, prop)
 	}
 
 	if err := p.Properties(ctx, *dvp.Config.DistributedVirtualSwitch, []string{"uuid"}, &dvs); err != nil {

--- a/object/distributed_virtual_portgroup_test.go
+++ b/object/distributed_virtual_portgroup_test.go
@@ -14,10 +14,37 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package object
+package object_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+)
 
 // DistributedVirtualPortgroup should implement the Reference interface.
-var _ Reference = DistributedVirtualPortgroup{}
+var _ object.Reference = object.DistributedVirtualPortgroup{}
 
 // DistributedVirtualPortgroup should implement the NetworkReference interface.
-var _ NetworkReference = DistributedVirtualPortgroup{}
+var _ object.NetworkReference = object.DistributedVirtualPortgroup{}
+
+func TestDistributedVirtualPortgroupEthernetCardBackingInfo(t *testing.T) {
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		obj := simulator.Map.Any("DistributedVirtualPortgroup").(*simulator.DistributedVirtualPortgroup)
+
+		pg := object.NewDistributedVirtualPortgroup(c, obj.Self)
+		_, err := pg.EthernetCardBackingInfo(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		obj.Config.DistributedVirtualSwitch = nil // expect to fail if switch can't be read
+		_, err = pg.EthernetCardBackingInfo(ctx)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}


### PR DESCRIPTION
The error message sounded like a permission issue with the DVPG itself, rather than the Switch.
Attempt to make the error message more clear, add comments and vcsim based test.

Closes #1517