### PR TITLE
Fix govc device.pci.add: incorrect DeviceID value

### DIFF
--- a/govc/device/pci/add.go
+++ b/govc/device/pci/add.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"strconv"
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
@@ -130,7 +129,7 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 		device := &types.VirtualPCIPassthrough{}
 		device.Backing = &types.VirtualPCIPassthroughDeviceBackingInfo{
-			Id: d.PciDevice.Id, DeviceId: strconv.Itoa(int(d.PciDevice.DeviceId)),
+			Id: d.PciDevice.Id, DeviceId: fmt.Sprintf("%x", d.PciDevice.DeviceId),
 			SystemId: d.SystemId, VendorId: d.PciDevice.VendorId,
 		}
 		device.Connectable = &types.VirtualDeviceConnectInfo{StartConnected: true, Connected: true}


### PR DESCRIPTION
As described in the issue https://github.com/vmware/govmomi/issues/2248,

`DeviceId` string attribute of `VirtualPCIPassthroughDeviceBackingInfo` object should contain the hexadecimal value of PCI device's DeviceID instead of decimal value.

Passing the decimal value does not lead to a govc execution error but prevents the targeted virtual machine boot as the real PCI device's DeviceID does not match the one stored in virtual machine VMX data.

This fix has been tested on 7.0u1 and 6.7.0u3 ESXi hosts and resolved the issue on both 2 hosts.