### PR TITLE
govc: output formatting enhancements

### DIFF
--- a/govc/cli/command.go
+++ b/govc/cli/command.go
@@ -183,7 +183,13 @@ error:
 			// propagate exit code, e.g. from guest.run
 			rc = x.ExitCode()
 		} else {
-			fmt.Fprintf(os.Stderr, "%s: %s\n", os.Args[0], err)
+			w, ok := cmd.(interface{ WriteError(error) bool })
+			if ok {
+				ok = w.WriteError(err)
+			}
+			if !ok {
+				fmt.Fprintf(os.Stderr, "%s: %s\n", os.Args[0], err)
+			}
 		}
 	}
 

--- a/govc/test/cli.bats
+++ b/govc/test/cli.bats
@@ -169,3 +169,23 @@ load test_helper
   assert_failure
   assert_matches "did you mean:"
 }
+
+@test "govc format error" {
+  vcsim_env
+
+  vm=DC0_H0_VM0
+
+  run govc vm.power -json -on $vm
+  assert_failure
+  jq . <<<"$output"
+
+  run govc vm.power -xml -on $vm
+  assert_failure
+  if type xmlstarlet ; then
+    xmlstarlet fo <<<"$output"
+  fi
+
+  run govc vm.power -dump -on $vm
+  assert_failure
+  gofmt <<<"$output"
+}

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -309,7 +309,7 @@ load test_helper
     [ ${#lines[@]} -eq 0 ]
 
     # If VM is not found (using -json flag): Valid json output, exit code==0
-    run govc vm.info -json $id
+    run env GOVC_INDENT=false govc vm.info -json $id
     assert_success
     assert_line "{\"VirtualMachines\":null}"
 


### PR DESCRIPTION
- Default to indented output by default for -{json,xml,dump}

- Add xml output option

- Format errors if possible when -{json,xml,dump} is given