### PR TITLE
Avoid encoding/xml import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ goimports:
 	@echo checking go imports...
 	@command -v goimports >/dev/null 2>&1 || $(GO) get golang.org/x/tools/cmd/goimports
 	@! goimports -d . 2>&1 | egrep -v '^$$'
+	@! TERM=xterm git grep encoding/xml -- '*.go' ':!vim25/xml/*.go'
 
 govet:
 	@echo checking go vet...

--- a/vim25/client.go
+++ b/vim25/client.go
@@ -19,7 +19,6 @@ package vim25
 import (
 	"context"
 	"encoding/json"
-	"encoding/xml"
 	"fmt"
 	"net/http"
 	"path"
@@ -28,6 +27,7 @@ import (
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
 )
 
 const (


### PR DESCRIPTION
Make sure we use vim25/xml everywhere.
No functional harm in this case, but reduces govc binary size a bit (190K)