### PR TITLE
Change CnsCreateVolume to return PlacementResult for static provisioning

### DIFF
--- a/cns/simulator/simulator.go
+++ b/cns/simulator/simulator.go
@@ -93,8 +93,16 @@ func (m *CnsVolumeManager) CnsCreateVolume(ctx context.Context, req *cnstypes.Cn
 				}
 
 				volumes[newVolume.VolumeId] = newVolume
-				operationResult = append(operationResult, &cnstypes.CnsVolumeOperationResult{
-					VolumeId: newVolume.VolumeId,
+				placementResults := []cnstypes.CnsPlacementResult{}
+				placementResults = append(placementResults, cnstypes.CnsPlacementResult{
+					Datastore: datastore.Reference(),
+				})
+				operationResult = append(operationResult, &cnstypes.CnsVolumeCreateResult{
+					CnsVolumeOperationResult: cnstypes.CnsVolumeOperationResult{
+						VolumeId: newVolume.VolumeId,
+					},
+					Name:             createSpec.Name,
+					PlacementResults: placementResults,
 				})
 
 			} else {

--- a/cns/simulator/simulator_test.go
+++ b/cns/simulator/simulator_test.go
@@ -30,8 +30,9 @@ import (
 )
 
 const (
-	testLabel = "testLabel"
-	testValue = "testValue"
+	testLabel              = "testLabel"
+	testValue              = "testValue"
+	simulatorBackingDiskID = "fake-volume-Handle"
 )
 
 func TestSimulator(t *testing.T) {
@@ -71,17 +72,20 @@ func TestSimulator(t *testing.T) {
 	// Get a simulator DS
 	datastore := simulator.Map.Any("Datastore").(*simulator.Datastore)
 
-	// Create
+	// Create volume for static provisioning
 	var capacityInMb int64 = 1024
-	createSpecList := []cnstypes.CnsVolumeCreateSpec{
+	createSpecListForStaticProvision := []cnstypes.CnsVolumeCreateSpec{
 		{
 			Name:       "test",
 			VolumeType: "TestVolumeType",
 			Datastores: []vim25types.ManagedObjectReference{
 				datastore.Self,
 			},
-			BackingObjectDetails: &cnstypes.CnsBackingObjectDetails{
-				CapacityInMb: capacityInMb,
+			BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+				CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{
+					CapacityInMb: capacityInMb,
+				},
+				BackingDiskId: simulatorBackingDiskID,
 			},
 			Profile: []vim25types.BaseVirtualMachineProfileSpec{
 				&vim25types.VirtualMachineDefinedProfileSpec{
@@ -90,7 +94,7 @@ func TestSimulator(t *testing.T) {
 			},
 		},
 	}
-	createTask, err := cnsClient.CreateVolume(ctx, createSpecList)
+	createTask, err := cnsClient.CreateVolume(ctx, createSpecListForStaticProvision)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,6 +117,75 @@ func TestSimulator(t *testing.T) {
 	}
 	volumeId := createVolumeOperationRes.VolumeId.Id
 	volumeCreateResult := (createTaskResult).(*cnstypes.CnsVolumeCreateResult)
+	t.Logf("volumeCreateResult %+v", volumeCreateResult)
+
+	// Delete the static provisioning volume
+	deleteVolumeList := []cnstypes.CnsVolumeId{
+		{
+			Id: volumeId,
+		},
+	}
+	deleteTask, err := cnsClient.DeleteVolume(ctx, deleteVolumeList, true)
+
+	deleteTaskInfo, err := cns.GetTaskInfo(ctx, deleteTask)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deleteTaskResult, err := cns.GetTaskResult(ctx, deleteTaskInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleteTaskResult == nil {
+		t.Fatalf("Empty delete task results")
+	}
+
+	deleteVolumeOperationRes := deleteTaskResult.GetCnsVolumeOperationResult()
+	if deleteVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to delete volume: fault=%+v", deleteVolumeOperationRes.Fault)
+	}
+
+	// Create
+	createSpecList := []cnstypes.CnsVolumeCreateSpec{
+		{
+			Name:       "test",
+			VolumeType: "TestVolumeType",
+			Datastores: []vim25types.ManagedObjectReference{
+				datastore.Self,
+			},
+			BackingObjectDetails: &cnstypes.CnsBackingObjectDetails{
+				CapacityInMb: capacityInMb,
+			},
+			Profile: []vim25types.BaseVirtualMachineProfileSpec{
+				&vim25types.VirtualMachineDefinedProfileSpec{
+					ProfileId: uuid.New().String(),
+				},
+			},
+		},
+	}
+	createTask, err = cnsClient.CreateVolume(ctx, createSpecList)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createTaskInfo, err = cns.GetTaskInfo(ctx, createTask)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createTaskResult, err = cns.GetTaskResult(ctx, createTaskInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if createTaskResult == nil {
+		t.Fatalf("Empty create task results")
+	}
+	createVolumeOperationRes = createTaskResult.GetCnsVolumeOperationResult()
+	if createVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to create volume: fault=%+v", createVolumeOperationRes.Fault)
+	}
+	volumeId = createVolumeOperationRes.VolumeId.Id
+	volumeCreateResult = (createTaskResult).(*cnstypes.CnsVolumeCreateResult)
 	t.Logf("volumeCreateResult %+v", volumeCreateResult)
 
 	// Extend
@@ -297,19 +370,19 @@ func TestSimulator(t *testing.T) {
 	}
 
 	// Delete
-	deleteVolumeList := []cnstypes.CnsVolumeId{
+	deleteVolumeList = []cnstypes.CnsVolumeId{
 		{
 			Id: volumeId,
 		},
 	}
-	deleteTask, err := cnsClient.DeleteVolume(ctx, deleteVolumeList, true)
+	deleteTask, err = cnsClient.DeleteVolume(ctx, deleteVolumeList, true)
 
-	deleteTaskInfo, err := cns.GetTaskInfo(ctx, deleteTask)
+	deleteTaskInfo, err = cns.GetTaskInfo(ctx, deleteTask)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	deleteTaskResult, err := cns.GetTaskResult(ctx, deleteTaskInfo)
+	deleteTaskResult, err = cns.GetTaskResult(ctx, deleteTaskInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -317,7 +390,7 @@ func TestSimulator(t *testing.T) {
 		t.Fatalf("Empty delete task results")
 	}
 
-	deleteVolumeOperationRes := deleteTaskResult.GetCnsVolumeOperationResult()
+	deleteVolumeOperationRes = deleteTaskResult.GetCnsVolumeOperationResult()
 	if deleteVolumeOperationRes.Fault != nil {
 		t.Fatalf("Failed to delete volume: fault=%+v", deleteVolumeOperationRes.Fault)
 	}


### PR DESCRIPTION
This change is to make CnsCreateVolume to return PlacementResult for static provisioning. Also add unit test for this case.

Test Result:
```
lipingx-a01:simulator lipingx$ go test -v .
=== RUN   TestSimulator
--- PASS: TestSimulator (0.06s)
    simulator_test.go:120: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:fake-volume-Handle} Fault:<nil>} Name:test PlacementResults:[{Datastore:Datastore:/var/folders/q6/vmy5pmc12vd9bq12y9t3_1g400_y41/T/govcsim-DC0-LocalDS_0-382707820@folder-5 PlacementFaults:[]}]}
    simulator_test.go:189: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:f598b2ed-dea2-49c2-b61e-195a3c36747f} Fault:<nil>} Name:test PlacementResults:[{Datastore:Datastore:/var/folders/q6/vmy5pmc12vd9bq12y9t3_1g400_y41/T/govcsim-DC0-LocalDS_0-382707820@folder-5 PlacementFaults:[]}]}
PASS
ok  	github.com/vmware/govmomi/cns/simulator	0.660s

```