### PR TITLE
Add appliance log forwarding config handler and govc verb

### DIFF
--- a/govc/appliance/logging/forwarding.go
+++ b/govc/appliance/logging/forwarding.go
@@ -28,17 +28,13 @@ import (
 	vlogging "github.com/vmware/govmomi/vapi/appliance/logging"
 )
 
-func main() {
-	fmt.Println("vim-go")
-}
-
 type forwarding struct {
 	*flags.ClientFlag
 	*flags.OutputFlag
 }
 
 func init() {
-	cli.Register("appliance.logging.forwarding", &forwarding{})
+	cli.Register("vcsa.log.forwarding.info", &forwarding{})
 }
 
 func (cmd *forwarding) Register(ctx context.Context, f *flag.FlagSet) {
@@ -59,15 +55,11 @@ func (cmd *forwarding) Process(ctx context.Context) error {
 	return nil
 }
 
-func (cmd *forwarding) Usage() string {
-	return ""
-}
-
 func (cmd *forwarding) Description() string {
 	return `Retrieve the VC Appliance log forwarding configuration
 
 Examples:
-  govc appliance.logging.forwarding`
+  govc vcsa.log.forwarding.info`
 }
 
 func (cmd *forwarding) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -76,9 +68,9 @@ func (cmd *forwarding) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	fwd := vlogging.NewForwarding(c)
+	fwd := vlogging.NewManager(c)
 
-	res, err := fwd.Config(ctx)
+	res, err := fwd.Forwarding(ctx)
 	if err != nil {
 		return nil
 	}

--- a/govc/appliance/logging/forwarding.go
+++ b/govc/appliance/logging/forwarding.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	vlogging "github.com/vmware/govmomi/vapi/appliance/logging"
+)
+
+func main() {
+	fmt.Println("vim-go")
+}
+
+type forwarding struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("appliance.logging.forwarding", &forwarding{})
+}
+
+func (cmd *forwarding) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *forwarding) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *forwarding) Usage() string {
+	return ""
+}
+
+func (cmd *forwarding) Description() string {
+	return `Retrieve the VC Appliance log forwarding configuration
+
+Examples:
+  govc appliance.logging.forwarding`
+}
+
+func (cmd *forwarding) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
+
+	fwd := vlogging.NewForwarding(c)
+
+	res, err := fwd.Config(ctx)
+	if err != nil {
+		return nil
+	}
+
+	return cmd.WriteResult(forwardingConfigResult(res))
+}
+
+type forwardingConfigResult []vlogging.Config
+
+func (res forwardingConfigResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, c := range res {
+		fmt.Fprintf(tw, "Hostname:\t%s\n", c.Hostname)
+		fmt.Fprintf(tw, "Port:\t%d\n", c.Port)
+		fmt.Fprintf(tw, "Protocol:\t%s\n", c.Protocol)
+	}
+
+	return tw.Flush()
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	_ "github.com/vmware/govmomi/govc/about"
+	_ "github.com/vmware/govmomi/govc/appliance/logging"
 	"github.com/vmware/govmomi/govc/cli"
 	_ "github.com/vmware/govmomi/govc/cluster"
 	_ "github.com/vmware/govmomi/govc/cluster/group"

--- a/govc/main.go
+++ b/govc/main.go
@@ -20,7 +20,6 @@ import (
 	"os"
 
 	_ "github.com/vmware/govmomi/govc/about"
-	_ "github.com/vmware/govmomi/govc/appliance/logging"
 	"github.com/vmware/govmomi/govc/cli"
 	_ "github.com/vmware/govmomi/govc/cluster"
 	_ "github.com/vmware/govmomi/govc/cluster/group"
@@ -85,6 +84,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/tags/category"
 	_ "github.com/vmware/govmomi/govc/task"
 	_ "github.com/vmware/govmomi/govc/vapp"
+	_ "github.com/vmware/govmomi/govc/vcsa/log"
 	_ "github.com/vmware/govmomi/govc/version"
 	_ "github.com/vmware/govmomi/govc/vm"
 	_ "github.com/vmware/govmomi/govc/vm/disk"

--- a/govc/vcsa/log/forwarding.go
+++ b/govc/vcsa/log/forwarding.go
@@ -25,19 +25,19 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	vlogging "github.com/vmware/govmomi/vapi/appliance/logging"
+	vlogging "github.com/vmware/govmomi/vapi/vcsa/log"
 )
 
-type forwarding struct {
+type info struct {
 	*flags.ClientFlag
 	*flags.OutputFlag
 }
 
 func init() {
-	cli.Register("vcsa.log.forwarding.info", &forwarding{})
+	cli.Register("vcsa.log.forwarding.info", &info{})
 }
 
-func (cmd *forwarding) Register(ctx context.Context, f *flag.FlagSet) {
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
 	cmd.ClientFlag.Register(ctx, f)
 
@@ -45,7 +45,7 @@ func (cmd *forwarding) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.OutputFlag.Register(ctx, f)
 }
 
-func (cmd *forwarding) Process(ctx context.Context) error {
+func (cmd *info) Process(ctx context.Context) error {
 	if err := cmd.ClientFlag.Process(ctx); err != nil {
 		return err
 	}
@@ -55,14 +55,14 @@ func (cmd *forwarding) Process(ctx context.Context) error {
 	return nil
 }
 
-func (cmd *forwarding) Description() string {
+func (cmd *info) Description() string {
 	return `Retrieve the VC Appliance log forwarding configuration
 
 Examples:
   govc vcsa.log.forwarding.info`
 }
 
-func (cmd *forwarding) Run(ctx context.Context, f *flag.FlagSet) error {
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 	c, err := cmd.RestClient()
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func (cmd *forwarding) Run(ctx context.Context, f *flag.FlagSet) error {
 	return cmd.WriteResult(forwardingConfigResult(res))
 }
 
-type forwardingConfigResult []vlogging.Config
+type forwardingConfigResult []vlogging.Forwarding
 
 func (res forwardingConfigResult) Write(w io.Writer) error {
 	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)

--- a/govc/vcsa/log/forwarding.go
+++ b/govc/vcsa/log/forwarding.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	vlogging "github.com/vmware/govmomi/vapi/vcsa/log"
+	vlogging "github.com/vmware/govmomi/vapi/appliance/logging"
 )
 
 type info struct {

--- a/vapi/appliance/logging/forwarding.go
+++ b/vapi/appliance/logging/forwarding.go
@@ -37,8 +37,8 @@ func NewManager(client *rest.Client) *Manager {
 	}
 }
 
-// Config represents configuration for log message forwarding.
-type Config struct {
+// Forwarding represents configuration for log message forwarding.
+type Forwarding struct {
 	Hostname string `json:"hostname,omitempty"`
 	Port     int    `json:"port,omitempty"`
 	Protocol string `json:"protocol,omitempty"`
@@ -49,8 +49,8 @@ func (m *Manager) getManagerResource() *rest.Resource {
 }
 
 // Forwarding returns all logging forwarding config.
-func (m *Manager) Forwarding(ctx context.Context) ([]Config, error) {
+func (m *Manager) Forwarding(ctx context.Context) ([]Forwarding, error) {
 	r := m.getManagerResource()
-	var res []Config
+	var res []Forwarding
 	return res, m.Do(ctx, r.Request(http.MethodGet), &res)
 }

--- a/vapi/appliance/logging/forwarding.go
+++ b/vapi/appliance/logging/forwarding.go
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0.
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+const ApplianceLoggingForwardingPath = "/appliance/logging/forwarding"
+
+// Forwarding provides convenience methods to configure appliance logging forwarding.
+type Forwarding struct {
+	*rest.Client
+}
+
+// NewForwarding creates a new Forwarding with the given client
+func NewForwarding(client *rest.Client) *Forwarding {
+	return &Forwarding{
+		Client: client,
+	}
+}
+
+// Config represents configuration for log message forwarding.
+type Config struct {
+	Hostname string `json:"hostname,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	Protocol string `json:"protocol,omitempty"`
+}
+
+func (f *Forwarding) getForwardingResource() *rest.Resource {
+	return f.Resource(ApplianceLoggingForwardingPath)
+}
+
+// Config returns all logging forwarding config.
+func (f *Forwarding) Config(ctx context.Context) ([]Config, error) {
+	r := f.getForwardingResource()
+	var res []Config
+	return res, f.Do(ctx, r.Request(http.MethodGet), &res)
+}

--- a/vapi/appliance/logging/forwarding.go
+++ b/vapi/appliance/logging/forwarding.go
@@ -23,16 +23,16 @@ import (
 	"github.com/vmware/govmomi/vapi/rest"
 )
 
-const ApplianceLoggingForwardingPath = "/appliance/logging/forwarding"
+const applianceLoggingForwardingPath = "/appliance/logging/forwarding"
 
-// Forwarding provides convenience methods to configure appliance logging forwarding.
-type Forwarding struct {
+// Manager provides convenience methods to configure appliance logging forwarding.
+type Manager struct {
 	*rest.Client
 }
 
-// NewForwarding creates a new Forwarding with the given client
-func NewForwarding(client *rest.Client) *Forwarding {
-	return &Forwarding{
+// NewManager creates a new Manager with the given client
+func NewManager(client *rest.Client) *Manager {
+	return &Manager{
 		Client: client,
 	}
 }
@@ -44,13 +44,13 @@ type Config struct {
 	Protocol string `json:"protocol,omitempty"`
 }
 
-func (f *Forwarding) getForwardingResource() *rest.Resource {
-	return f.Resource(ApplianceLoggingForwardingPath)
+func (m *Manager) getManagerResource() *rest.Resource {
+	return m.Resource(applianceLoggingForwardingPath)
 }
 
-// Config returns all logging forwarding config.
-func (f *Forwarding) Config(ctx context.Context) ([]Config, error) {
-	r := f.getForwardingResource()
+// Forwarding returns all logging forwarding config.
+func (m *Manager) Forwarding(ctx context.Context) ([]Config, error) {
+	r := m.getManagerResource()
 	var res []Config
-	return res, f.Do(ctx, r.Request(http.MethodGet), &res)
+	return res, m.Do(ctx, r.Request(http.MethodGet), &res)
 }


### PR DESCRIPTION
Appliance logging config can be retrieved via the VAPI REST
endpoint.  The govc output is as follows.

```
$ govc appliance.logging.forwaring
Hostname:  10.186.54.118
Port:      5480
Protocol:  TLS
Hostname:  2.2.2.2
Port:      9999
Protocol:  TLS
```