### PR TITLE
Add Configure ACL go bindings

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -192,3 +192,16 @@ func (c *Client) RelocateVolume(ctx context.Context, relocateSpecs ...cnstypes.B
 	}
 	return object.NewTask(c.vim25Client, res.Returnval), nil
 }
+
+// ConfigureVolumeACLs calls the CNS Configure ACL API.
+func (c *Client) ConfigureVolumeACLs(ctx context.Context, aclConfigSpecs ...cnstypes.CnsVolumeACLConfigureSpec) (*object.Task, error) {
+	req := cnstypes.CnsConfigureVolumeACLs{
+		This:           CnsVolumeManagerInstance,
+		ACLConfigSpecs: aclConfigSpecs,
+	}
+	res, err := methods.CnsConfigureVolumeACLs(ctx, c.serviceClient, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(c.vim25Client, res.Returnval), nil
+}

--- a/cns/methods/methods.go
+++ b/cns/methods/methods.go
@@ -220,3 +220,23 @@ func CnsRelocateVolume(ctx context.Context, r soap.RoundTripper, req *types.CnsR
 
 	return resBody.Res, nil
 }
+
+type CnsConfigureVolumeACLsBody struct {
+	Req    *types.CnsConfigureVolumeACLs         `xml:"urn:vsan CnsConfigureVolumeACLs,omitempty"`
+	Res    *types.CnsConfigureVolumeACLsResponse `xml:"urn:vsan CnsConfigureVolumeACLsResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsConfigureVolumeACLsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsConfigureVolumeACLs(ctx context.Context, r soap.RoundTripper, req *types.CnsConfigureVolumeACLs) (*types.CnsConfigureVolumeACLsResponse, error) {
+	var reqBody, resBody CnsConfigureVolumeACLsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -594,3 +594,46 @@ type CnsAlreadyRegisteredFault struct {
 func init() {
 	types.Add("CnsAlreadyRegisteredFault", reflect.TypeOf((*CnsAlreadyRegisteredFault)(nil)).Elem())
 }
+
+type CnsConfigureVolumeACLs CnsConfigureVolumeACLsRequestType
+
+func init() {
+	types.Add("vsan:CnsConfigureVolumeACLs", reflect.TypeOf((*CnsConfigureVolumeACLs)(nil)).Elem())
+}
+
+type CnsConfigureVolumeACLsRequestType struct {
+	This           types.ManagedObjectReference `xml:"_this"`
+	ACLConfigSpecs []CnsVolumeACLConfigureSpec  `xml:"ACLConfigSpecs"`
+}
+
+func init() {
+	types.Add("vsan:CnsConfigureVolumeACLsRequestType", reflect.TypeOf((*CnsConfigureVolumeACLsRequestType)(nil)).Elem())
+}
+
+type CnsConfigureVolumeACLsResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type CnsVolumeACLConfigureSpec struct {
+	types.DynamicData
+
+	VolumeId              CnsVolumeId                `xml:"volumeId"`
+	AccessControlSpecList []BaseCnsAccessControlSpec `xml:"accessControlSpecList,typeattr"`
+}
+
+func init() {
+	types.Add("vsan:CnsVolumeACLConfigureSpec", reflect.TypeOf((*CnsVolumeACLConfigureSpec)(nil)).Elem())
+}
+func (b *CnsAccessControlSpec) GetCnsAccessControlSpec() *CnsAccessControlSpec { return b }
+
+type BaseCnsAccessControlSpec interface {
+	GetCnsAccessControlSpec() *CnsAccessControlSpec
+}
+
+type CnsAccessControlSpec struct {
+	types.DynamicData
+}
+
+func init() {
+	types.Add("vsan:CnsAccessControlSpec", reflect.TypeOf((*CnsAccessControlSpec)(nil)).Elem())
+}


### PR DESCRIPTION
This pull request is adding a go binding for new CNS API `CnsConfigureVolumeACLs`.

CnsConfigureVolumeACLs will modify the ACL configurations for existing volumes and this API is currently supported for file volumes