### PR TITLE
govc: add find -p flag

### DIFF
--- a/find/finder.go
+++ b/find/finder.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/vmware/govmomi/internal"
 	"github.com/vmware/govmomi/list"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
@@ -76,18 +77,7 @@ func InventoryPath(ctx context.Context, client *vim25.Client, obj types.ManagedO
 	if err != nil {
 		return "", err
 	}
-
-	val := "/"
-
-	for _, entity := range entities {
-		// Skip root folder in building inventory path.
-		if entity.Parent == nil {
-			continue
-		}
-		val = path.Join(val, entity.Name)
-	}
-
-	return val, err
+	return internal.InventoryPath(entities), nil
 }
 
 // findRoot makes it possible to use "find" mode with a different root path.

--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -433,6 +433,9 @@ EOF
   run govc find . -name "$vm"
   assert_output "$folder/$vm"
 
+  run govc find -p "$folder/$vm" -type Datacenter
+  assert_output "$dc"
+
   run govc find "$folder" -name "$vm"
   assert_output "$folder/$vm"
 

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -1,0 +1,38 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"path"
+
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+// InventoryPath composed of entities by Name
+func InventoryPath(entities []mo.ManagedEntity) string {
+	val := "/"
+
+	for _, entity := range entities {
+		// Skip root folder in building inventory path.
+		if entity.Parent == nil {
+			continue
+		}
+		val = path.Join(val, entity.Name)
+	}
+
+	return val
+}


### PR DESCRIPTION
Useful for finding object parents, such as the Datacenter for a given inventory path.