### PR TITLE
Add Placement object in CNS CreateVolume response and related tests.

### DIFF
--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -155,6 +155,8 @@ func TestClient(t *testing.T) {
 		t.Fatalf("Failed to create volume: fault=%+v", createVolumeOperationRes.Fault)
 	}
 	volumeId := createVolumeOperationRes.VolumeId.Id
+	volumeCreateResult := (createTaskResult).(*cnstypes.CnsVolumeCreateResult)
+	t.Logf("volumeCreateResult %+v", volumeCreateResult)
 	t.Logf("Volume created sucessfully. volumeId: %s", volumeId)
 
 	if cnsClient.serviceClient.Version != ReleaseVSAN67u3 {

--- a/cns/simulator/simulator.go
+++ b/cns/simulator/simulator.go
@@ -130,8 +130,16 @@ func (m *CnsVolumeManager) CnsCreateVolume(ctx context.Context, req *cnstypes.Cn
 					}
 
 					volumes[newVolume.VolumeId] = newVolume
-					operationResult = append(operationResult, &cnstypes.CnsVolumeOperationResult{
-						VolumeId: newVolume.VolumeId,
+					placementResults := []cnstypes.CnsPlacementResult{}
+					placementResults = append(placementResults, cnstypes.CnsPlacementResult{
+						Datastore: datastore.Reference(),
+					})
+					operationResult = append(operationResult, &cnstypes.CnsVolumeCreateResult{
+						CnsVolumeOperationResult: cnstypes.CnsVolumeOperationResult{
+							VolumeId: newVolume.VolumeId,
+						},
+						Name:             createSpec.Name,
+						PlacementResults: placementResults,
 					})
 				}
 			}

--- a/cns/simulator/simulator_test.go
+++ b/cns/simulator/simulator_test.go
@@ -112,6 +112,8 @@ func TestSimulator(t *testing.T) {
 		t.Fatalf("Failed to create volume: fault=%+v", createVolumeOperationRes.Fault)
 	}
 	volumeId := createVolumeOperationRes.VolumeId.Id
+	volumeCreateResult := (createTaskResult).(*cnstypes.CnsVolumeCreateResult)
+	t.Logf("volumeCreateResult %+v", volumeCreateResult)
 
 	// Extend
 	var newCapacityInMb int64 = 2048

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -338,9 +338,19 @@ func init() {
 	types.Add("CnsVolumeOperationBatchResult", reflect.TypeOf((*CnsVolumeOperationBatchResult)(nil)).Elem())
 }
 
+type CnsPlacementResult struct {
+	Datastore       types.ManagedObjectReference  `xml:"datastore,omitempty"`
+	PlacementFaults []*types.LocalizedMethodFault `xml:"placementFaults,omitempty"`
+}
+
+func init() {
+	types.Add("CnsPlacementResult", reflect.TypeOf((*CnsPlacementResult)(nil)).Elem())
+}
+
 type CnsVolumeCreateResult struct {
 	CnsVolumeOperationResult
-	Name string `xml:"name,omitempty"`
+	Name             string               `xml:"name,omitempty"`
+	PlacementResults []CnsPlacementResult `xml:"placementResults,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
This change is to add Placement object in CNS CreateVolume response. Also modify the related unit test.

With this change, volumeCreateResult returns Placement object.
```
 volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:a9b3d651-39c4-4018-8aea-f58f7eda0e2e} Fault:<nil>} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0 PlacementResults:[{Datastore:Datastore:datastore-36 PlacementFaults:[]}]}
