### PR TITLE
Add Content Library subscriptions support

### DIFF
--- a/govc/flags/library.go
+++ b/govc/flags/library.go
@@ -46,7 +46,11 @@ func (e errContentLibraryMatch) Error() string {
 	if kind == "" {
 		kind = "library|item"
 	}
-	return fmt.Sprintf("%q=%q matches %d items, %q id must be specified", e.Key, e.Val, e.Count, kind)
+	hint := ""
+	if e.Count > 1 {
+		hint = fmt.Sprintf(" (use %q ID instead of NAME)", kind)
+	}
+	return fmt.Sprintf("%q=%q matches %d items%s", e.Key, e.Val, e.Count, hint)
 }
 
 func ContentLibraryResult(ctx context.Context, c *rest.Client, kind string, path string) (finder.FindResult, error) {

--- a/govc/library/publish.go
+++ b/govc/library/publish.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+type publish struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("library.publish", &publish{})
+}
+
+func (cmd *publish) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *publish) Usage() string {
+	return "NAME|ITEM [SUBSCRIPTION-ID]..."
+}
+
+func (cmd *publish) Description() string {
+	return `Publish library NAME or ITEM to subscribers.
+
+If no subscriptions are specified, then publishes the library to all its subscribers.
+See 'govc library.subscriber.ls' to get a list of subscription IDs.
+
+Examples:
+  govc library.publish /my-library
+  govc library.publish /my-library subscription-id1 subscription-id2
+  govc library.publish /my-library/my-item
+  govc library.publish /my-library/my-item subscription-id1 subscription-id2`
+}
+
+func (cmd *publish) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		res, err := flags.ContentLibraryResult(ctx, c, "", f.Arg(0))
+		if err != nil {
+			return err
+		}
+
+		m := library.NewManager(c)
+
+		ids := f.Args()[1:]
+
+		switch t := res.GetResult().(type) {
+		case library.Library:
+			return m.PublishLibrary(ctx, &t, ids)
+		case library.Item:
+			return m.PublishLibraryItem(ctx, &t, false, ids)
+		default:
+			return fmt.Errorf("%q is a %T", res.GetPath(), t)
+		}
+	})
+}

