### PR TITLE
vcsim: set HostSystem IP in cluster AddHost_Task

### DIFF
--- a/govc/test/cluster.bats
+++ b/govc/test/cluster.bats
@@ -227,3 +227,21 @@ _EOF_
   run govc cluster.override.remove -vm DC0_C0_RP0_VM0
   assert_success
 }
+
+@test "cluster.add" {
+    vcsim_env
+    unset GOVC_HOST
+
+    ip=$(govc object.collect -o -json host/DC0_C0/DC0_C0_H0 | jq -r .Config.Network.Vnic[].Spec.Ip.IpAddress)
+    assert_equal 127.0.0.1 "$ip"
+
+    govc cluster.add -cluster DC0_C0 -hostname 10.0.0.42 -username user -password pass
+    assert_success
+
+    ip=$(govc object.collect -o -json host/DC0_C0/10.0.0.42 | jq -r .Config.Network.Vnic[].Spec.Ip.IpAddress)
+
+    assert_equal 10.0.0.42 "$ip"
+    govc host.info -json '*' | jq -r .HostSystems[].Config.Network.Vnic[].Spec.Ip
+    name=$(govc host.info -json -host.ip 10.0.0.42 | jq -r .HostSystems[].Name)
+    assert_equal 10.0.0.42 "$name"
+}

--- a/simulator/host_system.go
+++ b/simulator/host_system.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"net"
 	"os"
 	"time"
 
@@ -63,6 +64,10 @@ func NewHostSystem(host mo.HostSystem) *HostSystem {
 	info := *esx.HostHardwareInfo
 	hs.Hardware = &info
 
+	cfg := new(types.HostConfigInfo)
+	deepCopy(hs.Config, cfg)
+	hs.Config = cfg
+
 	config := []struct {
 		ref **types.ManagedObjectReference
 		obj mo.Reference
@@ -87,6 +92,9 @@ func (h *HostSystem) configure(spec types.HostConnectSpec, connected bool) {
 	h.Runtime.ConnectionState = types.HostSystemConnectionStateDisconnected
 	if connected {
 		h.Runtime.ConnectionState = types.HostSystemConnectionStateConnected
+	}
+	if net.ParseIP(spec.HostName) != nil {
+		h.Config.Network.Vnic[0].Spec.Ip.IpAddress = spec.HostName
 	}
 
 	h.Summary.Config.Name = spec.HostName

--- a/simulator/object.go
+++ b/simulator/object.go
@@ -17,10 +17,13 @@ limitations under the License.
 package simulator
 
 import (
+	"bytes"
+
 	"github.com/google/uuid"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
 )
 
 func SetCustomValue(ctx *Context, req *types.SetCustomValue) soap.HasFault {
@@ -58,4 +61,19 @@ func newUUID(s string) string {
 // sha1UUID returns a stable UUID based on input s
 func sha1UUID(s string) uuid.UUID {
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(s))
+}
+
+// deepCopy uses xml encode/decode to copy src to dst
+func deepCopy(src, dst interface{}) {
+	b, err := xml.Marshal(src)
+	if err != nil {
+		panic(err)
+	}
+
+	dec := xml.NewDecoder(bytes.NewReader(b))
+	dec.TypeFunc = types.TypeFunc()
+	err = dec.Decode(dst)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/simulator/object_test.go
+++ b/simulator/object_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator/esx"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -186,5 +187,12 @@ func TestObjectCustomFields(t *testing.T) {
 
 	if len(vm.AvailableField) != 0 {
 		t.Fatalf("len(vm.AvailableField) expected 0, got %d", len(vm.AvailableField))
+	}
+}
+
+func BenchmarkDeepCopy(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		config := new(types.HostConfigInfo)
+		deepCopy(esx.HostConfigInfo, config)
 	}
 }


### PR DESCRIPTION
If HostConnectSpec.HostName is an IP address, also use it to set
Config.Network.Vnic[0].Spec.Ip.IpAddress

Fixes #1981