### PR TITLE
Update ConfigureVolumeACLs bindings in cns types

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -617,23 +617,15 @@ type CnsConfigureVolumeACLsResponse struct {
 type CnsVolumeACLConfigureSpec struct {
 	types.DynamicData
 
-	VolumeId              CnsVolumeId                `xml:"volumeId"`
-	AccessControlSpecList []BaseCnsAccessControlSpec `xml:"accessControlSpecList,typeattr"`
+	VolumeId              CnsVolumeId               `xml:"volumeId"`
+	AccessControlSpecList []CnsNFSAccessControlSpec `xml:"accessControlSpecList,typeattr"`
 }
 
-func init() {
-	types.Add("vsan:CnsVolumeACLConfigureSpec", reflect.TypeOf((*CnsVolumeACLConfigureSpec)(nil)).Elem())
-}
-func (b *CnsAccessControlSpec) GetCnsAccessControlSpec() *CnsAccessControlSpec { return b }
-
-type BaseCnsAccessControlSpec interface {
-	GetCnsAccessControlSpec() *CnsAccessControlSpec
-}
-
-type CnsAccessControlSpec struct {
+type CnsNFSAccessControlSpec struct {
 	types.DynamicData
+	Permission []vsanfstypes.VsanFileShareNetPermission `xml:"netPermission,omitempty,typeattr"`
 }
 
 func init() {
-	types.Add("vsan:CnsAccessControlSpec", reflect.TypeOf((*CnsAccessControlSpec)(nil)).Elem())
+	types.Add("CnsNFSAccessControlSpec", reflect.TypeOf((*CnsNFSAccessControlSpec)(nil)).Elem())
 }


### PR DESCRIPTION
This PR is updating the fields for ConfigureVolume ACLs API bindings in CNS types.
With this change we will be able to invoke ConfigureVolumeACL API using CNS client.

Updated the file volume test in cns/client_test.go and verified that the new fields/types work as expected and invoke the API correctly.

```
chethanv-a01:cns chethanv$ go test -v
# github.com/vmware/govmomi/cns [github.com/vmware/govmomi/cns.test]
./client_test.go:60:2: datastoreForMigration declared but not used
./client_test.go:65:2: resporcePoolPath declared but not used
FAIL    github.com/vmware/govmomi/cns [build failed]
chethanv-a01:cns chethanv$ go test -v
=== RUN   TestClient
    client_test.go:682: Creating CNS file volume using the spec: {DynamicData:{} Name:pvc-file-share-volume VolumeType:FILE Datastores:[Datastore:datastore-42] Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType:KUBERNETES ClusterId:demo-cluster-id VSphereUser:Administrator@vsphere.local ClusterFlavor:VANILLA ClusterDistribution:OpenShift} EntityMetadata:[] ContainerClusterArray:[{DynamicData:{} ClusterType:KUBERNETES ClusterId:demo-cluster-id VSphereUser:Administrator@vsphere.local ClusterFlavor:VANILLA ClusterDistribution:OpenShift}]} BackingObjectDetails:0xc0003c0780 Profile:[] CreateSpec:0xc0003afd80}
    client_test.go:707: Fileshare volume created sucessfully. filevolumeId: file:0a81aea1-41c5-4e08-bf76-cd7a0f6f772a
    client_test.go:712: Calling QueryVolume using queryFilter: {DynamicData:{} VolumeIds:[{DynamicData:{} Id:file:0a81aea1-41c5-4e08-bf76-cd7a0f6f772a}] Names:[] ContainerClusterIds:[] StoragePolicyId: Datastores:[] Labels:[] ComplianceStatus: DatastoreAccessibilityStatus: Cursor:<nil> healthStatus:}
    client_test.go:718: Successfully Queried Volumes. queryResult: &{DynamicData:{} Volumes:[{DynamicData:{} VolumeId:{DynamicData:{} Id:file:0a81aea1-41c5-4e08-bf76-cd7a0f6f772a} DatastoreUrl:ds:///vmfs/volumes/vsan:52327ce34a37382f-8d36b0a82dc5c3f6/ Name:pvc-file-share-volume VolumeType:FILE StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType:KUBERNETES ClusterId:demo-cluster-id VSphereUser:Administrator@vsphere.local ClusterFlavor:VANILLA ClusterDistribution:OpenShift} EntityMetadata:[] ContainerClusterArray:[{DynamicData:{} ClusterType:KUBERNETES ClusterId:demo-cluster-id VSphereUser:Administrator@vsphere.local ClusterFlavor:VANILLA ClusterDistribution:OpenShift}]} BackingObjectDetails:0xc0003c18c0 ComplianceStatus:compliant DatastoreAccessibilityStatus:notApplicable HealthStatus:unknown}] Cursor:{DynamicData:{} Offset:1 Limit:100 TotalRecords:1}}
    client_test.go:720: File Share Name: 52aba773-0053-57a4-7f39-c55b1bedcdc9 with accessPoints: [{DynamicData:{} Key:NFSv4.1 Value:h172-16-10-10.chethanvtest.testdomain:/vsanfs/52aba773-0053-57a4-7f39-c55b1bedcdc9} {DynamicData:{} Key:NFSv3 Value:h172-16-10-11.chethanvtest.testdomain:/52aba773-0053-57a4-7f39-c55b1bedcdc9}]
    client_test.go:743: Invoking ConfigureVolumeACLs using the spec: types.CnsVolumeACLConfigureSpec{
            VolumeId: types.CnsVolumeId{
                Id: "file:0a81aea1-41c5-4e08-bf76-cd7a0f6f772a",
            },
            AccessControlSpecList: []types.CnsNFSAccessControlSpec{
                {
                    Permission: []types.VsanFileShareNetPermission{
                        {Ips:"192.168.124.2", Permissions:"READ_ONLY", AllowRoot:false},
                    },
                },
            },
        }
    client_test.go:767: Deleting fileshare volume: [{DynamicData:{} Id:file:0a81aea1-41c5-4e08-bf76-cd7a0f6f772a}]
    client_test.go:791: fileshare volume:"file:0a81aea1-41c5-4e08-bf76-cd7a0f6f772a" deleted sucessfully
--- PASS: TestClient (70.71s)
PASS
```