### PR TITLE
simulator: fix handling of nil Reference in container walk

### DIFF
--- a/simulator/view_manager.go
+++ b/simulator/view_manager.go
@@ -139,7 +139,7 @@ func (v *ContainerView) include(o types.ManagedObjectReference) bool {
 }
 
 func walk(root mo.Reference, f func(child types.ManagedObjectReference)) {
-	if _, ok := root.(types.ManagedObjectReference); ok {
+	if _, ok := root.(types.ManagedObjectReference); ok || root == nil {
 		return
 	}
 


### PR DESCRIPTION
I introduced a regression in #1967, by not handling a nil mo.Reference before
calling getManagedObject(), which leads in some cases to:

  panic: reflect: call of reflect.Value.Elem on zero Value

This change just restores the old behavior of doing nothing if the Reference is
nil (thus couldn't be cast into any of the known managed object types)