### PR TITLE
Adding subProfileName in pbm.CapabilityProfileCreateSpec

### DIFF
--- a/pbm/pbm_util.go
+++ b/pbm/pbm_util.go
@@ -27,6 +27,7 @@ import (
 // A struct to capture pbm create spec details.
 type CapabilityProfileCreateSpec struct {
 	Name           string
+	SubProfileName string
 	Description    string
 	Category       string
 	CapabilityList []Capability
@@ -64,6 +65,7 @@ func CreateCapabilityProfileSpec(pbmCreateSpec CapabilityProfileCreateSpec) (*ty
 			SubProfiles: []types.PbmCapabilitySubProfile{
 				types.PbmCapabilitySubProfile{
 					Capability: capabilities,
+					Name:       pbmCreateSpec.SubProfileName,
 				},
 			},
 		},


### PR DESCRIPTION
Pbm Client test results

```
asumit$ go test  ./pbm 
--- FAIL: TestClient (9.53s)
    client_test.go:59: PBM version=2.0
    client_test.go:137: checking 8 datatores for compatibility results
    client_test.go:162: CheckRequirements results: 104
    client_test.go:207: VSAN Profile: "3b139387-61e3-418c-bbab-dedaae8ce3a6" successfully created
    client_test.go:214: Profile: "3b139387-61e3-418c-bbab-dedaae8ce3a6" exists on vCenter
    client_test.go:218: Found 8 compatible-datastores for profile: "3b139387-61e3-418c-bbab-dedaae8ce3a6"
    client_test.go:222: Found 96 non-compatible datastores for profile: "3b139387-61e3-418c-bbab-dedaae8ce3a6"
    client_test.go:226: 96   8   8
    client_test.go:227: datastore count mismatch
    client_test.go:283: VSAN-SIOC Profile: "979e678b-860c-4ea7-bbef-4aa072a5d7d3" successfully created
    client_test.go:295: VSAN-SIOC profile: "979e678b-860c-4ea7-bbef-4aa072a5d7d3" and retrieved profileID: "979e678b-860c-4ea7-bbef-4aa072a5d7d3" successfully matched
    client_test.go:307: vsan-sioc profile: "Kubernetes-VSAN-SIOC-TestPolicy2" and retrieved profileName: "Kubernetes-VSAN-SIOC-TestPolicy2" successfully matched
    client_test.go:314: Profile: [{DynamicData:{} UniqueId:3b139387-61e3-418c-bbab-dedaae8ce3a6} {DynamicData:{} UniqueId:979e678b-860c-4ea7-bbef-4aa072a5d7d3}] successfully deleted
    client_test.go:315: test over 
FAIL
FAIL    github.com/vmware/govmomi/pbm   12.257s
FAIL
```

The tests are failing because of datastore count mismatch, that is not related to this change.
The datastore count logic is not correct here, it needs to be fixed.