### PR TITLE
check if config isn't nil before returning an uuid

### DIFF
--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -855,8 +855,10 @@ func (v VirtualMachine) UUID(ctx context.Context) string {
 	if err != nil {
 		return ""
 	}
-
-	return o.Config.Uuid
+	if o.Config != nil {
+		return o.Config.Uuid
+	}
+	return ""
 }
 
 func (v VirtualMachine) QueryChangedDiskAreas(ctx context.Context, baseSnapshot, curSnapshot *types.ManagedObjectReference, disk *types.VirtualDisk, offset int64) (types.DiskChangeInfo, error) {


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

This checks if a config isn't nil, before returning an uuid this can happen under some cases see: https://vdc-download.vmware.com/vmwb-repository/dcr-public/b50dcbbf-051d-4204-a3e7-e1b618c1e384/538cf2ec-b34f-4bae-a332-3820ef9e7773/vim.VirtualMachine.html

cc @dougm 