### PR TITLE
govc: remove ClientFlag.WithRestClient

### DIFF
--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -405,15 +405,6 @@ func (flag *ClientFlag) Logout(ctx context.Context) error {
 	return nil
 }
 
-func (flag *ClientFlag) WithRestClient(ctx context.Context, f func(*rest.Client) error) error {
-	c, err := flag.RestClient()
-	if err != nil {
-		return err
-	}
-
-	return f(c)
-}
-
 // Environ returns the govc environment variables for this connection
 func (flag *ClientFlag) Environ(extra bool) []string {
 	var env []string

--- a/govc/library/checkin.go
+++ b/govc/library/checkin.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/vcenter"
 )
 
@@ -64,19 +63,22 @@ func (cmd *checkin) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		l, err := flags.ContentLibraryItem(ctx, c, path)
-		if err != nil {
-			return err
-		}
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		version, err := vcenter.NewManager(c).CheckIn(ctx, l.ID, vm, &cmd.CheckIn)
-		if err != nil {
-			return err
-		}
+	l, err := flags.ContentLibraryItem(ctx, c, path)
+	if err != nil {
+		return err
+	}
 
-		fmt.Printf("%s (%s) checked in as content version %s", l.Name, l.ID, version)
+	version, err := vcenter.NewManager(c).CheckIn(ctx, l.ID, vm, &cmd.CheckIn)
+	if err != nil {
+		return err
+	}
 
-		return nil
-	})
+	fmt.Printf("%s (%s) checked in as content version %s", l.Name, l.ID, version)
+
+	return nil
 }

--- a/govc/library/checkout.go
+++ b/govc/library/checkout.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/vcenter"
 )
 
@@ -97,35 +96,38 @@ func (cmd *checkout) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	return cmd.FolderFlag.WithRestClient(ctx, func(c *rest.Client) error {
-		l, err := flags.ContentLibraryItem(ctx, c, path)
-		if err != nil {
-			return err
-		}
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		spec := vcenter.CheckOut{
-			Name: name,
-			Placement: &vcenter.Placement{
-				Folder: folder.Reference().Value,
-			},
-		}
-		if pool != nil {
-			spec.Placement.ResourcePool = pool.Reference().Value
-		}
-		if host != nil {
-			spec.Placement.Host = host.Reference().Value
-		}
-		if cluster != nil {
-			spec.Placement.Cluster = cluster.Reference().Value
-		}
+	l, err := flags.ContentLibraryItem(ctx, c, path)
+	if err != nil {
+		return err
+	}
 
-		id, err := vcenter.NewManager(c).CheckOut(ctx, l.ID, &spec)
-		if err != nil {
-			return err
-		}
+	spec := vcenter.CheckOut{
+		Name: name,
+		Placement: &vcenter.Placement{
+			Folder: folder.Reference().Value,
+		},
+	}
+	if pool != nil {
+		spec.Placement.ResourcePool = pool.Reference().Value
+	}
+	if host != nil {
+		spec.Placement.Host = host.Reference().Value
+	}
+	if cluster != nil {
+		spec.Placement.Cluster = cluster.Reference().Value
+	}
 
-		fmt.Println(id)
+	id, err := vcenter.NewManager(c).CheckOut(ctx, l.ID, &spec)
+	if err != nil {
+		return err
+	}
 
-		return nil
-	})
+	fmt.Println(id)
+
+	return nil
 }

--- a/govc/library/cp.go
+++ b/govc/library/cp.go
@@ -24,7 +24,6 @@ import (
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vapi/library"
-	"github.com/vmware/govmomi/vapi/rest"
 )
 
 type cp struct {
@@ -59,30 +58,33 @@ func (cmd *cp) Run(ctx context.Context, f *flag.FlagSet) error {
 	srcPath := f.Arg(0)
 	dstPath := f.Arg(1)
 
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		m := library.NewManager(c)
-		src, err := flags.ContentLibraryItem(ctx, c, srcPath)
-		if err != nil {
-			return err
-		}
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		dst, err := flags.ContentLibrary(ctx, c, dstPath)
-		if err != nil {
-			return err
-		}
+	m := library.NewManager(c)
+	src, err := flags.ContentLibraryItem(ctx, c, srcPath)
+	if err != nil {
+		return err
+	}
 
-		cmd.LibraryID = dst.ID
-		if cmd.Name == "" {
-			cmd.Name = src.Name
-		}
+	dst, err := flags.ContentLibrary(ctx, c, dstPath)
+	if err != nil {
+		return err
+	}
 
-		id, err := m.CopyLibraryItem(ctx, src, cmd.Item)
-		if err != nil {
-			return err
-		}
+	cmd.LibraryID = dst.ID
+	if cmd.Name == "" {
+		cmd.Name = src.Name
+	}
 
-		fmt.Println(id)
+	id, err := m.CopyLibraryItem(ctx, src, cmd.Item)
+	if err != nil {
+		return err
+	}
 
-		return nil
-	})
+	fmt.Println(id)
+
+	return nil
 }