```
Full Test Result:
```
lipingx-a01:cns lipingx$ go test -v
=== RUN   TestClient
--- PASS: TestClient (12.32s)
    client_test.go:133: Creating volume using the spec: types.CnsVolumeCreateSpec{
            Name:       "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
            VolumeType: "BLOCK",
            Datastores: []types.ManagedObjectReference{
                {Type:"Datastore", Value:"datastore-36"},
            },
            Metadata: types.CnsVolumeMetadata{
                ContainerCluster: types.CnsContainerCluster{
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "OpenShift",
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    CapacityInMb: 5120,
                },
                BackingDiskId:      "",
                BackingDiskUrlPath: "",
            },
            Profile:    nil,
            CreateSpec: nil,
        }
    client_test.go:159: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:a9b3d651-39c4-4018-8aea-f58f7eda0e2e} Fault:<nil>} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0 PlacementResults:[{Datastore:Datastore:datastore-36 PlacementFaults:[]}]}
    client_test.go:160: Volume created sucessfully. volumeId: a9b3d651-39c4-4018-8aea-f58f7eda0e2e
    client_test.go:180: Creating volume using the spec: types.CnsVolumeCreateSpec{
            Name:       "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
            VolumeType: "BLOCK",
            Datastores: nil,
            Metadata:   types.CnsVolumeMetadata{
                ContainerCluster: types.CnsContainerCluster{
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "OpenShift",
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    CapacityInMb: 5120,
                },
                BackingDiskId:      "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                BackingDiskUrlPath: "",
            },
            Profile:    nil,
            CreateSpec: nil,
        }
    client_test.go:201: reCreateVolumeOperationRes.: &types.CnsVolumeOperationResult{
            VolumeId: types.CnsVolumeId{},
            Fault:    &types.LocalizedMethodFault{
                Fault: types.CnsFault{
                    BaseMethodFault: nil,
                    Reason:          "could not update cns metadata for the existing CNS volume with id: a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                },
                LocalizedMessage: "CnsFault error: could not update cns metadata for the existing CNS volume with id: a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
            },
        }
    client_test.go:203: reCreateVolumeOperationRes.Fault: &types.LocalizedMethodFault{
            Fault: types.CnsFault{
                BaseMethodFault: nil,
                Reason:          "could not update cns metadata for the existing CNS volume with id: a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
            },
            LocalizedMessage: "CnsFault error: could not update cns metadata for the existing CNS volume with id: a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
        }
    client_test.go:218: Calling QueryVolume using queryFilter: types.CnsQueryFilter{
            VolumeIds: []types.CnsVolumeId{
                {
                    Id: "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                },
            },
            Names:                        nil,
            ContainerClusterIds:          nil,
            StoragePolicyId:              "",
            Datastores:                   nil,
            Labels:                       nil,
            ComplianceStatus:             "",
            DatastoreAccessibilityStatus: "",
            Cursor:                       (*types.CnsCursor)(nil),
            healthStatus:                 "",
        }
    client_test.go:224: Successfully Queried Volumes. queryResult: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                    },
                    DatastoreUrl:    "ds:///vmfs/volumes/vsan:52b2a856546dad28-790edbe992ed4030/",
                    Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:      "BLOCK",
                    StoragePolicyId: "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:        types.CnsVolumeMetadata{
                        ContainerCluster: types.CnsContainerCluster{
                            ClusterType:         "KUBERNETES",
                            ClusterId:           "demo-cluster-id",
                            VSphereUser:         "Administrator@vsphere.local",
                            ClusterFlavor:       "VANILLA",
                            ClusterDistribution: "OpenShift",
                        },
                        EntityMetadata:        nil,
                        ContainerClusterArray: []types.CnsContainerCluster{
                            {
                                ClusterType:         "KUBERNETES",
                                ClusterId:           "demo-cluster-id",
                                VSphereUser:         "Administrator@vsphere.local",
                                ClusterFlavor:       "VANILLA",
                                ClusterDistribution: "OpenShift",
                            },
                        },
                    },
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 5120,
                        },
                        BackingDiskId:      "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "green",
                },
            },
            Cursor: types.CnsCursor{
                Offset:       1,
                Limit:        100,
                TotalRecords: 1,
            },
        }
    client_test.go:230: Calling QueryVolumeInfo using: []types.CnsVolumeId{
            {
                Id: "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
            },
        }
    client_test.go:255: Successfully Queried Volumes. queryVolumeInfoTaskResult: &types.CnsQueryVolumeInfoResult{
            CnsVolumeOperationResult: types.CnsVolumeOperationResult{},
            VolumeInfo:               &types.CnsBlockVolumeInfo{
                CnsVolumeInfo:  types.CnsVolumeInfo{},
                VStorageObject: types.VStorageObject{
                    Config: types.VStorageObjectConfigInfo{
                        BaseConfigInfo: types.BaseConfigInfo{
                            Id: types.ID{
                                Id: "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                            },
                            Name:                        "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                            CreateTime:                  time.Now(),
                            KeepAfterDeleteVm:           types.NewBool(true),
                            RelocationDisabled:          types.NewBool(false),
                            NativeSnapshotSupported:     types.NewBool(false),
                            ChangedBlockTrackingEnabled: types.NewBool(false),
                            Backing:                     &types.BaseConfigInfoDiskFileBackingInfo{
                                BaseConfigInfoFileBackingInfo: types.BaseConfigInfoFileBackingInfo{
                                    BaseConfigInfoBackingInfo: types.BaseConfigInfoBackingInfo{
                                        Datastore: types.ManagedObjectReference{Type:"Datastore", Value:"datastore-36"},
                                    },
                                    FilePath:        "[vsanDatastore] 0309755f-fed5-5c1f-d141-0200ac0f5559/3609c2ae7b9c4d27a17d7f3b3e629e62.vmdk",
                                    BackingObjectId: "31ac905f-d054-6102-2a2d-0200ac78575f",
                                    Parent:          nil,
                                    DeltaSizeInMB:   0,
                                    KeyId:           (*types.CryptoKeyId)(nil),
                                },
                                ProvisioningType: "thin",
                            },
                            Iofilter: nil,
                        },
                        CapacityInMB:    5120,
                        ConsumptionType: []string{"disk"},
                        ConsumerId:      nil,
                    },
                },
            },
        }
    client_test.go:299: Extending volume using the spec: []types.CnsVolumeExtendSpec{
            {
                VolumeId: types.CnsVolumeId{
                    Id: "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                },
                CapacityInMb: 10240,
            },
        }
    client_test.go:324: Volume extended sucessfully. Volume ID: a9b3d651-39c4-4018-8aea-f58f7eda0e2e
    client_test.go:327: Calling QueryVolume after ExtendVolume using queryFilter: {DynamicData:{} VolumeIds:[{DynamicData:{} Id:a9b3d651-39c4-4018-8aea-f58f7eda0e2e}] Names:[] ContainerClusterIds:[] StoragePolicyId: Datastores:[] Labels:[] ComplianceStatus: DatastoreAccessibilityStatus: Cursor:<nil> healthStatus:}
    client_test.go:333: Successfully Queried Volumes after ExtendVolume. queryResult: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                    },
                    DatastoreUrl:    "ds:///vmfs/volumes/vsan:52b2a856546dad28-790edbe992ed4030/",
                    Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:      "BLOCK",
                    StoragePolicyId: "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:        types.CnsVolumeMetadata{
                        ContainerCluster: types.CnsContainerCluster{
                            ClusterType:         "KUBERNETES",
                            ClusterId:           "demo-cluster-id",
                            VSphereUser:         "Administrator@vsphere.local",
                            ClusterFlavor:       "VANILLA",
                            ClusterDistribution: "OpenShift",
                        },
                        EntityMetadata:        nil,
                        ContainerClusterArray: []types.CnsContainerCluster{
                            {
                                ClusterType:         "KUBERNETES",
                                ClusterId:           "demo-cluster-id",
                                VSphereUser:         "Administrator@vsphere.local",
                                ClusterFlavor:       "VANILLA",
                                ClusterDistribution: "OpenShift",
                            },
                        },
                    },
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 10240,
                        },
                        BackingDiskId:      "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "green",
                },
            },
            Cursor: types.CnsCursor{
                Offset:       1,
                Limit:        100,
                TotalRecords: 1,
            },
        }
    client_test.go:338: Volume extended sucessfully to the new size. Volume ID: a9b3d651-39c4-4018-8aea-f58f7eda0e2e New Size: 10240
    client_test.go:414: Updating volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:a9b3d651-39c4-4018-8aea-f58f7eda0e2e} Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType:KUBERNETES ClusterId:demo-cluster-id VSphereUser:Administrator@vsphere.local ClusterFlavor:VANILLA ClusterDistribution:OpenShift} EntityMetadata:[0xc000376c00 0xc000376c80 0xc000376d00] ContainerClusterArray:[{DynamicData:{} ClusterType:KUBERNETES ClusterId:demo-cluster-id VSphereUser:Administrator@vsphere.local ClusterFlavor:VANILLA ClusterDistribution:OpenShift}]}}
    client_test.go:439: Successfully updated volume metadata
    client_test.go:442: Calling QueryVolume using queryFilter: types.CnsQueryFilter{
            VolumeIds: []types.CnsVolumeId{
                {
                    Id: "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                },
            },
            Names:                        nil,
            ContainerClusterIds:          nil,
            StoragePolicyId:              "",
            Datastores:                   nil,
            Labels:                       nil,
            ComplianceStatus:             "",
            DatastoreAccessibilityStatus: "",
            Cursor:                       (*types.CnsCursor)(nil),
            healthStatus:                 "",
        }
    client_test.go:448: Successfully Queried Volumes. queryResult: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                    },
                    DatastoreUrl:    "ds:///vmfs/volumes/vsan:52b2a856546dad28-790edbe992ed4030/",
                    Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:      "BLOCK",
                    StoragePolicyId: "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:        types.CnsVolumeMetadata{
                        ContainerCluster: types.CnsContainerCluster{
                            ClusterType:         "KUBERNETES",
                            ClusterId:           "demo-cluster-id",
                            VSphereUser:         "Administrator@vsphere.local",
                            ClusterFlavor:       "VANILLA",
                            ClusterDistribution: "OpenShift",
                        },
                        EntityMetadata: []types.BaseCnsEntityMetadata{
                            &types.CnsKubernetesEntityMetadata{
                                CnsEntityMetadata: types.CnsEntityMetadata{
                                    EntityName: "example-pod",
                                    Labels:     nil,
                                    Delete:     false,
                                    ClusterID:  "demo-cluster-id",
                                },
                                EntityType:     "POD",
                                Namespace:      "default",
                                ReferredEntity: []types.CnsKubernetesEntityReference{
                                    {EntityType:"PERSISTENT_VOLUME_CLAIM", EntityName:"example-vanilla-block-pvc", Namespace:"default", ClusterID:"demo-cluster-id"},
                                },
                            },
                            &types.CnsKubernetesEntityMetadata{
                                CnsEntityMetadata: types.CnsEntityMetadata{
                                    EntityName: "example-vanilla-block-pvc",
                                    Labels:     []types.KeyValue{
                                        {
                                            Key:   "testLabel",
                                            Value: "testValue",
                                        },
                                    },
                                    Delete:    false,
                                    ClusterID: "demo-cluster-id",
                                },
                                EntityType:     "PERSISTENT_VOLUME_CLAIM",
                                Namespace:      "default",
                                ReferredEntity: []types.CnsKubernetesEntityReference{
                                    {EntityType:"PERSISTENT_VOLUME", EntityName:"pvc-53465372-5c12-4818-96f8-0ace4f4fd116", Namespace:"", ClusterID:"demo-cluster-id"},
                                },
                            },
                            &types.CnsKubernetesEntityMetadata{
                                CnsEntityMetadata: types.CnsEntityMetadata{
                                    EntityName: "pvc-53465372-5c12-4818-96f8-0ace4f4fd116",
                                    Labels:     []types.KeyValue{
                                        {
                                            Key:   "testLabel",
                                            Value: "testValue",
                                        },
                                    },
                                    Delete:    false,
                                    ClusterID: "demo-cluster-id",
                                },
                                EntityType:     "PERSISTENT_VOLUME",
                                Namespace:      "",
                                ReferredEntity: nil,
                            },
                        },
                        ContainerClusterArray: []types.CnsContainerCluster{
                            {
                                ClusterType:         "KUBERNETES",
                                ClusterId:           "demo-cluster-id",
                                VSphereUser:         "Administrator@vsphere.local",
                                ClusterFlavor:       "VANILLA",
                                ClusterDistribution: "OpenShift",
                            },
                        },
                    },
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 10240,
                        },
                        BackingDiskId:      "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "green",
                },
            },
            Cursor: types.CnsCursor{
                Offset:       1,
                Limit:        100,
                TotalRecords: 1,
            },
        }
    client_test.go:465: Successfully Queried all Volumes. queryResult: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "edac2a22-def5-4b21-9b3c-b78afb022ddb",
                    },
                    DatastoreUrl:         "",
                    Name:                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                    VolumeType:           "BLOCK",
                    StoragePolicyId:      "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:             types.CnsVolumeMetadata{},
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 200,
                        },
                        BackingDiskId:      "edac2a22-def5-4b21-9b3c-b78afb022ddb",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "",
                },
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "c49f311f-8e69-476f-a1e8-9bca75d62cfc",
                    },
                    DatastoreUrl:         "",
                    Name:                 "pvc-0836bc6b-8da7-4133-a94b-eede0b96bf33",
                    VolumeType:           "BLOCK",
                    StoragePolicyId:      "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:             types.CnsVolumeMetadata{},
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 200,
                        },
                        BackingDiskId:      "c49f311f-8e69-476f-a1e8-9bca75d62cfc",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "",
                },
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                    },
                    DatastoreUrl:         "",
                    Name:                 "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:           "BLOCK",
                    StoragePolicyId:      "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:             types.CnsVolumeMetadata{},
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 10240,
                        },
                        BackingDiskId:      "a9b3d651-39c4-4018-8aea-f58f7eda0e2e",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "",
                },
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "2c2d3791-22c2-43f3-8522-4733cfd5fb76",
                    },
                    DatastoreUrl:         "",
                    Name:                 "vol12",
                    VolumeType:           "BLOCK",
                    StoragePolicyId:      "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:             types.CnsVolumeMetadata{},
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 64,
                        },
                        BackingDiskId:      "2c2d3791-22c2-43f3-8522-4733cfd5fb76",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "",
                },
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "2f721747-ae4a-4f11-aa47-9dd7a212e84b",
                    },
                    DatastoreUrl:         "",
                    Name:                 "pvc-bfab1faf-04db-4a2a-83b2-1e44a6cdd740",
                    VolumeType:           "BLOCK",
                    StoragePolicyId:      "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:             types.CnsVolumeMetadata{},
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 200,
                        },
                        BackingDiskId:      "2f721747-ae4a-4f11-aa47-9dd7a212e84b",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "",
                },
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "a387618e-16b6-4823-a2ec-779be26ce1f0",
                    },
                    DatastoreUrl:         "",
                    Name:                 "pvc-3138fc0f-3998-4425-8ac2-a87049e56651",
                    VolumeType:           "BLOCK",
                    StoragePolicyId:      "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:             types.CnsVolumeMetadata{},
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 200,
                        },
                        BackingDiskId:      "a387618e-16b6-4823-a2ec-779be26ce1f0",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "",
                },
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "8cc20a9b-8eb3-4ca4-b3b9-d57acff16f49",
                    },
                    DatastoreUrl:         "",
                    Name:                 "vol12",
                    VolumeType:           "BLOCK",
                    StoragePolicyId:      "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:             types.CnsVolumeMetadata{},
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 64,
                        },
                        BackingDiskId:      "8cc20a9b-8eb3-4ca4-b3b9-d57acff16f49",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "",
                },
            },
            Cursor: types.CnsCursor{
                Offset:       7,
                Limit:        0,
                TotalRecords: 7,
            },
        }
    client_test.go:516: Node VM created sucessfully. vmRef: VirtualMachine:vm-52
    client_test.go:530: Attaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:a9b3d651-39c4-4018-8aea-f58f7eda0e2e} Vm:VirtualMachine:vm-52}
    client_test.go:555: Volume attached sucessfully. Disk UUID: 6000C296-2c3d-8e35-d835-095a9d993a10
    client_test.go:558: Re-Attaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:a9b3d651-39c4-4018-8aea-f58f7eda0e2e} Vm:VirtualMachine:vm-52}
    client_test.go:580: reAttachVolumeOperationRes.Fault: &types.LocalizedMethodFault{
            Fault: &types.ResourceInUse{
                VimFault: types.VimFault{},
                Type:     "",
                Name:     "volume",
            },
            LocalizedMessage: "The resource 'volume' is in use.",
        }
    client_test.go:598: Detaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:a9b3d651-39c4-4018-8aea-f58f7eda0e2e} Vm:VirtualMachine:vm-52}
    client_test.go:622: Volume detached sucessfully
    client_test.go:625: Deleting volume: [{DynamicData:{} Id:a9b3d651-39c4-4018-8aea-f58f7eda0e2e}]
    client_test.go:649: Volume: "a9b3d651-39c4-4018-8aea-f58f7eda0e2e" deleted sucessfully
PASS
ok  	github.com/vmware/govmomi/cns	12.390s
```
simulator test result:
```
lipingx-a01:simulator lipingx$ go test -v
=== RUN   TestSimulator
--- PASS: TestSimulator (0.05s)
    simulator_test.go:116: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:a9fe158a-423c-42a6-a149-c2c6484f6dcd} Fault:<nil>} Name:test PlacementResults:[{Datastore:Datastore:/var/folders/q6/vmy5pmc12vd9bq12y9t3_1g400_y41/T/govcsim-DC0-LocalDS_0-524194942@folder-5 PlacementFaults:[]}]}
PASS
ok  	github.com/vmware/govmomi/cns/simulator	0.134s

```