### PR TITLE
simulator: relax excessive type assertions in SearchIndex

### DIFF
--- a/simulator/host_system.go
+++ b/simulator/host_system.go
@@ -35,6 +35,11 @@ type HostSystem struct {
 	mo.HostSystem
 }
 
+func asHostSystemMO(obj mo.Reference) (*mo.HostSystem, bool) {
+	h, ok := getManagedObject(obj).Addr().Interface().(*mo.HostSystem)
+	return h, ok
+}
+
 func NewHostSystem(host mo.HostSystem) *HostSystem {
 	if hostPortUnique { // configure unique port for each host
 		port := &esx.HostSystem.Summary.Config.Port

--- a/simulator/search_index.go
+++ b/simulator/search_index.go
@@ -33,7 +33,7 @@ func (s *SearchIndex) FindByDatastorePath(r *types.FindByDatastorePath) soap.Has
 	res := &methods.FindByDatastorePathBody{Res: new(types.FindByDatastorePathResponse)}
 
 	for ref, obj := range Map.objects {
-		vm, ok := obj.(*VirtualMachine)
+		vm, ok := asVirtualMachineMO(obj)
 		if !ok {
 			continue
 		}
@@ -124,7 +124,7 @@ func (s *SearchIndex) FindByUuid(req *types.FindByUuid) soap.HasFault {
 	if req.VmSearch {
 		// Find Virtual Machine using UUID
 		for ref, obj := range Map.objects {
-			vm, ok := obj.(*VirtualMachine)
+			vm, ok := asVirtualMachineMO(obj)
 			if !ok {
 				continue
 			}
@@ -143,7 +143,7 @@ func (s *SearchIndex) FindByUuid(req *types.FindByUuid) soap.HasFault {
 	} else {
 		// Find Host System using UUID
 		for ref, obj := range Map.objects {
-			host, ok := obj.(*HostSystem)
+			host, ok := asHostSystemMO(obj)
 			if !ok {
 				continue
 			}
@@ -180,7 +180,7 @@ func (s *SearchIndex) FindAllByDnsName(req *types.FindAllByDnsName) soap.HasFaul
 	if req.VmSearch {
 		// Find Virtual Machine using DNS name
 		for ref, obj := range Map.objects {
-			vm, ok := obj.(*VirtualMachine)
+			vm, ok := asVirtualMachineMO(obj)
 			if !ok {
 				continue
 			}
@@ -191,7 +191,7 @@ func (s *SearchIndex) FindAllByDnsName(req *types.FindAllByDnsName) soap.HasFaul
 	} else {
 		// Find Host System using DNS name
 		for ref, obj := range Map.objects {
-			host, ok := obj.(*HostSystem)
+			host, ok := asHostSystemMO(obj)
 			if !ok {
 				continue
 			}
@@ -229,7 +229,7 @@ func (s *SearchIndex) FindAllByIp(req *types.FindAllByIp) soap.HasFault {
 	if req.VmSearch {
 		// Find Virtual Machine using IP
 		for ref, obj := range Map.objects {
-			vm, ok := obj.(*VirtualMachine)
+			vm, ok := asVirtualMachineMO(obj)
 			if !ok {
 				continue
 			}
@@ -240,7 +240,7 @@ func (s *SearchIndex) FindAllByIp(req *types.FindAllByIp) soap.HasFault {
 	} else {
 		// Find Host System using IP
 		for ref, obj := range Map.objects {
-			host, ok := obj.(*HostSystem)
+			host, ok := asHostSystemMO(obj)
 			if !ok {
 				continue
 			}

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -50,6 +50,11 @@ type VirtualMachine struct {
 	imc *types.CustomizationSpec
 }
 
+func asVirtualMachineMO(obj mo.Reference) (*mo.VirtualMachine, bool) {
+	vm, ok := getManagedObject(obj).Addr().Interface().(*mo.VirtualMachine)
+	return vm, ok
+}
+
 func NewVirtualMachine(parent types.ManagedObjectReference, spec *types.VirtualMachineConfigSpec) (*VirtualMachine, types.BaseMethodFault) {
 	vm := &VirtualMachine{}
 	vm.Parent = &parent


### PR DESCRIPTION
This change relaxes some strong constraints on the exact type of VM and host
objects in the SearchIndex.
Previously, when registering a custom implementation of those objects the
SearchIndex would simply fail to find them. Using the corresponding MO instead
removes that limitation.