### PR TITLE
UseParseInt(x, 10, 32) instead of int32(Atoi(x))

### DIFF
--- a/object/custom_fields_manager.go
+++ b/object/custom_fields_manager.go
@@ -127,7 +127,7 @@ func (m CustomFieldsManager) FindKey(ctx context.Context, name string) (int32, e
 		}
 	}
 
-	k, err := strconv.Atoi(name)
+	k, err := strconv.ParseInt(name, 10, 32)
 	if err == nil {
 		// assume literal int key
 		return int32(k), nil


### PR DESCRIPTION
The Go's [`Atoi(x)`](https://golang.org/pkg/strconv/#Atoi) is equivalent of [`ParseInt(x, 10, 0)`](https://golang.org/pkg/strconv/#ParseInt) which may return 64-bit numbers.

This PR makes it so instead of overflowing this number, the `CustomFieldsManager.FindKey` function will return an `ErrKeyNameNotFound` if a too big number is passed in the `name` string.

PS: I haven't tested this change, please do so, but it should just work, assuming that the code did not depend on int overflow before.