### PR TITLE
added support for returning array of BaseCnsVolumeOperationResult for QueryVolumeInfo API

### DIFF
--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -213,7 +213,7 @@ func TestClient(t *testing.T) {
 		t.Errorf("Failed to query volume. Error: %+v \n", err)
 		t.Fatal(err)
 	}
-	t.Logf("Sucessfully Queried Volumes. queryResult: %+v", pretty.Sprint(queryResult))
+	t.Logf("Successfully Queried Volumes. queryResult: %+v", pretty.Sprint(queryResult))
 
 	// Test QueryVolumeInfo API
 	// QueryVolumeInfo is not supported on ReleaseVSAN67u3 and ReleaseVSAN70
@@ -230,20 +230,22 @@ func TestClient(t *testing.T) {
 			t.Errorf("Failed to query volumes with QueryVolumeInfo. Error: %+v \n", err)
 			t.Fatal(err)
 		}
-		queryVolumeInfoTaskResult, err := GetTaskResult(ctx, queryVolumeInfoTaskInfo)
+		queryVolumeInfoTaskResults, err := GetTaskResultArray(ctx, queryVolumeInfoTaskInfo)
 		if err != nil {
 			t.Errorf("Failed to query volumes with QueryVolumeInfo. Error: %+v \n", err)
 			t.Fatal(err)
 		}
