### PR TITLE
Fix for fatal error in VCSim: concurrent map iteration and map write

### DIFF
--- a/simulator/search_index.go
+++ b/simulator/search_index.go
@@ -32,6 +32,9 @@ type SearchIndex struct {
 func (s *SearchIndex) FindByDatastorePath(r *types.FindByDatastorePath) soap.HasFault {
 	res := &methods.FindByDatastorePathBody{Res: new(types.FindByDatastorePathResponse)}
 
+	Map.m.Lock()
+	defer Map.m.Unlock()
+
 	for ref, obj := range Map.objects {
 		vm, ok := asVirtualMachineMO(obj)
 		if !ok {
@@ -121,6 +124,9 @@ func (s *SearchIndex) FindChild(req *types.FindChild) soap.HasFault {
 func (s *SearchIndex) FindByUuid(req *types.FindByUuid) soap.HasFault {
 	body := &methods.FindByUuidBody{Res: new(types.FindByUuidResponse)}
 
+	Map.m.Lock()
+	defer Map.m.Unlock()
+
 	if req.VmSearch {
 		// Find Virtual Machine using UUID
 		for ref, obj := range Map.objects {
@@ -177,6 +183,9 @@ func (s *SearchIndex) FindByDnsName(req *types.FindByDnsName) soap.HasFault {
 func (s *SearchIndex) FindAllByDnsName(req *types.FindAllByDnsName) soap.HasFault {
 	body := &methods.FindAllByDnsNameBody{Res: new(types.FindAllByDnsNameResponse)}
 
+	Map.m.Lock()
+	defer Map.m.Unlock()
+
 	if req.VmSearch {
 		// Find Virtual Machine using DNS name
 		for ref, obj := range Map.objects {
@@ -225,6 +234,9 @@ func (s *SearchIndex) FindByIp(req *types.FindByIp) soap.HasFault {
 
 func (s *SearchIndex) FindAllByIp(req *types.FindAllByIp) soap.HasFault {
 	body := &methods.FindAllByIpBody{Res: new(types.FindAllByIpResponse)}
+
+	Map.m.Lock()
+	defer Map.m.Unlock()
 
 	if req.VmSearch {
 		// Find Virtual Machine using IP


### PR DESCRIPTION
fatal error: concurrent map iteration and map write
goroutine 43135 [running]:
runtime.throw(0x10562ad, 0x26)
/goroot/src/runtime/panic.go:774 +0x72 fp=0xc0007dd040 sp=0xc0007dd010 pc=0x42f872
runtime.mapiternext(0xc0007dd108)
/goroot/src/runtime/map.go:858 +0x579 fp=0xc0007dd0c8 sp=0xc0007dd040 pc=0x410c79
github.com/vmware/govmomi/simulator.(*SearchIndex).FindByUuid(0xc0002f8f00, 0xc001e898b0, 0x0, 0x0)
/gopath/src/github.com/vmware/govmomi/simulator/search_index.go:126 +0xfe fp=0xc0007dd178 sp=0xc0007dd0c8 pc=0xba53ae
runtime.call32(0xc0005110b0, 0xc0016c03c0, 0xc00166f6c0, 0x1000000020)
/goroot/src/runtime/asm_amd64.s:539 +0x3b fp=0xc0007dd1a8 sp=0xc0007dd178 pc=0x45ac8b
reflect.Value.call(0xf85260, 0xc0002f8f00, 0x1a13, 0x10092c3, 0x4, 0xc00166f680, 0x1, 0x1, 0xb, 0xb, ...)
/goroot/src/reflect/value.go:460 +0x5f6 fp=0xc0007dd3c8 sp=0xc0007dd1a8 pc=0x492a46
reflect.Value.Call(0xf85260, 0xc0002f8f00, 0x1a13, 0xc00166f680, 0x1, 0x1, 0x100d547, 0x42e61a, 0x100d547)
/goroot/src/reflect/value.go:321 +0xb4 fp=0xc0007dd448 sp=0xc0007dd3c8 pc=0x492204
github.com/vmware/govmomi/simulator.(*Service).call.func1()
/gopath/src/github.com/vmware/govmomi/simulator/simulator.go:216 +0x64 fp=0xc0007dd4a8 sp=0xc0007dd448 pc=0xbdaac4
github.com/vmware/govmomi/simulator.(*Registry).WithLock(0xc00007c5a0, 0x11c7fc0, 0xc0002f8f00, 0xc0007dd720)
/gopath/src/github.com/vmware/govmomi/simulator/registry.go:551 +0x37 fp=0xc0007dd528 sp=0xc0007dd4a8 pc=0xba0597
github.com/vmware/govmomi/simulator.(*Service).call(0xc00007c660, 0xc00072f9e0, 0xc001e6bd00, 0x600, 0xc001e6bd00)
/gopath/src/github.com/vmware/govmomi/simulator/simulator.go:215 +0x60c fp=0xc0007dd770 sp=0xc0007dd528 pc=0xbab31c
github.com/vmware/govmomi/simulator.(*Service).ServeSDK(0xc00007c660, 0x11d6380, 0xc001b49960, 0xc001d99600)
/gopath/src/github.com/vmware/govmomi/simulator/simulator.go:472 +0x426 fp=0xc0007ddb60 sp=0xc0007dd770 pc=0xbae5a6
github.com/vmware/govmomi/simulator.(*Service).ServeSDK-fm(0x11d6380, 0xc001b49960, 0xc001d99600)
/gopath/src/github.com/vmware/govmomi/simulator/simulator.go:426 +0x48 fp=0xc0007ddb90 sp=0xc0007ddb60 pc=0xbedd78
net/http.HandlerFunc.ServeHTTP(0xc00036a4b0, 0x11d6380, 0xc001b49960, 0xc001d99600)
/goroot/src/net/http/server.go:2007 +0x44 fp=0xc0007ddbb8 sp=0xc0007ddb90 pc=0x6e9fe4
net/http.(*ServeMux).ServeHTTP(0x1a6ed00, 0x11d6380, 0xc001b49960, 0xc001d99600)
/goroot/src/net/http/server.go:2387 +0x1bd fp=0xc0007ddc18 sp=0xc0007ddbb8 pc=0x6ebebd
net/http.serverHandler.ServeHTTP(0xc00032f960, 0x11d6380, 0xc001b49960, 0xc001d99600)
/goroot/src/net/http/server.go:2802 +0xa4 fp=0xc0007ddc48 sp=0xc0007ddc18 pc=0x6ed434
net/http.(*conn).serve(0xc00117adc0, 0x11d7f80, 0xc0014a0040)
/goroot/src/net/http/server.go:1890 +0x875 fp=0xc0007ddfc8 sp=0xc0007ddc48 pc=0x6e8dd5