### PR TITLE
Fixed ContainerView.RetrieveWithFilter fetch all specs if empty list of properties given

### DIFF
--- a/property/collector.go
+++ b/property/collector.go
@@ -143,7 +143,7 @@ func (p *Collector) Retrieve(ctx context.Context, objs []types.ManagedObjectRefe
 			spec := types.PropertySpec{
 				Type: obj.Type,
 			}
-			if ps == nil {
+			if len(ps) == 0 {
 				spec.All = types.NewBool(true)
 			} else {
 				spec.PathSet = ps


### PR DESCRIPTION
This fixes #1872