### PR TITLE
Updated projects to include VMware Event Broker Appliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Refer to the [CHANGELOG](CHANGELOG.md) for version to version changes.
 
 * [OPS](https://github.com/nanovms/ops)
 
+* [VMware Event Broker Appliance](https://github.com/vmware-samples/vcenter-event-broker-appliance/tree/development/vmware-event-router)
+
 ## Related projects
 
 * [rbvmomi](https://github.com/vmware/rbvmomi)


### PR DESCRIPTION
The [VMware Event Router](https://github.com/vmware-samples/vcenter-event-broker-appliance/tree/development/vmware-event-router) component within the [VMware Event Broker Appliance (VEBA) project](https://github.com/vmware-samples/vcenter-event-broker-appliance) utilizes govmomi.  

cc @embano1 

Signed-off-by: William Lam <wlam@vmware.com>