### PR TITLE
Add option to disable secure cookies with non-TLS endpoints

### DIFF
--- a/govc/README.md
+++ b/govc/README.md
@@ -182,6 +182,16 @@ Test connection using curl:
 Inventory path arguments with a leading '/' are subject
 to [Posix path conversion](http://www.mingw.org/wiki/Posix_path_conversion).
 
+### NotAuthenticated
+
+When connecting to a non-TLS endpoint, Go's http.Client will not send Secure cookies, resulting in a `NotAuthenticated` error.
+For example, running govc directly against the vCenter vpxd endpoint at `http://127.0.0.1:8085`.
+Set the environment variable `GOVMOMI_INSECURE_COOKIES=true` to workaround this:
+
+``` console
+% GOVMOMI_INSECURE_COOKIES=true govc ls -u http://user:pass@127.0.0.1:8085
+```
+
 ## Examples
 
 Several examples are embedded in the govc command [help](USAGE.md)

--- a/govc/test/cli.bats
+++ b/govc/test/cli.bats
@@ -189,3 +189,27 @@ load test_helper
   assert_failure
   gofmt <<<"$output"
 }
+
+@test "insecure cookies" {
+  vcsim_start -tls=false
+
+  run govc ls
+  assert_success
+
+  vcsim_stop
+
+  VCSIM_SECURE_COOKIES=true vcsim_start -tls=false
+
+  run govc ls
+  assert_failure
+  assert_matches NotAuthenticated # Go's cookiejar won't send Secure cookies if scheme != https
+
+  vcsim_stop
+
+  VCSIM_SECURE_COOKIES=true vcsim_start -tls=false
+
+  run env GOVMOMI_INSECURE_COOKIES=true govc ls
+  assert_success # soap.Client will set Cookie.Secure=false
+
+  vcsim_stop
+}

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -74,7 +74,8 @@ type Client struct {
 	Types     types.Func
 	UserAgent string
 
-	cookie string
+	cookie          string
+	insecureCookies bool
 }
 
 var schemeMatch = regexp.MustCompile(`^\w+://`)
@@ -155,6 +156,10 @@ func NewClient(u *url.URL, insecure bool) *Client {
 	// Remove user information from a copy of the URL
 	c.u = c.URL()
 	c.u.User = nil
+
+	if c.u.Scheme == "http" {
+		c.insecureCookies = os.Getenv("GOVMOMI_INSECURE_COOKIES") == "true"
+	}
 
 	return &c
 }
@@ -476,6 +481,16 @@ func (c *Client) UnmarshalJSON(b []byte) error {
 
 type kindContext struct{}
 
+func (c *Client) setInsecureCookies(res *http.Response) {
+	cookies := res.Cookies()
+	if len(cookies) != 0 {
+		for _, cookie := range cookies {
+			cookie.Secure = false
+		}
+		c.Jar.SetCookies(c.u, cookies)
+	}
+}
+
 func (c *Client) Do(ctx context.Context, req *http.Request, f func(*http.Response) error) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -517,6 +532,10 @@ func (c *Client) Do(ctx context.Context, req *http.Request, f func(*http.Respons
 
 	if d.enabled() {
 		d.debugResponse(res, ext)
+	}
+
+	if c.insecureCookies {
+		c.setInsecureCookies(res)
 	}
 
 	return f(res)


### PR DESCRIPTION
vCenter login methods include the Secure flag in Set-Cookie responses.
Go's cookiejar impl does not send secure cookies unless the URL scheme is https.
This prevents use of govmomi/govc against the non-TLS vpxd endpoint (127.0.0.1:8085)

To enable use of secure cookies in this case: export GOVMOMI_INSECURE_COOKIES=true

To make vcsim include the Secure flag in Set-Cookie responses: export VCSIM_SECURE_COOKIES=true