--- a/govc/library/create.go
+++ b/govc/library/create.go
@@ -25,7 +25,6 @@ import (
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vapi/library"
-	"github.com/vmware/govmomi/vapi/rest"
 )
 
 type create struct {
@@ -116,13 +115,16 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 	}
 
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		id, err := library.NewManager(c).CreateLibrary(ctx, cmd.library)
-		if err != nil {
-			return err
-		}
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		fmt.Println(id)
-		return nil
-	})
+	id, err := library.NewManager(c).CreateLibrary(ctx, cmd.library)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(id)
+	return nil
 }

--- a/govc/library/deploy.go
+++ b/govc/library/deploy.go
@@ -26,7 +26,6 @@ import (
 	"github.com/vmware/govmomi/govc/importx"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vapi/library"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/vcenter"
 	"github.com/vmware/govmomi/vim25/types"
 )
@@ -100,152 +99,155 @@ func (cmd *deploy) Run(ctx context.Context, f *flag.FlagSet) error {
 		name = *cmd.Options.Name
 	}
 
-	return cmd.DatastoreFlag.WithRestClient(ctx, func(c *rest.Client) error {
-		m := vcenter.NewManager(c)
+	c, err := cmd.DatastoreFlag.RestClient()
+	if err != nil {
+		return err
+	}
 
-		item, err := flags.ContentLibraryItem(ctx, c, path)
+	m := vcenter.NewManager(c)
+
+	item, err := flags.ContentLibraryItem(ctx, c, path)
+	if err != nil {
+		return err
+	}
+
+	ds, err := cmd.DatastoreIfSpecified()
+	if err != nil {
+		return err
+	}
+	rp, err := cmd.ResourcePoolIfSpecified()
+	if err != nil {
+		return err
+	}
+	host, err := cmd.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+	hostID := ""
+	if rp == nil {
+		if host == nil {
+			rp, err = cmd.ResourcePoolFlag.ResourcePool()
+		} else {
+			rp, err = host.ResourcePool(ctx)
+			hostID = host.Reference().Value
+		}
 		if err != nil {
 			return err
 		}
+	}
+	folder, err := cmd.Folder()
+	if err != nil {
+		return err
+	}
+	finder, err := cmd.FolderFlag.Finder(false)
+	if err != nil {
+		return err
+	}
 
-		ds, err := cmd.DatastoreIfSpecified()
+	var networks []vcenter.NetworkMapping
+	for _, net := range cmd.Options.NetworkMapping {
+		if net.Network == "" {
+			continue
+		}
+		obj, err := finder.Network(ctx, net.Network)
 		if err != nil {
 			return err
 		}
-		rp, err := cmd.ResourcePoolIfSpecified()
-		if err != nil {
-			return err
-		}
-		host, err := cmd.HostSystemIfSpecified()
-		if err != nil {
-			return err
-		}
-		hostID := ""
-		if rp == nil {
-			if host == nil {
-				rp, err = cmd.ResourcePoolFlag.ResourcePool()
-			} else {
-				rp, err = host.ResourcePool(ctx)
-				hostID = host.Reference().Value
-			}
-			if err != nil {
-				return err
-			}
-		}
-		folder, err := cmd.Folder()
-		if err != nil {
-			return err
-		}
-		finder, err := cmd.FolderFlag.Finder(false)
-		if err != nil {
-			return err
-		}
+		networks = append(networks, vcenter.NetworkMapping{
+			Key:   net.Name,
+			Value: obj.Reference().Value,
+		})
+	}
 
-		var networks []vcenter.NetworkMapping
-		for _, net := range cmd.Options.NetworkMapping {
-			if net.Network == "" {
-				continue
-			}
-			obj, err := finder.Network(ctx, net.Network)
-			if err != nil {
-				return err
-			}
-			networks = append(networks, vcenter.NetworkMapping{
-				Key:   net.Name,
-				Value: obj.Reference().Value,
-			})
-		}
+	var properties []vcenter.Property
+	for _, prop := range cmd.Options.PropertyMapping {
+		properties = append(properties, vcenter.Property{
+			ID:    prop.Key,
+			Value: prop.Value,
+		})
+	}
 
-		var properties []vcenter.Property
-		for _, prop := range cmd.Options.PropertyMapping {
-			properties = append(properties, vcenter.Property{
-				ID:    prop.Key,
-				Value: prop.Value,
-			})
-		}
+	dsID := ""
+	if ds != nil {
+		dsID = ds.Reference().Value
+	}
 
-		dsID := ""
-		if ds != nil {
-			dsID = ds.Reference().Value
-		}
+	cmd.FolderFlag.Log("Deploying library item...\n")
 
-		cmd.FolderFlag.Log("Deploying library item...\n")
+	var ref *types.ManagedObjectReference
 
-		var ref *types.ManagedObjectReference
-
-		switch item.Type {
-		case library.ItemTypeOVF:
-			deploy := vcenter.Deploy{
-				DeploymentSpec: vcenter.DeploymentSpec{
-					Name:               name,
-					DefaultDatastoreID: dsID,
-					AcceptAllEULA:      true,
-					Annotation:         cmd.Options.Annotation,
-					AdditionalParams: []vcenter.AdditionalParams{
-						{
-							Class:       vcenter.ClassDeploymentOptionParams,
-							Type:        vcenter.TypeDeploymentOptionParams,
-							SelectedKey: cmd.Options.Deployment,
-						},
-						{
-							Class:       vcenter.ClassPropertyParams,
-							Type:        vcenter.TypePropertyParams,
-							SelectedKey: cmd.Options.Deployment,
-							Properties:  properties,
-						},
+	switch item.Type {
+	case library.ItemTypeOVF:
+		deploy := vcenter.Deploy{
+			DeploymentSpec: vcenter.DeploymentSpec{
+				Name:               name,
+				DefaultDatastoreID: dsID,
+				AcceptAllEULA:      true,
+				Annotation:         cmd.Options.Annotation,
+				AdditionalParams: []vcenter.AdditionalParams{
+					{
+						Class:       vcenter.ClassDeploymentOptionParams,
+						Type:        vcenter.TypeDeploymentOptionParams,
+						SelectedKey: cmd.Options.Deployment,
 					},
-					NetworkMappings:     networks,
-					StorageProvisioning: cmd.Options.DiskProvisioning,
-					StorageProfileID:    cmd.profile,
+					{
+						Class:       vcenter.ClassPropertyParams,
+						Type:        vcenter.TypePropertyParams,
+						SelectedKey: cmd.Options.Deployment,
+						Properties:  properties,
+					},
 				},
-				Target: vcenter.Target{
-					ResourcePoolID: rp.Reference().Value,
-					HostID:         hostID,
-					FolderID:       folder.Reference().Value,
-				},
-			}
-			ref, err = m.DeployLibraryItem(ctx, item.ID, deploy)
-			if err != nil {
-				return err
-			}
-		case library.ItemTypeVMTX:
-			storage := &vcenter.DiskStorage{
-				Datastore: dsID,
-				StoragePolicy: &vcenter.StoragePolicy{
-					Policy: cmd.profile,
-					Type:   "USE_SOURCE_POLICY",
-				},
-			}
-			if cmd.profile != "" {
-				storage.StoragePolicy.Type = "USE_SPECIFIED_POLICY"
-			}
-
-			deploy := vcenter.DeployTemplate{
-				Name:          name,
-				Description:   cmd.Options.Annotation,
-				DiskStorage:   storage,
-				VMHomeStorage: storage,
-				Placement: &vcenter.Placement{
-					ResourcePool: rp.Reference().Value,
-					Host:         hostID,
-					Folder:       folder.Reference().Value,
-				},
-			}
-			ref, err = m.DeployTemplateLibraryItem(ctx, item.ID, deploy)
-			if err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("unsupported library item type: %s", item.Type)
+				NetworkMappings:     networks,
+				StorageProvisioning: cmd.Options.DiskProvisioning,
+				StorageProfileID:    cmd.profile,
+			},
+			Target: vcenter.Target{
+				ResourcePoolID: rp.Reference().Value,
+				HostID:         hostID,
+				FolderID:       folder.Reference().Value,
+			},
 		}
-
-		obj, err := finder.ObjectReference(ctx, *ref)
+		ref, err = m.DeployLibraryItem(ctx, item.ID, deploy)
 		if err != nil {
 			return err
 		}
+	case library.ItemTypeVMTX:
+		storage := &vcenter.DiskStorage{
+			Datastore: dsID,
+			StoragePolicy: &vcenter.StoragePolicy{
+				Policy: cmd.profile,
+				Type:   "USE_SOURCE_POLICY",
+			},
+		}
+		if cmd.profile != "" {
+			storage.StoragePolicy.Type = "USE_SPECIFIED_POLICY"
+		}
 
-		vm := obj.(*object.VirtualMachine)
+		deploy := vcenter.DeployTemplate{
+			Name:          name,
+			Description:   cmd.Options.Annotation,
+			DiskStorage:   storage,
+			VMHomeStorage: storage,
+			Placement: &vcenter.Placement{
+				ResourcePool: rp.Reference().Value,
+				Host:         hostID,
+				Folder:       folder.Reference().Value,
+			},
+		}
+		ref, err = m.DeployTemplateLibraryItem(ctx, item.ID, deploy)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported library item type: %s", item.Type)
+	}
 
-		return cmd.Deploy(vm, cmd.FolderFlag.OutputFlag)
-	})
+	obj, err := finder.ObjectReference(ctx, *ref)
+	if err != nil {
+		return err
+	}
+
+	vm := obj.(*object.VirtualMachine)
+
+	return cmd.Deploy(vm, cmd.FolderFlag.OutputFlag)
 }

--- a/govc/library/export.go
+++ b/govc/library/export.go
@@ -30,7 +30,6 @@ import (
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vapi/library"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
@@ -82,111 +81,114 @@ func (cmd *export) Process(ctx context.Context) error {
 }
 
 func (cmd *export) Run(ctx context.Context, f *flag.FlagSet) error {
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		var names []string
-		m := library.NewManager(c)
-		res, err := flags.ContentLibraryResult(ctx, c, "", f.Arg(0))
-		if err != nil {
-			return err
-		}
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		switch t := res.GetResult().(type) {
-		case library.Item:
-			cmd.Item = t
-		case library.File:
-			names = []string{t.Name}
-			cmd.Item = res.GetParent().GetResult().(library.Item)
-		default:
-			return fmt.Errorf("%q is a %T", f.Arg(0), t)
-		}
+	var names []string
+	m := library.NewManager(c)
+	res, err := flags.ContentLibraryResult(ctx, c, "", f.Arg(0))
+	if err != nil {
+		return err
+	}
 
-		dst := f.Arg(1)
-		one := len(names) == 1
-		var log io.Writer = os.Stdout
-		isStdout := one && dst == "-"
-		if isStdout {
-			log = ioutil.Discard
-		}
+	switch t := res.GetResult().(type) {
+	case library.Item:
+		cmd.Item = t
+	case library.File:
+		names = []string{t.Name}
+		cmd.Item = res.GetParent().GetResult().(library.Item)
+	default:
+		return fmt.Errorf("%q is a %T", f.Arg(0), t)
+	}
 
-		session, err := m.CreateLibraryItemDownloadSession(ctx, library.Session{
-			LibraryItemID: cmd.ID,
-		})
-		if err != nil {
-			return err
-		}
+	dst := f.Arg(1)
+	one := len(names) == 1
+	var log io.Writer = os.Stdout
+	isStdout := one && dst == "-"
+	if isStdout {
+		log = ioutil.Discard
+	}
 
-		if len(names) == 0 {
-			files, err := m.ListLibraryItemDownloadSessionFile(ctx, session)
-			if err != nil {
-				return err
-			}
-
-			for _, file := range files {
-				names = append(names, file.Name)
-			}
-		}
-
-		for _, name := range names {
-			_, err = m.PrepareLibraryItemDownloadSessionFile(ctx, session, name)
-			if err != nil {
-				return err
-			}
-		}
-
-		download := func(src *url.URL, name string) error {
-			p := soap.DefaultDownload
-			p.Headers = map[string]string{
-				"vmware-api-session-id": c.SessionID,
-			}
-			if isStdout {
-				s, _, err := c.Download(ctx, src, &p)
-				if err != nil {
-					return err
-				}
-				_, err = io.Copy(os.Stdout, s)
-				_ = s.Close()
-				return err
-			}
-
-			if cmd.OutputFlag.TTY {
-				logger := cmd.ProgressLogger(fmt.Sprintf("Downloading %s... ", src.String()))
-				defer logger.Wait()
-				p.Progress = logger
-			}
-
-			if one && dst != "" {
-				name = dst
-			} else {
-				name = filepath.Join(dst, name)
-			}
-			return c.DownloadFile(ctx, name, src, &p)
-		}
-
-		for _, name := range names {
-			var info *library.DownloadFile
-			_, _ = fmt.Fprintf(log, "Checking %s... ", name)
-			for {
-				info, err = m.GetLibraryItemDownloadSessionFile(ctx, session, name)
-				if err != nil {
-					return err
-				}
-				if info.Status == "PREPARED" {
-					_, _ = fmt.Fprintln(log, info.Status)
-					break // with this status we have a DownloadEndpoint.URI
-				}
-				time.Sleep(time.Second)
-			}
-
-			src, err := url.Parse(info.DownloadEndpoint.URI)
-			if err != nil {
-				return err
-			}
-			err = download(src, name)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
+	session, err := m.CreateLibraryItemDownloadSession(ctx, library.Session{
+		LibraryItemID: cmd.ID,
 	})
+	if err != nil {
+		return err
+	}
+
+	if len(names) == 0 {
+		files, err := m.ListLibraryItemDownloadSessionFile(ctx, session)
+		if err != nil {
+			return err
+		}
+
+		for _, file := range files {
+			names = append(names, file.Name)
+		}
+	}
+
+	for _, name := range names {
+		_, err = m.PrepareLibraryItemDownloadSessionFile(ctx, session, name)
+		if err != nil {
+			return err
+		}
+	}
+
+	download := func(src *url.URL, name string) error {
+		p := soap.DefaultDownload
+		p.Headers = map[string]string{
+			"vmware-api-session-id": c.SessionID,
+		}
+		if isStdout {
+			s, _, err := c.Download(ctx, src, &p)
+			if err != nil {
+				return err
+			}
+			_, err = io.Copy(os.Stdout, s)
+			_ = s.Close()
+			return err
+		}
+
+		if cmd.OutputFlag.TTY {
+			logger := cmd.ProgressLogger(fmt.Sprintf("Downloading %s... ", src.String()))
+			defer logger.Wait()
+			p.Progress = logger
+		}
+
+		if one && dst != "" {
+			name = dst
+		} else {
+			name = filepath.Join(dst, name)
+		}
+		return c.DownloadFile(ctx, name, src, &p)
+	}
+
+	for _, name := range names {
+		var info *library.DownloadFile
+		_, _ = fmt.Fprintf(log, "Checking %s... ", name)
+		for {
+			info, err = m.GetLibraryItemDownloadSessionFile(ctx, session, name)
+			if err != nil {
+				return err
+			}
+			if info.Status == "PREPARED" {
+				_, _ = fmt.Fprintln(log, info.Status)
+				break // with this status we have a DownloadEndpoint.URI
+			}
+			time.Sleep(time.Second)
+		}
+
+		src, err := url.Parse(info.DownloadEndpoint.URI)
+		if err != nil {
+			return err
+		}
+		err = download(src, name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/govc/library/import.go
+++ b/govc/library/import.go
@@ -31,7 +31,6 @@ import (
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/govc/importx"
 	"github.com/vmware/govmomi/vapi/library"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
@@ -141,101 +140,104 @@ func (cmd *item) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 	}
 
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		m := library.NewManager(c)
-		res, err := flags.ContentLibraryResult(ctx, c, "", f.Arg(0))
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
+
+	m := library.NewManager(c)
+	res, err := flags.ContentLibraryResult(ctx, c, "", f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	switch t := res.GetResult().(type) {
+	case library.Library:
+		cmd.LibraryID = t.ID
+		cmd.ID, err = m.CreateLibraryItem(ctx, cmd.Item)
+		if err != nil {
+			return err
+		}
+	case library.Item:
+		cmd.Item = t
+	default:
+		return fmt.Errorf("%q is a %T", f.Arg(0), t)
+	}
+
+	session, err := m.CreateLibraryItemUpdateSession(ctx, library.Session{
+		LibraryItemID: cmd.ID,
+	})
+
+	if cmd.pull {
+		_, err = m.AddLibraryItemFileFromURI(ctx, session, filepath.Base(file), file)
 		if err != nil {
 			return err
 		}
 
-		switch t := res.GetResult().(type) {
-		case library.Library:
-			cmd.LibraryID = t.ID
-			cmd.ID, err = m.CreateLibraryItem(ctx, cmd.Item)
-			if err != nil {
-				return err
-			}
-		case library.Item:
-			cmd.Item = t
-		default:
-			return fmt.Errorf("%q is a %T", f.Arg(0), t)
+		return m.WaitOnLibraryItemUpdateSession(ctx, session, 3*time.Second, nil)
+	}
+
+	upload := func(name string) error {
+		f, size, err := archive.Open(name)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		if e, ok := f.(*importx.TapeArchiveEntry); ok {
+			name = e.Name // expand path.Match's (e.g. "*.ovf" -> "name.ovf")
 		}
 
-		session, err := m.CreateLibraryItemUpdateSession(ctx, library.Session{
-			LibraryItemID: cmd.ID,
-		})
-
-		if cmd.pull {
-			_, err = m.AddLibraryItemFileFromURI(ctx, session, filepath.Base(file), file)
-			if err != nil {
-				return err
-			}
-
-			return m.WaitOnLibraryItemUpdateSession(ctx, session, 3*time.Second, nil)
+		info := library.UpdateFile{
+			Name:       name,
+			SourceType: "PUSH",
+			Checksum:   manifest[name],
+			Size:       size,
 		}
 
-		upload := func(name string) error {
-			f, size, err := archive.Open(name)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-
-			if e, ok := f.(*importx.TapeArchiveEntry); ok {
-				name = e.Name // expand path.Match's (e.g. "*.ovf" -> "name.ovf")
-			}
-
-			info := library.UpdateFile{
-				Name:       name,
-				SourceType: "PUSH",
-				Checksum:   manifest[name],
-				Size:       size,
-			}
-
-			update, err := m.AddLibraryItemFile(ctx, session, info)
-			if err != nil {
-				return err
-			}
-
-			p := soap.DefaultUpload
-			p.Headers = map[string]string{
-				"vmware-api-session-id": session,
-			}
-			p.ContentLength = size
-			u, err := url.Parse(update.UploadEndpoint.URI)
-			if err != nil {
-				return err
-			}
-			if cmd.OutputFlag.TTY {
-				logger := cmd.ProgressLogger(fmt.Sprintf("Uploading %s... ", name))
-				p.Progress = logger
-				defer logger.Wait()
-			}
-			return c.Upload(ctx, f, u, &p)
-		}
-
-		if err = upload(base); err != nil {
+		update, err := m.AddLibraryItemFile(ctx, session, info)
+		if err != nil {
 			return err
 		}
 
-		if cmd.Type == library.ItemTypeOVF {
-			o, err := archive.ReadOvf(base)
-			if err != nil {
-				return err
-			}
+		p := soap.DefaultUpload
+		p.Headers = map[string]string{
+			"vmware-api-session-id": session,
+		}
+		p.ContentLength = size
+		u, err := url.Parse(update.UploadEndpoint.URI)
+		if err != nil {
+			return err
+		}
+		if cmd.OutputFlag.TTY {
+			logger := cmd.ProgressLogger(fmt.Sprintf("Uploading %s... ", name))
+			p.Progress = logger
+			defer logger.Wait()
+		}
+		return c.Upload(ctx, f, u, &p)
+	}
 
-			e, err := archive.ReadEnvelope(o)
-			if err != nil {
-				return fmt.Errorf("failed to parse ovf: %s", err)
-			}
+	if err = upload(base); err != nil {
+		return err
+	}
 
-			for i := range e.References {
-				if err = upload(e.References[i].Href); err != nil {
-					return err
-				}
-			}
+	if cmd.Type == library.ItemTypeOVF {
+		o, err := archive.ReadOvf(base)
+		if err != nil {
+			return err
 		}
 
-		return m.CompleteLibraryItemUpdateSession(ctx, session)
-	})
+		e, err := archive.ReadEnvelope(o)
+		if err != nil {
+			return fmt.Errorf("failed to parse ovf: %s", err)
+		}
+
+		for i := range e.References {
+			if err = upload(e.References[i].Href); err != nil {
+				return err
+			}
+		}
+	}
+
+	return m.CompleteLibraryItemUpdateSession(ctx, session)
 }

--- a/govc/library/ls.go
+++ b/govc/library/ls.go
@@ -26,7 +26,6 @@ import (
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vapi/library"
 	"github.com/vmware/govmomi/vapi/library/finder"
-	"github.com/vmware/govmomi/vapi/rest"
 )
 
 type ls struct {
@@ -75,13 +74,16 @@ func (r lsResultsWriter) Write(w io.Writer) error {
 }
 
 func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		m := library.NewManager(c)
-		finder := finder.NewFinder(m)
-		findResults, err := finder.Find(ctx, f.Args()...)
-		if err != nil {
-			return err
-		}
-		return cmd.WriteResult(lsResultsWriter(findResults))
-	})
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
+
+	m := library.NewManager(c)
+	finder := finder.NewFinder(m)
+	findResults, err := finder.Find(ctx, f.Args()...)
+	if err != nil {
+		return err
+	}
+	return cmd.WriteResult(lsResultsWriter(findResults))
 }

--- a/govc/library/publish.go
+++ b/govc/library/publish.go
@@ -24,7 +24,6 @@ import (
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vapi/library"
-	"github.com/vmware/govmomi/vapi/rest"
 )
 
 type publish struct {
@@ -58,23 +57,26 @@ Examples:
 }
 
 func (cmd *publish) Run(ctx context.Context, f *flag.FlagSet) error {
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		res, err := flags.ContentLibraryResult(ctx, c, "", f.Arg(0))
-		if err != nil {
-			return err
-		}
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		m := library.NewManager(c)
+	res, err := flags.ContentLibraryResult(ctx, c, "", f.Arg(0))
+	if err != nil {
+		return err
+	}
 
-		ids := f.Args()[1:]
+	m := library.NewManager(c)
 
-		switch t := res.GetResult().(type) {
-		case library.Library:
-			return m.PublishLibrary(ctx, &t, ids)
-		case library.Item:
-			return m.PublishLibraryItem(ctx, &t, false, ids)
-		default:
-			return fmt.Errorf("%q is a %T", res.GetPath(), t)
-		}
-	})
+	ids := f.Args()[1:]
+
+	switch t := res.GetResult().(type) {
+	case library.Library:
+		return m.PublishLibrary(ctx, &t, ids)
+	case library.Item:
+		return m.PublishLibraryItem(ctx, &t, false, ids)
+	default:
+		return fmt.Errorf("%q is a %T", res.GetPath(), t)
+	}
 }

--- a/govc/library/rm.go
+++ b/govc/library/rm.go
@@ -24,7 +24,6 @@ import (
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vapi/library"
-	"github.com/vmware/govmomi/vapi/rest"
 )
 
 type rm struct {
@@ -55,20 +54,23 @@ Examples:
 }
 
 func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		m := library.NewManager(c)
-		res, err := flags.ContentLibraryResult(ctx, c, "", f.Arg(0))
-		if err != nil {
-			return err
-		}
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		switch t := res.GetResult().(type) {
-		case library.Library:
-			return m.DeleteLibrary(ctx, &t)
-		case library.Item:
-			return m.DeleteLibraryItem(ctx, &t)
-		default:
-			return fmt.Errorf("%q is a %T", f.Arg(0), t)
-		}
-	})
+	m := library.NewManager(c)
+	res, err := flags.ContentLibraryResult(ctx, c, "", f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	switch t := res.GetResult().(type) {
+	case library.Library:
+		return m.DeleteLibrary(ctx, &t)
+	case library.Item:
+		return m.DeleteLibraryItem(ctx, &t)
+	default:
+		return fmt.Errorf("%q is a %T", f.Arg(0), t)
+	}
 }

--- a/govc/library/subscriber/info.go
+++ b/govc/library/subscriber/info.go
@@ -27,7 +27,6 @@ import (
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vapi/library"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -118,18 +117,21 @@ func (r infoResultsWriter) Write(w io.Writer) error {
 }
 
 func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		lib, err := flags.ContentLibrary(ctx, c, f.Arg(0))
-		if err != nil {
-			return err
-		}
-		m := library.NewManager(c)
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		s, err := m.GetSubscriber(ctx, lib, f.Arg(1))
-		if err != nil {
-			return err
-		}
+	lib, err := flags.ContentLibrary(ctx, c, f.Arg(0))
+	if err != nil {
+		return err
+	}
+	m := library.NewManager(c)
 
-		return cmd.WriteResult(infoResultsWriter{s, cmd})
-	})
+	s, err := m.GetSubscriber(ctx, lib, f.Arg(1))
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(infoResultsWriter{s, cmd})
 }

