### PR TITLE
govc: use OutputFlag for import.spec

### DIFF
--- a/govc/flags/output.go
+++ b/govc/flags/output.go
@@ -140,6 +140,11 @@ func dumpValue(val interface{}) interface{} {
 			}
 			return f.Interface()
 		}
+
+		if rval.NumField() == 1 && rval.Type().Field(0).Anonymous {
+			// common case where govc type wraps govmomi type to implement OutputWriter
+			return f.Interface()
+		}
 	}
 
 	return val

--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -32,7 +32,7 @@ load test_helper
 }
 
 @test "import.ovf" {
-  esx_env
+  vcsim_env
 
   run govc import.ovf $GOVC_IMAGES/${TTYLINUX_NAME}.ovf
   assert_success
@@ -51,7 +51,7 @@ load test_helper
 }
 
 @test "import.ovf -host.ipath" {
-  esx_env # TODO: should be against vcsim
+  vcsim_env
 
   run govc import.ovf -host.ipath="$(govc find / -type h | head -1)" "$GOVC_IMAGES/${TTYLINUX_NAME}.ovf"
   assert_success
@@ -61,7 +61,7 @@ load test_helper
 }
 
 @test "import.ovf with name in options" {
-  esx_env
+  vcsim_env
 
   name=$(new_id)
   file=$($mktemp --tmpdir govc-test-XXXXX)
@@ -77,7 +77,7 @@ load test_helper
 }
 
 @test "import.ovf with import.spec result" {
-  esx_env
+  vcsim_env
 
   file=$($mktemp --tmpdir govc-test-XXXXX)
   name=$(new_id)
@@ -92,7 +92,7 @@ load test_helper
 }
 
 @test "import.ovf with name as argument" {
-  esx_env
+  vcsim_env
 
   name=$(new_id)
 


### PR DESCRIPTION
As of d2e6b7df, the output of '-json' is indented by default.
Make use of that behavior with the import.spec command.

Enable several import tests against vcsim.