### PR TITLE
vcsim: fixes for PowerCLI

### DIFF
--- a/govc/test/sso.bats
+++ b/govc/test/sso.bats
@@ -27,6 +27,13 @@ load test_helper
   run govc sso.service.ls -t cs.identity -U
   assert_success "$sts"
 
+  run govc sso.service.ls -t sso:sts -U
+  assert_success "$sts"
+
+  cert=$(govc about.cert -show | grep -v CERTIFICATE | tr -d '\n')
+  trust=$(govc sso.service.ls -json -t sso:sts | jq -r .[].ServiceEndpoints[].SslTrust[0])
+  assert_equal "$cert" "$trust"
+
   govc sso.service.ls -t cs.identity | grep com.vmware.cis | grep -v https:
   govc sso.service.ls -t cs.identity -l | grep https:
   govc sso.service.ls -p com.vmware.cis -t cs.identity -P wsTrust -T com.vmware.cis.cs.identity.sso -l | grep wsTrust

--- a/lookup/simulator/registration_info.go
+++ b/lookup/simulator/registration_info.go
@@ -53,7 +53,7 @@ func registrationInfo() []types.LookupServiceRegistrationInfo {
 	instance := opts["VirtualCenter.InstanceName"]
 
 	// Real PSC has 30+ services by default, we just provide a few that are useful for vmomi interaction..
-	return []types.LookupServiceRegistrationInfo{
+	info := []types.LookupServiceRegistrationInfo{
 		{
 			LookupServiceRegistrationCommonServiceInfo: types.LookupServiceRegistrationCommonServiceInfo{
 				LookupServiceRegistrationMutableServiceInfo: types.LookupServiceRegistrationMutableServiceInfo{
@@ -130,4 +130,9 @@ func registrationInfo() []types.LookupServiceRegistrationInfo {
 			SiteId:    siteID,
 		},
 	}
+
+	sts := info[0]
+	sts.ServiceType.Type = "sso:sts" // obsolete service type, but still used by PowerCLI
+
+	return append(info, sts)
 }

--- a/lookup/simulator/simulator_test.go
+++ b/lookup/simulator/simulator_test.go
@@ -136,7 +136,7 @@ func TestClient(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if len(info) != 2 {
+		if len(info) != 3 {
 			t.Errorf("len=%d", len(info))
 		}
 	}

--- a/simulator/event_manager.go
+++ b/simulator/event_manager.go
@@ -392,6 +392,14 @@ func (c *EventHistoryCollector) SetCollectorPageSize(ctx *Context, req *types.Se
 	return body
 }
 
+func (c *EventHistoryCollector) ResetCollector(ctx *Context, req *types.ResetCollector) soap.HasFault {
+	c.pos = len(c.GetLatestPage())
+
+	return &methods.ResetCollectorBody{
+		Res: new(types.ResetCollectorResponse),
+	}
+}
+
 func (c *EventHistoryCollector) RewindCollector(ctx *Context, req *types.RewindCollector) soap.HasFault {
 	c.pos = 0
 	return &methods.RewindCollectorBody{


### PR DESCRIPTION
Commit 08adb5d6 (#1740) removed the obsolute sso:sts type in favor of cs.identity,
but PowerCLI still uses sso:sts.

Commit 43d69860 (#1595) changed endpoint registration to happen before vcsim's TLS cert is known,
leaving ServiceEndpoints.SslTrust empty, but PowerCLI requires this field be non-empty.