--- a/govc/library/subscriber/create.go
+++ b/govc/library/subscriber/create.go
@@ -1,0 +1,148 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriber
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+type create struct {
+	*flags.ClusterFlag
+	*flags.ResourcePoolFlag
+	*flags.HostSystemFlag
+	*flags.NetworkFlag
+	*flags.FolderFlag
+}
+
+func init() {
+	cli.Register("library.subscriber.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.NetworkFlag, ctx = flags.NewNetworkFlag(ctx)
+	cmd.NetworkFlag.Register(ctx, f)
+
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.NetworkFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.FolderFlag.Process(ctx)
+}
+
+func (cmd *create) Usage() string {
+	return "PUBLISHED-LIBRARY SUBSCRIPTION-LIBRARY"
+}
+
+func (cmd *create) Description() string {
+	return `Create library subscriber.
+
+Examples:
+  govc library.subscriber.create -cluster my-cluster published-library subscription-library`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.FolderFlag.WithRestClient(ctx, func(c *rest.Client) error {
+		lib, err := flags.ContentLibrary(ctx, c, f.Arg(0))
+		if err != nil {
+			return err
+		}
+		m := library.NewManager(c)
+
+		sub, err := flags.ContentLibrary(ctx, c, f.Arg(1))
+		if err != nil {
+			return err
+		}
+
+		cluster, err := cmd.ClusterIfSpecified()
+		if err != nil {
+			return err
+		}
+		pool, err := cmd.ResourcePoolIfSpecified()
+		if err != nil {
+			return err
+		}
+		host, err := cmd.HostSystemIfSpecified()
+		if err != nil {
+			return err
+		}
+		folder, err := cmd.Folder()
+		if err != nil {
+			return err
+		}
+		network, err := cmd.Network()
+		if err != nil {
+			return err
+		}
+
+		spec := library.SubscriberLibrary{
+			Target:    "USE_EXISTING",
+			Location:  "LOCAL",
+			LibraryID: sub.ID,
+			Placement: &library.Placement{
+				Folder:  folder.Reference().Value,
+				Network: network.Reference().Value,
+			},
+		}
+
+		if pool != nil {
+			spec.Placement.ResourcePool = pool.Reference().Value
+		}
+		if host != nil {
+			spec.Placement.Host = host.Reference().Value
+		}
+		if cluster != nil {
+			spec.Placement.Cluster = cluster.Reference().Value
+		}
+
+		id, err := m.CreateSubscriber(ctx, lib, spec)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(id)
+		return nil
+	})
+}

--- a/govc/library/subscriber/info.go
+++ b/govc/library/subscriber/info.go
@@ -1,0 +1,135 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriber
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("library.subscriber.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *info) Usage() string {
+	return "PUBLISHED-LIBRARY SUBSCRIPTION-ID"
+}
+
+func (cmd *info) Description() string {
+	return `Library subscriber info.
+
+Examples:
+  id=$(govc library.subscriber.ls | grep my-library-name | awk '{print $1}')
+  govc library.subscriber.info published-library-name $id`
+}
+
+// path returns the inventory path for id, if possible
+func (cmd *info) path(kind, id string) string {
+	if id == "" {
+		return ""
+	}
+	ref := types.ManagedObjectReference{Type: kind, Value: id}
+	c, err := cmd.Client()
+	if err == nil {
+		ctx := context.Background()
+		e, err := find.NewFinder(c, false).Element(ctx, ref)
+		if err == nil {
+			return e.Path
+		}
+	}
+	return id
+}
+
+type infoResultsWriter struct {
+	*library.Subscriber
+	cmd *info
+}
+
+func (r infoResultsWriter) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	_, _ = fmt.Fprintf(tw, "Name:\t%s\n", r.LibraryName)
+	_, _ = fmt.Fprintf(tw, "  ID:\t%s\n", r.LibraryID)
+	_, _ = fmt.Fprintf(tw, "  Location:\t%s\n", r.LibraryLocation)
+
+	p := r.cmd.path
+
+	if r.Vcenter != nil {
+		p = func(kind, id string) string { return id }
+		port := ""
+		if r.Vcenter.Port != 0 {
+			port = fmt.Sprintf(":%d", r.Vcenter.Port)
+		}
+		_, _ = fmt.Fprintf(tw, "  vCenter:\t\n")
+		_, _ = fmt.Fprintf(tw, "    URL:\thttps://%s%s\n", r.Vcenter.Hostname, port)
+		_, _ = fmt.Fprintf(tw, "    GUID:\t%s\n", r.Vcenter.ServerGUID)
+	}
+
+	_, _ = fmt.Fprintf(tw, "  Placement:\t\n")
+	_, _ = fmt.Fprintf(tw, "    Folder:\t%s\n", p("Folder", r.Placement.Folder))
+	_, _ = fmt.Fprintf(tw, "    Cluster:\t%s\n", p("ClusterComputeResource", r.Placement.Cluster))
+	_, _ = fmt.Fprintf(tw, "    Pool:\t%s\n", p("ResourcePool", r.Placement.ResourcePool))
+	_, _ = fmt.Fprintf(tw, "    Network:\t%s\n", p("Network", r.Placement.Network))
+
+	return tw.Flush()
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		lib, err := flags.ContentLibrary(ctx, c, f.Arg(0))
+		if err != nil {
+			return err
+		}
+		m := library.NewManager(c)
+
+		s, err := m.GetSubscriber(ctx, lib, f.Arg(1))
+		if err != nil {
+			return err
+		}
+
+		return cmd.WriteResult(infoResultsWriter{s, cmd})
+	})
+}