--- a/govc/library/subscriber/ls.go
+++ b/govc/library/subscriber/ls.go
@@ -26,7 +26,6 @@ import (
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vapi/library"
-	"github.com/vmware/govmomi/vapi/rest"
 )
 
 type ls struct {
@@ -74,18 +73,21 @@ func (r lsResultsWriter) Write(w io.Writer) error {
 }
 
 func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		lib, err := flags.ContentLibrary(ctx, c, f.Arg(0))
-		if err != nil {
-			return err
-		}
-		m := library.NewManager(c)
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		s, err := m.ListSubscribers(ctx, lib)
-		if err != nil {
-			return err
-		}
+	lib, err := flags.ContentLibrary(ctx, c, f.Arg(0))
+	if err != nil {
+		return err
+	}
+	m := library.NewManager(c)
 
-		return cmd.WriteResult(lsResultsWriter(s))
-	})
+	s, err := m.ListSubscribers(ctx, lib)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(lsResultsWriter(s))
 }

--- a/govc/library/subscriber/rm.go
+++ b/govc/library/subscriber/rm.go
@@ -23,7 +23,6 @@ import (
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vapi/library"
-	"github.com/vmware/govmomi/vapi/rest"
 )
 
 type rm struct {
@@ -54,13 +53,16 @@ Examples:
 }
 
 func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		lib, err := flags.ContentLibrary(ctx, c, f.Arg(0))
