### PR TITLE
govc: fix vm.clone panic when target VM already exists

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -709,6 +709,9 @@ load test_helper
   run govc vm.clone -cluster DC0_C0 -vm "$vm" "$clone"
   assert_success
 
+  run govc vm.clone -cluster DC0_C0 -vm "$vm" "$clone"
+  assert_failure # already exists
+
   run govc vm.clone -force -vm "$vm" "$clone"
   assert_success # clone vm with the same name
 }

--- a/govc/vm/clone.go
+++ b/govc/vm/clone.go
@@ -440,7 +440,7 @@ func (cmd *clone) cloneVM(ctx context.Context) (*object.VirtualMachine, error) {
 
 		_, err := datastore.Stat(ctx, vmxPath)
 		if err == nil {
-			dsPath := cmd.Datastore.Path(vmxPath)
+			dsPath := datastore.Path(vmxPath)
 			return nil, fmt.Errorf("file %s already exists", dsPath)
 		}
 	}


### PR DESCRIPTION
Fixes #2087