### PR TITLE
Add ClusterDistribution field for CNS telemetry

### DIFF
--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -101,10 +101,11 @@ func TestClient(t *testing.T) {
 
 	var containerClusterArray []cnstypes.CnsContainerCluster
 	containerCluster := cnstypes.CnsContainerCluster{
-		ClusterType:   string(cnstypes.CnsClusterTypeKubernetes),
-		ClusterId:     "demo-cluster-id",
-		VSphereUser:   "Administrator@vsphere.local",
-		ClusterFlavor: string(cnstypes.CnsClusterFlavorVanilla),
+		ClusterType:         string(cnstypes.CnsClusterTypeKubernetes),
+		ClusterId:           "demo-cluster-id",
+		VSphereUser:         "Administrator@vsphere.local",
+		ClusterFlavor:       string(cnstypes.CnsClusterFlavorVanilla),
+		ClusterDistribution: "OpenShift",
 	}
 	containerClusterArray = append(containerClusterArray, containerCluster)
 

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -287,10 +287,11 @@ type CnsQueryAllVolumeResponse struct {
 type CnsContainerCluster struct {
 	types.DynamicData
 
-	ClusterType   string `xml:"clusterType"`
-	ClusterId     string `xml:"clusterId"`
-	VSphereUser   string `xml:"vSphereUser"`
-	ClusterFlavor string `xml:"clusterFlavor,omitempty"`
+	ClusterType         string `xml:"clusterType"`
+	ClusterId           string `xml:"clusterId"`
+	VSphereUser         string `xml:"vSphereUser"`
+	ClusterFlavor       string `xml:"clusterFlavor,omitempty"`
+	ClusterDistribution string `xml:"clusterDistribution,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
This pull request is adding a go binding for ClusterDistribution to support CNS telemetry.

Testing:
```
% export CNS_VC_URL='https://Administrator@vsphere.local:Admin!23@10.78.100.14/sdk'
% export CNS_DATACENTER='VSAN-DC'
% export CNS_DATASTORE='vsanDatastore'

% go test -v
=== RUN   TestClient
--- PASS: TestClient (32.61s)
    client_test.go:128: Creating volume using the spec: types.CnsVolumeCreateSpec{
            Name:       "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
            VolumeType: "BLOCK",
            Datastores: []types.ManagedObjectReference{
                {Type:"Datastore", Value:"datastore-36"},
            },
            Metadata: types.CnsVolumeMetadata{
                ContainerCluster: types.CnsContainerCluster{
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "OpenShift",
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    CapacityInMb: 5120,
                },
                BackingDiskId:      "",
                BackingDiskUrlPath: "",
            },
            Profile:    nil,
            CreateSpec: nil,
        }
.
.
.
client_test.go:217: Successfully Queried Volumes. queryResult: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "0cdfb822-2ddd-4897-a067-3fe37682371d",
                    },
                    DatastoreUrl:    "ds:///vmfs/volumes/vsan:524f0c83003d697c-b67ae4bec09d8333/",
                    Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:      "BLOCK",
                    StoragePolicyId: "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:        types.CnsVolumeMetadata{
                        ContainerCluster: types.CnsContainerCluster{
                            ClusterType:         "KUBERNETES",
                            ClusterId:           "demo-cluster-id",
                            VSphereUser:         "Administrator@vsphere.local",
                            ClusterFlavor:       "VANILLA",
                            ClusterDistribution: "OpenShift",
                        },
                        EntityMetadata:        nil,
                        ContainerClusterArray: []types.CnsContainerCluster{
                            {
                                ClusterType:         "KUBERNETES",
                                ClusterId:           "demo-cluster-id",
                                VSphereUser:         "Administrator@vsphere.local",
                                ClusterFlavor:       "VANILLA",
                                ClusterDistribution: "OpenShift",
                            },
                        },
                    },
.
.
.

PASS
ok  	github.com/vmware/govmomi/cns	32.642s
```
simulator test
```
=== RUN   TestSimulator
--- PASS: TestSimulator (0.04s)
PASS
ok  	github.com/vmware/govmomi/cns/simulator	0.064s
```
@divyenpatel @SandeepPissay @chethanv28 