### PR TITLE
Expose Soap client default transport 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+### 0.22.2 (2020-02-04)
+
+* Expose soap client default transport
+
 ### 0.22.1 (2020-01-13)
 
 * Fix SAML token auth using Holder-of-Key with delegated Bearer identity against 6.7 U3b+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,9 @@ We follow the conventions on [How to Write a Git Commit Message](http://chris.be
 
 Be sure to include any related GitHub issue references in the commit message.
 
+### Running CI checks and tests
+You can run both `make check` and `make test` from the top level of the repository. While `make check` will catch formatting and import errors, it will not apply any fixes. The developer is expected to do that.
+
 ## Reporting Bugs and Creating Issues
 
 When opening a new issue, try to roughly follow the commit message format conventions above.

--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
@@ -308,15 +307,14 @@ func (flag *ClientFlag) configure(sc *soap.Client) (soap.RoundTripper, error) {
 		return nil, err
 	}
 
-	if t, ok := sc.Transport.(*http.Transport); ok {
-		var err error
+	t := sc.DefaultTransport()
+	var err error
 
-		value := os.Getenv("GOVC_TLS_HANDSHAKE_TIMEOUT")
-		if value != "" {
-			t.TLSHandshakeTimeout, err = time.ParseDuration(value)
-			if err != nil {
-				return nil, err
-			}
+	value := os.Getenv("GOVC_TLS_HANDSHAKE_TIMEOUT")
+	if value != "" {
+		t.TLSHandshakeTimeout, err = time.ParseDuration(value)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/govc/flags/host_connect.go
+++ b/govc/flags/host_connect.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"net/http"
 	"net/url"
 
 	"github.com/vmware/govmomi/object"
@@ -75,7 +74,7 @@ func (flag *HostConnectFlag) Spec(c *vim25.Client) types.HostConnectSpec {
 
 		if spec.SslThumbprint == "" && flag.noverify {
 			var info object.HostCertificateInfo
-			t := c.Transport.(*http.Transport)
+			t := c.DefaultTransport()
 			_ = info.FromURL(&url.URL{Host: spec.HostName}, t.TLSClientConfig)
 			spec.SslThumbprint = info.ThumbprintSHA1
 		}

--- a/session/manager.go
+++ b/session/manager.go
@@ -19,7 +19,6 @@ package session
 import (
 	"context"
 	"io/ioutil"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -124,7 +123,7 @@ func (sm *Manager) LoginExtensionByCertificate(ctx context.Context, key string) 
 		// "Post https://sdkTunnel:8089/sdk: x509: certificate is valid for $vcenter_hostname, not sdkTunnel"
 		// The only easy way around this is to disable verification for the call to LoginExtensionByCertificate().
 		// TODO: find a way to avoid disabling InsecureSkipVerify.
-		c.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
+		c.DefaultTransport().TLSClientConfig.InsecureSkipVerify = true
 	}
 
 	req := types.LoginExtensionByCertificate{

--- a/vapi/library/library.go
+++ b/vapi/library/library.go
@@ -124,7 +124,7 @@ func (c *Manager) CreateLibrary(ctx context.Context, library Library) (string, e
 		if u.Scheme == "https" && sub.SslThumbprint == "" {
 			thumbprint := c.Thumbprint(u.Host)
 			if thumbprint == "" {
-				t := c.Transport.(*http.Transport)
+				t := c.DefaultTransport()
 				if t.TLSClientConfig.InsecureSkipVerify {
 					var info object.HostCertificateInfo
 					_ = info.FromURL(u, t.TLSClientConfig)

--- a/vapi/library/library_item_updatesession_file.go
+++ b/vapi/library/library_item_updatesession_file.go
@@ -116,7 +116,7 @@ func (c *Manager) getContentLengthAndFingerprint(
 	}
 	fingerprint := c.Thumbprint(resp.Request.URL.Host)
 	if fingerprint == "" {
-		if c.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify {
+		if c.DefaultTransport().TLSClientConfig.InsecureSkipVerify {
 			fingerprint = soap.ThumbprintSHA1(resp.TLS.PeerCertificates[0])
 		}
 	}

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -159,6 +159,10 @@ func NewClient(u *url.URL, insecure bool) *Client {
 	return &c
 }
 
+func (c *Client) DefaultTransport() *http.Transport {
+	return c.t
+}
+
 // NewServiceClient creates a NewClient with the given URL.Path and namespace.
 func (c *Client) NewServiceClient(path string, namespace string) *Client {
 	vc := c.URL()
@@ -173,7 +177,7 @@ func (c *Client) NewServiceClient(path string, namespace string) *Client {
 
 	client := NewClient(u, c.k)
 	client.Namespace = "urn:" + namespace
-	client.Transport.(*http.Transport).TLSClientConfig = c.Transport.(*http.Transport).TLSClientConfig
+	client.DefaultTransport().TLSClientConfig = c.DefaultTransport().TLSClientConfig
 	if cert := c.Certificate(); cert != nil {
 		client.SetCertificate(*cert)
 	}


### PR DESCRIPTION
Now there is a "prettier" way to customize things like certificate verification (at your own risk)