### PR TITLE
Add GetProfileNameByID functionality to PBM

### DIFF
--- a/pbm/client.go
+++ b/pbm/client.go
@@ -239,3 +239,28 @@ func (c *Client) FetchCapabilityMetadata(ctx context.Context, rtype *types.PbmPr
 
 	return res.Returnval, nil
 }
+
+// GetProfileNameByID gets storage profile name by ID
+func (c *Client) GetProfileNameByID(ctx context.Context, profileID string) (string, error) {
+	resourceType := types.PbmProfileResourceType{
+		ResourceType: string(types.PbmProfileResourceTypeEnumSTORAGE),
+	}
+	category := types.PbmProfileCategoryEnumREQUIREMENT
+	ids, err := c.QueryProfile(ctx, resourceType, string(category))
+	if err != nil {
+		return "", err
+	}
+
+	profiles, err := c.RetrieveContent(ctx, ids)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range profiles {
+		profile := profiles[i].GetPbmProfile()
+		if profile.ProfileId.UniqueId == profileID {
+			return profile.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no pbm profile found with id: %q", profileID)
+}

--- a/pbm/client_test.go
+++ b/pbm/client_test.go
@@ -283,17 +283,30 @@ func TestClient(t *testing.T) {
 	t.Logf("VSAN-SIOC Profile: %q successfully created", vsansiocProfileID.UniqueId)
 
 	// 9. Get ProfileID by Name
-	profileID, err := pc.ProfileIDByName(ctx, "Kubernetes-VSAN-SIOC-TestPolicy")
+	profileID, err := pc.ProfileIDByName(ctx, pbmCreateSpecVSANandSIOC.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if vsansiocProfileID.UniqueId != profileID {
-		t.Errorf("vsan-sioc profile: %q and retrieved profileID: %q successfully matched", vsansiocProfileID.UniqueId, profileID)
+		t.Errorf("vsan-sioc profile: %q and retrieved profileID: %q did not match", vsansiocProfileID.UniqueId, profileID)
 	}
+
 	t.Logf("VSAN-SIOC profile: %q and retrieved profileID: %q successfully matched", vsansiocProfileID.UniqueId, profileID)
 
-	// 10. Delete VSAN and VSAN-SIOC profile.
+	// 10. Get ProfileName by ID
+	profileName, err := pc.GetProfileNameByID(ctx, profileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if profileName != pbmCreateSpecVSANandSIOC.Name {
+		t.Errorf("vsan-sioc profile: %q and retrieved profileName: %q did not match", pbmCreateSpecVSANandSIOC.Name, profileName)
+	}
+
+	t.Logf("vsan-sioc profile: %q and retrieved profileName: %q successfully matched", pbmCreateSpecVSANandSIOC.Name, profileName)
+
+	// 11. Delete VSAN and VSAN-SIOC profile.
 	_, err = pc.DeleteProfile(ctx, []types.PbmProfileId{*vsanProfileID, *vsansiocProfileID})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Add `GetProfileNameByID` functionality to govmomi. 

Also added a sample test code to test this function.

```
TestClient: client_test.go:284: VSAN-SIOC Profile: "2d8a11a7-6da5-4f9e-a3ae-b308aeb90500" successfully created
TestClient: client_test.go:297: VSAN-SIOC profile: "2d8a11a7-6da5-4f9e-a3ae-b308aeb90500" and retrieved profileID: "2d8a11a7-6da5-4f9e-a3ae-b308aeb90500" successfully matched
TestClient: client_test.go:309: vsan-sioc profile: "Kubernetes-VSAN-SIOC-TestPolicy" and retrieved profileName: "Kubernetes-VSAN-SIOC-TestPolicy" successfully matched
TestClient: client_test.go:316: Profile: [{DynamicData:{} UniqueId:af9ec97a-7ad1-4d38-bd67-693c1b3b8f58} {DynamicData:{} UniqueId:2d8a11a7-6da5-4f9e-a3ae-b308aeb90500}] successfully deleted
```

cc @divyenpatel @dougm 