### PR TITLE
Add SetTaskState SetTaskDescription UpdateProgress to object package

### DIFF
--- a/object/task.go
+++ b/object/task.go
@@ -65,8 +65,8 @@ func (t *Task) Cancel(ctx context.Context) error {
 	return err
 }
 
-// SetTaskState sets task state and optionally sets results or fault, as appropriate for state.
-func (t *Task) SetTaskState(ctx context.Context, state types.TaskInfoState, result types.AnyType, fault *types.LocalizedMethodFault) error {
+// SetState sets task state and optionally sets results or fault, as appropriate for state.
+func (t *Task) SetState(ctx context.Context, state types.TaskInfoState, result types.AnyType, fault *types.LocalizedMethodFault) error {
 	req := types.SetTaskState{
 		This:   t.Reference(),
 		State:  state,
@@ -77,8 +77,8 @@ func (t *Task) SetTaskState(ctx context.Context, state types.TaskInfoState, resu
 	return err
 }
 
-// SetTaskDescription updates task description to describe the current phase of the task.
-func (t *Task) SetTaskDescription(ctx context.Context, description types.LocalizableMessage) error {
+// SetDescription updates task description to describe the current phase of the task.
+func (t *Task) SetDescription(ctx context.Context, description types.LocalizableMessage) error {
 	req := types.SetTaskDescription{
 		This:        t.Reference(),
 		Description: description,

--- a/object/task.go
+++ b/object/task.go
@@ -64,3 +64,37 @@ func (t *Task) Cancel(ctx context.Context) error {
 
 	return err
 }
+
+// SetTaskState sets task state and optionally sets results or fault, as appropriate for state.
+func (t *Task) SetTaskState(ctx context.Context, state types.TaskInfoState, result types.AnyType, fault *types.LocalizedMethodFault) error {
+	req := types.SetTaskState{
+		This:   t.Reference(),
+		State:  state,
+		Result: result,
+		Fault:  fault,
+	}
+	_, err := methods.SetTaskState(ctx, t.Common.Client(), &req)
+	return err
+}
+
+// SetTaskDescription updates task description to describe the current phase of the task.
+func (t *Task) SetTaskDescription(ctx context.Context, description types.LocalizableMessage) error {
+	req := types.SetTaskDescription{
+		This:        t.Reference(),
+		Description: description,
+	}
+	_, err := methods.SetTaskDescription(ctx, t.Common.Client(), &req)
+	return err
+}
+
+// UpdateProgress Sets percentage done for this task and recalculates overall percentage done.
+// If a percentDone value of less than zero or greater than 100 is specified,
+// a value of zero or 100 respectively is used.
+func (t *Task) UpdateProgress(ctx context.Context, percentDone int) error {
+	req := types.UpdateProgress{
+		This:        t.Reference(),
+		PercentDone: int32(percentDone),
+	}
+	_, err := methods.UpdateProgress(ctx, t.Common.Client(), &req)
+	return err
+}


### PR DESCRIPTION
SetTaskState lets you set the state of the task.
SetTaskDescription sets the description of the task in the UI
UpdateProgress changes the progress bar of the task in the UI.