--- a/govc/library/subscriber/ls.go
+++ b/govc/library/subscriber/ls.go
@@ -1,0 +1,91 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriber
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("library.subscriber.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *ls) Description() string {
+	return `List library subscriptions.
+
+Examples:
+  govc library.subscriber.ls library-name`
+}
+
+type lsResultsWriter []library.SubscriberSummary
+
+func (r lsResultsWriter) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", "Subscription ID", "Library Name", "Library ID", "vCenter")
+
+	for _, i := range r {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", i.SubscriptionID, i.LibraryName, i.LibraryID, i.LibraryVcenterHostname)
+	}
+
+	return tw.Flush()
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		lib, err := flags.ContentLibrary(ctx, c, f.Arg(0))
+		if err != nil {
+			return err
+		}
+		m := library.NewManager(c)
+
+		s, err := m.ListSubscribers(ctx, lib)
+		if err != nil {
+			return err
+		}
+
+		return cmd.WriteResult(lsResultsWriter(s))
+	})
+}

--- a/govc/library/subscriber/rm.go
+++ b/govc/library/subscriber/rm.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriber
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+type rm struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("library.subscriber.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Usage() string {
+	return "SUBSCRIPTION-ID"
+}
+
+func (cmd *rm) Description() string {
+	return `Delete subscription of the published library.
+
+The subscribed library associated with the subscription will not be deleted.
+
+Examples:
+  id=$(govc library-subscriber.ls | grep my-library-name | awk '{print $1}')
+  govc library.subscriber.rm $id`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		lib, err := flags.ContentLibrary(ctx, c, f.Arg(0))
+		if err != nil {
+			return err
+		}
+		m := library.NewManager(c)
+
+		return m.DeleteSubscriber(ctx, lib, f.Arg(0))
+	})
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -64,6 +64,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/importx"
 	_ "github.com/vmware/govmomi/govc/library"
 	_ "github.com/vmware/govmomi/govc/library/session"
+	_ "github.com/vmware/govmomi/govc/library/subscriber"
 	_ "github.com/vmware/govmomi/govc/license"
 	_ "github.com/vmware/govmomi/govc/logs"
 	_ "github.com/vmware/govmomi/govc/ls"

