### PR TITLE
govc: add object.collect -o flag

### DIFF
--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -131,6 +131,14 @@ load test_helper
   # test against an interface field
   run govc object.collect 'network/VM Network' summary
   assert_success
+
+  run govc object.collect -dump -o 'network/VM Network'
+  assert_success
+  gofmt <<<"$output"
+
+  run govc object.collect -json -o 'network/VM Network'
+  assert_success
+  jq . <<<"$output"
 }
 
 @test "object.collect vcsim" {


### PR DESCRIPTION
The main use case for -o is to output a Managed Object structure as Go code,
for use within vcsim.  It also provides a more concise version of -json and
-xml encoded structures, compared to the default ObjectUpdate version.