-		if err != nil {
-			return err
-		}
-		m := library.NewManager(c)
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		return m.DeleteSubscriber(ctx, lib, f.Arg(0))
-	})
+	lib, err := flags.ContentLibrary(ctx, c, f.Arg(0))
+	if err != nil {
+		return err
+	}
+	m := library.NewManager(c)
+
+	return m.DeleteSubscriber(ctx, lib, f.Arg(0))
 }

--- a/govc/tags/association/attach.go
+++ b/govc/tags/association/attach.go
@@ -96,16 +96,19 @@ func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
 	tagID := f.Arg(0)
 	managedObj := f.Arg(1)
 
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		ref, err := convertPath(ctx, c, cmd.DatacenterFlag, managedObj)
-		if err != nil {
-			return err
-		}
-		m := tags.NewManager(c)
-		tag, err := m.GetTagForCategory(ctx, tagID, cmd.cat)
-		if err != nil {
-			return err
-		}
-		return m.AttachTag(ctx, tag.ID, ref)
-	})
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
+
+	ref, err := convertPath(ctx, c, cmd.DatacenterFlag, managedObj)
+	if err != nil {
+		return err
+	}
+	m := tags.NewManager(c)
+	tag, err := m.GetTagForCategory(ctx, tagID, cmd.cat)
+	if err != nil {
+		return err
+	}
+	return m.AttachTag(ctx, tag.ID, ref)
 }

