### PR TITLE
govc: guest -i flag only applies to ProcessManager

### DIFF
--- a/govc/vm/guest/auth.go
+++ b/govc/vm/guest/auth.go
@@ -28,6 +28,7 @@ import (
 
 type AuthFlag struct {
 	auth types.NamePasswordAuthentication
+	proc bool
 }
 
 func newAuthFlag(ctx context.Context) (*AuthFlag, context.Context) {
@@ -59,7 +60,9 @@ func (flag *AuthFlag) Register(ctx context.Context, f *flag.FlagSet) {
 	}
 	usage := fmt.Sprintf("Guest VM credentials [%s]", env)
 	f.Var(flag, "l", usage)
-	f.BoolVar(&flag.auth.GetGuestAuthentication().InteractiveSession, "i", false, "Interactive session")
+	if flag.proc {
+		f.BoolVar(&flag.auth.GuestAuthentication.InteractiveSession, "i", false, "Interactive session")
+	}
 }
 
 func (flag *AuthFlag) Process(ctx context.Context) error {

--- a/govc/vm/guest/getenv.go
+++ b/govc/vm/guest/getenv.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func (cmd *getenv) Register(ctx context.Context, f *flag.FlagSet) {
-	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag, ctx = newGuestProcessFlag(ctx)
 	cmd.GuestFlag.Register(ctx, f)
 }
 

--- a/govc/vm/guest/guest.go
+++ b/govc/vm/guest/guest.go
@@ -45,6 +45,12 @@ func newGuestFlag(ctx context.Context) (*GuestFlag, context.Context) {
 	return f, ctx
 }
 
+func newGuestProcessFlag(ctx context.Context) (*GuestFlag, context.Context) {
+	f, gctx := newGuestFlag(ctx)
+	f.proc = true
+	return f, gctx
+}
+
 func (flag *GuestFlag) Register(ctx context.Context, f *flag.FlagSet) {
 	flag.ClientFlag.Register(ctx, f)
 	flag.VirtualMachineFlag.Register(ctx, f)

--- a/govc/vm/guest/kill.go
+++ b/govc/vm/guest/kill.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 func (cmd *kill) Register(ctx context.Context, f *flag.FlagSet) {
-	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag, ctx = newGuestProcessFlag(ctx)
 	cmd.GuestFlag.Register(ctx, f)
 
 	f.Var(&cmd.pids, "p", "Process ID")

--- a/govc/vm/guest/ps.go
+++ b/govc/vm/guest/ps.go
@@ -77,7 +77,7 @@ func (cmd *ps) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
 	cmd.OutputFlag.Register(ctx, f)
 
-	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag, ctx = newGuestProcessFlag(ctx)
 	cmd.GuestFlag.Register(ctx, f)
 
 	cmd.uids = make(map[string]bool)

--- a/govc/vm/guest/run.go
+++ b/govc/vm/guest/run.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 func (cmd *run) Register(ctx context.Context, f *flag.FlagSet) {
-	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag, ctx = newGuestProcessFlag(ctx)
 	cmd.GuestFlag.Register(ctx, f)
 
 	f.StringVar(&cmd.data, "d", "", "Input data string. A value of '-' reads from OS stdin")

--- a/govc/vm/guest/start.go
+++ b/govc/vm/guest/start.go
@@ -49,7 +49,7 @@ func init() {
 }
 
 func (cmd *start) Register(ctx context.Context, f *flag.FlagSet) {
-	cmd.GuestFlag, ctx = newGuestFlag(ctx)
+	cmd.GuestFlag, ctx = newGuestProcessFlag(ctx)
 	cmd.GuestFlag.Register(ctx, f)
 
 	f.StringVar(&cmd.dir, "C", "", "The absolute path of the working directory for the program to start")


### PR DESCRIPTION
8a069c27 added the -i flag to all guest.* commands,
but it only applies to ProcessManager methods, not used for FileManager.