### PR TITLE
change negative one to rand neg int32

### DIFF
--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -434,7 +434,7 @@ func (l VirtualDeviceList) AssignController(device types.BaseVirtualDevice, c ty
 	d.UnitNumber = new(int32)
 	*d.UnitNumber = l.newUnitNumber(c)
 	if d.Key == 0 {
-		d.Key = -1
+		d.Key = int32(rand.Uint32()) * -1
 	}
 }
 


### PR DESCRIPTION
Update AssignController to return a negative random int32 instead of -1 per vsphere7 resrictions on adding devices with the same key resulting in an error.

Related Issues: https://github.com/rancher/rancher/issues/25404
Per this code: https://github.com/rancher/machine/blob/master/drivers/vmwarevsphere/create.go#L162-L181
We add a disk + cdrom, since CreateDisk and CreateCdrom both call AssignController the Key on both devices are -1. This will also fix CreateFloppy and CreateSerialPort
See also: https://github.com/vmware/govmomi/pull/2154

@dougm Same problem, different func