### PR TITLE
Compute Policy support

### DIFF
--- a/govc/compute/policy/create.go
+++ b/govc/compute/policy/create.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/compute"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+type create struct {
+	*flags.ClientFlag
+	compute.Policy
+}
+
+func init() {
+	cli.Register("compute.policy.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.Policy.Name, "n", "", "Policy name")
+	f.StringVar(&cmd.Policy.Description, "d", "", "Description")
+	f.StringVar(&cmd.Policy.HostTag, "host", "", "Host Tag")
+	f.StringVar(&cmd.Policy.VMTag, "vm", "", "VM Tag")
+}
+
+func (cmd *create) Usage() string {
+	return "CAPABILITY"
+}
+
+func (cmd *create) Description() string {
+	return `Create compute policy.
+
+Examples:
+  capability=com.vmware.vcenter.compute.policies.capabilities.vm_vm_anti_affinity
+  govc compute.policy.create -n my-policy -d my-desc -vm my-tag $capability`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := compute.NewPolicyManager(c)
+
+		cmd.Capability = f.Arg(0)
+
+		id, err := m.Create(ctx, cmd.Policy)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(id)
+
+		return nil
+	})
+}

--- a/govc/compute/policy/ls.go
+++ b/govc/compute/policy/ls.go
@@ -1,0 +1,119 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/compute"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	cap bool
+}
+
+func init() {
+	cli.Register("compute.policy.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.cap, "c", false, "List capabilities")
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *ls) Description() string {
+	return `List compute policies.
+
+Examples:
+  govc compute.policy.ls
+  govc compute.policy.ls -c`
+}
+
+type lsResult []compute.Policy
+
+func (res lsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, r := range res {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\n", r.Policy, r.Capability, r.Name)
+	}
+
+	return tw.Flush()
+}
+
+func (res lsResult) Dump() interface{} {
+	return []compute.Policy(res)
+}
+
+type lsCapabilityResult []compute.Capability
+
+func (res lsCapabilityResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, r := range res {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\n", r.Capability, r.Name)
+	}
+
+	return tw.Flush()
+}
+
+func (res lsCapabilityResult) Dump() interface{} {
+	return []compute.Capability(res)
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := compute.NewPolicyManager(c)
+
+		if cmd.cap {
+			res, err := m.ListCapability(ctx)
+			if err != nil {
+				return err
+			}
+
+			return cmd.WriteResult(lsCapabilityResult(res))
+		}
+
+		res, err := m.List(ctx)
+		if err != nil {
+			return err
+		}
+
+		return cmd.WriteResult(lsResult(res))
+	})
+}

--- a/govc/compute/policy/rm.go
+++ b/govc/compute/policy/rm.go
@@ -1,0 +1,61 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/compute"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+type rm struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("compute.policy.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Usage() string {
+	return "ID"
+}
+
+func (cmd *rm) Description() string {
+	return `Delete compute policy.
+
+Examples:
+  govc compute.policy.rm 6a1f6d01-b21a-474d-87d0-5e9eba001046`
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
+		m := compute.NewPolicyManager(c)
+
+		id := f.Arg(0)
+
+		return m.Delete(ctx, id)
+	})
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/cluster/group"
 	_ "github.com/vmware/govmomi/govc/cluster/override"
 	_ "github.com/vmware/govmomi/govc/cluster/rule"
+	_ "github.com/vmware/govmomi/govc/compute/policy"
 	_ "github.com/vmware/govmomi/govc/datacenter"
 	_ "github.com/vmware/govmomi/govc/datastore"
 	_ "github.com/vmware/govmomi/govc/datastore/cluster"

--- a/govc/test/compute.bats
+++ b/govc/test/compute.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "compute.policy" {
+  vcsim_env
+
+  run govc compute.policy.ls
+  assert_success ""
+
+  run govc compute.policy.ls -c
+  assert_success
+
+  run govc compute.policy.ls -c -json
+  assert_success
+
+  capability=$(jq -r .[0].capability <<<"$output")
+
+  run govc compute.policy.create -n my-policy -d my-desc
+  assert_failure
+
+  run govc compute.policy.create -n my-policy -d my-desc enoent
+  assert_failure
+
+  run govc compute.policy.create -n my-policy -d my-desc "$capability"
+  assert_failure
+
+  run govc compute.policy.create -n my-policy -d my-desc -host my-tag "$capability"
+  assert_success
+  id="$output"
+
+  run govc compute.policy.ls
+  assert_success
+  assert_matches "$id"
+
+  run govc compute.policy.rm enoent
+  assert_failure
+
+  run govc compute.policy.rm "$id"
+  assert_success
+}

