### PR TITLE
Default to separate session cache directories

### DIFF
--- a/session/cache/session.go
+++ b/session/cache/session.go
@@ -18,7 +18,7 @@ package cache
 
 import (
 	"context"
-	"crypto/sha256"
+	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -99,7 +99,7 @@ func (s *Session) key(path string) string {
 	// Key session file off of full URI and insecure setting.
 	// Hash key to get a predictable, canonical format.
 	key := fmt.Sprintf("%s#insecure=%t", p.String(), s.Insecure)
-	return fmt.Sprintf("%064x", sha256.Sum256([]byte(key)))
+	return fmt.Sprintf("%040x", sha1.Sum([]byte(key)))
 }
 
 func (s *Session) file(p string) string {

--- a/session/cache/session.go
+++ b/session/cache/session.go
@@ -52,7 +52,8 @@ type Client interface {
 // such as SAML token authentication (see govc session.login for example).
 type Session struct {
 	URL         *url.URL // URL of a vCenter or ESXi instance
-	Dir         string   // Dir defaults to "$HOME/.govmomi/sessions"
+	DirSOAP     string   // DirSOAP cache directory. Defaults to "$HOME/.govmomi/sessions"
+	DirREST     string   // DirREST cache directory. Defaults to "$HOME/.govmomi/rest_sessions"
 	Insecure    bool     // Insecure param for soap.NewClient (tls.Config.InsecureSkipVerify)
 	Passthrough bool     // Passthrough disables caching when set to true
 
@@ -101,15 +102,23 @@ func (s *Session) key(path string) string {
 	return fmt.Sprintf("%064x", sha256.Sum256([]byte(key)))
 }
 
-func (s *Session) dir() string {
-	if s.Dir != "" {
-		return s.Dir
-	}
-	return filepath.Join(home, "sessions")
-}
-
 func (s *Session) file(p string) string {
-	return filepath.Join(s.dir(), s.key(p))
+	dir := ""
+
+	switch p {
+	case rest.Path:
+		dir = s.DirREST
+		if dir == "" {
+			dir = filepath.Join(home, "rest_sessions")
+		}
+	default:
+		dir = s.DirSOAP
+		if dir == "" {
+			dir = filepath.Join(home, "sessions")
+		}
+	}
+
+	return filepath.Join(dir, s.key(p))
 }
 
 // Save a Client in the file cache.


### PR DESCRIPTION
Follow up to #1898 - use the same defaults as Terraform for session file cache.