-		if queryVolumeInfoTaskResult == nil {
+		if queryVolumeInfoTaskResults == nil {
 			t.Fatalf("Empty queryVolumeInfoTaskResult")
 			t.FailNow()
 		}
-		queryVolumeInfoOperationRes := queryVolumeInfoTaskResult.GetCnsVolumeOperationResult()
-		if queryVolumeInfoOperationRes.Fault != nil {
-			t.Fatalf("Failed to query volumes with QueryVolumeInfo. fault=%+v", queryVolumeInfoOperationRes.Fault)
+		for _, queryVolumeInfoTaskResult := range queryVolumeInfoTaskResults {
+			queryVolumeInfoOperationRes := queryVolumeInfoTaskResult.GetCnsVolumeOperationResult()
+			if queryVolumeInfoOperationRes.Fault != nil {
+				t.Fatalf("Failed to query volumes with QueryVolumeInfo. fault=%+v", queryVolumeInfoOperationRes.Fault)
+			}
+			t.Logf("Successfully Queried Volumes. queryVolumeInfoTaskResult: %+v", pretty.Sprint(queryVolumeInfoTaskResult))
 		}
-		t.Logf("Sucessfully Queried Volumes. queryVolumeInfoTaskResult: %+v", pretty.Sprint(queryVolumeInfoTaskResult))
 	}
 	// Test ExtendVolume API
 	var newCapacityInMb int64 = 10240
@@ -289,7 +291,7 @@ func TestClient(t *testing.T) {
 		t.Errorf("Failed to query volume. Error: %+v \n", err)
 		t.Fatal(err)
 	}
-	t.Logf("Sucessfully Queried Volumes after ExtendVolume. queryResult: %+v", pretty.Sprint(queryResult))
+	t.Logf("Successfully Queried Volumes after ExtendVolume. queryResult: %+v", pretty.Sprint(queryResult))
 	queryCapacity := queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).CapacityInMb
 	if newCapacityInMb != queryCapacity {
 		t.Errorf("After extend volume %s, expected new volume size is %d, but actual volume size is %d.", extendVolumeId, newCapacityInMb, queryCapacity)
@@ -395,7 +397,7 @@ func TestClient(t *testing.T) {
 	if updateVolumeOperationRes.Fault != nil {
 		t.Fatalf("Failed to update volume metadata: fault=%+v", updateVolumeOperationRes.Fault)
 	} else {
-		t.Logf("Sucessfully updated volume metadata")
+		t.Logf("Successfully updated volume metadata")
 	}
 
 	t.Logf("Calling QueryVolume using queryFilter: %+v", pretty.Sprint(queryFilter))
@@ -404,7 +406,7 @@ func TestClient(t *testing.T) {
 		t.Errorf("Failed to query volume. Error: %+v \n", err)
 		t.Fatal(err)
 	}
-	t.Logf("Sucessfully Queried Volumes. queryResult: %+v", pretty.Sprint(queryResult))
+	t.Logf("Successfully Queried Volumes. queryResult: %+v", pretty.Sprint(queryResult))
 
 	// Test QueryAll
 	querySelection := cnstypes.CnsQuerySelection{
@@ -421,7 +423,7 @@ func TestClient(t *testing.T) {
 		t.Errorf("Failed to query all volumes. Error: %+v \n", err)
 		t.Fatal(err)
 	}
-	t.Logf("Sucessfully Queried all Volumes. queryResult: %+v", pretty.Sprint(queryResult))
+	t.Logf("Successfully Queried all Volumes. queryResult: %+v", pretty.Sprint(queryResult))
 
 	// Create a VM to test Attach Volume API.
 	virtualMachineConfigSpec := vim25types.VirtualMachineConfigSpec{
@@ -675,7 +677,7 @@ func TestClient(t *testing.T) {
 			t.Errorf("Failed to query volume. Error: %+v \n", err)
 			t.Fatal(err)
 		}
-		t.Logf("Sucessfully Queried Volumes. queryResult: %+v", queryResult)
+		t.Logf("Successfully Queried Volumes. queryResult: %+v", queryResult)
 		fileBackingInfo := queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails)
 		t.Logf("File Share Name: %s with accessPoints: %+v", fileBackingInfo.Name, fileBackingInfo.AccessPoints)
 
@@ -815,7 +817,7 @@ func TestClient(t *testing.T) {
 			t.Errorf("Failed to query volume. Error: %+v \n", err)
 			t.Fatal(err)
 		}
-		t.Logf("Sucessfully Queried Volumes. queryResult: %+v", pretty.Sprint(queryResult))
+		t.Logf("Successfully Queried Volumes. queryResult: %+v", pretty.Sprint(queryResult))
 
 		t.Logf("Deleting CNS volume created above using BACKING_DISK_URL_PATH: %s with volume: %+v", backingDiskURLPath, volumeIDList)
 		deleteTask, err = cnsClient.DeleteVolume(ctx, volumeIDList, true)

--- a/cns/cns_util.go
+++ b/cns/cns_util.go
@@ -51,6 +51,23 @@ func GetTaskResult(ctx context.Context, taskInfo *vim25types.TaskInfo) (cnstypes
 	return nil, errors.New("TaskInfo result is empty")
 }
 
+// GetTaskResultArray gets the task result array for a specified task info
+func GetTaskResultArray(ctx context.Context, taskInfo *vim25types.TaskInfo) ([]cnstypes.BaseCnsVolumeOperationResult, error) {
+	if taskInfo == nil {
+		return nil, errors.New("TaskInfo is empty")
+	}
+	if taskInfo.Result != nil {
+		volumeOperationBatchResult := taskInfo.Result.(cnstypes.CnsVolumeOperationBatchResult)
+		if &volumeOperationBatchResult == nil ||
+			volumeOperationBatchResult.VolumeResults == nil ||
+			len(volumeOperationBatchResult.VolumeResults) == 0 {
+			return nil, errors.New("Cannot get VolumeOperationResult")
+		}
+		return volumeOperationBatchResult.VolumeResults, nil
+	}
+	return nil, errors.New("TaskInfo result is empty")
+}
+
 // dropUnknownCreateSpecElements helps drop newly added elements in the CnsVolumeCreateSpec, which are not known to the prior vSphere releases
 func dropUnknownCreateSpecElements(c *Client, createSpecList []cnstypes.CnsVolumeCreateSpec) []cnstypes.CnsVolumeCreateSpec {
 	var updatedcreateSpecList []cnstypes.CnsVolumeCreateSpec


### PR DESCRIPTION
Fixes https://github.com/vmware/govmomi/issues/2010, https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/249

Fixed issue reported by @SandeepPissay at - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/235#discussion_r437054326

QueryVolumeInfo can take multiple Volumes IDs as input and should returns an array of BaseCnsVolumeOperationResult.

In this PR, I am adding function `GetTaskResultArray` to help retrieve array of BaseCnsVolumeOperationResult for all specified volumes in the QueryVolumeInfo request.

Testing Done.

**Request**

```
  client_test.go:224: Calling QueryVolumeInfo using: []types.CnsVolumeId{
            {
                Id: "759f3fa8-f692-4a8e-b65c-3fcd56d0f947",
            },
            {
                Id: "c2c2d2bb-f864-4e4f-9bde-39ca6b1302b6",
            },
            {
                Id: "6885ca7d-09a3-40f5-9706-475cbd479934",
            },
        }
```

**Response**

```
    client_test.go:244: queryVolumeInfoTaskResults: []types.BaseCnsVolumeOperationResult{
            &types.CnsQueryVolumeInfoResult{
                CnsVolumeOperationResult: types.CnsVolumeOperationResult{},
                VolumeInfo:               &types.CnsBlockVolumeInfo{
                    CnsVolumeInfo:  types.CnsVolumeInfo{},
                    VStorageObject: types.VStorageObject{
                        Config: types.VStorageObjectConfigInfo{
                            BaseConfigInfo: types.BaseConfigInfo{
                                Id: types.ID{
                                    Id: "759f3fa8-f692-4a8e-b65c-3fcd56d0f947",
                                },
                                Name:                        "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                                CreateTime:                  time.Now(),
                                KeepAfterDeleteVm:           types.NewBool(true),
                                RelocationDisabled:          types.NewBool(false),
                                NativeSnapshotSupported:     types.NewBool(false),
                                ChangedBlockTrackingEnabled: types.NewBool(false),
                                Backing:                     &types.BaseConfigInfoDiskFileBackingInfo{
                                    BaseConfigInfoFileBackingInfo: types.BaseConfigInfoFileBackingInfo{
                                        BaseConfigInfoBackingInfo: types.BaseConfigInfoBackingInfo{
                                            Datastore: types.ManagedObjectReference{Type:"Datastore", Value:"datastore-68"},
                                        },
                                        FilePath:        "[vsanDatastore] 879cd65e-6165-91a3-d047-02000359156d/cdde909c19b64305826a0e0e96fbdc06.vmdk",
                                        BackingObjectId: "4ac6fb5e-f617-2568-199f-020003bb3e3c",
                                        Parent:          nil,
                                        DeltaSizeInMB:   0,
                                        KeyId:           (*types.CryptoKeyId)(nil),
                                    },
                                    ProvisioningType: "thin",
                                },
                                Iofilter: nil,
                            },
                            CapacityInMB:    5120,
                            ConsumptionType: []string{"disk"},
                            ConsumerId:      nil,
                        },
                    },
                },
            },
            &types.CnsQueryVolumeInfoResult{
                CnsVolumeOperationResult: types.CnsVolumeOperationResult{},
                VolumeInfo:               &types.CnsBlockVolumeInfo{
                    CnsVolumeInfo:  types.CnsVolumeInfo{},
                    VStorageObject: types.VStorageObject{
                        Config: types.VStorageObjectConfigInfo{
                            BaseConfigInfo: types.BaseConfigInfo{
                                Id: types.ID{
                                    Id: "c2c2d2bb-f864-4e4f-9bde-39ca6b1302b6",
                                },
                                Name:                        "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                                CreateTime:                  time.Now(),
                                KeepAfterDeleteVm:           types.NewBool(true),
                                RelocationDisabled:          types.NewBool(false),
                                NativeSnapshotSupported:     types.NewBool(false),
                                ChangedBlockTrackingEnabled: types.NewBool(false),
                                Backing:                     &types.BaseConfigInfoDiskFileBackingInfo{
                                    BaseConfigInfoFileBackingInfo: types.BaseConfigInfoFileBackingInfo{
                                        BaseConfigInfoBackingInfo: types.BaseConfigInfoBackingInfo{
                                            Datastore: types.ManagedObjectReference{Type:"Datastore", Value:"datastore-68"},
                                        },
                                        FilePath:        "[vsanDatastore] 879cd65e-6165-91a3-d047-02000359156d/a1feda38c5ca4f9d9e63721b8fbaeb83.vmdk",
                                        BackingObjectId: "acbcfb5e-1d86-55b1-932c-020003e15f4d",
                                        Parent:          nil,
                                        DeltaSizeInMB:   0,
                                        KeyId:           (*types.CryptoKeyId)(nil),
                                    },
                                    ProvisioningType: "thin",
                                },
                                Iofilter: nil,
                            },
                            CapacityInMB:    10240,
                            ConsumptionType: []string{"disk"},
                            ConsumerId:      nil,
                        },
                    },
                },
            },
            &types.CnsQueryVolumeInfoResult{
                CnsVolumeOperationResult: types.CnsVolumeOperationResult{},
                VolumeInfo:               &types.CnsBlockVolumeInfo{
                    CnsVolumeInfo:  types.CnsVolumeInfo{},
                    VStorageObject: types.VStorageObject{
                        Config: types.VStorageObjectConfigInfo{
                            BaseConfigInfo: types.BaseConfigInfo{
                                Id: types.ID{
                                    Id: "6885ca7d-09a3-40f5-9706-475cbd479934",
                                },
                                Name:                        "pvc-60209158-c603-4534-85df-6d193490b5fa",
                                CreateTime:                  time.Now(),
                                KeepAfterDeleteVm:           types.NewBool(true),
                                RelocationDisabled:          types.NewBool(false),
                                NativeSnapshotSupported:     types.NewBool(false),
                                ChangedBlockTrackingEnabled: types.NewBool(false),
                                Backing:                     &types.BaseConfigInfoDiskFileBackingInfo{
                                    BaseConfigInfoFileBackingInfo: types.BaseConfigInfoFileBackingInfo{
                                        BaseConfigInfoBackingInfo: types.BaseConfigInfoBackingInfo{
                                            Datastore: types.ManagedObjectReference{Type:"Datastore", Value:"datastore-68"},
                                        },
                                        FilePath:        "[vsanDatastore] 879cd65e-6165-91a3-d047-02000359156d/ac0b516b5eb54abe890dae868ad36e4a.vmdk",
                                        BackingObjectId: "66a8e75e-c096-baad-99b6-020003df5b47",
                                        Parent:          nil,
                                        DeltaSizeInMB:   0,
                                        KeyId:           (*types.CryptoKeyId)(nil),
                                    },
                                    ProvisioningType: "thin",
                                },
                                Iofilter: nil,
                            },
                            CapacityInMB:    5120,
                            ConsumptionType: []string{"disk"},
                            ConsumerId:      nil,
                        },
                    },
                },
            },
        }
```