--- a/govc/tags/association/detach.go
+++ b/govc/tags/association/detach.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/tags"
 )
 
@@ -62,16 +61,19 @@ func (cmd *detach) Run(ctx context.Context, f *flag.FlagSet) error {
 	tagID := f.Arg(0)
 	managedObj := f.Arg(1)
 
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		ref, err := convertPath(ctx, c, cmd.DatacenterFlag, managedObj)
-		if err != nil {
-			return err
-		}
-		m := tags.NewManager(c)
-		tag, err := m.GetTagForCategory(ctx, tagID, cmd.cat)
-		if err != nil {
-			return err
-		}
-		return m.DetachTag(ctx, tag.ID, ref)
-	})
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
+
+	ref, err := convertPath(ctx, c, cmd.DatacenterFlag, managedObj)
+	if err != nil {
+		return err
+	}
+	m := tags.NewManager(c)
+	tag, err := m.GetTagForCategory(ctx, tagID, cmd.cat)
+	if err != nil {
+		return err
+	}
+	return m.DetachTag(ctx, tag.ID, ref)
 }

--- a/govc/tags/category/create.go
+++ b/govc/tags/category/create.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/tags"
 )
 
@@ -85,13 +84,16 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 	cmd.cat.Name = f.Arg(0)
 	cmd.cat.Cardinality = cardinality(cmd.multi)
 
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		id, err := tags.NewManager(c).CreateCategory(ctx, &cmd.cat)
-		if err != nil {
-			return err
-		}
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		fmt.Println(id)
-		return nil
-	})
+	id, err := tags.NewManager(c).CreateCategory(ctx, &cmd.cat)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(id)
+	return nil
 }

