### PR TITLE
vapi: sync access to rest.Client.SessionID

### DIFF
--- a/govc/library/export.go
+++ b/govc/library/export.go
@@ -139,7 +139,7 @@ func (cmd *export) Run(ctx context.Context, f *flag.FlagSet) error {
 	download := func(src *url.URL, name string) error {
 		p := soap.DefaultDownload
 		p.Headers = map[string]string{
-			"vmware-api-session-id": c.SessionID,
+			"vmware-api-session-id": c.SessionID(),
 		}
 		if isStdout {
 			s, _, err := c.Download(ctx, src, &p)

--- a/govc/session/login.go
+++ b/govc/session/login.go
@@ -263,9 +263,9 @@ func (cmd *login) setCookie(ctx context.Context, c *vim25.Client) error {
 
 func (cmd *login) setRestCookie(ctx context.Context, c *rest.Client) error {
 	if cmd.cookie == "" {
-		cmd.cookie = c.SessionID
+		cmd.cookie = c.SessionID()
 	} else {
-		c.SessionID = cmd.cookie
+		c.SessionID(cmd.cookie)
 
 		// Check the session is still valid
 		s, err := c.Session(ctx)

--- a/govc/session/ls.go
+++ b/govc/session/ls.go
@@ -140,7 +140,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 				return err
 			}
 			m.SessionList = append(m.SessionList, types.UserSession{
-				Key:            rc.SessionID,
+				Key:            rc.SessionID(),
 				UserName:       rs.User + " (REST)",
 				LoginTime:      rs.Created,
 				LastActiveTime: rs.LastAccessed,

--- a/session/cache/session.go
+++ b/session/cache/session.go
@@ -325,18 +325,16 @@ func (s *Session) Login(ctx context.Context, c Client, config func(*soap.Client)
 		*client = *vc
 		c = client
 	case *rest.Client:
-		vc := &vim25.Client{Client: sc}
-		rc := rest.NewClient(vc)
+		client.Client = sc.NewServiceClient(rest.Path, "")
 
 		login := s.loginREST
 		if s.LoginREST != nil {
 			login = s.LoginREST
 		}
-		if err = login(ctx, rc); err != nil {
+		if err = login(ctx, client); err != nil {
 			return err
 		}
 
-		*client = *rc
 		c = client
 	default:
 		panic(fmt.Sprintf("unsupported client type=%T", client))


### PR DESCRIPTION
Required for the upcoming KeepAlive support.