### PR TITLE
vcsim: escape datastore name

### DIFF
--- a/simulator/datastore.go
+++ b/simulator/datastore.go
@@ -40,7 +40,7 @@ func (ds *Datastore) model(m *Model) error {
 		// rewrite saved vmfs path to a local temp dir
 		u.Path = path.Clean(u.Path)
 		parent := strings.ReplaceAll(path.Dir(u.Path), "/", "_")
-		name := path.Base(u.Path)
+		name := strings.ReplaceAll(path.Base(u.Path), ":", "_")
 
 		dir, err := m.createTempDir(parent, name)
 		if err != nil {


### PR DESCRIPTION
The vmfs path from a saved inventory may include a ':', e.g. 'vsan:52eb3a2d910-...'

Fixes #2231