### PR TITLE
Add non-null HostLicensableResourceInfo to HostSystem

### DIFF
--- a/simulator/esx/host_system.go
+++ b/simulator/esx/host_system.go
@@ -1740,8 +1740,8 @@ var HostSystem = mo.HostSystem{
 		CurrentEVCModeKey:  "",
 		Gateway:            (*types.HostListSummaryGatewaySummary)(nil),
 	},
-	Hardware:           (*types.HostHardwareInfo)(nil),
-	Capability:         (*types.HostCapability)(nil),
+	Hardware:   (*types.HostHardwareInfo)(nil),
+	Capability: (*types.HostCapability)(nil),
 	LicensableResource: types.HostLicensableResourceInfo{
 		Resource: []types.KeyAnyValue{
 			{

--- a/simulator/esx/host_system.go
+++ b/simulator/esx/host_system.go
@@ -1742,7 +1742,17 @@ var HostSystem = mo.HostSystem{
 	},
 	Hardware:           (*types.HostHardwareInfo)(nil),
 	Capability:         (*types.HostCapability)(nil),
-	LicensableResource: types.HostLicensableResourceInfo{},
+	LicensableResource: types.HostLicensableResourceInfo{
+		Resource: []types.KeyAnyValue{
+			{
+				Key: "numCpuPackages",
+				Value: types.KeyValue{
+					Key:   "numCpuPackages",
+					Value: "2",
+				},
+			},
+		},
+	},
 	ConfigManager: types.HostConfigManager{
 		DynamicData:               types.DynamicData{},
 		CpuScheduler:              &types.ManagedObjectReference{Type: "HostCpuSchedulerSystem", Value: "cpuSchedulerSystem"},


### PR DESCRIPTION
HostSystem has a required field 'LicensableResource': https://code.vmware.com/apis/704/vsphere/vim.HostSystem.html#field_detail
This causes some clients that validate manditory fields with an error that might look like: 'Missing value for non-optional field resource'
The MOB view of a vanilla *real* ESXi host might look something like:
---------------------------------------------------------
| Name     | Type          | Value                      |
---------------------------------------------------------
| resource | KeyAnyValue[] | resource["numCpuPackages"] |
---------------------------------------------------------

This commit fills in this value with a sensible value that matches the NumCpuPackages specified in host_hardware_info,
and prevents clients from failing when encountering this resource.