### PR TITLE
Fix delegated Holder-of-Key token signature

### DIFF
--- a/sts/internal/types.go
+++ b/sts/internal/types.go
@@ -473,7 +473,7 @@ func (a *AttributeStatement) C14N() string {
 
 type AttributeValue struct {
 	XMLName xml.Name
-	Type    string `xml:"type,attr"`
+	Type    string `xml:"type,attr,typeattr"`
 	Value   string `xml:",innerxml"`
 }
 

--- a/vim25/xml/read.go
+++ b/vim25/xml/read.go
@@ -507,8 +507,9 @@ func (d *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
 				case fAttr:
 					strv := finfo.value(sv)
 					if a.Name.Local == finfo.name && (finfo.xmlns == "" || finfo.xmlns == a.Name.Space) {
+						needTypeAttr := (finfo.flags & fTypeAttr) != 0
 						// HACK: avoid using xsi:type value for a "type" attribute, such as ManagedObjectReference.Type for example.
-						if a.Name != xmlSchemaInstance && a.Name != xsiType {
+						if needTypeAttr || (a.Name != xmlSchemaInstance && a.Name != xsiType) {
 							if err := d.unmarshalAttr(strv, a); err != nil {
 								return err
 							}


### PR DESCRIPTION
The vim25/xml sync in #1800 broke delegated HoK signatures,
due to an empty AttributeValue.Type in the RequestSecurityToken body.

Make use of the 'typeattr' field flag to ensure the Type field is
properly marshaled in this case.