### PR TITLE
govc: add dvs.portgroup.{add,change} '-auto-expand' flag

### DIFF
--- a/govc/dvs/portgroup/add.go
+++ b/govc/dvs/portgroup/add.go
@@ -53,6 +53,16 @@ func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
 func (cmd *add) Description() string {
 	return `Add portgroup to DVS.
 
+The '-type' options are defined by the dvs.DistributedVirtualPortgroup.PortgroupType API.
+The UI labels '-type' as "Port binding" with the following choices:
+    "Static binding":  earlyBinding
+    "Dynanic binding": lateBinding
+    "No binding":      ephemeral
+
+The '-auto-expand' option is labeled in the UI as "Port allocation".
+The default value is false, behaves as the UI labeled "Fixed" choice.
+When given '-auto-expand=true', behaves as the UI labeled "Elastic" choice.
+
 Examples:
   govc dvs.create DSwitch
   govc dvs.portgroup.add -dvs DSwitch -type earlyBinding -nports 16 ExternalNetwork

--- a/govc/dvs/portgroup/spec.go
+++ b/govc/dvs/portgroup/spec.go
@@ -63,6 +63,7 @@ func (spec *DVPortgroupConfigSpec) Register(ctx context.Context, f *flag.FlagSet
 	f.Var(flags.NewInt32(&vlanId), "vlan", "VLAN ID")
 	f.StringVar(&vlanRange, "vlan-range", "0-4094", "VLAN Ranges with comma delimited")
 	f.StringVar(&vlanMode, "vlan-mode", "vlan", fmt.Sprintf("vlan mode (%s)", strings.Join(vlanModes, "|")))
+	f.Var(flags.NewOptionalBool(&spec.AutoExpand), "auto-expand", "Ignore the limit on the number of ports")
 }
 
 func getRange(vlanRange string) []types.NumericRange {


### PR DESCRIPTION
Fixes #2119