### PR TITLE
Add vSAN 7.0U1 release constant

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -36,6 +36,7 @@ const (
 const (
 	ReleaseVSAN67u3 = "vSAN 6.7U3"
 	ReleaseVSAN70   = "7.0"
+	ReleaseVSAN70u1 = "vSAN 7.0U1"
 )
 
 var (


### PR DESCRIPTION
This PR adds a constant for vSAN 7.0U1 release. This version will be used by CSI, just like for older versions.

![Screen Shot 2021-02-08 at 2 11 49 PM](https://user-images.githubusercontent.com/5894281/107288362-307a1a80-6a18-11eb-8a9b-e889861a3f8a.png)
