### PR TITLE
govc: support VirtualApp with -pool flag

### DIFF
--- a/govc/importx/ovf.go
+++ b/govc/importx/ovf.go
@@ -275,9 +275,14 @@ func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 		}
 	}
 
-	folder, err := cmd.FolderOrDefault("vm")
-	if err != nil {
-		return nil, err
+	var folder *object.Folder
+	// The folder argument must not be set on a VM in a vApp, otherwise causes
+	// InvalidArgument fault: A specified parameter was not correct: pool
+	if cmd.ResourcePool.Reference().Type != "VirtualApp" {
+		folder, err = cmd.FolderOrDefault("vm")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	lease, err := cmd.ResourcePool.ImportVApp(ctx, spec.ImportSpec, folder, host)

--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -3,7 +3,7 @@
 load test_helper
 
 @test "import.ova" {
-  vcsim_env
+  vcsim_env -app 1
 
   run govc import.ova "$GOVC_IMAGES/$TTYLINUX_NAME.ova"
   assert_success
@@ -33,6 +33,9 @@ load test_helper
   assert_matches "disk-"
 
   run govc vm.destroy "$TTYLINUX_NAME"
+  assert_success
+
+  run govc import.ova -pool /DC0/host/DC0_C0/Resources/DC0_C0_APP0 "$GOVC_IMAGES/$TTYLINUX_NAME.ova"
   assert_success
 }
 

--- a/simulator/ovf_manager.go
+++ b/simulator/ovf_manager.go
@@ -49,7 +49,7 @@ func ovfNetwork(ctx *Context, req *types.CreateImportSpec, item ovf.ResourceAllo
 	if len(item.Connection) == 0 {
 		return nil
 	}
-	pool := ctx.Map.Get(req.ResourcePool).(*ResourcePool)
+	pool := ctx.Map.Get(req.ResourcePool).(mo.Entity)
 	ref := ctx.Map.getEntityDatacenter(pool).defaultNetwork()[0] // Default to VM Network
 	c := item.Connection[0]
 

--- a/simulator/resource_pool.go
+++ b/simulator/resource_pool.go
@@ -189,6 +189,10 @@ func (p *ResourcePool) UpdateConfig(c *types.UpdateConfig) soap.HasFault {
 	return body
 }
 
+func (a *VirtualApp) ImportVApp(ctx *Context, req *types.ImportVApp) soap.HasFault {
+	return (&ResourcePool{ResourcePool: a.ResourcePool}).ImportVApp(ctx, req)
+}
+
 func (p *ResourcePool) ImportVApp(ctx *Context, req *types.ImportVApp) soap.HasFault {
 	body := new(methods.ImportVAppBody)
 
@@ -201,6 +205,10 @@ func (p *ResourcePool) ImportVApp(ctx *Context, req *types.ImportVApp) soap.HasF
 	dc := ctx.Map.getEntityDatacenter(p)
 	folder := ctx.Map.Get(dc.VmFolder).(*Folder)
 	if req.Folder != nil {
+		if p.Self.Type == "VirtualApp" {
+			body.Fault_ = Fault("", &types.InvalidArgument{InvalidProperty: "pool"})
+			return body
+		}
 		folder = ctx.Map.Get(*req.Folder).(*Folder)
 	}
 


### PR DESCRIPTION
VirtualApp extends ResourcePool, so the govc -pool flag should support VirtualApp types.

Fixes #1956