### PR TITLE
Simplify ObjectName method

### DIFF
--- a/object/network.go
+++ b/object/network.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/vmware/govmomi/vim25"
-	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -40,19 +39,14 @@ func (n Network) GetInventoryPath() string {
 
 // EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this Network
 func (n Network) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
-	var e mo.Network
-
-	// Use Network.Name rather than Common.Name as the latter does not return the complete name if it contains a '/'
-	// We can't use Common.ObjectName here either as we need the ManagedEntity.Name field is not set since mo.Network
-	// has its own Name field.
-	err := n.Properties(ctx, n.Reference(), []string{"name"}, &e)
+	name, err := n.ObjectName(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	backing := &types.VirtualEthernetCardNetworkBackingInfo{
 		VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
-			DeviceName: e.Name,
+			DeviceName: name,
 		},
 	}
 


### PR DESCRIPTION
Using mo.ManagedEntity does not work with network entities as mo.Network
has its own Name field. Switching to ObjectContent which works with all
types, avoiding the 2nd call for network types.

- Fix comment regarding InventoryPath (see #734)