### PR TITLE
add / remove pci passthrough device for one VM

### DIFF
--- a/govc/device/pci/add.go
+++ b/govc/device/pci/add.go
@@ -1,0 +1,144 @@
+/*
+Copyright (c) 2014-2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pci
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"strconv"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("device.pci.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *add) Description() string {
+	return `Add PCI Passthrough device to VM.
+
+Examples:
+  govc device.pci.ls -vm $vm
+  govc device.pci.add -vm $vm {pci address}*
+  govc device.info -vm $vm
+
+Assuming vm name is helloworld, list command has below output
+
+$ govc device.pci.ls --vm helloworld
+System ID                             Address       Vendor Name Device Name
+5b087ce4-ce46-72c0-c7c2-28ac9e22c3c2  0000:60:00.0  Pensando    Ethernet Controller 1
+5b087ce4-ce46-72c0-c7c2-28ac9e22c3c2  0000:61:00.0  Pensando    Ethernet Controller 2
+
+To add only 'Ethernet Controller 1', command should be as below. No output upon success.
+
+$ govc device.pci.add --vm helloworld 0000:60:00.0
+
+To add both 'Ethernet Controller 1' and 'Ethernet Controller 2', command should be as below.
+No output upon success.
+
+$ govc device.pci.add --vm helloworld 0000:60:00.0 0000:61:00.0
+
+Device.info command can be used to list new device as below.
+
+$ govc device.info --vm helloworld
+...
+Name:               pcipassthrough-13000
+  Type:             VirtualPCIPassthrough
+  Label:            PCI device 0
+  Summary:
+  Key:              13000
+  Controller:       pci-100
+  Unit number:      18
+Name:               pcipassthrough-13001
+  Type:             VirtualPCIPassthrough
+  Label:            PCI device 1
+  Summary:
+  Key:              13001
+  Controller:       pci-100
+  Unit number:      19
+`
+}
+
+func (cmd *add) Usage() string {
+	return "<PCI ADDRESS>..."
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	if len(f.Args()) == 0 {
+		return flag.ErrHelp
+	}
+
+	reqDevices := map[string]*types.VirtualMachinePciPassthroughInfo{}
+	for _, n := range f.Args() {
+		reqDevices[n] = nil
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	vmConfigOptions, err := vm.QueryConfigTarget(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, d := range vmConfigOptions.PciPassthrough {
+		info := d.GetVirtualMachinePciPassthroughInfo()
+		if info == nil {
+			return errors.New("received invalid pci passthrough info")
+		}
+
+		_, ok := reqDevices[info.PciDevice.Id]
+		if !ok {
+			continue
+		}
+		reqDevices[info.PciDevice.Id] = info
+	}
+
+	newDevices := []types.BaseVirtualDevice{}
+	for id, d := range reqDevices {
+		if d == nil {
+			return fmt.Errorf("%s is not found in allowed PCI passthrough device list", id)
+		}
+		device := &types.VirtualPCIPassthrough{}
+		device.Backing = &types.VirtualPCIPassthroughDeviceBackingInfo{
+			Id: d.PciDevice.Id, DeviceId: strconv.Itoa(int(d.PciDevice.DeviceId)),
+			SystemId: d.SystemId, VendorId: d.PciDevice.VendorId,
+		}
+		device.Connectable = &types.VirtualDeviceConnectInfo{StartConnected: true, Connected: true}
+		newDevices = append(newDevices, device)
+	}
+
+	return vm.AddDevice(ctx, newDevices...)
+}

--- a/govc/device/pci/ls.go
+++ b/govc/device/pci/ls.go
@@ -1,0 +1,95 @@
+/*
+Copyright (c) 2014-2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pci
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ls struct {
+	*flags.VirtualMachineFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("device.pci.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Description() string {
+	return `List allowed PCI passthrough devices that could be attach to VM.
+
+Examples:
+  govc device.pci.ls -vm VM`
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	vmConfigOptions, err := vm.QueryConfigTarget(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(&infoResult{PciDevices: vmConfigOptions.PciPassthrough})
+}
+
+type infoResult struct {
+	PciDevices []types.BaseVirtualMachinePciPassthroughInfo
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "System ID\tAddress\tDevice Name\n")
+	for _, d := range r.PciDevices {
+		info := d.GetVirtualMachinePciPassthroughInfo()
+		pd := info.PciDevice
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", info.SystemId, pd.Id, pd.VendorName, pd.DeviceName)
+	}
+	return tw.Flush()
+}

--- a/govc/device/pci/remove.go
+++ b/govc/device/pci/remove.go
@@ -1,0 +1,124 @@
+/*
+Copyright (c) 2014-2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pci
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type remove struct {
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("device.pci.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Usage() string {
+	return "<PCI ADDRESS>..."
+}
+
+func (cmd *remove) Description() string {
+	return `Remove PCI Passthrough device from VM.
+
+Examples:
+  govc device.info -vm $vm
+  govc device.pci.remove -vm $vm {pci address}*
+  govc device.info -vm $vm
+
+Assuming vm name is helloworld, device info command has below output
+
+$ govc device.info --vm helloworld
+...
+Name:               pcipassthrough-13000
+  Type:             VirtualPCIPassthrough
+  Label:            PCI device 0
+  Summary:
+  Key:              13000
+  Controller:       pci-100
+  Unit number:      18
+Name:               pcipassthrough-13001
+  Type:             VirtualPCIPassthrough
+  Label:            PCI device 1
+  Summary:
+  Key:              13001
+  Controller:       pci-100
+  Unit number:      19
+
+To remove only 'pcipassthrough-13000', command should be as below. No output upon success.
+
+$ govc device.pci.remove --vm helloworld pcipassthrough-13000
+
+To remove both 'pcipassthrough-13000' and 'pcipassthrough-13001', command should be as below.
+No output upon success.
+
+$ govc device.pci.remove --vm helloworld pcipassthrough-13000 pcipassthrough-13001
+`
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	if len(f.Args()) == 0 {
+		return flag.ErrHelp
+	}
+
+	reqDevices := map[string]bool{}
+	for _, n := range f.Args() {
+		reqDevices[n] = false
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	rmDevices := []types.BaseVirtualDevice{}
+	for _, d := range vmDevices.SelectByType(&types.VirtualPCIPassthrough{}) {
+		name := vmDevices.Name(d)
+		_, ok := reqDevices[name]
+		if !ok {
+			continue
+		}
+		reqDevices[name] = true
+		rmDevices = append(rmDevices, d)
+	}
+
+	for id, found := range reqDevices {
+		if !found {
+			return fmt.Errorf("%s is not found, please check and try again", id)
+		}
+	}
+	return vm.RemoveDevice(ctx, false, rmDevices...)
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/device"
 	_ "github.com/vmware/govmomi/govc/device/cdrom"
 	_ "github.com/vmware/govmomi/govc/device/floppy"
+	_ "github.com/vmware/govmomi/govc/device/pci"
 	_ "github.com/vmware/govmomi/govc/device/scsi"
 	_ "github.com/vmware/govmomi/govc/device/serial"
 	_ "github.com/vmware/govmomi/govc/device/usb"


### PR DESCRIPTION
also enable list command to display available pci passthrough devices

this allows automation or human to associate pci passthrough device

Signed-off-by: leslie-qiwa <leslie.qiwa@gmail.com>

https://github.com/vmware/govmomi/issues/1563