### PR TITLE
Fix data race issue from vim.25/retry code

### DIFF
--- a/vim25/retry.go
+++ b/vim25/retry.go
@@ -60,7 +60,8 @@ type retry struct {
 	// fn is a custom function that is called when an error occurs.
 	// It returns whether or not to retry, and if so, how long to
 	// delay before retrying.
-	fn RetryFunc
+	fn               RetryFunc
+	maxRetryAttempts int
 }
 
 // Retry wraps the specified soap.RoundTripper and invokes the
@@ -70,8 +71,24 @@ type retry struct {
 // is returned from the RoundTrip function.
 func Retry(roundTripper soap.RoundTripper, fn RetryFunc) soap.RoundTripper {
 	r := &retry{
-		roundTripper: roundTripper,
-		fn:           fn,
+		roundTripper:     roundTripper,
+		fn:               fn,
+		maxRetryAttempts: 0,
+	}
+
+	return r
+}
+
+// RetryWithAttempts wraps the specified soap.RoundTripper and invokes the
+// specified RetryFunc. The RetryFunc returns whether or not to
+// retry the call, and if so, how long to wait before retrying. If
+// the result of this function is to not retry, the original error
+// is returned from the RoundTrip function.
+func RetryWithAttempts(roundTripper soap.RoundTripper, fn RetryFunc, retryAttempts int) soap.RoundTripper {
+	r := &retry{
+		roundTripper:     roundTripper,
+		fn:               fn,
+		maxRetryAttempts: retryAttempts,
 	}
 
 	return r
@@ -79,7 +96,9 @@ func Retry(roundTripper soap.RoundTripper, fn RetryFunc) soap.RoundTripper {
 
 func (r *retry) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
 	var err error
-
+	if r.maxRetryAttempts != 0 {
+		return r.roundTripWithAttempts(ctx, req, res)
+	}
 	for {
 		err = r.roundTripper.RoundTrip(ctx, req, res)
 		if err == nil {
@@ -91,8 +110,26 @@ func (r *retry) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
 			time.Sleep(delay)
 			continue
 		}
-
 		break
+	}
+
+	return err
+}
+
+func (r *retry) roundTripWithAttempts(ctx context.Context, req, res soap.HasFault) error {
+	var err error
+
+	for attempt := 0; attempt < r.maxRetryAttempts; attempt++ {
+		err = r.roundTripper.RoundTrip(ctx, req, res)
+		if err == nil {
+			break
+		}
+
+		// Invoke retry function to see if another attempt should be made.
+		if retry, delay := r.fn(err); retry {
+			time.Sleep(delay)
+			continue
+		}
 	}
 
 	return err


### PR DESCRIPTION
Issue: Data race at vim25/retry.go:49 vmware#2266

Fix:
To maintain backward compatibility introduced new optional
variable in retry struct and new function with parameter
retryAttempts.