### PR TITLE
vcsim: record/replay EnvironmentBrowser.QueryConfigOption

### DIFF
--- a/govc/object/save.go
+++ b/govc/object/save.go
@@ -112,9 +112,18 @@ func saveDVS(ctx context.Context, c *vim25.Client, ref types.ManagedObjectRefere
 	return []saveMethod{{"FetchDVPorts", res}}, nil
 }
 
+func saveEnvironmentBrowser(ctx context.Context, c *vim25.Client, ref types.ManagedObjectReference) ([]saveMethod, error) {
+	res, err := methods.QueryConfigOption(ctx, c, &types.QueryConfigOption{This: ref})
+	if err != nil {
+		return nil, err
+	}
+	return []saveMethod{{"QueryConfigOption", res}}, nil
+}
+
 // saveObjects maps object types to functions that can save data that isn't available via the PropertyCollector
 var saveObjects = map[string]func(context.Context, *vim25.Client, types.ManagedObjectReference) ([]saveMethod, error){
 	"VmwareDistributedVirtualSwitch": saveDVS,
+	"EnvironmentBrowser":             saveEnvironmentBrowser,
 }
 
 func (cmd *save) save(content []types.ObjectContent) error {

--- a/simulator/environment_browser.go
+++ b/simulator/environment_browser.go
@@ -28,6 +28,8 @@ import (
 
 type EnvironmentBrowser struct {
 	mo.EnvironmentBrowser
+
+	types.QueryConfigOptionResponse
 }
 
 func newEnvironmentBrowser() *types.ManagedObjectReference {
@@ -57,9 +59,12 @@ func (b *EnvironmentBrowser) hosts(ctx *Context) []types.ManagedObjectReference 
 func (b *EnvironmentBrowser) QueryConfigOption(req *types.QueryConfigOption) soap.HasFault {
 	body := new(methods.QueryConfigOptionBody)
 
-	opt := &types.VirtualMachineConfigOption{
-		Version:       esx.HardwareVersion,
-		DefaultDevice: esx.VirtualDevice,
+	opt := b.QueryConfigOptionResponse.Returnval
+	if opt == nil {
+		opt = &types.VirtualMachineConfigOption{
+			Version:       esx.HardwareVersion,
+			DefaultDevice: esx.VirtualDevice,
+		}
 	}
 
 	body.Res = &types.QueryConfigOptionResponse{
@@ -85,9 +90,12 @@ func guestFamily(id string) string {
 func (b *EnvironmentBrowser) QueryConfigOptionEx(req *types.QueryConfigOptionEx) soap.HasFault {
 	body := new(methods.QueryConfigOptionExBody)
 
-	opt := &types.VirtualMachineConfigOption{
-		Version:       esx.HardwareVersion,
-		DefaultDevice: esx.VirtualDevice,
+	opt := b.QueryConfigOptionResponse.Returnval
+	if opt == nil {
+		opt = &types.VirtualMachineConfigOption{
+			Version:       esx.HardwareVersion,
+			DefaultDevice: esx.VirtualDevice,
+		}
 	}
 
 	if req.Spec != nil {


### PR DESCRIPTION
By default vcsim's QueryConfigOption has a very minimal response.
With this change, record/replay includes the entire structure.

Fixes #2228