### PR TITLE
Add BackingDiskUrlPath and CnsAlreadyFault go bindings to CNS APIs

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -35,6 +35,7 @@ const (
 
 const (
 	ReleaseVSAN67u3 = "vSAN 6.7U3"
+	ReleaseVSAN70   = "7.0"
 )
 
 var (

--- a/cns/cns_util.go
+++ b/cns/cns_util.go
@@ -53,9 +53,9 @@ func GetTaskResult(ctx context.Context, taskInfo *vim25types.TaskInfo) (cnstypes
 
 // dropUnknownCreateSpecElements helps drop newly added elements in the CnsVolumeCreateSpec, which are not known to the prior vSphere releases
 func dropUnknownCreateSpecElements(c *Client, createSpecList []cnstypes.CnsVolumeCreateSpec) []cnstypes.CnsVolumeCreateSpec {
+	var updatedcreateSpecList []cnstypes.CnsVolumeCreateSpec
 	if c.serviceClient.Version == ReleaseVSAN67u3 {
 		// Dropping optional fields not known to vSAN 6.7U3
-		var updatedcreateSpecList []cnstypes.CnsVolumeCreateSpec
 		for _, createSpec := range createSpecList {
 			createSpec.Metadata.ContainerCluster.ClusterFlavor = ""
 			createSpec.Metadata.ContainerClusterArray = nil
@@ -67,6 +67,13 @@ func dropUnknownCreateSpecElements(c *Client, createSpecList []cnstypes.CnsVolum
 				updatedEntityMetadata = append(updatedEntityMetadata, cnstypes.BaseCnsEntityMetadata(k8sEntityMetadata))
 			}
 			createSpec.Metadata.EntityMetadata = updatedEntityMetadata
+			createSpec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).BackingDiskUrlPath = ""
+			updatedcreateSpecList = append(updatedcreateSpecList, createSpec)
+		}
+		createSpecList = updatedcreateSpecList
+	} else if c.serviceClient.Version == ReleaseVSAN70 {
+		for _, createSpec := range createSpecList {
+			createSpec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).BackingDiskUrlPath = ""
 			updatedcreateSpecList = append(updatedcreateSpecList, createSpec)
 		}
 		createSpecList = updatedcreateSpecList

--- a/cns/types/if.go
+++ b/cns/types/if.go
@@ -34,6 +34,18 @@ func init() {
 	types.Add("BaseCnsFault", reflect.TypeOf((*CnsFault)(nil)).Elem())
 }
 
+func (b *CnsAlreadyRegisteredFault) GetCnsAlreadyRegisteredFault() *CnsAlreadyRegisteredFault {
+	return b
+}
+
+type BaseCnsAlreadyRegisteredFault interface {
+	GetCnsAlreadyRegisteredFault() *CnsAlreadyRegisteredFault
+}
+
+func init() {
+	types.Add("BaseCnsAlreadyRegisteredFault", reflect.TypeOf((*CnsAlreadyRegisteredFault)(nil)).Elem())
+}
+
 func (b *CnsBackingObjectDetails) GetCnsBackingObjectDetails() *CnsBackingObjectDetails { return b }
 
 type BaseCnsBackingObjectDetails interface {

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -364,7 +364,8 @@ func init() {
 type CnsBlockBackingDetails struct {
 	CnsBackingObjectDetails
 
-	BackingDiskId string `xml:"backingDiskId,omitempty"`
+	BackingDiskId      string `xml:"backingDiskId,omitempty"`
+	BackingDiskUrlPath string `xml:"backingDiskUrlPath,omitempty"`
 }
 
 func init() {
@@ -474,4 +475,14 @@ type CnsFault struct {
 
 func init() {
 	types.Add("CnsFault", reflect.TypeOf((*CnsFault)(nil)).Elem())
+}
+
+type CnsAlreadyRegisteredFault struct {
+	CnsFault `xml:"fault,typeattr"`
+
+	VolumeId string `xml:"volumeId,omitempty"`
+}
+
+func init() {
+	types.Add("CnsAlreadyRegisteredFault", reflect.TypeOf((*CnsAlreadyRegisteredFault)(nil)).Elem())
 }


### PR DESCRIPTION
This PR does the following

-  Add BackingDiskUrlPath and CnsAlreadyFault go bindings to CNS APIs
-  Update CreateVolume CNS Util  to include BackingDiskUrlPath
-  Add sample test for Create CNS API using backing disk Url path

Logs for sample test code
```
    TestClient: client_test.go:668: Creating volume using the spec: types.CnsVolumeCreateSpec{
            Name:       "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
            VolumeType: "BLOCK",
            Datastores: nil,
            Metadata:   types.CnsVolumeMetadata{
                ContainerCluster: types.CnsContainerCluster{
                    ClusterType:   "KUBERNETES",
                    ClusterId:     "demo-cluster-id",
                    VSphereUser:   "Administrator@vsphere.local",
                    ClusterFlavor: "VANILLA",
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{},
                BackingDiskId:           "",
                BackingDiskUrlPath:      "https://10.161.1.195/folder/testdisk9.vmdk?dcPath=test-vpx-1586388419-26155-wcp.wcp-sanity&dsName=nfs0-1",
            },
            Profile:    nil,
            CreateSpec: nil,
        }
    TestClient: client_test.go:699: Volume created sucessfully. volumeId: 2fa1593a-4f2c-4d74-962a-db338662a97d
    TestClient: client_test.go:706: Calling QueryVolume using queryFilter: types.CnsQueryFilter{
            VolumeIds: []types.CnsVolumeId{
                {
                    Id: "2fa1593a-4f2c-4d74-962a-db338662a97d",
                },
            },
            Names:                        nil,
            ContainerClusterIds:          nil,
            StoragePolicyId:              "",
            Datastores:                   nil,
            Labels:                       nil,
            ComplianceStatus:             "",
            DatastoreAccessibilityStatus: "",
            Cursor:                       (*types.CnsCursor)(nil),
            healthStatus:                 "",
        }
    TestClient: client_test.go:712: Sucessfully Queried Volumes. queryResult: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "2fa1593a-4f2c-4d74-962a-db338662a97d",
                    },
                    DatastoreUrl:    "ds:///vmfs/volumes/c479f901-bab8a7c3/",
                    Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:      "BLOCK",
                    StoragePolicyId: "",
                    Metadata:        types.CnsVolumeMetadata{
                        ContainerCluster: types.CnsContainerCluster{
                            ClusterType:   "KUBERNETES",
                            ClusterId:     "demo-cluster-id",
                            VSphereUser:   "Administrator@vsphere.local",
                            ClusterFlavor: "VANILLA",
                        },
                        EntityMetadata:        nil,
                        ContainerClusterArray: []types.CnsContainerCluster{
                            {
                                ClusterType:   "KUBERNETES",
                                ClusterId:     "demo-cluster-id",
                                VSphereUser:   "Administrator@vsphere.local",
                                ClusterFlavor: "VANILLA",
                            },
                        },
                    },
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 1024,
                        },
                        BackingDiskId:      "2fa1593a-4f2c-4d74-962a-db338662a97d",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "",
                    DatastoreAccessibilityStatus: "",
                    HealthStatus:                 "",
                },
            },
            Cursor: types.CnsCursor{
                Offset:       1,
                Limit:        100,
                TotalRecords: 1,
            },
        }
--- PASS: TestClient (11.86s)
```

cc @divyenpatel @dougm 
