### PR TITLE
vSAN methods QueryVsanObjects and VsanQueryObjectIdentities has been added 

### DIFF
--- a/vsan/client.go
+++ b/vsan/client.go
@@ -84,3 +84,28 @@ func (c *Client) VsanPerfQueryPerf(ctx context.Context, cluster *vimtypes.Manage
 	}
 	return res.Returnval, nil
 }
+
+// Creates the vsan object identities instance. This is to be queried from vsan health.
+var (
+	VsanQueryObjectIdentitiesInstance = vimtypes.ManagedObjectReference{
+		Type:  "VsanObjectSystem",
+		Value: "vsan-cluster-object-system",
+	}
+)
+
+// VsanQueryObjectIdentities return host uuid
+func (c *Client) VsanQueryObjectIdentities(ctx context.Context, cluster vimtypes.ManagedObjectReference) (*vsantypes.VsanObjectIdentityAndHealth, error) {
+	req := vsantypes.VsanQueryObjectIdentities{
+		This:    VsanQueryObjectIdentitiesInstance,
+		Cluster: cluster,
+	}
+
+	res, err := methods.VsanQueryObjectIdentities(ctx, c.serviceClient, &req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+
+}

--- a/vsan/methods/methods.go
+++ b/vsan/methods/methods.go
@@ -44,6 +44,29 @@ func VsanPerfGetSupportedEntityTypes(ctx context.Context, r soap.RoundTripper, r
 	return resBody.Res, nil
 }
 
+//Object Identities
+
+type VsanQueryObjectIdentitiesBody struct {
+	Req    *types.VsanQueryObjectIdentities         `xml:"urn:vsan VsanQueryObjectIdentities,omitempty"`
+	Res    *types.VsanQueryObjectIdentitiesResponse `xml:"urn:vsan VsanQueryObjectIdentitiesResponse,omitempty"`
+	Fault_ *soap.Fault                              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VsanQueryObjectIdentitiesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VsanQueryObjectIdentities(ctx context.Context, r soap.RoundTripper, req *types.VsanQueryObjectIdentities) (*types.VsanQueryObjectIdentitiesResponse, error) {
+	var reqBody, resBody VsanQueryObjectIdentitiesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+
+}
+
 // Health summary
 type VsanQueryVcClusterHealthSummaryBody struct {
 	Req    *types.VsanQueryVcClusterHealthSummary         `xml:"urn:vsan VsanQueryVcClusterHealthSummary,omitempty"`
@@ -138,6 +161,26 @@ func (b *VsanClusterGetConfigBody) Fault() *soap.Fault { return b.Fault_ }
 
 func VsanClusterGetConfig(ctx context.Context, r soap.RoundTripper, req *types.VsanClusterGetConfig) (*types.VsanClusterGetConfigResponse, error) {
 	var reqBody, resBody VsanClusterGetConfigBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type QueryVsanObjectsBody struct {
+	Req    *types.QueryVsanObjects         `xml:"urn:vsan QueryVsanObjects,omitempty"`
+	Res    *types.QueryVsanObjectsResponse `xml:"urn:vsan QueryVsanObjectsResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *QueryVsanObjectsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func QueryVsanObjects(ctx context.Context, r soap.RoundTripper, req *types.QueryVsanObjects) (*types.QueryVsanObjectsResponse, error) {
+	var reqBody, resBody QueryVsanObjectsBody
 
 	reqBody.Req = req
 

--- a/vsan/types/types.go
+++ b/vsan/types/types.go
@@ -83,6 +83,52 @@ func init() {
 	t["VsanPerfThreshold"] = reflect.TypeOf((*VsanPerfThreshold)(nil)).Elem()
 }
 
+// Vsan Query Object Identies
+type VsanQueryObjectIdentities VsanQueryObjectIdentitiesRequestType
+
+func init() {
+	t["VsanQueryObjectIdentities"] = reflect.TypeOf((*VsanQueryObjectIdentities)(nil)).Elem()
+}
+
+type VsanQueryObjectIdentitiesRequestType struct {
+	This                types.ManagedObjectReference `xml:"_this"`
+	Cluster             types.ManagedObjectReference `xml:"cluster"`
+	ObjTypes            []string                     `xml:"objTypes,omitempty"`
+	ObjUuids            []string                     `xml:"objUuids,omitempty"`
+	IncludeObjIdentity  *bool                        `xml:"includeObjIdentity"`
+	IncludeHealth       *bool                        `xml:"includeHealth,omitempty"`
+	IncludeSpaceSummary *bool                        `xml:"includeSpaceSummary"`
+}
+
+func init() {
+	t["VsanQueryObjectIdentitiesRequestType"] = reflect.TypeOf((*VsanQueryObjectIdentitiesRequestType)(nil)).Elem()
+}
+
+type VsanQueryObjectIdentitiesResponse struct {
+	Returnval VsanObjectIdentityAndHealth `xml:"returnval"`
+}
+
+type VsanObjectIdentityAndHealth struct {
+	DynamicData
+
+	Health       *VsanObjectOverallHealth `xml:"health,omitempty"`
+	Identities   *VsanObjectIdentity      `xml:"identities,omitempty"`
+	RawData      string                   `xml:"rawData,omitempty"`
+	SpaceSummary []VsanObjectSpaceSummary `xml:"spaceSummary,omitempty"`
+}
+
+func init() {
+	t["VsanObjectIdentityAndHealth"] = reflect.TypeOf((*VsanObjectIdentityAndHealth)(nil)).Elem()
+}
+
+type VsanObjectIdentity struct {
+	Uuid string `xml:"uuid,omitempty"`
+}
+
+func init() {
+	t["VsanObjectIdentity"] = reflect.TypeOf((*VsanObjectIdentity)(nil)).Elem()
+}
+
 // Cluster health summary
 type VsanQueryVcClusterHealthSummary VsanQueryVcClusterHealthSummaryRequestType
 
@@ -1407,6 +1453,25 @@ func init() {
 
 type VsanClusterGetConfigResponse struct {
 	Returnval VsanConfigInfoEx `xml:"returnval"`
+}
+
+type QueryVsanObjectsRequestType struct {
+	This  types.ManagedObjectReference `xml:"_this"`
+	Uuids []string                     `xml:"uuids"`
+}
+
+func init() {
+	types.Add("QueryVsanObjecstRequestType", reflect.TypeOf((*QueryVsanObjectsRequestType)(nil)).Elem())
+}
+
+type QueryVsanObjects QueryVsanObjectsRequestType
+
+func init() {
+	types.Add("QueryVsanObjects", reflect.TypeOf((*QueryVsanObjects)(nil)).Elem())
+}
+
+type QueryVsanObjectsResponse struct {
+	Returnval string `xml:"returnval"`
 }
 
 type VsanConfigInfoEx struct {


### PR DESCRIPTION
Added couple of vsan api interface which is required for my e2e-test automation

Testing Done:
go test -v

```
=== RUN   TestClient
--- PASS: TestClient (4.04s)
=== RUN   TestVsanQueryObjectIdentities
    TestVsanQueryObjectIdentities: client_test.go:128: Printing clusterConfig:
         &types.VsanObjectIdentityAndHealth{
            Health:       (*types.VsanObjectOverallHealth)(nil),
            Identities:   &types.VsanObjectIdentity{Uuid:"84c65a5f-46ed-c821-dedf-02005e6ac5d0"},
            RawData:      "",
            SpaceSummary: nil,
        }
--- PASS: TestVsanQueryObjectIdentities (4.71s)
PASS
ok      github.com/vmware/govmomi/vsan  8.770s
```