### PR TITLE
Disk mode should override default value in vm.disk.attach

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -4547,7 +4547,7 @@ Options:
   -disk=                 Disk path name
   -ds=                   Datastore [GOVC_DATASTORE]
   -link=true             Link specified disk
-  -mode=                 Disk mode (persistent|nonpersistent|undoable|independent_persistent|independent_nonpersistent|append)
+  -mode=                 Disk mode override (persistent|nonpersistent|undoable|independent_persistent|independent_nonpersistent|append)
   -persist=true          Persist attached disk
   -sharing=              Sharing (sharingNone|sharingMultiWriter)
   -vm=                   Virtual machine [GOVC_VM]

--- a/govc/vm/disk/attach.go
+++ b/govc/vm/disk/attach.go
@@ -105,10 +105,6 @@ func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
 	backing := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
 	backing.Sharing = cmd.sharing
 
-	if len(cmd.mode) != 0 {
-		backing.DiskMode = cmd.mode
-	}
-
 	if cmd.link {
 		if cmd.persist {
 			backing.DiskMode = string(types.VirtualDiskModeIndependent_persistent)
@@ -118,12 +114,16 @@ func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
 
 		disk = devices.ChildDisk(disk)
 		return vm.AddDevice(ctx, disk)
+	} else {
+		if cmd.persist {
+			backing.DiskMode = string(types.VirtualDiskModePersistent)
+		} else {
+			backing.DiskMode = string(types.VirtualDiskModeNonpersistent)
+		}
 	}
 
-	if cmd.persist {
-		backing.DiskMode = string(types.VirtualDiskModePersistent)
-	} else {
-		backing.DiskMode = string(types.VirtualDiskModeNonpersistent)
+	if len(cmd.mode) != 0 {
+		backing.DiskMode = cmd.mode
 	}
 
 	return vm.AddDevice(ctx, disk)


### PR DESCRIPTION
Resolve #1833

The rationale for this change is to have a consistent `backing.DiskMode` override logic in `vm.disk.attach`:

|`link`|`persist`|`mode`|old `DiskMode`|new `DiskMode`|
|---|---|---|---|---|
|`true`|`true`||`persistent`|`independent_persistent`|
|`true`|`false`||`nonpersistent`|`independent_nonpersistent`|
|`false`|`true`||`persistent`|`persistent`|
|`false`|`false`||`nonpersistent`|`nonpersistent`|
|`true`|`true`|`undoable`|`persistent`|`undoable`|
|`true`|`false`|`undoable`|`nonpersistent`|`undoable`|
|`false`|`true`|`undoable`|`persistent`|`undoable`|
|`false`|`false`|`undoable`|`nonpersistent`|`undoable`|

Note: the **default** behaviour changed from `persistent` to `independent_persistent` given that by default both `link` and `persist` are `true`.