--- a/govc/tags/category/info.go
+++ b/govc/tags/category/info.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/tags"
 )
 
@@ -87,24 +86,26 @@ func (t infoResult) Write(w io.Writer) error {
 func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 	arg := f.Arg(0)
 
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		m := tags.NewManager(c)
-		var res infoResult
-		var err error
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		if f.NArg() == 1 {
-			cat, cerr := m.GetCategory(ctx, arg)
-			if cerr != nil {
-				return cerr
-			}
-			res = append(res, *cat)
-		} else {
-			res, err = m.GetCategories(ctx)
-			if err != nil {
-				return err
-			}
+	m := tags.NewManager(c)
+	var res infoResult
+
+	if f.NArg() == 1 {
+		cat, cerr := m.GetCategory(ctx, arg)
+		if cerr != nil {
+			return cerr
 		}
+		res = append(res, *cat)
+	} else {
+		res, err = m.GetCategories(ctx)
+		if err != nil {
+			return err
+		}
+	}
 
-		return cmd.WriteResult(res)
-	})
+	return cmd.WriteResult(res)
 }

--- a/govc/tags/category/ls.go
+++ b/govc/tags/category/ls.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/tags"
 )
 
@@ -69,12 +68,15 @@ func (r lsResult) Write(w io.Writer) error {
 }
 
 func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		l, err := tags.NewManager(c).GetCategories(ctx)
