### PR TITLE
Update .goreleaser.yml for support a new cpu architecture 

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
     - amd64
     - 386
     - arm64
+    - mips64le
   env:
     - CGO_ENABLED=0
   main: ./govc/main.go
@@ -27,6 +28,7 @@ builds:
     - amd64
     - 386
     - arm64
+    - mips64le
   env:
     - CGO_ENABLED=0
   main: ./vcsim/main.go


### PR DESCRIPTION
hello，I am going to submit mips64le architecture，The main reasons for adding support for mips64le architecture are:
1、The mips64le architecture is also the mainstream cpu architecture (amd64, arm64), which is used by many users;
2、Golang supports cross compilation, and mips64le is officially supported.
3、This project is an underlying dependency library of the kubernetes project  [k/k](https://github.com/kubernetes/kubernetes), therefore I wish to submit this patch.
Therefore, I hope that the release package also supports the mips64le architecture, which is convenient for more users.
Signed-off-by: houfangdong houfangdong@loongson.com