--- a/vapi/compute/internal/internal.go
+++ b/vapi/compute/internal/internal.go
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+const (
+	PolicyPath             = "/vcenter/compute/policies"
+	PolicyCapabilitiesPath = "/vcenter/compute/policies/capabilities"
+)

--- a/vapi/compute/policy.go
+++ b/vapi/compute/policy.go
@@ -1,0 +1,67 @@
+/*
+Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0.
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compute
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+// PolicyManager provides convenience methods to operate Compute Policy
+type PolicyManager struct {
+	*rest.Client
+}
+
+// NewPolicyManager creates a new PolicyManager with the given client
+func NewPolicyManager(client *rest.Client) *PolicyManager {
+	return &PolicyManager{
+		Client: client,
+	}
+}
+
+// Policy represents the structure a compute policy.
+type Policy struct {
+	Class       string `json:"@class,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	VMTag       string `json:"vm_tag,omitempty"`
+	Capability  string `json:"capability,omitempty"`
+	Policy      string `json:"policy,omitempty"`
+}
+
+// Create creates a new Compute Policy and returns the id.
+func (c *PolicyManager) Create(ctx context.Context, policy Policy) (string, error) {
+	spec := struct {
+		ComputePolicy Policy `json:"spec"`
+	}{
+		ComputePolicy: policy,
+	}
+
+	r := c.Resource(internal.ComputePolicyPath)
+	var res string
+	return res, c.Do(ctx, r.Request(http.MethodPost, spec), &res)
+}
+
+// List returns information about the compute policies available in this vCenter server.
+func (c *PolicyManager) List(ctx context.Context) ([]Policy, error) {
+	r := c.Resource(internal.ComputePolicyPath)
+	var res []Policy
+	return res, c.Do(ctx, r.Request(http.MethodGet), &res)
+}

--- a/vapi/compute/policy.go
+++ b/vapi/compute/policy.go
@@ -19,8 +19,9 @@ package compute
 import (
 	"context"
 	"net/http"
+	"path"
 
-	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vapi/compute/internal"
 	"github.com/vmware/govmomi/vapi/rest"
 )
 
@@ -38,30 +39,62 @@ func NewPolicyManager(client *rest.Client) *PolicyManager {
 
 // Policy represents the structure a compute policy.
 type Policy struct {
-	Class       string `json:"@class,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Capability  string `json:"capability,omitempty"`
+	Description string `json:"description,omitempty"`
+	Policy      string `json:"policy,omitempty"`
+	HostTag     string `json:"host_tag,omitempty"`
+	VMTag       string `json:"vm_tag,omitempty"`
+}
+
+// Capability contains information about a compute policy capability.
+type Capability struct {
+	Capability  string `json:"capability,omitempty"`
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	VMTag       string `json:"vm_tag,omitempty"`
-	Capability  string `json:"capability,omitempty"`
-	Policy      string `json:"policy,omitempty"`
 }
 
 // Create creates a new Compute Policy and returns the id.
 func (c *PolicyManager) Create(ctx context.Context, policy Policy) (string, error) {
 	spec := struct {
-		ComputePolicy Policy `json:"spec"`
-	}{
-		ComputePolicy: policy,
-	}
+		Policy `json:"spec"`
+	}{policy}
 
-	r := c.Resource(internal.ComputePolicyPath)
+	r := c.Resource(internal.PolicyPath)
 	var res string
 	return res, c.Do(ctx, r.Request(http.MethodPost, spec), &res)
 }
 
+// Delete deletes a Compute Policy.
+func (c *PolicyManager) Delete(ctx context.Context, id string) error {
+	r := c.Resource(path.Join(internal.PolicyPath, id))
+	return c.Do(ctx, r.Request(http.MethodDelete), nil)
+}
+
 // List returns information about the compute policies available in this vCenter server.
 func (c *PolicyManager) List(ctx context.Context) ([]Policy, error) {
-	r := c.Resource(internal.ComputePolicyPath)
+	r := c.Resource(internal.PolicyPath)
 	var res []Policy
 	return res, c.Do(ctx, r.Request(http.MethodGet), &res)
+}
+
+// Get returns information about a specific compute policy
+func (c *PolicyManager) Get(ctx context.Context, id string) ([]Policy, error) {
+	r := c.Resource(path.Join(internal.PolicyPath, id))
+	var res []Policy
+	return res, c.Do(ctx, r.Request(http.MethodGet), &res)
+}
+
+// ListCapability returns information about the compute policy capabilities available in this vCenter server.
+func (c *PolicyManager) ListCapability(ctx context.Context) ([]Capability, error) {
+	r := c.Resource(internal.PolicyCapabilitiesPath)
+	var res []Capability
+	return res, c.Do(ctx, r.Request(http.MethodGet), &res)
+}
+
+// GetCapability returns information about the compute policy capability id.
+func (c *PolicyManager) GetCapability(ctx context.Context, id string) (*Capability, error) {
+	r := c.Resource(path.Join(internal.PolicyCapabilitiesPath, id))
+	var res Capability
+	return &res, c.Do(ctx, r.Request(http.MethodGet), &res)
 }

--- a/vapi/compute/simulator/simulator.go
+++ b/vapi/compute/simulator/simulator.go
@@ -1,0 +1,193 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/google/uuid"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/compute"
+	"github.com/vmware/govmomi/vapi/rest"
+	vapi "github.com/vmware/govmomi/vapi/simulator"
+
+	"github.com/vmware/govmomi/vapi/compute/internal"
+)
+
+func init() {
+	simulator.RegisterEndpoint(func(s *simulator.Service, r *simulator.Registry) {
+		New(s.Listen).Register(s, r)
+	})
+}
+
+// captured via govc compute.policy.ls -c -dump
+var capabilities = []compute.Capability{
+	{
+		Capability:  "com.vmware.vcenter.compute.policies.capabilities.vm_host_anti_affinity",
+		Name:        "VM-Host anti-affinity",
+		Description: "Virtual machines that have the VM tag will not be placed on hosts that have the host tag.",
+	},
+	{
+		Capability:  "com.vmware.vcenter.compute.policies.capabilities.vm_vm_affinity",
+		Name:        "VM-VM affinity",
+		Description: "All virtual machines that share the tag will be affined to each other.",
+	},
+	{
+		Capability:  "com.vmware.vcenter.compute.policies.capabilities.vm_host_affinity",
+		Name:        "VM-Host affinity",
+		Description: "Virtual machines that have the VM tag will be placed on hosts that have the host tag.",
+	},
+	{
+		Capability:  "com.vmware.vcenter.compute.policies.capabilities.vm.evacuation.vmotion",
+		Name:        "VM evacuation by vMotion",
+		Description: "Virtual machines that have the VM tag will be vMotioned when their host is evacuated.",
+	},
+	{
+		Capability:  "com.vmware.vcenter.compute.policies.capabilities.vm_vm_anti_affinity",
+		Name:        "VM-VM anti-affinity",
+		Description: "All virtual machines that share the tag will be anti-affine to each other.",
+	},
+	{
+		Capability:  "com.vmware.vcenter.compute.policies.capabilities.disable_drs_vmotion",
+		Name:        "Disable DRS vMotion",
+		Description: "All virtual machines that share the tag will stay on the host on which they are powered-on, except when the host is put into maintenance mode or failed over.",
+	},
+	{
+		Capability:  "com.vmware.vcenter.compute.policies.capabilities.cluster_scale_in_ignore_vm_capabilities",
+		Name:        "Scale-in ignore VM capabilities",
+		Description: "When considering scaling-in a cluster, policies that have been created with the listed capabilities are ignored for virtual machines that have the tag.",
+	},
+}
+
+// Handler implements the Cluster Policies API simulator
+type Handler struct {
+	Policies map[string]compute.Policy
+	URL      *url.URL
+}
+
+// New creates a Handler instance
+func New(u *url.URL) *Handler {
+	return &Handler{
+		Policies: make(map[string]compute.Policy),
+		URL:      u,
+	}
+}
+
+// Register Cluster Policies API paths with the vapi simulator's http.ServeMux
+func (h *Handler) Register(s *simulator.Service, r *simulator.Registry) {
+	if r.IsVPX() {
+		s.HandleFunc(rest.Path+internal.PolicyPath, h.policies)
+		s.HandleFunc(rest.Path+internal.PolicyPath+"/", h.policiesID)
+		s.HandleFunc(rest.Path+internal.PolicyCapabilitiesPath, h.capabilities)
+		s.HandleFunc(rest.Path+internal.PolicyCapabilitiesPath+"/", h.capabilitiesID)
+	}
+}
+
+func capability(id string) *compute.Capability {
+	for _, c := range capabilities {
+		if c.Capability == id {
+			return &c
+		}
+	}
+	return nil
+}
+
+func (h *Handler) policies(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		var res []compute.Policy
+		for _, p := range h.Policies {
+			res = append(res, p)
+		}
+		vapi.OK(w, res)
+	case http.MethodPost:
+		var spec struct {
+			compute.Policy `json:"spec"`
+		}
+
+		if !vapi.Decode(r, w, &spec) {
+			return
+		}
+
+		c := capability(spec.Capability)
+
+		tag := spec.VMTag
+		if tag == "" {
+			tag = spec.HostTag
+		}
+		// TODO: validate tag
+
+		if c == nil || tag == "" || spec.Name == "" || spec.Description == "" {
+			vapi.BadRequest(w, "com.vmware.vapi.std.errors.invalid_argument")
+			return
+		}
+
+		id := uuid.New().String()
+		h.Policies[id] = compute.Policy{
+			Capability:  spec.Capability,
+			Description: spec.Description,
+			Name:        spec.Name,
+			Policy:      id,
+		}
+
+		vapi.OK(w, id)
+	}
+}
+
+func (h *Handler) policiesID(w http.ResponseWriter, r *http.Request) {
+	id := path.Base(r.URL.Path)
+	p, ok := h.Policies[id]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		vapi.OK(w, p)
+	case http.MethodDelete:
+		delete(h.Policies, id)
+		vapi.OK(w)
+	}
+}
+
+func (h *Handler) capabilities(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	vapi.OK(w, capabilities)
+}
+
+func (h *Handler) capabilitiesID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := path.Base(r.URL.Path)
+	c := capability(id)
+	if c == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	vapi.OK(w, c)
+}

--- a/vapi/internal/internal.go
+++ b/vapi/internal/internal.go
@@ -42,6 +42,7 @@ const (
 	VCenterOVFLibraryItem          = "/com/vmware/vcenter/ovf/library-item"
 	VCenterVMTXLibraryItem         = "/vcenter/vm-template/library-items"
 	VCenterVM                      = "/vcenter/vm"
+	ComputePolicyPath              = "/vcenter/compute/policies"
 	SessionCookieName              = "vmware-api-session-id"
 )
 

--- a/vapi/internal/internal.go
+++ b/vapi/internal/internal.go
@@ -42,7 +42,6 @@ const (
 	VCenterOVFLibraryItem          = "/com/vmware/vcenter/ovf/library-item"
 	VCenterVMTXLibraryItem         = "/vcenter/vm-template/library-items"
 	VCenterVM                      = "/vcenter/vm"
-	ComputePolicyPath              = "/vcenter/compute/policies"
 	SessionCookieName              = "vmware-api-session-id"
 )
 

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -43,6 +43,7 @@ import (
 	_ "github.com/vmware/govmomi/pbm/simulator"
 	_ "github.com/vmware/govmomi/sts/simulator"
 	_ "github.com/vmware/govmomi/vapi/cluster/simulator"
+	_ "github.com/vmware/govmomi/vapi/compute/simulator"
 	_ "github.com/vmware/govmomi/vapi/simulator"
 )
 


### PR DESCRIPTION
- Add vAPI REST client support

- Add govc compute.policy.{ls,rm.create} commands

- Add simulator support and bats tests
