### PR TITLE
govc: avoid truncation in object.collect

### DIFF
--- a/govc/object/collect.go
+++ b/govc/object/collect.go
@@ -434,8 +434,8 @@ func (cmd *collect) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	return cmd.WithCancel(ctx, func(wctx context.Context) error {
+		matches := 0
 		return property.WaitForUpdates(wctx, p, filter, func(updates []types.ObjectUpdate) bool {
-			matches := 0
 			for _, update := range updates {
 				if entered && update.Kind == types.ObjectUpdateKindEnter {
 					// on the first update we only get kind "enter"
@@ -456,10 +456,15 @@ func (cmd *collect) Run(ctx context.Context, f *flag.FlagSet) error {
 				_ = cmd.WriteResult(c)
 			}
 
+			if filter.Truncated {
+				return false // vCenter truncates updates if > 100
+			}
+
 			entered = true
 
 			if hasFilter {
 				if matches > 0 {
+					matches = 0 // reset
 					return true
 				}
 				return false

--- a/property/wait.go
+++ b/property/wait.go
@@ -29,6 +29,7 @@ type WaitFilter struct {
 	types.CreateFilter
 	Options          *types.WaitOptions
 	PropagateMissing bool
+	Truncated        bool
 }
 
 // Add a new ObjectSpec and PropertySpec to the WaitFilter
@@ -127,6 +128,10 @@ func WaitForUpdates(ctx context.Context, c *Collector, filter *WaitFilter, f fun
 		}
 
 		req.Version = set.Version
+		filter.Truncated = false
+		if set.Truncated != nil {
+			filter.Truncated = *set.Truncated
+		}
 
 		for _, fs := range set.FilterSet {
 			if filter.PropagateMissing {


### PR DESCRIPTION
vCenter caps WaitForUpdates to 100 max, when doing so sets the Truncated field to true.
Check this field in object.collect to avoid truncating results.

Fixes #1893