### PR TITLE
Add retry tests for CNS Create API with backingdiskUrlPath and fix CNS binding for CnsAlreadyRegisteredFault

### DIFF
--- a/cns/cns_util.go
+++ b/cns/cns_util.go
@@ -67,13 +67,19 @@ func dropUnknownCreateSpecElements(c *Client, createSpecList []cnstypes.CnsVolum
 				updatedEntityMetadata = append(updatedEntityMetadata, cnstypes.BaseCnsEntityMetadata(k8sEntityMetadata))
 			}
 			createSpec.Metadata.EntityMetadata = updatedEntityMetadata
-			createSpec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).BackingDiskUrlPath = ""
+			_, ok := createSpec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+			if ok {
+				createSpec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).BackingDiskUrlPath = ""
+			}
 			updatedcreateSpecList = append(updatedcreateSpecList, createSpec)
 		}
 		createSpecList = updatedcreateSpecList
 	} else if c.serviceClient.Version == ReleaseVSAN70 {
 		for _, createSpec := range createSpecList {
-			createSpec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).BackingDiskUrlPath = ""
+			_, ok := createSpec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+			if ok {
+				createSpec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).BackingDiskUrlPath = ""
+			}
 			updatedcreateSpecList = append(updatedcreateSpecList, createSpec)
 		}
 		createSpecList = updatedcreateSpecList

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -480,7 +480,7 @@ func init() {
 type CnsAlreadyRegisteredFault struct {
 	CnsFault `xml:"fault,typeattr"`
 
-	VolumeId string `xml:"volumeId,omitempty"`
+	VolumeId CnsVolumeId `xml:"volumeId,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
This PR does the following

1. In CNS Client test, add retry logic to create a CNS volume with backingdiskUrlPath. This time it will catch CnsAlreadyRegisteredFault and print the log message.
2. Fix binding for CnsAlreadyRegisteredFault

executed all tests in cns/client_test.go and adding relevant logs related to this PR.
```
    TestClient: client_test.go:668: Creating volume using the spec: types.CnsVolumeCreateSpec{
            Name:       "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
            VolumeType: "BLOCK",
            Datastores: nil,
            Metadata:   types.CnsVolumeMetadata{
                ContainerCluster: types.CnsContainerCluster{
                    ClusterType:   "KUBERNETES",
                    ClusterId:     "demo-cluster-id",
                    VSphereUser:   "Administrator@vsphere.local",
                    ClusterFlavor: "VANILLA",
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{},
                BackingDiskId:           "",
                BackingDiskUrlPath:      "https://10.185.4.64/folder/testdisk4.vmdk?dcPath=test-vpx-1586889245-13110-hostpool&dsName=test-vpx-1586889245-13110-ds-1",
            },
            Profile:    nil,
            CreateSpec: nil,
        }
    TestClient: client_test.go:701: Volume created sucessfully. volumeId: c54cfa95-1d8d-45c2-ab5a-7dd2dba76f8b
    TestClient: client_test.go:717: Creating volume using the spec: types.CnsVolumeCreateSpec{
            Name:       "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
            VolumeType: "BLOCK",
            Datastores: nil,
            Metadata:   types.CnsVolumeMetadata{
                ContainerCluster: types.CnsContainerCluster{
                    ClusterType:   "KUBERNETES",
                    ClusterId:     "demo-cluster-id",
                    VSphereUser:   "Administrator@vsphere.local",
                    ClusterFlavor: "VANILLA",
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{},
                BackingDiskId:           "",
                BackingDiskUrlPath:      "https://10.185.4.64/folder/testdisk4.vmdk?dcPath=test-vpx-1586889245-13110-hostpool&dsName=test-vpx-1586889245-13110-ds-1",
            },
            Profile:    nil,
            CreateSpec: nil,
        }
    TestClient: client_test.go:738: reCreateVolumeOperationRes.: &types.CnsVolumeOperationResult{
            VolumeId: types.CnsVolumeId{},
            Fault:    &types.LocalizedMethodFault{
                Fault: types.CnsAlreadyRegisteredFault{
                    CnsFault: types.CnsFault{
                        BaseMethodFault: nil,
                        Reason:          "CNS: Disk(id: c54cfa95-1d8d-45c2-ab5a-7dd2dba76f8b, url: https://10.185.4.64/folder/testdisk4.vmdk?dcPath=test-vpx-1586889245-13110-hostpool&dsName=test-vpx-1586889245-13110-ds-1) is already registered.",
                    },
                    VolumeId: types.CnsVolumeId{
                        Id: "c54cfa95-1d8d-45c2-ab5a-7dd2dba76f8b",
                    },
                },
                LocalizedMessage: "Volume is already registered with ID c54cfa95-1d8d-45c2-ab5a-7dd2dba76f8b. Error message: CNS: Disk(id: c54cfa95-1d8d-45c2-ab5a-7dd2dba76f8b, url: https://10.185.4.64/folder/testdisk4.vmdk?dcPath=test-vpx-1586889245-13110-hostpool&dsName=test-vpx-1586889245-13110-ds-1) is already registered.",
            },
        }
    TestClient: client_test.go:740: Failed to create volume: fault=&{DynamicData:{} Fault:{CnsFault:{BaseMethodFault:<nil> Reason:CNS: Disk(id: c54cfa95-1d8d-45c2-ab5a-7dd2dba76f8b, url: https://10.185.4.64/folder/testdisk4.vmdk?dcPath=test-vpx-1586889245-13110-hostpool&dsName=test-vpx-1586889245-13110-ds-1) is already registered.} VolumeId:{DynamicData:{} Id:c54cfa95-1d8d-45c2-ab5a-7dd2dba76f8b}} LocalizedMessage:Volume is already registered with ID c54cfa95-1d8d-45c2-ab5a-7dd2dba76f8b. Error message: CNS: Disk(id: c54cfa95-1d8d-45c2-ab5a-7dd2dba76f8b, url: https://10.185.4.64/folder/testdisk4.vmdk?dcPath=test-vpx-1586889245-13110-hostpool&dsName=test-vpx-1586889245-13110-ds-1) is already registered.}
    TestClient: client_test.go:745: Fault is CnsAlreadyRegisteredFault. backingDiskURLPath: "https://10.185.4.64/folder/testdisk4.vmdk?dcPath=test-vpx-1586889245-13110-hostpool&dsName=test-vpx-1586889245-13110-ds-1" is already registered
    TestClient: client_test.go:755: Calling QueryVolume using queryFilter: types.CnsQueryFilter{
            VolumeIds: []types.CnsVolumeId{
                {
                    Id: "c54cfa95-1d8d-45c2-ab5a-7dd2dba76f8b",
                },
            },
            Names:                        nil,
            ContainerClusterIds:          nil,
            StoragePolicyId:              "",
            Datastores:                   nil,
            Labels:                       nil,
            ComplianceStatus:             "",
            DatastoreAccessibilityStatus: "",
            Cursor:                       (*types.CnsCursor)(nil),
            healthStatus:                 "",
        }
    TestClient: client_test.go:761: Sucessfully Queried Volumes. queryResult: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "c54cfa95-1d8d-45c2-ab5a-7dd2dba76f8b",
                    },
                    DatastoreUrl:    "ds:///vmfs/volumes/7de60e4b-dd000e05/",
                    Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:      "BLOCK",
                    StoragePolicyId: "",
                    Metadata:        types.CnsVolumeMetadata{
                        ContainerCluster: types.CnsContainerCluster{
                            ClusterType:   "KUBERNETES",
                            ClusterId:     "demo-cluster-id",
                            VSphereUser:   "Administrator@vsphere.local",
                            ClusterFlavor: "VANILLA",
                        },
                        EntityMetadata:        nil,
                        ContainerClusterArray: []types.CnsContainerCluster{
                            {
                                ClusterType:   "KUBERNETES",
                                ClusterId:     "demo-cluster-id",
                                VSphereUser:   "Administrator@vsphere.local",
                                ClusterFlavor: "VANILLA",
                            },
                        },
                    },
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 5120,
                        },
                        BackingDiskId:      "c54cfa95-1d8d-45c2-ab5a-7dd2dba76f8b",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "",
                    DatastoreAccessibilityStatus: "",
                    HealthStatus:                 "",
                },
            },
            Cursor: types.CnsCursor{
                Offset:       1,
                Limit:        100,
                TotalRecords: 1,
            },
        }
```

cc @divyenpatel @dougm 
