### PR TITLE
vcsim: avoid panic if ovf:capacityAllocationUnits is not present

### DIFF
--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -68,6 +68,14 @@ load test_helper
 
   run govc vm.destroy ${TTYLINUX_NAME}
   assert_success
+
+  # ensure vcsim doesn't panic without capacityAllocationUnits
+  dir=$($mktemp --tmpdir -d govc-test-XXXXX)
+  sed -e s/capacityAllocationUnits/invalid/ "$GOVC_IMAGES/$TTYLINUX_NAME.ovf" > "$dir/$TTYLINUX_NAME.ovf"
+  touch "$dir/$TTYLINUX_NAME-disk1.vmdk" # .vmdk contents don't matter to vcsim
+  run govc import.ovf "$dir/$TTYLINUX_NAME.ovf"
+  assert_success
+  rm -rf "$dir"
 }
 
 @test "import.ovf -host.ipath" {

--- a/simulator/ovf_manager.go
+++ b/simulator/ovf_manager.go
@@ -83,6 +83,9 @@ func ovfNetwork(ctx *Context, req *types.CreateImportSpec, item ovf.ResourceAllo
 
 func ovfDiskCapacity(disk *ovf.VirtualDiskDesc) int64 {
 	b, _ := strconv.ParseUint(disk.Capacity, 10, 64)
+	if disk.CapacityAllocationUnits == nil {
+		return int64(b)
+	}
 	c := strings.Fields(*disk.CapacityAllocationUnits)
 	if len(c) == 3 && c[0] == "byte" && c[1] == "*" { // "byte * 2^20"
 		p := strings.Split(c[2], "^")


### PR DESCRIPTION
The vcsim OvfManager.CreateImportSpec implementation assumed the
Disk ovf:capacityAllocationUnits attribute is always present and would
panic if it wasn't.
Return the Disk capacity without any conversion to fix this case.

Fixes #1909