### PR TITLE
Example doc comments update using API docs content

### DIFF
--- a/vim25/mo/mo.go
+++ b/vim25/mo/mo.go
@@ -1231,6 +1231,12 @@ func init() {
 	t["LocalizationManager"] = reflect.TypeOf((*LocalizationManager)(nil)).Elem()
 }
 
+// ManagedEntity is an abstract base type for all managed objects present in
+// the inventory tree. The base type provides common functionality for
+// traversing the tree structure, as well as health monitoring and other basic
+// functions.
+//
+// Most Virtual Infrastructure managed object types extend this type.
 type ManagedEntity struct {
 	ExtensibleManagedObject
 


### PR DESCRIPTION
I'm new to the API and this package and am learning my way around both. The main project README helpfully directs the reader to the API docs for more information (thanks for that). That said, is there any interest in adding documentation directly in this package as doc comments? I'm going to guess "no", but I thought it would be worth asking to be sure.

This commit (and subsequent PR) is an example of what I'm referring to. Here, I copied the content 1:1 from the API documentation.

Thanks in advance for your feedback.

refs https://vdc-download.vmware.com/vmwb-repository/dcr-public/a5f4000f-1ea8-48a9-9221-586adff3c557/7ff50256-2cf2-45ea-aacd-87d231ab1ac7/vim.ManagedEntity.html