### PR TITLE
Add AttachDisk and DetachDisk wrappers for the virtualMachine object.

### DIFF
--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -469,6 +469,41 @@ func (v VirtualMachine) RemoveDevice(ctx context.Context, keepFiles bool, device
 	return v.configureDevice(ctx, types.VirtualDeviceConfigSpecOperationRemove, fop, device...)
 }
 
+// AttachDisk attaches the given disk to the VirtualMachine
+func (v VirtualMachine) AttachDisk(ctx context.Context, id string, datastore *Datastore, controllerKey int32, unitNumber int32) error {
+	req := types.AttachDisk_Task{
+		This:          v.Reference(),
+		DiskId:        types.ID{Id: id},
+		Datastore:     datastore.Reference(),
+		ControllerKey: controllerKey,
+		UnitNumber:    &unitNumber,
+	}
+
+	res, err := methods.AttachDisk_Task(ctx, v.c, &req)
+	if err != nil {
+		return err
+	}
+
+	task := NewTask(v.c, res.Returnval)
+	return task.Wait(ctx)
+}
+
+// DetachDisk detaches the given disk from the VirtualMachine
+func (v VirtualMachine) DetachDisk(ctx context.Context, id string) error {
+	req := types.DetachDisk_Task{
+		This:   v.Reference(),
+		DiskId: types.ID{Id: id},
+	}
+
+	res, err := methods.DetachDisk_Task(ctx, v.c, &req)
+	if err != nil {
+		return err
+	}
+
+	task := NewTask(v.c, res.Returnval)
+	return task.Wait(ctx)
+}
+
 // BootOptions returns the VirtualMachine's config.bootOptions property.
 func (v VirtualMachine) BootOptions(ctx context.Context) (*types.VirtualMachineBootOptions, error) {
 	var o mo.VirtualMachine


### PR DESCRIPTION
Simple change to add wrappers around AttachDisk_Task and DetachDisk_Task,
to allow calling them from the VirtualMachine object.
Fixes #1846