### PR TITLE
vcsim: avoid possible panic in UnregisterVM_Task

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1458,7 +1458,9 @@ func (vm *VirtualMachine) UnregisterVM(ctx *Context, c *types.UnregisterVM) soap
 	}
 
 	ctx.postEvent(&types.VmRemovedEvent{VmEvent: vm.event()})
-	Map.getEntityParent(vm, "Folder").(*Folder).removeChild(c.This)
+	if f, ok := Map.getEntityParent(vm, "Folder").(*Folder); ok {
+		f.removeChild(c.This)
+	}
 
 	r.Res = new(types.UnregisterVMResponse)
 


### PR DESCRIPTION
It is possible the VM's parent folder is destroyed in the middle of a VM Unregister call,
avoid a panic in that case.  See also: 1427d581 (#1744)