### PR TITLE
simulator: add interface for VirtualDiskManager

### DIFF
--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -453,9 +454,20 @@ func (r *Registry) FileManager() *FileManager {
 	return r.Get(r.content().FileManager.Reference()).(*FileManager)
 }
 
+type VirtualDiskManagerInterface interface {
+	mo.Reference
+	MO() mo.VirtualDiskManager
+	CreateVirtualDiskTask(*Context, *types.CreateVirtualDisk_Task) soap.HasFault
+	DeleteVirtualDiskTask(*Context, *types.DeleteVirtualDisk_Task) soap.HasFault
+	MoveVirtualDiskTask(*Context, *types.MoveVirtualDisk_Task) soap.HasFault
+	CopyVirtualDiskTask(*Context, *types.CopyVirtualDisk_Task) soap.HasFault
+	QueryVirtualDiskUuid(*Context, *types.QueryVirtualDiskUuid) soap.HasFault
+	SetVirtualDiskUuid(*Context, *types.SetVirtualDiskUuid) soap.HasFault
+}
+
 // VirtualDiskManager returns the VirtualDiskManager singleton
-func (r *Registry) VirtualDiskManager() *VirtualDiskManager {
-	return r.Get(r.content().VirtualDiskManager.Reference()).(*VirtualDiskManager)
+func (r *Registry) VirtualDiskManager() VirtualDiskManagerInterface {
+	return r.Get(r.content().VirtualDiskManager.Reference()).(VirtualDiskManagerInterface)
 }
 
 // ViewManager returns the ViewManager singleton

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -573,9 +573,8 @@ func (vm *VirtualMachine) updateDiskLayouts() types.BaseMethodFault {
 
 			var fileKeys []int32
 
-			dm := Map.VirtualDiskManager()
 			// Add disk descriptor and extent files
-			for _, diskName := range dm.names(dFileName) {
+			for _, diskName := range vdmNames(dFileName) {
 				// get full path including datastore location
 				p, fault := parseDatastorePath(diskName)
 				if fault != nil {
@@ -972,7 +971,6 @@ func (vm *VirtualMachine) configureDevice(devices object.VirtualDeviceList, spec
 	label := devices.Name(device)
 	summary := label
 	dc := Map.getEntityDatacenter(Map.Get(*vm.Parent).(mo.Entity))
-	dm := Map.VirtualDiskManager()
 
 	switch x := device.(type) {
 	case types.BaseVirtualEthernetCard:
@@ -1031,7 +1029,7 @@ func (vm *VirtualMachine) configureDevice(devices object.VirtualDeviceList, spec
 				info.FileName = filename
 			}
 
-			err := dm.createVirtualDisk(spec.FileOperation, &types.CreateVirtualDisk_Task{
+			err := vdmCreateVirtualDisk(spec.FileOperation, &types.CreateVirtualDisk_Task{
 				Datacenter: &dc.Self,
 				Name:       info.FileName,
 			})
@@ -1113,7 +1111,7 @@ func (vm *VirtualMachine) removeDevice(devices object.VirtualDeviceList, spec *t
 					if dc == nil {
 						continue // parent was destroyed
 					}
-					dm.DeleteVirtualDiskTask(&types.DeleteVirtualDisk_Task{
+					dm.DeleteVirtualDiskTask(internalContext, &types.DeleteVirtualDisk_Task{
 						Name:       file,
 						Datacenter: &dc.Self,
 					})

--- a/simulator/vstorage_object_manager.go
+++ b/simulator/vstorage_object_manager.go
@@ -200,7 +200,6 @@ func (m *VcenterVStorageObjectManager) createObject(req *types.CreateDisk_Task, 
 	ref := req.Spec.BackingSpec.GetVslmCreateSpecBackingSpec().Datastore
 	ds := Map.Get(ref).(*Datastore)
 	dc := Map.getEntityDatacenter(ds)
-	dm := Map.VirtualDiskManager()
 
 	objects, ok := m.objects[ds.Self]
 	if !ok {
@@ -240,7 +239,7 @@ func (m *VcenterVStorageObjectManager) createObject(req *types.CreateDisk_Task, 
 	}
 
 	if !register {
-		err := dm.createVirtualDisk(types.VirtualDeviceConfigSpecFileOperationCreate, &types.CreateVirtualDisk_Task{
+		err := vdmCreateVirtualDisk(types.VirtualDeviceConfigSpecFileOperationCreate, &types.CreateVirtualDisk_Task{
 			Datacenter: &dc.Self,
 			Name:       path.String(),
 		})
@@ -291,7 +290,7 @@ func (m *VcenterVStorageObjectManager) DeleteVStorageObjectTask(req *types.Delet
 		ds := Map.Get(req.Datastore).(*Datastore)
 		dc := Map.getEntityDatacenter(ds)
 		dm := Map.VirtualDiskManager()
-		dm.DeleteVirtualDiskTask(&types.DeleteVirtualDisk_Task{
+		dm.DeleteVirtualDiskTask(internalContext, &types.DeleteVirtualDisk_Task{
 			Name:       backing.FilePath,
 			Datacenter: &dc.Self,
 		})


### PR DESCRIPTION
This is part of a fix for #1841.

It allows custom implementations of the VirtualDiskManager to be registered into
the registry without disrupting internal use of the corresponding singleton, as
long as they match VirtualDiskManagerInterface.

The methods there are extended to include a *simulator.Context. Even though the
default implementations don't need it, custom implementations might.