### PR TITLE
vapi: use header authentication in file Upload/Download

### DIFF
--- a/govc/library/export.go
+++ b/govc/library/export.go
@@ -138,9 +138,7 @@ func (cmd *export) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	download := func(src *url.URL, name string) error {
 		p := soap.DefaultDownload
-		p.Headers = map[string]string{
-			"vmware-api-session-id": c.SessionID(),
-		}
+
 		if isStdout {
 			s, _, err := c.Download(ctx, src, &p)
 			if err != nil {

--- a/govc/library/import.go
+++ b/govc/library/import.go
@@ -202,9 +202,6 @@ func (cmd *item) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		p := soap.DefaultUpload
-		p.Headers = map[string]string{
-			"vmware-api-session-id": session,
-		}
 		p.ContentLength = size
 		u, err := url.Parse(update.UploadEndpoint.URI)
 		if err != nil {

--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -107,6 +107,7 @@ load test_helper
 
   name="$BATS_TMPDIR/govc-$id-export"
   run govc library.export "/my-content/$TTYLINUX_NAME/*.ovf" "$name"
+  assert_success
   assert_equal "$(cat "$GOVC_IMAGES/$TTYLINUX_NAME.ovf")" "$(cat "$name")"
   rm "$name"
 


### PR DESCRIPTION
PR #1884 switch REST from Cookie to Header authentication. This caused existing
Content Library use of file Upload/Download to break with 401 Unauthorized
responses.

These wrappers simply add the vmware-api-session-id header to the requests.