### PR TITLE
vcsim: QueryConfigOptionEx Spec is optional

### DIFF
--- a/govc/vm/option/info.go
+++ b/govc/vm/option/info.go
@@ -133,13 +133,21 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	req := types.QueryConfigOptionEx{
 		This: content[0].PropSet[0].Val.(types.ManagedObjectReference),
-		Spec: &types.EnvironmentBrowserConfigOptionQuerySpec{
-			GuestId: f.Args(),
-		},
+	}
+
+	spec := func() *types.EnvironmentBrowserConfigOptionQuerySpec {
+		if req.Spec == nil {
+			req.Spec = new(types.EnvironmentBrowserConfigOptionQuerySpec)
+		}
+		return req.Spec
+	}
+
+	if f.NArg() != 0 {
+		spec().GuestId = f.Args()
 	}
 
 	if host != nil {
-		req.Spec.Host = types.NewReference(host.Reference())
+		spec().Host = types.NewReference(host.Reference())
 	}
 
 	opt, err := methods.QueryConfigOptionEx(ctx, c, &req)

--- a/simulator/environment_browser.go
+++ b/simulator/environment_browser.go
@@ -90,18 +90,20 @@ func (b *EnvironmentBrowser) QueryConfigOptionEx(req *types.QueryConfigOptionEx)
 		DefaultDevice: esx.VirtualDevice,
 	}
 
-	// From the SDK QueryConfigOptionEx doc:
-	// "If guestId is nonempty, the guestOSDescriptor array of the config option is filtered to match against the guest IDs in the spec.
-	//  If there is no match, the whole list is returned."
-	for _, id := range req.Spec.GuestId {
-		for _, gid := range GuestID {
-			if string(gid) == id {
-				opt.GuestOSDescriptor = []types.GuestOsDescriptor{{
-					Id:     id,
-					Family: guestFamily(id),
-				}}
+	if req.Spec != nil {
+		// From the SDK QueryConfigOptionEx doc:
+		// "If guestId is nonempty, the guestOSDescriptor array of the config option is filtered to match against the guest IDs in the spec.
+		//  If there is no match, the whole list is returned."
+		for _, id := range req.Spec.GuestId {
+			for _, gid := range GuestID {
+				if string(gid) == id {
+					opt.GuestOSDescriptor = []types.GuestOsDescriptor{{
+						Id:     id,
+						Family: guestFamily(id),
+					}}
 
-				break
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
vcsim would panic if Spec is nil.

Change govc vm.option.info to set Spec only if needed,
providing coverage in the existing govc/test/vm.bats:vm.option.info test