### PR TITLE
Change EthernetCardTypes key return from -1 to rand neg int32

### DIFF
--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -19,6 +19,7 @@ package object
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -67,7 +68,7 @@ func EthernetCardTypes() VirtualDeviceList {
 		&types.VirtualSriovEthernetCard{},
 	}).Select(func(device types.BaseVirtualDevice) bool {
 		c := device.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-		c.GetVirtualDevice().Key = -1
+		c.GetVirtualDevice().Key = int32(rand.Uint32()) * -1
 		return true
 	})
 }


### PR DESCRIPTION
Problem: Add two network cards to a VM, code like https://github.com/rancher/machine/blob/master/drivers/vmwarevsphere/vm.go#L109-L126 
* vsphere6.7 allowed this
* vsphere7 returns a duplicate key error `com.vmware.vim.vpxd.vmprov.duplicateDeviceKey`

Fix: You can change the key yourself with similar rand code e.g. add `netdev.GetVirtualDevice().Key = int32(rand.Uint32()) * -1` in the code above but ultimately if you don't know that vsphere7 will return the error it's very hard to track down and should probably be fixed in govmomi.

@dougm if there are more places this -1 thing is going to be an issue I have no problem adding this change in more places just let me know what to look for, obviously the only place we had issues today is with network cards.

Related Issue: https://github.com/rancher/rancher/issues/27732