### PR TITLE
Add support for attach-tag-to-multiple-objects

### DIFF
--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -620,8 +620,18 @@ func (s *handler) associationID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var spec internal.Association
-	if !s.decode(r, w, &spec) {
-		return
+	var specs struct {
+		ObjectIDs []internal.AssociatedObject `json:"object_ids"`
+	}
+	switch s.action(r) {
+	case "attach", "detach", "list-attached-objects":
+		if !s.decode(r, w, &spec) {
+			return
+		}
+	case "attach-tag-to-multiple-objects":
+		if !s.decode(r, w, &specs) {
+			return
+		}
 	}
 
 	switch s.action(r) {
@@ -637,6 +647,11 @@ func (s *handler) associationID(w http.ResponseWriter, r *http.Request) {
 			ids = append(ids, id)
 		}
 		OK(w, ids)
+	case "attach-tag-to-multiple-objects":
+		for _, obj := range specs.ObjectIDs {
+			s.Association[id][obj] = true
+		}
+		OK(w)
 	}
 }
 

--- a/vapi/tags/tag_association.go
+++ b/vapi/tags/tag_association.go
@@ -60,6 +60,26 @@ func (c *Manager) DetachTag(ctx context.Context, tagID string, ref mo.Reference)
 	return c.Do(ctx, url.Request(http.MethodPost, spec), nil)
 }
 
+// AttachTagToMultipleObjects attaches a tag ID to multiple managed objects
+func (c *Manager) AttachTagToMultipleObjects(ctx context.Context, tagID string, refs []mo.Reference) error {
+	id, err := c.tagID(ctx, tagID)
+	if err != nil {
+		return err
+	}
+
+	var ids []internal.AssociatedObject
+	for i := range refs {
+		ids = append(ids, internal.AssociatedObject(refs[i].Reference()))
+	}
+
+	spec := struct {
+		ObjectIDs []internal.AssociatedObject `json:"object_ids"`
+	}{ids}
+
+	url := c.Resource(internal.AssociationPath).WithID(id).WithAction("attach-tag-to-multiple-objects")
+	return c.Do(ctx, url.Request(http.MethodPost, spec), nil)
+}
+
 // ListAttachedTags fetches the array of tag IDs attached to the given object.
 func (c *Manager) ListAttachedTags(ctx context.Context, ref mo.Reference) ([]string, error) {
 	spec := internal.NewAssociation(ref)


### PR DESCRIPTION
Added method for attaching a tag to multiple objects following this documentation:
https://vdc-download.vmware.com/vmwb-repository/dcr-public/1cd28284-3b72-4885-9e31-d1c6d9e26686/71ef7304-a6c9-43b3-a3cd-868b2c236c81/doc/operations/com/vmware/cis/tagging/tag_association.attach_tag_to_multiple_objects-operation.html

Tested with vCenter 6.5 and 6.7.