### PR TITLE
sts: fix SignRequest bodyhash for non-empty request body

### DIFF
--- a/sts/signer.go
+++ b/sts/signer.go
@@ -265,7 +265,7 @@ func (s *Signer) SignRequest(req *http.Request) error {
 				return fmt.Errorf("sts: reading http.Request body: %s", rerr)
 			}
 		}
-		bhash := sha256.New().Sum(body)
+		bhash := sha256.Sum256(body)
 
 		port := req.URL.Port()
 		if port == "" {
@@ -284,7 +284,7 @@ func (s *Signer) SignRequest(req *http.Request) error {
 			buf.WriteString(msg[i])
 			buf.WriteByte('\n')
 		}
-		buf.Write(bhash)
+		buf.Write(bhash[:])
 		buf.WriteByte('\n')
 
 		sum := sha256.Sum256(buf.Bytes())
@@ -311,7 +311,7 @@ func (s *Signer) SignRequest(req *http.Request) error {
 		})
 		add(param{
 			key: "bodyhash",
-			val: base64.StdEncoding.EncodeToString(bhash),
+			val: base64.StdEncoding.EncodeToString(bhash[:]),
 		})
 	}
 


### PR DESCRIPTION
The only request that is signed by this method always has an empty body:
https://vmware.github.io/vsphere-automation-sdk-rest/vsphere/operations/com/vmware/cis/session.create-operation.html
The 'bodyhash' header param of an empty string is still required in the signature however.
But should the request body be non-empty, we need to use sha256.Sum256() as @dgryski pointed out.