### PR TITLE
fix simulator disk manager fault message.

### DIFF
--- a/simulator/virtual_disk_manager.go
+++ b/simulator/virtual_disk_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -78,7 +79,10 @@ func (m *VirtualDiskManager) createVirtualDisk(op types.VirtualDeviceConfigSpecF
 
 func (m *VirtualDiskManager) CreateVirtualDiskTask(req *types.CreateVirtualDisk_Task) soap.HasFault {
 	task := CreateTask(m, "createVirtualDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
-		return nil, m.createVirtualDisk(types.VirtualDeviceConfigSpecFileOperationCreate, req)
+		if err := m.createVirtualDisk(types.VirtualDeviceConfigSpecFileOperationCreate, req); err != nil {
+			return "", err
+		}
+		return req.Name, nil
 	})
 
 	return &methods.CreateVirtualDisk_TaskBody{
@@ -192,8 +196,8 @@ func (m *VirtualDiskManager) QueryVirtualDiskUuid(req *types.QueryVirtualDiskUui
 
 	_, err := os.Stat(file)
 	if err != nil {
-		fault = fm.fault(file, err, new(types.CannotAccessFile))
-		body.Fault_ = Fault("", fault)
+		fault = fm.fault(req.Name, err, new(types.CannotAccessFile))
+		body.Fault_ = Fault(fmt.Sprintf("File %s was not found", req.Name), fault)
 		return body
 	}
 


### PR DESCRIPTION
This change makes the simulator behave more like a real vCenter in the presence
of missing VMKDs. In particular, it conforms to an expectation of VCP, which
allows to use the simulator with that k8s provider.