### PR TITLE
govc: add library.clone -ovf flag

### DIFF
--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -234,6 +234,25 @@ EOF
   assert_failure
 }
 
+@test "library.clone ovf" {
+  vcsim_env
+
+  vm=DC0_H0_VM0
+  item="${vm}_item"
+
+  run govc library.create my-content
+  assert_success
+
+  run govc library.clone -vm $vm -ovf my-content $item
+  assert_success
+
+  run govc vm.destroy $vm
+  assert_success
+
+  run govc library.ls my-content/
+  assert_success /my-content/$item
+}
+
 @test "library.deploy vmtx" {
   vcsim_env
 

--- a/vapi/vcenter/vcenter_ovf.go
+++ b/vapi/vcenter/vcenter_ovf.go
@@ -64,7 +64,6 @@ const (
 	ClassPropertyParams        = "com.vmware.vcenter.ovf.property_params"
 	TypeDeploymentOptionParams = "DeploymentOptionParams"
 	TypeExtraConfigParams      = "ExtraConfigParams"
-	TypeExtraConfigs           = "ExtraConfigs"
 	TypeIPAllocationParams     = "IpAllocationParams"
 	TypePropertyParams         = "PropertyParams"
 	TypeSizeParams             = "SizeParams"
@@ -204,6 +203,33 @@ func (e *DeploymentError) Error() string {
 	return "deploy error: " + msg
 }
 
+// LibraryTarget specifies a Library or Library item
+type LibraryTarget struct {
+	LibraryID     string `json:"library_id,omitempty"`
+	LibraryItemID string `json:"library_item_id,omitempty"`
+}
+
+// CreateSpec info used to create an OVF package from a VM
+type CreateSpec struct {
+	Description string   `json:"description,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Flags       []string `json:"flags,omitempty"`
+}
+
+// OVF data used by CreateOVF
+type OVF struct {
+	Spec   CreateSpec    `json:"create_spec"`
+	Source ResourceID    `json:"source"`
+	Target LibraryTarget `json:"target"`
+}
+
+// CreateResult used for decoded a CreateOVF response
+type CreateResult struct {
+	Succeeded bool             `json:"succeeded,omitempty"`
+	ID        string           `json:"ovf_library_item_id,omitempty"`
+	Error     *DeploymentError `json:"error,omitempty"`
+}
+
 // Deployment is the results from issuing a library OVF deployment
 type Deployment struct {
 	Succeeded  bool             `json:"succeeded,omitempty"`
@@ -236,6 +262,23 @@ func NewManager(client *rest.Client) *Manager {
 	return &Manager{
 		Client: client,
 	}
+}
+
+// CreateOVF creates a library OVF item in content library from an existing VM
+func (c *Manager) CreateOVF(ctx context.Context, ovf OVF) (string, error) {
+	if ovf.Source.Type == "" {
+		ovf.Source.Type = "VirtualMachine"
+	}
+	url := c.Resource(internal.VCenterOVFLibraryItem)
+	var res CreateResult
+	err := c.Do(ctx, url.Request(http.MethodPost, ovf), &res)
+	if err != nil {
+		return "", err
+	}
+	if res.Succeeded {
+		return res.ID, nil
+	}
+	return "", res.Error
 }
 
 // DeployLibraryItem deploys a library OVF

--- a/vapi/vcenter/vcenter_vmtx.go
+++ b/vapi/vcenter/vcenter_vmtx.go
@@ -113,7 +113,7 @@ type CheckIn struct {
 	Message string `json:"message"`
 }
 
-// CreateTemplate creates a library item in content library from an existing VM
+// CreateTemplate creates a library VMTX item in content library from an existing VM
 func (c *Manager) CreateTemplate(ctx context.Context, vmtx Template) (string, error) {
 	url := c.Resource(internal.VCenterVMTXLibraryItem)
 	var res string


### PR DESCRIPTION
The library.clone flag only supported cloning as VM Template (vmtx),
but the UI supports both vmtx and ovf.

Fixes #1814