### PR TITLE
vcsim: support tags with the same name

### DIFF
--- a/govc/test/tags.bats
+++ b/govc/test/tags.bats
@@ -83,7 +83,20 @@ load test_helper
   assert_success
   tag_id="$output"
 
-  govc tags.ls | grep $test_name
+  count=$(govc tags.ls | grep -c $test_name)
+  [ "$count" = "1" ]
+
+  run govc tags.create -c "$category_name" $test_name
+  assert_failure # already_exists
+
+  run govc tags.category.create -m "$category_name-2"
+  assert_success
+
+  run govc tags.create -c "$category_name-2" $test_name
+  assert_success # same name but different category
+
+  count=$(govc tags.ls | grep -c $test_name)
+  [ "$count" = "2" ]
 
   id=$(govc tags.ls -json | jq -r '.[].id')
   assert_matches "$id" "$tag_id"

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -489,7 +489,7 @@ func (s *handler) tag(w http.ResponseWriter, r *http.Request) {
 		}
 		if s.decode(r, w, &spec) {
 			for _, tag := range s.Tag {
-				if tag.Name == spec.Tag.Name {
+				if tag.Name == spec.Tag.Name && tag.CategoryID == spec.Tag.CategoryID {
 					BadRequest(w, "com.vmware.vapi.std.errors.already_exists")
 					return
 				}


### PR DESCRIPTION
vCenter allows tags with the same name, provided the category is not the same.