### PR TITLE
Replaced `ClassOvfParams` with `ClassDeploymentOptionParams`

### DIFF
--- a/govc/library/deploy.go
+++ b/govc/library/deploy.go
@@ -183,7 +183,7 @@ func (cmd *deploy) Run(ctx context.Context, f *flag.FlagSet) error {
 					Annotation:         cmd.Options.Annotation,
 					AdditionalParams: []vcenter.AdditionalParams{
 						{
-							Class:       vcenter.ClassOvfParams,
+							Class:       vcenter.ClassDeploymentOptionParams,
 							Type:        vcenter.TypeDeploymentOptionParams,
 							SelectedKey: cmd.Options.Deployment,
 						},

--- a/vapi/vcenter/vcenter_ovf.go
+++ b/vapi/vcenter/vcenter_ovf.go
@@ -60,13 +60,13 @@ type AdditionalParams struct {
 }
 
 const (
-	ClassOvfParams             = "com.vmware.vcenter.ovf.ovf_params"
-	ClassPropertyParams        = "com.vmware.vcenter.ovf.property_params"
-	TypeDeploymentOptionParams = "DeploymentOptionParams"
-	TypeExtraConfigParams      = "ExtraConfigParams"
-	TypeIPAllocationParams     = "IpAllocationParams"
-	TypePropertyParams         = "PropertyParams"
-	TypeSizeParams             = "SizeParams"
+	ClassDeploymentOptionParams = "com.vmware.vcenter.ovf.deployment_option_params"
+	ClassPropertyParams         = "com.vmware.vcenter.ovf.property_params"
+	TypeDeploymentOptionParams  = "DeploymentOptionParams"
+	TypeExtraConfigParams       = "ExtraConfigParams"
+	TypeIPAllocationParams      = "IpAllocationParams"
+	TypePropertyParams          = "PropertyParams"
+	TypeSizeParams              = "SizeParams"
 )
 
 // DeploymentOption contains the information about a deployment option as defined in the OVF specification


### PR DESCRIPTION
Resolve #1856

As per the VMware vSphere Automation SDK REST 6.7.0 API documentation (ref. https://code.vmware.com/apis/366/vsphere-automation/VMware-vSphere-Automation-SDK-REST-6.7.0/docs/apidocs/operations/com/vmware/vcenter/ovf/library_item.deploy-operation.html) the `deployment_spec.additional_parameters` field contains additional OVF parameters that may be needed for the deployment.

> Examples of OVF parameters that can be specified through this field include, but are not limited to:
> vcenter.ovf.deployment_option_params
> vcenter.ovf.extra_config_params
> vcenter.ovf.ip_allocation_params
> vcenter.ovf.property_params
> vcenter.ovf.scale_out_params
> vcenter.ovf.vcenter_extension_params

Given the above the correct `@class` for specifying deployment option params is `vcenter.ovf.deployment_option_params` and not `com.vmware.vcenter.ovf.ovf_params`.