### PR TITLE
vcsim: modify markdown link at README.md

### DIFF
--- a/vcsim/README.md
+++ b/vcsim/README.md
@@ -255,7 +255,7 @@ Network                 /godc/network/VM Network
 ## Generated inventory names
 
 The generated names include a prefix per-type and integer suffix per-instance.
-See the [simulator.Model](model) documentation for a complete list of type prefixes.
+See the [simulator.Model][model] documentation for a complete list of type prefixes.
 For example, the name **DC0_C1_RP0_VM6** is composed of:
 
 | Prefix | Instance | Type                   | Flag     |


### PR DESCRIPTION
I modified markdown link. 
Because this link goes to incorrect link (404 Not Found).