### PR TITLE
vcsim: fixes for PowerCLI Get-VirtualNetwork

### DIFF
--- a/gen/vim_wsdl.rb
+++ b/gen/vim_wsdl.rb
@@ -206,7 +206,7 @@ class Simple
 
   def pointer_type?
     ["UnitNumber"].include?(var_name) or
-      optional? && ["OwnerId", "GroupId", "MaxWaitSeconds", "Reservation", "Limit", "OverheadLimit", "ResourceReductionToToleratePercent"].include?(var_name)
+      optional? && ["IpPoolId", "OwnerId", "GroupId", "MaxWaitSeconds", "Reservation", "Limit", "OverheadLimit", "ResourceReductionToToleratePercent"].include?(var_name)
   end
 
   def var_type

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -12,6 +12,26 @@ load test_helper
   ruby ./vcsim_test.rb "$(govc env -x GOVC_URL_PORT)"
 }
 
+@test "vcsim powercli" {
+  if ! docker version ; then
+    skip "docker client not installed"
+  fi
+
+  vcsim_env -l 0.0.0.0:0
+
+  server=$(govc env -x GOVC_URL_HOST)
+  port=$(govc env -x GOVC_URL_PORT)
+
+  docker run --rm vmware/powerclicore /usr/bin/pwsh -f - <<EOF
+Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -confirm:\$false | Out-Null
+Connect-VIServer -Server $server -Port $port -User user -Password pass
+
+Get-VM
+Get-VIEvent
+Get-VirtualNetwork
+EOF
+}
+
 @test "vcsim examples" {
   vcsim_env
 

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -618,6 +618,7 @@ func (f *Folder) CreateDVSTask(ctx *Context, req *types.CreateDVS_Task) soap.Has
 		dvs.AddDVPortgroupTask(ctx, &types.AddDVPortgroup_Task{
 			Spec: []types.DVPortgroupConfigSpec{{
 				Name: dvs.Name + "-DVUplinks" + strings.TrimPrefix(dvs.Self.Value, "dvs"),
+				Type: string(types.DistributedVirtualPortgroupPortgroupTypeEarlyBinding),
 				DefaultPortConfig: &types.VMwareDVSPortSetting{
 					Vlan: &types.VmwareDistributedVirtualSwitchTrunkVlanSpec{
 						VlanId: []types.NumericRange{{Start: 0, End: 4094}},

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -618,8 +618,12 @@ func (m *Model) Create() error {
 
 		for npg := 0; npg < m.Portgroup; npg++ {
 			name := m.fmtName(dcName+"_DVPG", npg)
+			spec := types.DVPortgroupConfigSpec{
+				Name: name,
+				Type: string(types.DistributedVirtualPortgroupPortgroupTypeEarlyBinding),
+			}
 
-			task, err := dvs.AddPortgroup(ctx, []types.DVPortgroupConfigSpec{{Name: name}})
+			task, err := dvs.AddPortgroup(ctx, []types.DVPortgroupConfigSpec{spec})
 			if err != nil {
 				return err
 			}
@@ -642,6 +646,7 @@ func (m *Model) Create() error {
 			spec := types.DVPortgroupConfigSpec{
 				Name:              name,
 				LogicalSwitchUuid: uuid.New().String(),
+				Type:              string(types.DistributedVirtualPortgroupPortgroupTypeEarlyBinding),
 			}
 
 			task, err := dvs.AddPortgroup(ctx, []types.DVPortgroupConfigSpec{spec})

--- a/sts/simulator/simulator.go
+++ b/sts/simulator/simulator.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/vmware/govmomi/simulator"
@@ -57,6 +58,8 @@ type handler struct{}
 // ServeHTTP handles STS requests.
 func (s *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	action := r.Header.Get("SOAPAction")
+	action = strings.TrimSuffix(action, `"`) // PowerCLI sts client quotes the header value
+
 	env := soap.Envelope{}
 	now := time.Now()
 	lifetime := &internal.Lifetime{

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -32821,7 +32821,7 @@ type NetworkSummary struct {
 	Name       string                  `xml:"name"`
 	Accessible bool                    `xml:"accessible"`
 	IpPoolName string                  `xml:"ipPoolName"`
-	IpPoolId   int32                   `xml:"ipPoolId,omitempty"`
+	IpPoolId   *int32                  `xml:"ipPoolId"`
 }
 
 func init() {


### PR DESCRIPTION
- The PowerCLI sts client double quotes the SOAP-Action header, resulting in:
  sts: unsupported action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"

- NetworkSummary.IpPoolId needs to be empty if the network is not associated with an IP pool

- Set the required field DistributedVirtualPortgroup.Config.Type