### PR TITLE
vapi: prefer header authn to cookie authn

### DIFF
--- a/govc/library/export.go
+++ b/govc/library/export.go
@@ -135,7 +135,9 @@ func (cmd *export) Run(ctx context.Context, f *flag.FlagSet) error {
 
 		download := func(src *url.URL, name string) error {
 			p := soap.DefaultDownload
-
+			p.Headers = map[string]string{
+				"vmware-api-session-id": c.SessionID,
+			}
 			if isStdout {
 				s, _, err := c.Download(ctx, src, &p)
 				if err != nil {

--- a/vapi/internal/internal.go
+++ b/vapi/internal/internal.go
@@ -43,6 +43,7 @@ const (
 	VCenterVMTXLibraryItem         = "/vcenter/vm-template/library-items"
 	VCenterVM                      = "/vcenter/vm"
 	SessionCookieName              = "vmware-api-session-id"
+	UseHeaderAuthn                 = "vmware-use-header-authn"
 )
 
 // AssociatedObject is the same structure as types.ManagedObjectReference,

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -363,6 +363,7 @@ func Decode(r *http.Request, w http.ResponseWriter, val interface{}) bool {
 
 func (s *handler) session(w http.ResponseWriter, r *http.Request) {
 	id := r.Header.Get(internal.SessionCookieName)
+	useHeaderAuthn := strings.ToLower(r.Header.Get(internal.UseHeaderAuthn))
 
 	switch r.Method {
 	case http.MethodPost:
@@ -382,11 +383,13 @@ func (s *handler) session(w http.ResponseWriter, r *http.Request) {
 		id = uuid.New().String()
 		now := time.Now()
 		s.Session[id] = &rest.Session{User: user, Created: now, LastAccessed: now}
-		http.SetCookie(w, &http.Cookie{
-			Name:  internal.SessionCookieName,
-			Value: id,
-			Path:  rest.Path,
-		})
+		if useHeaderAuthn != "true" {
+			http.SetCookie(w, &http.Cookie{
+				Name:  internal.SessionCookieName,
+				Value: id,
+				Path:  rest.Path,
+			})
+		}
 		OK(w, id)
 	case http.MethodDelete:
 		delete(s.Session, id)


### PR DESCRIPTION
Cookie based authentication will be deprecated soon, switch to using
header based authentication by default.

Note: for vCenter versions that doesn't support vmware-use-header-authn,
rest.Client will continue to use cookie authn transparently via Go's
http.Client cookie.Jar