### PR TITLE
Honoring the instance uuid provided in spec by caller

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1621,8 +1621,9 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 			return nil, &types.InvalidArgument{InvalidProperty: "spec.location.pool"}
 		}
 		config := types.VirtualMachineConfigSpec{
-			Name:    req.Name,
-			GuestId: vm.Config.GuestId,
+			Name:         req.Name,
+			GuestId:      vm.Config.GuestId,
+			InstanceUuid: req.Spec.Config.InstanceUuid,
 			Files: &types.VirtualMachineFileInfo{
 				VmPathName: vmx.String(),
 			},

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1621,15 +1621,15 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 			return nil, &types.InvalidArgument{InvalidProperty: "spec.location.pool"}
 		}
 		config := types.VirtualMachineConfigSpec{
-			Name:         req.Name,
-			GuestId:      vm.Config.GuestId,
-			InstanceUuid: req.Spec.Config.InstanceUuid,
+			Name:    req.Name,
+			GuestId: vm.Config.GuestId,
 			Files: &types.VirtualMachineFileInfo{
 				VmPathName: vmx.String(),
 			},
 		}
 		if req.Spec.Config != nil {
 			config.ExtraConfig = req.Spec.Config.ExtraConfig
+			config.InstanceUuid = req.Spec.Config.InstanceUuid
 		}
 
 		defaultDevices := object.VirtualDeviceList(esx.VirtualDevice)


### PR DESCRIPTION
This change is for honoring the InstanceUuid provided by caller in case of VM cloning.
Actual vSphere supports this scenario.