### PR TITLE
IPv6 support for govc vm.customize

### DIFF
--- a/govc/vm/customize.go
+++ b/govc/vm/customize.go
@@ -39,6 +39,7 @@ type customize struct {
 	host      types.CustomizationFixedName
 	mac       flags.StringList
 	ip        flags.StringList
+	ip6       flags.StringList
 	gateway   flags.StringList
 	netmask   flags.StringList
 	dnsserver flags.StringList
@@ -59,15 +60,11 @@ func (cmd *customize) Register(ctx context.Context, f *flag.FlagSet) {
 	f.StringVar(&cmd.domain, "domain", "", "Domain name")
 	f.StringVar(&cmd.host.Name, "name", "", "Host name")
 	f.Var(&cmd.mac, "mac", "MAC address")
-	cmd.mac = nil
-	f.Var(&cmd.ip, "ip", "IP address")
-	cmd.ip = nil
+	f.Var(&cmd.ip, "ip", "IPv4 address")
+	f.Var(&cmd.ip6, "ip6", "IPv6 addresses with optional netmask (defaults to /64), separated by space")
 	f.Var(&cmd.gateway, "gateway", "Gateway")
-	cmd.gateway = nil
 	f.Var(&cmd.netmask, "netmask", "Netmask")
-	cmd.netmask = nil
 	f.Var(&cmd.dnsserver, "dns-server", "DNS server")
-	cmd.dnsserver = nil
 	f.StringVar(&cmd.kind, "type", "Linux", "Customization type if spec NAME is not specified (Linux|Windows)")
 }
 
@@ -96,6 +93,36 @@ Examples:
   govc vm.customize -vm VM -auto-login 3 NAME
   govc vm.customize -vm VM -prefix demo NAME
   govc vm.customize -vm VM -tz America/New_York NAME`
+}
+
+// Parse a string of multiple IPv6 addresses with optional netmask separated by space
+func parseIPv6Argument(argv string) (ipconf []types.BaseCustomizationIpV6Generator, err error) {
+	for _, substring := range strings.Split(argv, " ") {
+		// check if subnet mask was specified
+		switch strings.Count(substring, "/") {
+		// no mask, set default
+		case 0:
+			ipconf = append(ipconf, &types.CustomizationFixedIpV6{
+				IpAddress:  substring,
+				SubnetMask: 64,
+			})
+		// a single forward slash was found: parse and use subnet mask
+		case 1:
+			parts := strings.Split(substring, "/")
+			mask, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return nil, fmt.Errorf("unable to convert subnet mask to int: %w", err)
+			}
+			ipconf = append(ipconf, &types.CustomizationFixedIpV6{
+				IpAddress:  parts[0],
+				SubnetMask: int32(mask),
+			})
+		// to many forward slash; return error
+		default:
+			return nil, fmt.Errorf("unable to parse IPv6 address (too many subnet separators): %s", substring)
+		}
+	}
+	return ipconf, nil
 }
 
 func (cmd *customize) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -232,6 +259,20 @@ func (cmd *customize) Run(ctx context.Context, f *flag.FlagSet) error {
 				nic.Adapter.DnsServerList = strings.Split(cmd.dnsserver[i], ",")
 			}
 		}
+	}
+
+	for i, ip6 := range cmd.ip6 {
+		ipconfig, err := parseIPv6Argument(ip6)
+		if err != nil {
+			return err
+		}
+		// use the same logic as the ip switch: the first occurrence of the ip6 switch is assigned to the first nic,
+		// the second to the second nic and so forth.
+		if spec.NicSettingMap == nil || len(spec.NicSettingMap) < i {
+			return fmt.Errorf("unable to find a network adapter for IPv6 settings %d (%s)", i, ip6)
+		}
+		nic := &spec.NicSettingMap[i]
+		nic.Adapter.IpV6Spec.Ip = append(nic.Adapter.IpV6Spec.Ip, ipconfig...)
 	}
 
 	task, err := vm.Customize(ctx, *spec)


### PR DESCRIPTION
This patch adds rudimentary support to configure IPv6 in vm nics (fixes #1971).