### PR TITLE
vcsim: use HostNetworkSystem wrapper with -load flag

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -454,6 +454,9 @@ docker_name() {
 
   objs=$(govc find / | wc -l)
   assert_equal 23 "$objs"
+
+  run govc host.portgroup.add -host DC0_H0 -vswitch vSwitch0 bridge
+  assert_success # issue #2016
 }
 
 @test "vcsim trace file" {

--- a/simulator/host_network_system.go
+++ b/simulator/host_network_system.go
@@ -46,6 +46,16 @@ func NewHostNetworkSystem(host *mo.HostSystem) *HostNetworkSystem {
 	}
 }
 
+func (s *HostNetworkSystem) init(r *Registry) {
+	for _, obj := range r.objects {
+		if h, ok := obj.(*HostSystem); ok {
+			if h.ConfigManager.NetworkSystem.Value == s.Self.Value {
+				s.Host = &h.HostSystem
+			}
+		}
+	}
+}
+
 func (s *HostNetworkSystem) folder() *Folder {
 	f := Map.getEntityDatacenter(s.Host).NetworkFolder
 	return Map.Get(f).(*Folder)

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -237,6 +237,7 @@ var kinds = map[string]reflect.Type{
 	"GuestOperationsManager":         reflect.TypeOf((*GuestOperationsManager)(nil)).Elem(),
 	"HostDatastoreBrowser":           reflect.TypeOf((*HostDatastoreBrowser)(nil)).Elem(),
 	"HostLocalAccountManager":        reflect.TypeOf((*HostLocalAccountManager)(nil)).Elem(),
+	"HostNetworkSystem":              reflect.TypeOf((*HostNetworkSystem)(nil)).Elem(),
 	"HostSystem":                     reflect.TypeOf((*HostSystem)(nil)).Elem(),
 	"IpPoolManager":                  reflect.TypeOf((*IpPoolManager)(nil)).Elem(),
 	"LicenseManager":                 reflect.TypeOf((*LicenseManager)(nil)).Elem(),


### PR DESCRIPTION
The simulator.HostNetworkSystem wrapper was not included in the refactor to
support 'vcsim -load'

Fixes #2106