### PR TITLE
Refactor govc session persistence into session/cache package

### DIFF
--- a/govc/about/cert.go
+++ b/govc/about/cert.go
@@ -88,7 +88,7 @@ func (r *certResult) Write(w io.Writer) error {
 	}
 
 	if r.cmd.thumbprint {
-		u := r.cmd.URLWithoutPassword()
+		u := r.cmd.Session.URL
 		_, err := fmt.Fprintf(w, "%s %s\n", u.Host, r.info.ThumbprintSHA1)
 		return err
 	}
@@ -97,7 +97,7 @@ func (r *certResult) Write(w io.Writer) error {
 }
 
 func (cmd *cert) Run(ctx context.Context, f *flag.FlagSet) error {
-	u := cmd.URLWithoutPassword()
+	u := cmd.Session.URL
 	c := soap.NewClient(u, false)
 	t := c.Client.Transport.(*http.Transport)
 	r := certResult{cmd: cmd}
@@ -110,7 +110,7 @@ func (cmd *cert) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	if r.info.Err != nil && r.cmd.IsSecure() {
+	if r.info.Err != nil && !r.cmd.Session.Insecure {
 		cmd.Out = os.Stderr
 		// using same exit code as curl:
 		defer os.Exit(60)

--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -18,14 +18,10 @@ package flags
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
-	"log"
 	"net/url"
 	"os"
 	"os/signal"
@@ -35,11 +31,10 @@ import (
 	"time"
 
 	"github.com/vmware/govmomi/session"
-	"github.com/vmware/govmomi/sts"
+	"github.com/vmware/govmomi/session/cache"
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
-	"github.com/vmware/govmomi/vim25/types"
 )
 
 const (
@@ -66,12 +61,10 @@ type ClientFlag struct {
 
 	*DebugFlag
 
-	url           *url.URL
 	username      string
 	password      string
 	cert          string
 	key           string
-	insecure      bool
 	persist       bool
 	minAPIVersion string
 	vimNamespace  string
@@ -79,8 +72,8 @@ type ClientFlag struct {
 	tlsCaCerts    string
 	tlsKnownHosts string
 	client        *vim25.Client
-
-	Login func(context.Context, *vim25.Client) error
+	restClient    *rest.Client
+	Session       cache.Session
 }
 
 var (
@@ -100,32 +93,13 @@ func NewClientFlag(ctx context.Context) (*ClientFlag, context.Context) {
 	}
 
 	v := &ClientFlag{}
-	v.Login = v.login
 	v.DebugFlag, ctx = NewDebugFlag(ctx)
 	ctx = context.WithValue(ctx, clientFlagKey, v)
 	return v, ctx
 }
 
-func (flag *ClientFlag) URLWithoutPassword() *url.URL {
-	if flag.url == nil {
-		return nil
-	}
-
-	withoutCredentials := *flag.url
-	withoutCredentials.User = url.User(flag.url.User.Username())
-	return &withoutCredentials
-}
-
-func (flag *ClientFlag) Userinfo() *url.Userinfo {
-	return flag.url.User
-}
-
-func (flag *ClientFlag) IsSecure() bool {
-	return !flag.insecure
-}
-
 func (flag *ClientFlag) String() string {
-	url := flag.URLWithoutPassword()
+	url := flag.Session.Endpoint()
 	if url == nil {
 		return ""
 	}
@@ -136,7 +110,7 @@ func (flag *ClientFlag) String() string {
 func (flag *ClientFlag) Set(s string) error {
 	var err error
 
-	flag.url, err = soap.ParseURL(s)
+	flag.Session.URL, err = soap.ParseURL(s)
 
 	return err
 }
@@ -176,7 +150,7 @@ func (flag *ClientFlag) Register(ctx context.Context, f *flag.FlagSet) {
 			}
 
 			usage := fmt.Sprintf("Skip verification of server certificate [%s]", envInsecure)
-			f.BoolVar(&flag.insecure, "k", insecure, usage)
+			f.BoolVar(&flag.Session.Insecure, "k", insecure, usage)
 		}
 
 		{
@@ -238,8 +212,12 @@ func (flag *ClientFlag) Process(ctx context.Context) error {
 			return err
 		}
 
-		if flag.url == nil {
+		if flag.Session.URL == nil {
 			return errors.New("specify an " + cDescr)
+		}
+
+		if !flag.persist {
+			flag.Session.Passthrough = true
 		}
 
 		flag.username, err = session.Secret(flag.username)
@@ -256,14 +234,14 @@ func (flag *ClientFlag) Process(ctx context.Context) error {
 			var password string
 			var ok bool
 
-			if flag.url.User != nil {
-				password, ok = flag.url.User.Password()
+			if flag.Session.URL.User != nil {
+				password, ok = flag.Session.URL.User.Password()
 			}
 
 			if ok {
-				flag.url.User = url.UserPassword(flag.username, password)
+				flag.Session.URL.User = url.UserPassword(flag.username, password)
 			} else {
-				flag.url.User = url.User(flag.username)
+				flag.Session.URL.User = url.User(flag.username)
 			}
 		}
 
@@ -271,23 +249,23 @@ func (flag *ClientFlag) Process(ctx context.Context) error {
 		if flag.password != "" {
 			var username string
 
-			if flag.url.User != nil {
-				username = flag.url.User.Username()
+			if flag.Session.URL.User != nil {
+				username = flag.Session.URL.User.Username()
 			}
 
-			flag.url.User = url.UserPassword(username, flag.password)
+			flag.Session.URL.User = url.UserPassword(username, flag.password)
 		}
 
 		return nil
 	})
 }
 
-// configure TLS and retry settings before making any connections
-func (flag *ClientFlag) configure(sc *soap.Client) (soap.RoundTripper, error) {
+// configure TLS
+func (flag *ClientFlag) configure(sc *soap.Client) error {
 	if flag.cert != "" {
 		cert, err := tls.LoadX509KeyPair(flag.cert, flag.key)
 		if err != nil {
-			return nil, fmt.Errorf("%s=%q %s=%q: %s", envCertificate, flag.cert, envPrivateKey, flag.key, err)
+			return fmt.Errorf("%s=%q %s=%q: %s", envCertificate, flag.cert, envPrivateKey, flag.key, err)
 		}
 
 		sc.SetCertificate(cert)
@@ -300,11 +278,11 @@ func (flag *ClientFlag) configure(sc *soap.Client) (soap.RoundTripper, error) {
 	sc.UserAgent = fmt.Sprintf("govc/%s", Version)
 
 	if err := flag.SetRootCAs(sc); err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := sc.LoadThumbprints(flag.tlsKnownHosts); err != nil {
-		return nil, err
+		return err
 	}
 
 	t := sc.DefaultTransport()
@@ -314,111 +292,11 @@ func (flag *ClientFlag) configure(sc *soap.Client) (soap.RoundTripper, error) {
 	if value != "" {
 		t.TLSHandshakeTimeout, err = time.ParseDuration(value)
 		if err != nil {
-			return nil, err
+			return err
 		}
-	}
-
-	// Retry twice when a temporary I/O error occurs.
-	// This means a maximum of 3 attempts.
-	return vim25.Retry(sc, vim25.TemporaryNetworkError(3)), nil
-}
-
-func (flag *ClientFlag) sessionFile() string {
-	url := flag.URLWithoutPassword()
-
-	// Key session file off of full URI and insecure setting.
-	// Hash key to get a predictable, canonical format.
-	key := fmt.Sprintf("%s#insecure=%t", url.String(), flag.insecure)
-	name := fmt.Sprintf("%064x", sha256.Sum256([]byte(key)))
-	return filepath.Join(home, "sessions", name)
-}
-
-func (flag *ClientFlag) saveClient(c *vim25.Client) error {
-	if !flag.persist {
-		return nil
-	}
-
-	p := flag.sessionFile()
-	err := os.MkdirAll(filepath.Dir(p), 0700)
-	if err != nil {
-		return err
-	}
-
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY, 0600)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	err = json.NewEncoder(f).Encode(c)
-	if err != nil {
-		return err
 	}
 
 	return nil
-}
-
-func (flag *ClientFlag) restoreClient(c *vim25.Client) (bool, error) {
-	if !flag.persist {
-		return false, nil
-	}
-
-	f, err := os.Open(flag.sessionFile())
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	defer f.Close()
-
-	dec := json.NewDecoder(f)
-	err = dec.Decode(c)
-	if err != nil {
-		return false, err
-	}
-
-	return true, nil
-}
-
-func (flag *ClientFlag) loadClient() (*vim25.Client, error) {
-	c := new(vim25.Client)
-	ok, err := flag.restoreClient(c)
-	if err != nil {
-		return nil, err
-	}
-
-	if !ok || !c.Valid() {
-		return nil, nil
-	}
-
-	c.RoundTripper, err = flag.configure(c.Client)
-	if err != nil {
-		return nil, err
-	}
-
-	m := session.NewManager(c)
-	u, err := m.UserSession(context.TODO())
-	if err != nil {
-		if soap.IsSoapFault(err) {
-			fault := soap.ToSoapFault(err).VimFault()
-			// If the PropertyCollector is not found, the saved session for this URL is not valid
-			if _, ok := fault.(types.ManagedObjectNotFound); ok {
-				return nil, nil
-			}
-		}
-
-		return nil, err
-	}
-
-	// If the session is nil, the client is not authenticated
-	if u == nil {
-		return nil, nil
-	}
-
-	return c, nil
 }
 
 func (flag *ClientFlag) SetRootCAs(c *soap.Client) error {
@@ -426,77 +304,6 @@ func (flag *ClientFlag) SetRootCAs(c *soap.Client) error {
 		return c.SetRootCAs(flag.tlsCaCerts)
 	}
 	return nil
-}
-
-func (flag *ClientFlag) login(ctx context.Context, c *vim25.Client) error {
-	m := session.NewManager(c)
-	u := flag.url.User
-	name := u.Username()
-
-	if name == "" && !c.IsVC() {
-		// If no username is provided, try to acquire a local ticket.
-		// When invoked remotely, ESX returns an InvalidRequestFault.
-		// So, rather than return an error here, fallthrough to Login() with the original User to
-		// to avoid what would be a confusing error message.
-		luser, lerr := flag.localTicket(ctx, m)
-		if lerr == nil {
-			// We are running directly on an ESX or Workstation host and can use the ticket with Login()
-			u = luser
-			name = u.Username()
-		}
-	}
-	if name == "" {
-		// Skip auto-login if we don't have a username
-		flag.persist = true // Not persisting, but this avoids the call to Logout()
-		return nil          // Avoid SaveSession for non-authenticated session
-	}
-
-	return m.Login(ctx, u)
-}
-
-func (flag *ClientFlag) newClient() (*vim25.Client, error) {
-	ctx := context.TODO()
-	sc := soap.NewClient(flag.url, flag.insecure)
-
-	rt, err := flag.configure(sc)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := vim25.NewClient(ctx, rt)
-	if err != nil {
-		return nil, err
-	}
-
-	// Set client, since we didn't pass it in the constructor
-	c.Client = sc
-
-	if flag.vimVersion == "" {
-		if err = c.UseServiceVersion(); err != nil {
-			return nil, err
-		}
-		flag.vimVersion = c.Version
-	}
-
-	if err := flag.Login(ctx, c); err != nil {
-		return nil, err
-	}
-
-	return c, flag.saveClient(c)
-}
-
-func (flag *ClientFlag) localTicket(ctx context.Context, m *session.Manager) (*url.Userinfo, error) {
-	ticket, err := m.AcquireLocalTicket(ctx, os.Getenv("USER"))
-	if err != nil {
-		return nil, err
-	}
-
-	password, err := ioutil.ReadFile(ticket.PasswordFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return url.UserPassword(ticket.UserName, string(password)), nil
 }
 
 func isDevelopmentVersion(apiVersion string) bool {
@@ -543,17 +350,10 @@ func (flag *ClientFlag) Client() (*vim25.Client, error) {
 		return flag.client, nil
 	}
 
-	c, err := flag.loadClient()
+	c := new(vim25.Client)
+	err := flag.Session.Login(context.Background(), c, flag.configure)
 	if err != nil {
 		return nil, err
-	}
-
-	// loadClient returns nil if it was unable to load a session from disk
-	if c == nil {
-		c, err = flag.newClient()
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	// Check that the endpoint has the right API version
@@ -562,54 +362,54 @@ func (flag *ClientFlag) Client() (*vim25.Client, error) {
 		return nil, err
 	}
 
+	if flag.vimVersion == "" {
+		err = c.UseServiceVersion()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Retry twice when a temporary I/O error occurs.
+	// This means a maximum of 3 attempts.
+	c.RoundTripper = vim25.Retry(c.Client, vim25.TemporaryNetworkError(3))
 	flag.client = c
+
 	return flag.client, nil
 }
 
-func (flag *ClientFlag) Logout(ctx context.Context) error {
-	if flag.persist || flag.client == nil {
-		return nil
+func (flag *ClientFlag) RestClient() (*rest.Client, error) {
+	if flag.restClient != nil {
+		return flag.restClient, nil
 	}
 
-	m := session.NewManager(flag.client)
+	c := new(rest.Client)
 
-	return m.Logout(ctx)
+	err := flag.Session.Login(context.Background(), c, flag.configure)
+	if err != nil {
+		return nil, err
+	}
+
+	flag.restClient = c
+	return flag.restClient, nil
+}
+
+func (flag *ClientFlag) Logout(ctx context.Context) error {
+	if flag.client != nil {
+		_ = flag.Session.Logout(ctx, flag.client)
+	}
+
+	if flag.restClient != nil {
+		_ = flag.Session.Logout(ctx, flag.restClient)
+	}
+
+	return nil
 }
 
 func (flag *ClientFlag) WithRestClient(ctx context.Context, f func(*rest.Client) error) error {
-	vc, err := flag.Client()
+	c, err := flag.RestClient()
 	if err != nil {
 		return err
 	}
-
-	c := rest.NewClient(vc)
-
-	// TODO: rest.Client session cookie should be persisted as the soap.Client session cookie is.
-	if vc.Certificate() == nil {
-		if err = c.Login(ctx, flag.Userinfo()); err != nil {
-			return err
-		}
-	} else {
-		// TODO: session.login should support rest.Client SSO login to avoid this env var (depends on the TODO above)
-		token := os.Getenv("GOVC_LOGIN_TOKEN")
-		if token == "" {
-			return errors.New("GOVC_LOGIN_TOKEN must be set for rest.Client SSO login")
-		}
-		signer := &sts.Signer{
-			Certificate: c.Certificate(),
-			Token:       token,
-		}
-
-		if err = c.LoginByToken(c.WithSigner(ctx, signer)); err != nil {
-			return err
-		}
-	}
-
-	defer func() {
-		if err := c.Logout(ctx); err != nil {
-			log.Printf("user logout error: %v", err)
-		}
-	}()
 
 	return f(c)
 }
@@ -621,7 +421,7 @@ func (flag *ClientFlag) Environ(extra bool) []string {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	u := *flag.url
+	u := *flag.Session.URL
 	if u.User != nil {
 		add(envUsername, u.User.Username())
 
@@ -657,7 +457,7 @@ func (flag *ClientFlag) Environ(extra bool) []string {
 	}
 
 	if extra {
-		add("GOVC_URL_SCHEME", flag.url.Scheme)
+		add("GOVC_URL_SCHEME", flag.Session.URL.Scheme)
 
 		v := strings.SplitN(u.Host, ":", 2)
 		add("GOVC_URL_HOST", v[0])
@@ -665,13 +465,13 @@ func (flag *ClientFlag) Environ(extra bool) []string {
 			add("GOVC_URL_PORT", v[1])
 		}
 
-		add("GOVC_URL_PATH", flag.url.Path)
+		add("GOVC_URL_PATH", flag.Session.URL.Path)
 
-		if f := flag.url.Fragment; f != "" {
+		if f := flag.Session.URL.Fragment; f != "" {
 			add("GOVC_URL_FRAGMENT", f)
 		}
 
-		if q := flag.url.RawQuery; q != "" {
+		if q := flag.Session.URL.RawQuery; q != "" {
 			add("GOVC_URL_QUERY", q)
 		}
 	}

--- a/govc/session/logout.go
+++ b/govc/session/logout.go
@@ -27,6 +27,8 @@ import (
 
 type logout struct {
 	*flags.ClientFlag
+
+	vapi bool
 }
 
 func init() {
@@ -36,6 +38,8 @@ func init() {
 func (cmd *logout) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
 	cmd.ClientFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.vapi, "r", false, "REST logout")
 }
 
 func (cmd *logout) Process(ctx context.Context) error {
@@ -59,5 +63,15 @@ func (cmd *logout) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return session.NewManager(c).Logout(ctx)
+	err = session.NewManager(c).Logout(ctx)
+
+	if cmd.vapi {
+		rc, err := cmd.RestClient()
+		if err != nil {
+			return err
+		}
+		return rc.Logout(ctx)
+	}
+
+	return err
 }

--- a/govc/sso/client.go
+++ b/govc/sso/client.go
@@ -57,7 +57,7 @@ func WithClient(ctx context.Context, cmd *flags.ClientFlag, f func(*ssoadmin.Cli
 
 		req := sts.TokenRequest{
 			Certificate: vc.Certificate(),
-			Userinfo:    cmd.Userinfo(),
+			Userinfo:    cmd.Session.URL.User,
 		}
 
 		header.Security, cerr = tokens.Issue(ctx, req)

--- a/govc/sso/user/id.go
+++ b/govc/sso/user/id.go
@@ -91,7 +91,7 @@ func (r *userID) Dump() interface{} {
 func (cmd *id) Run(ctx context.Context, f *flag.FlagSet) error {
 	arg := f.Arg(0)
 	if arg == "" {
-		arg = cmd.Userinfo().Username()
+		arg = cmd.Session.URL.User.Username()
 	}
 
 	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {

--- a/session/cache/example_test.go
+++ b/session/cache/example_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/govmomi/session/cache"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+
+	"github.com/vmware/govmomi/vapi/rest"
+	_ "github.com/vmware/govmomi/vapi/simulator"
+)
+
+func ExampleSession_Login() {
+	simulator.Run(func(ctx context.Context, sim *vim25.Client) error {
+		u := sim.URL()
+		u.User = simulator.DefaultLogin
+
+		// Login() each client twice
+		// 1) creates a new authenticated session
+		// 2) uses a cached session (proved by removing the password)
+		for i := 0; i < 2; i++ {
+			s := &cache.Session{
+				URL:      u,
+				Insecure: true,
+			}
+
+			vc := new(vim25.Client)
+			err := s.Login(ctx, vc, nil)
+			if err != nil {
+				return err
+			}
+
+			rc := new(rest.Client)
+			err = s.Login(ctx, rc, nil)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("%s authenticated\n", u.User)
+			u.User = url.User(u.User.Username()) // Remove password
+		}
+		return nil
+	})
+	// Output:
+	// user:pass authenticated
+	// user authenticated
+}

--- a/session/cache/session.go
+++ b/session/cache/session.go
@@ -1,0 +1,353 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// Client interface to support client session caching
+type Client interface {
+	json.Marshaler
+	json.Unmarshaler
+
+	Valid() bool
+	Path() string
+}
+
+// Session provides methods to cache authenticated vim25.Client and rest.Client sessions.
+// Use of session cache avoids the expense of creating and deleting vSphere sessions.
+// It also helps avoid the problem of "leaking sessions", as Session.Login will only
+// create a new authenticated session if the cached session does not exist or is invalid.
+// By default, username/password authentication is used to create new sessions.
+// The Session.Login{SOAP,REST} fields can be set to use other methods,
+// such as SAML token authentication (see govc session.login for example).
+type Session struct {
+	URL         *url.URL // URL of a vCenter or ESXi instance
+	Dir         string   // Dir defaults to "$HOME/.govmomi/sessions"
+	Insecure    bool     // Insecure param for soap.NewClient (tls.Config.InsecureSkipVerify)
+	Passthrough bool     // Passthrough disables caching when set to true
+
+	LoginSOAP func(context.Context, *vim25.Client) error // LoginSOAP defaults to session.Manager.Login()
+	LoginREST func(context.Context, *rest.Client) error  // LoginREST defaults to rest.Client.Login()
+}
+
+var (
+	home = os.Getenv("GOVMOMI_HOME")
+)
+
+func init() {
+	if home == "" {
+		dir, err := os.UserHomeDir()
+		if err != nil {
+			dir = os.Getenv("HOME")
+		}
+		home = filepath.Join(dir, ".govmomi")
+	}
+}
+
+// Endpoint returns a copy of the Session.URL with Password, Query and Fragment removed.
+func (s *Session) Endpoint() *url.URL {
+	if s.URL == nil {
+		return nil
+	}
+	p := &url.URL{
+		Scheme: s.URL.Scheme,
+		Host:   s.URL.Host,
+		Path:   s.URL.Path,
+	}
+	if u := s.URL.User; u != nil {
+		p.User = url.User(u.Username()) // Remove password
+	}
+	return p
+}
+
+// key is a digest of the URL scheme + username + host + Client.Path()
+func (s *Session) key(path string) string {
+	p := s.Endpoint()
+	p.Path = path
+
+	// Key session file off of full URI and insecure setting.
+	// Hash key to get a predictable, canonical format.
+	key := fmt.Sprintf("%s#insecure=%t", p.String(), s.Insecure)
+	return fmt.Sprintf("%064x", sha256.Sum256([]byte(key)))
+}
+
+func (s *Session) dir() string {
+	if s.Dir != "" {
+		return s.Dir
+	}
+	return filepath.Join(home, "sessions")
+}
+
+func (s *Session) file(p string) string {
+	return filepath.Join(s.dir(), s.key(p))
+}
+
+// Save a Client in the file cache.
+// Session will not be saved if Session.Passthrough is true.
+func (s *Session) Save(c Client) error {
+	if s.Passthrough {
+		return nil
+	}
+
+	p := s.file(c.Path())
+
+	err := os.MkdirAll(filepath.Dir(p), 0700)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+
+	err = json.NewEncoder(f).Encode(c)
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	return f.Close()
+}
+
+func (s *Session) get(c Client) (bool, error) {
+	f, err := os.Open(s.file(c.Path()))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	dec := json.NewDecoder(f)
+	err = dec.Decode(c)
+	if err != nil {
+		_ = f.Close()
+		return false, err
+	}
+
+	return c.Valid(), f.Close()
+}
+
+func localTicket(ctx context.Context, m *session.Manager) (*url.Userinfo, error) {
+	name := os.Getenv("USER")
+	u, err := user.Current()
+	if err == nil {
+		name = u.Username
+	}
+
+	ticket, err := m.AcquireLocalTicket(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	password, err := ioutil.ReadFile(ticket.PasswordFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return url.UserPassword(ticket.UserName, string(password)), nil
+}
+
+func (s *Session) loginSOAP(ctx context.Context, c *vim25.Client) error {
+	m := session.NewManager(c)
+	u := s.URL.User
+	name := u.Username()
+
+	if name == "" && !c.IsVC() {
+		// If no username is provided, try to acquire a local ticket.
+		// When invoked remotely, ESX returns an InvalidRequestFault.
+		// So, rather than return an error here, fallthrough to Login() with the original User to
+		// to avoid what would be a confusing error message.
+		luser, lerr := localTicket(ctx, m)
+		if lerr == nil {
+			// We are running directly on an ESX or Workstation host and can use the ticket with Login()
+			u = luser
+			name = u.Username()
+		}
+	}
+	if name == "" {
+		// ServiceContent does not require authentication
+		return nil
+	}
+
+	return m.Login(ctx, u)
+}
+
+func (s *Session) loginREST(ctx context.Context, c *rest.Client) error {
+	return c.Login(ctx, s.URL.User)
+}
+
+func soapSessionValid(ctx context.Context, client *vim25.Client) (bool, error) {
+	m := session.NewManager(client)
+	u, err := m.UserSession(ctx)
+	if err != nil {
+		if soap.IsSoapFault(err) {
+			fault := soap.ToSoapFault(err).VimFault()
+			// If the PropertyCollector is not found, the saved session for this URL is not valid
+			if _, ok := fault.(types.ManagedObjectNotFound); ok {
+				return false, nil
+			}
+		}
+
+		return false, err
+	}
+
+	return u != nil, nil
+}
+
+func restSessionValid(ctx context.Context, client *rest.Client) (bool, error) {
+	s, err := client.Session(ctx)
+	if err != nil {
+		return false, err
+	}
+	return s != nil, nil
+}
+
+// Load a Client from the file cache.
+// Returns false if no cache exists or is invalid.
+// An error is returned if the file cannot be opened or is not json encoded.
+// After loading the Client from the file:
+// Returns true if the session is still valid, false otherwise indicating the client requires authentication.
+// An error is returned if the session ID cannot be validated.
+// Returns false if Session.Passthrough is true.
+func (s *Session) Load(ctx context.Context, c Client, config func(*soap.Client) error) (bool, error) {
+	if s.Passthrough {
+		return false, nil
+	}
+
+	ok, err := s.get(c)
+	if err != nil {
+		return false, err
+
+	}
+	if !ok {
+		return false, nil
+	}
+
+	switch client := c.(type) {
+	case *vim25.Client:
+		if config != nil {
+			if err := config(client.Client); err != nil {
+				return false, err
+			}
+		}
+		return soapSessionValid(ctx, client)
+	case *rest.Client:
+		if config != nil {
+			if err := config(client.Client); err != nil {
+				return false, err
+			}
+		}
+		return restSessionValid(ctx, client)
+	default:
+		panic(fmt.Sprintf("unsupported client type=%T", client))
+	}
+}
+
+// Login returns a cached session via Load() if valid.
+// Otherwise, creates a new authenticated session and saves to the cache.
+// The config func can be used to apply soap.Client configuration, such as TLS settings.
+// When Session.Passthrough is true, Login will always create a new session.
+func (s *Session) Login(ctx context.Context, c Client, config func(*soap.Client) error) error {
+	ok, err := s.Load(ctx, c, config)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+
+	sc := soap.NewClient(s.URL, s.Insecure)
+
+	if config != nil {
+		err = config(sc)
+		if err != nil {
+			return err
+		}
+	}
+
+	switch client := c.(type) {
+	case *vim25.Client:
+		vc, err := vim25.NewClient(ctx, sc)
+		if err != nil {
+			return err
+		}
+
+		login := s.loginSOAP
+		if s.LoginSOAP != nil {
+			login = s.LoginSOAP
+		}
+		if err = login(ctx, vc); err != nil {
+			return err
+		}
+
+		*client = *vc
+		c = client
+	case *rest.Client:
+		vc := &vim25.Client{Client: sc}
+		rc := rest.NewClient(vc)
+
+		login := s.loginREST
+		if s.LoginREST != nil {
+			login = s.LoginREST
+		}
+		if err = login(ctx, rc); err != nil {
+			return err
+		}
+
+		*client = *rc
+		c = client
+	default:
+		panic(fmt.Sprintf("unsupported client type=%T", client))
+	}
+
+	return s.Save(c)
+}
+
+// Login calls the Logout method for the given Client if Session.Passthrough is true.
+// Otherwise returns nil.
+func (s *Session) Logout(ctx context.Context, c Client) error {
+	if s.Passthrough {
+		switch client := c.(type) {
+		case *vim25.Client:
+			return session.NewManager(client).Logout(ctx)
+		case *rest.Client:
+			return client.Logout(ctx)
+		default:
+			panic(fmt.Sprintf("unsupported client type=%T", client))
+		}
+	}
+	return nil
+}

--- a/vim25/client.go
+++ b/vim25/client.go
@@ -180,6 +180,11 @@ func (c *Client) Valid() bool {
 	return true
 }
 
+// Path returns vim25.Path (see cache.Client)
+func (c *Client) Path() string {
+	return Path
+}
+
 // IsVC returns true if we are connected to a vCenter
 func (c *Client) IsVC() bool {
 	return c.ServiceContent.About.ApiType == "VirtualCenter"


### PR DESCRIPTION
- Add govc support for persistent REST sessions

- Add REST support to session.login command (including token auth)

Fixes #1873
Fixes #1810