### PR TITLE
providing examples for govc guest.run

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -2094,6 +2094,8 @@ Examples:
   govc guest.run -vm $name -d "hello $USER" cat
   govc guest.run -vm $name curl -s :invalid: || echo $? # exit code 6
   govc guest.run -vm $name -e FOO=bar -e BIZ=baz -C /tmp env
+  govc guest.run -dc=datacenter01 -l root:'mypassword' -vm=my_vm_hostname "ntpdate -u pool.ntp.org"
+
 
 Options:
   -C=                    The absolute path of the working directory for the program to start

--- a/govc/vm/guest/run.go
+++ b/govc/vm/guest/run.go
@@ -64,7 +64,9 @@ Examples:
   cal | govc guest.run -vm $name -d - cat
   govc guest.run -vm $name -d "hello $USER" cat
   govc guest.run -vm $name curl -s :invalid: || echo $? # exit code 6
-  govc guest.run -vm $name -e FOO=bar -e BIZ=baz -C /tmp env`
+  govc guest.run -vm $name -e FOO=bar -e BIZ=baz -C /tmp env
+  govc guest.run -dc=datacenter01 -l root:'mypassword' -vm=my_vm_hostname "ntpdate -u pool.ntp.org"`
+
 }
 
 func (cmd *run) Run(ctx context.Context, f *flag.FlagSet) error {


### PR DESCRIPTION
Adding another example for using guest.run. One that passes the datacenter and login credentials.