### PR TITLE
ExampleCollector_Retrieve: Add missing err return

### DIFF
--- a/property/example_test.go
+++ b/property/example_test.go
@@ -66,6 +66,10 @@ func ExampleCollector_Retrieve() {
 
 		var vms []mo.VirtualMachine
 		err = pc.Retrieve(ctx, host.Vm, []string{"name"}, &vms)
+		if err != nil {
+			return err
+		}
+
 		fmt.Printf("host has %d vms:", len(vms))
 		for i := range vms {
 			fmt.Print(" ", vms[i].Name)


### PR DESCRIPTION
Mirror the error return used earlier in this example. `golint` noted the omission when I copied the example locally to examine return values:

```
ineffectual assignment to `err` (ineffassign)
```