### PR TITLE
govc: support raw object references in import.ova NetworkMapping

### DIFF
--- a/govc/importx/ovf.go
+++ b/govc/importx/ovf.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/nfc"
@@ -163,34 +164,42 @@ func (cmd *ovfx) Map(op []Property) (p []types.KeyValue) {
 	return
 }
 
-func (cmd *ovfx) NetworkMap(e *ovf.Envelope) (p []types.OvfNetworkMapping) {
+func (cmd *ovfx) NetworkMap(e *ovf.Envelope) ([]types.OvfNetworkMapping, error) {
 	ctx := context.TODO()
 	finder, err := cmd.DatastoreFlag.Finder()
 	if err != nil {
-		return
+		return nil, err
 	}
 
-	networks := map[string]string{}
-
-	if e.Network != nil {
-		for _, net := range e.Network.Networks {
-			networks[net.Name] = net.Name
+	var nmap []types.OvfNetworkMapping
+	for _, m := range cmd.Options.NetworkMapping {
+		if m.Network == "" {
+			continue // Not set, let vSphere choose the default network
 		}
-	}
 
-	for _, net := range cmd.Options.NetworkMapping {
-		networks[net.Name] = net.Network
-	}
+		var ref types.ManagedObjectReference
 
-	for src, dst := range networks {
-		if net, err := finder.Network(ctx, dst); err == nil {
-			p = append(p, types.OvfNetworkMapping{
-				Name:    src,
-				Network: net.Reference(),
-			})
+		net, err := finder.Network(ctx, m.Network)
+		if err != nil {
+			switch err.(type) {
+			case *find.NotFoundError:
+				if !ref.FromString(m.Network) {
+					return nil, err
+				} // else this is a raw MO ref
+			default:
+				return nil, err
+			}
+		} else {
+			ref = net.Reference()
 		}
+
+		nmap = append(nmap, types.OvfNetworkMapping{
+			Name:    m.Name,
+			Network: ref,
+		})
 	}
-	return
+
+	return nmap, err
 }
 
 func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
@@ -224,6 +233,11 @@ func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 		name = cmd.Name
 	}
 
+	nmap, err := cmd.NetworkMap(e)
+	if err != nil {
+		return nil, err
+	}
+
 	cisp := types.OvfCreateImportSpecParams{
 		DiskProvisioning:   cmd.Options.DiskProvisioning,
 		EntityName:         name,
@@ -233,7 +247,7 @@ func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 			DeploymentOption: cmd.Options.Deployment,
 			Locale:           "US"},
 		PropertyMapping: cmd.Map(cmd.Options.PropertyMapping),
-		NetworkMapping:  cmd.NetworkMap(e),
+		NetworkMapping:  nmap,
 	}
 
 	host, err := cmd.HostSystemIfSpecified()

--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -178,6 +178,11 @@ load test_helper
   run govc import.ovf -options - "$ovf" <<<"$options"
   assert_failure # 2 networks have the same name
 
+  options=$(jq ".NetworkMapping[].Network = \"DVS0/NSX-dvpg\"" <<<"$spec")
+
+  run govc import.ovf -name ttylinux2 -options - "$ovf" <<<"$options"
+  assert_success # switch_name/portgroup_name is unique
+
   switch=$(govc find -i network -name DVS0)
   id=$(govc find -i network -config.distributedVirtualSwitch "$switch" -name NSX-dvpg)
   options=$(jq ".NetworkMapping[].Network = \"$id\"" <<<"$spec")

--- a/govc/test/network.bats
+++ b/govc/test/network.bats
@@ -38,6 +38,22 @@ load test_helper
 
   run govc device.remove -vm $vm $eth0
   assert_failure "govc: device '$eth0' not found"
+
+  # Test PG's with the same name
+  run govc dvs.create DVS1 # DVS0 already exists
+  assert_success
+
+  run govc dvs.portgroup.add -dvs DVS0 -type ephemeral NSX-dvpg
+  assert_success
+
+  run govc dvs.portgroup.add -dvs DVS1 -type ephemeral NSX-dvpg
+  assert_success
+
+  run govc vm.network.add -vm $vm -net NSX-dvpg
+  assert_failure # resolves to multiple networks
+
+  run govc vm.network.add -vm $vm -net DVS0/NSX-dvpg
+  assert_success # switch_name/portgroup_name is unique
 }
 
 @test "network change backing" {

--- a/govc/vm/network/add.go
+++ b/govc/vm/network/add.go
@@ -47,6 +47,7 @@ func (cmd *add) Description() string {
 
 Examples:
   govc vm.network.add -vm $vm -net "VM Network" -net.adapter e1000e
+  govc vm.network.add -vm $vm -net SwitchName/PortgroupName
   govc device.info -vm $vm ethernet-*`
 }
 


### PR DESCRIPTION
vCenter doesn't allow duplicate port group names within the network folder when creating via the UI
or the AddDVPortgroupTask() API. However, NSXt 3.0 can do so via other (unknown) means. With this
condition, govc would fail to map the given network name to its managed object reference.
To workaround this, a raw MO ref can now be used in the NetworkMapping, instead of the Network name
or inventory path.

Related history:
223168f0 * Add NetworkMapping section to importx options.
e3c3cd0a * Populate network mapping from ovf envelope (#546)

Fixes #1996