### PR TITLE
vcsim: validate session key in TerminateSession method

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -50,7 +50,7 @@ load test_helper
   govc cluster.create comp
   govc cluster.add -cluster comp -hostname test.host.com -username user -password pass
   govc cluster.add -cluster comp -hostname test2.host.com -username user -password pass
-  govc datastore.create -type local -name vol6 -path "$TMPDIR" test.host.com
+  govc datastore.create -type local -name vol6 -path "$BATS_TMPDIR" test.host.com
   govc pool.create comp/Resources/testPool
   govc vm.create -c 1 -ds vol6 -g centos64Guest -pool testPool -m 4096 "$id"
   govc vm.destroy "$id"
@@ -370,7 +370,7 @@ docker_name() {
 
   vcsim_stop
 
-  dir=$(mktemp -d govc-test-XXXXX)
+  dir=$($mktemp --tmpdir -d govc-test-XXXXX)
   echo nobody > "$dir/username"
   echo nothing > "$dir/password"
 

--- a/simulator/session_manager.go
+++ b/simulator/session_manager.go
@@ -175,6 +175,10 @@ func (s *SessionManager) TerminateSession(ctx *Context, req *types.TerminateSess
 			body.Fault_ = Fault("", new(types.InvalidArgument))
 			return body
 		}
+		if _, ok := s.sessions[id]; !ok {
+			body.Fault_ = Fault("", new(types.NotFound))
+			return body
+		}
 		delete(s.sessions, id)
 	}
 


### PR DESCRIPTION
Return NotFound fault if session key does not exist.

- Switch remaining session tests to use vcsim

- Add session persist test

- Use mktemp --tmpdir when creating test directories