### PR TITLE
Adding name variable in SubProfile inside pbmCapabilityProfileSpec

### DIFF
--- a/pbm/pbm_util.go
+++ b/pbm/pbm_util.go
@@ -27,6 +27,7 @@ import (
 // A struct to capture pbm create spec details.
 type CapabilityProfileCreateSpec struct {
 	Name           string
+	SubProfileName string
 	Description    string
 	Category       string
 	CapabilityList []Capability
@@ -64,6 +65,7 @@ func CreateCapabilityProfileSpec(pbmCreateSpec CapabilityProfileCreateSpec) (*ty
 			SubProfiles: []types.PbmCapabilitySubProfile{
 				types.PbmCapabilitySubProfile{
 					Capability: capabilities,
+					Name:       pbmCreateSpec.SubProfileName,
 				},
 			},
 		},


### PR DESCRIPTION

PbmCapabilitySubProfileConstraints was missing Name support in subProfile.
Adding a function to address the same.

https://github.com/vmware/govmomi/issues/1983#issuecomment-630532948