### PR TITLE
vcsim: CreateSnapshotTask now returns moref in result

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1894,7 +1894,7 @@ func (vm *VirtualMachine) CreateSnapshotTask(req *types.CreateSnapshot_Task) soa
 		changes = append(changes, types.PropertyChange{Name: "snapshot.currentSnapshot", Val: snapshot.Self})
 		Map.Update(vm, changes)
 
-		return nil, nil
+		return snapshot.Self, nil
 	})
 
 	return &methods.CreateSnapshot_TaskBody{

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -773,9 +773,19 @@ func TestVmSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = task.Wait(ctx)
+	info, err := task.WaitForResult(ctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	snapRef, ok := info.Result.(types.ManagedObjectReference)
+	if !ok {
+		t.Fatal("expected ManagedObjectRefrence result for CreateSnapshot")
+	}
+
+	_, err = vm.FindSnapshot(ctx, snapRef.Value)
+	if err != nil {
+		t.Fatal(err, "snapshot should be found by result reference")
 	}
 
 	_, err = fieldValue(reflect.ValueOf(simVm), "snapshot")


### PR DESCRIPTION
simulator CreateSnapshotTask should return the created snapshot mo-ref on success,
similar to vSphere behavior
issue #1991