### PR TITLE
govc: add 5.0 to vm.create hardware version map

### DIFF
--- a/govc/vm/create.go
+++ b/govc/vm/create.go
@@ -35,6 +35,7 @@ import (
 var hardwareVersions = []struct {
 	esx, vmx string
 }{
+	{"5.0", "vmx-8"},
 	{"5.5", "vmx-10"},
 	{"6.0", "vmx-11"},
 	{"6.5", "vmx-13"},


### PR DESCRIPTION
Fixes #1544