--- a/vapi/internal/internal.go
+++ b/vapi/internal/internal.go
@@ -38,6 +38,7 @@ const (
 	LocalLibraryPath               = "/com/vmware/content/local-library"
 	SubscribedLibraryPath          = "/com/vmware/content/subscribed-library"
 	SubscribedLibraryItem          = "/com/vmware/content/library/subscribed-item"
+	Subscriptions                  = "/com/vmware/content/library/subscriptions"
 	VCenterOVFLibraryItem          = "/com/vmware/vcenter/ovf/library-item"
 	VCenterVMTXLibraryItem         = "/vcenter/vm-template/library-items"
 	VCenterVM                      = "/vcenter/vm"
@@ -68,4 +69,17 @@ func NewAssociation(ref mo.Reference) Association {
 	return Association{
 		ObjectID: &obj,
 	}
+}
+
+type SubscriptionDestination struct {
+	ID string `json:"subscription"`
+}
+
+type SubscriptionDestinationSpec struct {
+	Subscriptions []SubscriptionDestination `json:"subscriptions,omitempty"`
+}
+
+type SubscriptionItemDestinationSpec struct {
+	Force         bool                      `json:"force_sync_content"`
+	Subscriptions []SubscriptionDestination `json:"subscriptions,omitempty"`
 }

--- a/vapi/library/library.go
+++ b/vapi/library/library.go
@@ -46,6 +46,7 @@ type Library struct {
 	Type             string            `json:"type,omitempty"`
 	Version          string            `json:"version,omitempty"`
 	Subscription     *Subscription     `json:"subscription_info,omitempty"`
+	Publication      *Publication      `json:"publish_info,omitempty"`
 }
 
 // Subscription info
@@ -57,6 +58,59 @@ type Subscription struct {
 	SslThumbprint        string `json:"ssl_thumbprint,omitempty"`
 	SubscriptionURL      string `json:"subscription_url,omitempty"`
 	UserName             string `json:"user_name,omitempty"`
+}
+
+// Publication info
+type Publication struct {
+	AuthenticationMethod string `json:"authentication_method"`
+	UserName             string `json:"user_name,omitempty"`
+	Password             string `json:"password,omitempty"`
+	CurrentPassword      string `json:"current_password,omitempty"`
+	PersistJSON          *bool  `json:"persist_json_enabled,omitempty"`
+	Published            *bool  `json:"published,omitempty"`
+	PublishURL           string `json:"publish_url,omitempty"`
+}
+
+// SubscriberSummary as returned by ListSubscribers
+type SubscriberSummary struct {
+	LibraryID              string `json:"subscribed_library"`
+	LibraryName            string `json:"subscribed_library_name"`
+	SubscriptionID         string `json:"subscription"`
+	LibraryVcenterHostname string `json:"subscribed_library_vcenter_hostname,omitempty"`
+}
+
+// Placement information used to place a virtual machine template
+type Placement struct {
+	ResourcePool string `json:"resource_pool,omitempty"`
+	Host         string `json:"host,omitempty"`
+	Folder       string `json:"folder,omitempty"`
+	Cluster      string `json:"cluster,omitempty"`
+	Network      string `json:"network,omitempty"`
+}
+
+// Vcenter contains information about the vCenter Server instance where a subscribed library associated with a subscription exists.
+type Vcenter struct {
+	Hostname   string `json:"hostname"`
+	Port       int    `json:"https_port,omitempty"`
+	ServerGUID string `json:"server_guid"`
+}
+
+// Subscriber contains the detailed info for a library subscriber.
+type Subscriber struct {
+	LibraryID       string     `json:"subscribed_library"`
+	LibraryName     string     `json:"subscribed_library_name"`
+	LibraryLocation string     `json:"subscribed_library_location"`
+	Placement       *Placement `json:"subscribed_library_placement,omitempty"`
+	Vcenter         *Vcenter   `json:"subscribed_library_vcenter,omitempty"`
+}
+
+// SubscriberLibrary is the specification for a subscribed library to be associated with a subscription.
+type SubscriberLibrary struct {
+	Target    string     `json:"target"`
+	LibraryID string     `json:"subscribed_library,omitempty"`
+	Location  string     `json:"location"`
+	Vcenter   *Vcenter   `json:"vcenter,omitempty"`
+	Placement *Placement `json:"placement,omitempty"`
 }
 
 // Patch merges updates from the given src.
@@ -146,6 +200,18 @@ func (c *Manager) SyncLibrary(ctx context.Context, library *Library) error {
 	return c.Do(ctx, url.Request(http.MethodPost), nil)
 }
 
+// PublishLibrary publishes the library to specified subscriptions.
+// If no subscriptions are specified, then publishes the library to all subscriptions.
+func (c *Manager) PublishLibrary(ctx context.Context, library *Library, subscriptions []string) error {
+	path := internal.LocalLibraryPath
+	var spec internal.SubscriptionDestinationSpec
+	for i := range subscriptions {
+		spec.Subscriptions = append(spec.Subscriptions, internal.SubscriptionDestination{ID: subscriptions[i]})
+	}
+	url := c.Resource(path).WithID(library.ID).WithAction("publish")
+	return c.Do(ctx, url.Request(http.MethodPost, spec), nil)
+}
+
 // DeleteLibrary deletes an existing library.
 func (c *Manager) DeleteLibrary(ctx context.Context, library *Library) error {
 	path := internal.LocalLibraryPath
@@ -203,4 +269,40 @@ func (c *Manager) GetLibraries(ctx context.Context) ([]Library, error) {
 
 	}
 	return libraries, nil
+}
+
+// ListSubscribers lists the subscriptions of the published library.
+func (c *Manager) ListSubscribers(ctx context.Context, library *Library) ([]SubscriberSummary, error) {
+	url := c.Resource(internal.Subscriptions).WithParam("library", library.ID)
+	var res []SubscriberSummary
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// CreateSubscriber creates a subscription of the published library.
+func (c *Manager) CreateSubscriber(ctx context.Context, library *Library, s SubscriberLibrary) (string, error) {
+	var spec struct {
+		Sub struct {
+			SubscriberLibrary SubscriberLibrary `json:"subscribed_library"`
+		} `json:"spec"`
+	}
+	spec.Sub.SubscriberLibrary = s
+	url := c.Resource(internal.Subscriptions).WithID(library.ID)
+	var res string
+	return res, c.Do(ctx, url.Request(http.MethodPost, &spec), &res)
+}
+
+// GetSubscriber returns information about the specified subscriber of the published library.
+func (c *Manager) GetSubscriber(ctx context.Context, library *Library, subscriber string) (*Subscriber, error) {
+	id := internal.SubscriptionDestination{ID: subscriber}
+	url := c.Resource(internal.Subscriptions).WithID(library.ID).WithAction("get")
+	var res Subscriber
+	return &res, c.Do(ctx, url.Request(http.MethodPost, &id), &res)
+}
+
+// DeleteSubscriber deletes the specified subscription of the published library.
+// The subscribed library associated with the subscription will not be deleted.
+func (c *Manager) DeleteSubscriber(ctx context.Context, library *Library, subscriber string) error {
+	id := internal.SubscriptionDestination{ID: subscriber}
+	url := c.Resource(internal.Subscriptions).WithID(library.ID).WithAction("delete")
+	return c.Do(ctx, url.Request(http.MethodPost, &id), nil)
 }

--- a/vapi/library/library_item.go
+++ b/vapi/library/library_item.go
@@ -107,6 +107,19 @@ func (c *Manager) SyncLibraryItem(ctx context.Context, item *Item, force bool) e
 	return c.Do(ctx, url.Request(http.MethodPost, body), nil)
 }
 
+// PublishLibraryItem publishes a library item to specified subscriptions.
+// If no subscriptions are specified, then publishes the library item to all subscriptions.
+func (c *Manager) PublishLibraryItem(ctx context.Context, item *Item, force bool, subscriptions []string) error {
+	body := internal.SubscriptionItemDestinationSpec{
+		Force: force,
+	}
+	for i := range subscriptions {
+		body.Subscriptions = append(body.Subscriptions, internal.SubscriptionDestination{ID: subscriptions[i]})
+	}
+	url := c.Resource(internal.LibraryItemPath).WithID(item.ID).WithAction("publish")
+	return c.Do(ctx, url.Request(http.MethodPost, body), nil)
+}
+
 // DeleteLibraryItem deletes an existing library item.
 func (c *Manager) DeleteLibraryItem(ctx context.Context, item *Item) error {
 	url := c.Resource(internal.LibraryItemPath).WithID(item.ID)

--- a/vapi/vcenter/vcenter_vmtx.go
+++ b/vapi/vcenter/vcenter_vmtx.go
@@ -53,12 +53,7 @@ type TemplateInfo struct {
 }
 
 // Placement information used to place the virtual machine template
-type Placement struct {
-	ResourcePool string `json:"resource_pool,omitempty"`
-	Host         string `json:"host,omitempty"`
-	Folder       string `json:"folder,omitempty"`
-	Cluster      string `json:"cluster,omitempty"`
-}
+type Placement = library.Placement
 
 // StoragePolicy for DiskStorage
 type StoragePolicy struct {


### PR DESCRIPTION
Quoting the H5 UI:
> Subscriptions allow a bi-directional relationship between Publisher and Subscriber libraries.
> This enables you to synchronize content both from the Publisher (Publish) and from the Subscriber (Sync).

- vapi: add library/subscriptions bindings

- vapi: add PublishLibrary binding

- vcsim: add library/subscriptions support

- vcsim: add publish support

- govc: add '-pub' flag to library.create (enable publishing)

- govc: add Publication section to library.info

- govc: add library.publish command

- govc: add library.subscriber.{create,rm,ls,info} commands