### PR TITLE
vcsim: apply ExtraConfig after devices

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -142,6 +142,25 @@ EOF
 
   run govc vm.ip "$TTYLINUX_NAME"
   assert_success "10.0.0.42"
+
+  run govc vm.destroy "$TTYLINUX_NAME"
+  assert_success
+
+  govc import.ovf -options - "$GOVC_IMAGES/$TTYLINUX_NAME.ovf" <<EOF
+{
+  "PropertyMapping": [
+    {
+      "Key": "ip0",
+      "Value": "10.0.0.43"
+    }
+  ],
+  "PowerOn": true,
+  "WaitForIP": true
+}
+EOF
+
+  run govc vm.ip "$TTYLINUX_NAME"
+  assert_success "10.0.0.43"
 }
 
 @test "vcsim vm.create" {

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -126,6 +126,22 @@ load test_helper
 
   run govc object.collect -s $vm config.uuid
   assert_success "$uuid"
+
+  govc import.ovf -options - "$GOVC_IMAGES/$TTYLINUX_NAME.ovf" <<EOF
+{
+  "PropertyMapping": [
+    {
+      "Key": "SET.guest.ipAddress",
+      "Value": "10.0.0.42"
+    }
+  ],
+  "PowerOn": true,
+  "WaitForIP": true
+}
+EOF
+
+  run govc vm.ip "$TTYLINUX_NAME"
+  assert_success "10.0.0.42"
 }
 
 @test "vcsim vm.create" {

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -306,6 +306,10 @@ func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 		vm.Guest.GuestFamily = guestFamily(spec.GuestId)
 	}
 
+	vm.Config.Modified = time.Now()
+}
+
+func (vm *VirtualMachine) applyExtraConfig(spec *types.VirtualMachineConfigSpec) {
 	var changes []types.PropertyChange
 	for _, c := range spec.ExtraConfig {
 		val := c.GetOptionValue()
@@ -335,8 +339,6 @@ func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 	if len(changes) != 0 {
 		Map.Update(vm, changes)
 	}
-
-	vm.Config.Modified = time.Now()
 }
 
 func validateGuestID(id string) types.BaseMethodFault {
@@ -1263,6 +1265,8 @@ func (vm *VirtualMachine) configureDevices(spec *types.VirtualMachineConfigSpec)
 	})
 
 	vm.updateDiskLayouts()
+
+	vm.applyExtraConfig(spec) // Do this after device config, as some may apply to the devices themselves (e.g. ethernet -> guest.net)
 
 	return nil
 }

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -309,11 +309,22 @@ func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 	vm.Config.Modified = time.Now()
 }
 
+var extraConfigAlias = map[string]string{
+	"ip0": "SET.guest.ipAddress",
+}
+
+func extraConfigKey(key string) string {
+	if k, ok := extraConfigAlias[key]; ok {
+		return k
+	}
+	return key
+}
+
 func (vm *VirtualMachine) applyExtraConfig(spec *types.VirtualMachineConfigSpec) {
 	var changes []types.PropertyChange
 	for _, c := range spec.ExtraConfig {
 		val := c.GetOptionValue()
-		key := strings.TrimPrefix(val.Key, "SET.")
+		key := strings.TrimPrefix(extraConfigKey(val.Key), "SET.")
 		if key == val.Key {
 			vm.Config.ExtraConfig = append(vm.Config.ExtraConfig, c)
 			continue


### PR DESCRIPTION
In order to set a VM guest net.config ipAddress, a VM ethernet card device must be present.
The original code worked fine for existing VMs, but we need to apply ExtraConfig after devices
for SET to work properly when creating new VMs.

Issue #1928