-		if err != nil {
-			return err
-		}
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		return cmd.WriteResult(lsResult(l))
-	})
+	l, err := tags.NewManager(c).GetCategories(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(lsResult(l))
 }

--- a/govc/tags/category/update.go
+++ b/govc/tags/category/update.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/tags"
 )
 
@@ -77,14 +76,17 @@ func (cmd *update) Run(ctx context.Context, f *flag.FlagSet) error {
 		cmd.cat.Cardinality = cardinality(*cmd.multi)
 	}
 
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		m := tags.NewManager(c)
-		cat, err := m.GetCategory(ctx, arg)
-		if err != nil {
-			return err
-		}
-		cat.Patch(&cmd.cat)
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		return m.UpdateCategory(ctx, cat)
-	})
+	m := tags.NewManager(c)
+	cat, err := m.GetCategory(ctx, arg)
+	if err != nil {
+		return err
+	}
+	cat.Patch(&cmd.cat)
+
+	return m.UpdateCategory(ctx, cat)
 }

--- a/govc/tags/create.go
+++ b/govc/tags/create.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/tags"
 )
 
@@ -71,13 +70,16 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	cmd.tag.Name = f.Arg(0)
 
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		id, err := tags.NewManager(c).CreateTag(ctx, &cmd.tag)
-		if err != nil {
-			return err
-		}
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
 
-		fmt.Println(id)
-		return nil
-	})
+	id, err := tags.NewManager(c).CreateTag(ctx, &cmd.tag)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(id)
+	return nil
 }

--- a/govc/tags/update.go
+++ b/govc/tags/update.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/tags"
 )
 
@@ -64,13 +63,16 @@ func (cmd *update) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 	arg := f.Arg(0)
 
-	return cmd.WithRestClient(ctx, func(c *rest.Client) error {
-		m := tags.NewManager(c)
-		tag, err := m.GetTagForCategory(ctx, arg, cmd.cat)
-		if err != nil {
-			return err
-		}
-		tag.Patch(&cmd.tag)
-		return m.UpdateTag(ctx, tag)
-	})
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
+
+	m := tags.NewManager(c)
+	tag, err := m.GetTagForCategory(ctx, arg, cmd.cat)
+	if err != nil {
+		return err
+	}
+	tag.Patch(&cmd.tag)
+	return m.UpdateTag(ctx, tag)
 }


### PR DESCRIPTION
With #1898 merged, the WithRestClient pattern is no longer needed.
Switch to using ClientFlag.RestClient instead.