### PR TITLE
govc: enable library.checkout and library.checkin by default

### DIFF
--- a/govc/library/checkin.go
+++ b/govc/library/checkin.go
@@ -33,7 +33,7 @@ type checkin struct {
 }
 
 func init() {
-	cli.Register("library.checkin", &checkin{}, true)
+	cli.Register("library.checkin", &checkin{})
 }
 
 func (cmd *checkin) Register(ctx context.Context, f *flag.FlagSet) {

--- a/govc/library/checkout.go
+++ b/govc/library/checkout.go
@@ -35,7 +35,7 @@ type checkout struct {
 }
 
 func init() {
-	cli.Register("library.checkout", &checkout{}, true)
+	cli.Register("library.checkout", &checkout{})
 }
 
 func (cmd *checkout) Register(ctx context.Context, f *flag.FlagSet) {

--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -283,7 +283,6 @@ EOF
   run govc library.deploy my-content/$item my-vm
   assert_success
 
-  export GOVC_SHOW_UNRELEASED=true
   run govc library.checkout my-content/enoent my-vm-checkout
   assert_failure # vmtx item does not exist
 


### PR DESCRIPTION
This feature is included with vSphere 7