### PR TITLE
go binding for CNS RelocateVolume API

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -166,7 +166,7 @@ func (c *Client) QueryVolumeInfo(ctx context.Context, volumeIDList []cnstypes.Cn
 	return object.NewTask(c.vim25Client, res.Returnval), nil
 }
 
-// QueryVolume calls the CNS QueryAllVolume API.
+// QueryAllVolume calls the CNS QueryAllVolume API.
 func (c *Client) QueryAllVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter, querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
 	req := cnstypes.CnsQueryAllVolume{
 		This:      CnsVolumeManagerInstance,
@@ -178,4 +178,17 @@ func (c *Client) QueryAllVolume(ctx context.Context, queryFilter cnstypes.CnsQue
 		return nil, err
 	}
 	return &res.Returnval, nil
+}
+
+// RelocateVolume calls the CNS Relocate API.
+func (c *Client) RelocateVolume(ctx context.Context, relocateSpecs ...cnstypes.BaseCnsVolumeRelocateSpec) (*object.Task, error) {
+	req := cnstypes.CnsRelocateVolume{
+		This:          CnsVolumeManagerInstance,
+		RelocateSpecs: relocateSpecs,
+	}
+	res, err := methods.CnsRelocateVolume(ctx, c.serviceClient, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(c.vim25Client, res.Returnval), nil
 }

--- a/cns/methods/methods.go
+++ b/cns/methods/methods.go
@@ -202,3 +202,21 @@ func CnsQueryAllVolume(ctx context.Context, r soap.RoundTripper, req *types.CnsQ
 
 	return resBody.Res, nil
 }
+
+type CnsRelocateVolumeBody struct {
+	Req    *types.CnsRelocateVolume         `xml:"urn:vsan CnsRelocateVolume,omitempty"`
+	Res    *types.CnsRelocateVolumeResponse `xml:"urn:vsan CnsRelocateVolumeResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsRelocateVolumeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsRelocateVolume(ctx context.Context, r soap.RoundTripper, req *types.CnsRelocateVolume) (*types.CnsRelocateVolumeResponse, error) {
+	var reqBody, resBody CnsRelocateVolumeBody
+	reqBody.Req = req
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/cns/types/if.go
+++ b/cns/types/if.go
@@ -66,6 +66,16 @@ func init() {
 	types.Add("BaseCnsBaseCreateSpec", reflect.TypeOf((*CnsBaseCreateSpec)(nil)).Elem())
 }
 
+type BaseCnsVolumeRelocateSpec interface {
+	GetCnsVolumeRelocateSpec() CnsVolumeRelocateSpec
+}
+
+func (s CnsVolumeRelocateSpec) GetCnsVolumeRelocateSpec() CnsVolumeRelocateSpec { return s }
+
+func init() {
+	types.Add("BaseCnsVolumeRelocateSpec", reflect.TypeOf((*CnsVolumeRelocateSpec)(nil)).Elem())
+}
+
 func (b *CnsEntityMetadata) GetCnsEntityMetadata() *CnsEntityMetadata { return b }
 
 type BaseCnsEntityMetadata interface {

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -499,6 +499,60 @@ func init() {
 	types.Add("CnsQueryVolumeInfoResult", reflect.TypeOf((*CnsQueryVolumeInfoResult)(nil)).Elem())
 }
 
+type CnsRelocateVolumeRequestType struct {
+	This          types.ManagedObjectReference `xml:"_this"`
+	RelocateSpecs []BaseCnsVolumeRelocateSpec  `xml:"relocateSpecs,typeattr"`
+}
+
+func init() {
+	types.Add("CnsRelocateVolumeRequestType", reflect.TypeOf((*CnsRelocateVolumeRequestType)(nil)).Elem())
+}
+
+type CnsRelocateVolume CnsRelocateVolumeRequestType
+
+func init() {
+	types.Add("CnsRelocateVolume", reflect.TypeOf((*CnsRelocateVolume)(nil)).Elem())
+}
+
+type CnsRelocateVolumeResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type CnsVolumeRelocateSpec struct {
+	types.DynamicData
+
+	VolumeId  CnsVolumeId                           `xml:"volumeId"`
+	Datastore types.ManagedObjectReference          `xml:"datastore"`
+	Profile   []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
+}
+
+func init() {
+	types.Add("CnsVolumeRelocateSpec", reflect.TypeOf((*CnsVolumeRelocateSpec)(nil)).Elem())
+}
+
+type CnsBlockVolumeRelocateSpec struct {
+	CnsVolumeRelocateSpec
+}
+
+func NewCnsBlockVolumeRelocateSpec(volumeId string, datastore types.ManagedObjectReference, profile ...types.BaseVirtualMachineProfileSpec) CnsBlockVolumeRelocateSpec {
+	cnsVolumeID := CnsVolumeId{
+		Id: volumeId,
+	}
+	volumeSpec := CnsVolumeRelocateSpec{
+		VolumeId:  cnsVolumeID,
+		Datastore: datastore,
+		Profile:   profile,
+	}
+	blockVolSpec := CnsBlockVolumeRelocateSpec{
+		CnsVolumeRelocateSpec: volumeSpec,
+	}
+	return blockVolSpec
+}
+
+func init() {
+	types.Add("CnsBlockVolumeRelocateSpec", reflect.TypeOf((*CnsBlockVolumeRelocateSpec)(nil)).Elem())
+}
+
 type CnsCursor struct {
 	types.DynamicData
 


### PR DESCRIPTION
This pull request is adding a go binding for new CNS API `Relocate`.

`Relocate` migrates the given volume to the specified target datastore and returns a `vim.Task` to track the progress and overall state of the migration operation.

API throws 
- `vim.fault.NotFound` in case the block volume is not found
- `vim.fault.InvalidArgument` in case of invalid input arguments
- `vim.fault.AlreadyExists` in case volume already exists in the target datastore
- `vim.fault.CnsFault` in case of any other failure scenario.

Testing
```
$ pwd
.../govmomi/cns

$ export CNS_VC_URL='https://Administrator@VSPHERE.LOCAL:Admin!23@10.92.206.216/sdk'
$ export CNS_DATACENTER='test-vpx-1602615587-4149-wcp.wcp-app-platform-sanity'
$ export CNS_DATASTORE='vSANDirect_10.92.218.55_mpx.vmhba0:C0:T6:L0'
$ export CNS_MIGRATION_DATASTORE='vSANDirect_10.92.218.55_mpx.vmhba0:C0:T5:L0'
 
$ go test -v -run TestClient

=== RUN   TestClient

    TestClient: client_test.go:133: Creating volume using the spec: types.CnsVolumeCreateSpec{...}
    TestClient: client_test.go:158: Volume created sucessfully. volumeId: 738cb4bf-024d-4c63-8ebf-0bf54b3e5416
    TestClient: client_test.go:178: Creating volume using the spec: types.CnsVolumeCreateSpec{...}
    TestClient: client_test.go:201: reCreateVolumeOperationRes.Fault: &types.LocalizedMethodFault{ Fault: types.CnsFault{ BaseMethodFault: nil, Reason: "could not update cns metadata for the existing CNS volume with id: 738cb4bf-024d-4c63-8ebf-0bf54b3e5416", }, LocalizedMessage: "CnsFault error: could not update cns metadata for the existing CNS volume with id: 738cb4bf-024d-4c63-8ebf-0bf54b3e5416", }
    TestClient: client_test.go:216: Calling QueryVolume using queryFilter: types.CnsQueryFilter{...}
    TestClient: client_test.go:222: Successfully Queried Volumes. queryResult: &types.CnsQueryResult{...}
    TestClient: client_test.go:228: Calling QueryVolumeInfo using: []types.CnsVolumeId{...}
    TestClient: client_test.go:253: Successfully Queried Volumes. queryVolumeInfoTaskResult: &types.CnsQueryVolumeInfoResult{...}


    TestClient: client_test.go:265: Relocating volume 738cb4bf-024d-4c63-8ebf-0bf54b3e5416 to datastore Datastore:datastore-99
    TestClient: client_test.go:283: Successfully Relocated volume. Relocate task info result: &types.CnsVolumeOperationResult{
            VolumeId: types.CnsVolumeId{
                Id: "738cb4bf-024d-4c63-8ebf-0bf54b3e5416",
            },
            Fault: (*types.LocalizedMethodFault)(nil),
        }

    TestClient: client_test.go:297: Extending volume using the spec: []types.CnsVolumeExtendSpec{...}
    TestClient: client_test.go:322: Volume extended sucessfully. Volume ID: 738cb4bf-024d-4c63-8ebf-0bf54b3e5416
    TestClient: client_test.go:325: Calling QueryVolume after ExtendVolume using queryFilter: {DynamicData:{} VolumeIds:[{DynamicData:{} Id:738cb4bf-024d-4c63-8ebf-0bf54b3e5416}] Names:[] ContainerClusterIds:[] StoragePolicyId: Datastores:[] Labels:[] ComplianceStatus: DatastoreAccessibilityStatus: Cursor:<nil> healthStatus:}
    TestClient: client_test.go:331: Successfully Queried Volumes after ExtendVolume. queryResult: &types.CnsQueryResult{...}
    TestClient: client_test.go:336: Volume extended sucessfully to the new size. Volume ID: 738cb4bf-024d-4c63-8ebf-0bf54b3e5416 New Size: 10240
    TestClient: client_test.go:412: Updating volume using the spec: {...}
    TestClient: client_test.go:437: Successfully updated volume metadata
    TestClient: client_test.go:440: Calling QueryVolume using queryFilter: types.CnsQueryFilter{...}
    TestClient: client_test.go:446: Successfully Queried Volumes. queryResult: &types.CnsQueryResult{...}
    TestClient: client_test.go:463: Successfully Queried all Volumes. queryResult: &types.CnsQueryResult{...}
    TestClient: client_test.go:514: Node VM created sucessfully. vmRef: VirtualMachine:vm-103
    TestClient: client_test.go:528: Attaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:738cb4bf-024d-4c63-8ebf-0bf54b3e5416} Vm:VirtualMachine:vm-103}
    TestClient: client_test.go:553: Volume attached sucessfully. Disk UUID: 6000C291-52dd-58ca-2069-e39d27842cb0
    TestClient: client_test.go:556: Re-Attaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:738cb4bf-024d-4c63-8ebf-0bf54b3e5416} Vm:VirtualMachine:vm-103}
    TestClient: client_test.go:578: reAttachVolumeOperationRes.Fault: &types.LocalizedMethodFault{Fault: &types.ResourceInUse{VimFault: types.VimFault{},Type:     "",Name:     "volume",},LocalizedMessage: "The resource 'volume' is in use.",}
    TestClient: client_test.go:596: Detaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:738cb4bf-024d-4c63-8ebf-0bf54b3e5416} Vm:VirtualMachine:vm-103}
    TestClient: client_test.go:620: Volume detached sucessfully
    TestClient: client_test.go:623: Deleting volume: [{DynamicData:{} Id:738cb4bf-024d-4c63-8ebf-0bf54b3e5416}]
    TestClient: client_test.go:647: Volume: "738cb4bf-024d-4c63-8ebf-0bf54b3e5416" deleted sucessfully

--- PASS: TestClient (35.40s)
PASS
ok      github.com/vmware/govmomi/cns   35.455s

```