### PR TITLE
vim25: fix race in TemporaryNetworkError retry func

### DIFF
--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -371,7 +371,7 @@ func (flag *ClientFlag) Client() (*vim25.Client, error) {
 
 	// Retry twice when a temporary I/O error occurs.
 	// This means a maximum of 3 attempts.
-	c.RoundTripper = vim25.Retry(c.Client, vim25.TemporaryNetworkError(3))
+	c.RoundTripper = vim25.Retry(c.Client, vim25.RetryTemporaryNetworkError, 3)
 	flag.client = c
 
 	return flag.client, nil

--- a/session/keep_alive_test.go
+++ b/session/keep_alive_test.go
@@ -40,7 +40,7 @@ func TestKeepAlive(t *testing.T) {
 
 		var mu sync.Mutex
 		n := 0
-		c.RoundTripper = vim25.Retry(c.Client, vim25.TemporaryNetworkError(3))
+		c.RoundTripper = vim25.Retry(c.Client, vim25.RetryTemporaryNetworkError, 3)
 		c.RoundTripper = session.KeepAliveHandler(c.RoundTripper, time.Millisecond, func(soap.RoundTripper) error {
 			mu.Lock()
 			n++

--- a/vim25/retry.go
+++ b/vim25/retry.go
@@ -25,33 +25,40 @@ import (
 
 type RetryFunc func(err error) (retry bool, delay time.Duration)
 
-// TemporaryNetworkError returns a RetryFunc that retries up to a maximum of n
-// times, only if the error returned by the RoundTrip function is a temporary
-// network error (for example: a connect timeout).
+// TemporaryNetworkError is deprecated. Use Retry() with RetryTemporaryNetworkError and retryAttempts instead.
 func TemporaryNetworkError(n int) RetryFunc {
-	return func(err error) (retry bool, delay time.Duration) {
-		var ok bool
-
-		t, ok := err.(interface {
-			// Temporary is implemented by url.Error and net.Error
-			Temporary() bool
-		})
-		if !ok {
-			// Never retry if this is not a Temporary error.
-			return false, 0
+	return func(err error) (bool, time.Duration) {
+		if IsTemporaryNetworkError(err) {
+			// Don't retry if we're out of tries.
+			if n--; n <= 0 {
+				return false, 0
+			}
+			return true, 0
 		}
-
-		if !t.Temporary() {
-			return false, 0
-		}
-
-		// Don't retry if we're out of tries.
-		if n--; n <= 0 {
-			return false, 0
-		}
-
-		return true, 0
+		return false, 0
 	}
+}
+
+// RetryTemporaryNetworkError returns a RetryFunc that returns IsTemporaryNetworkError(err)
+func RetryTemporaryNetworkError(err error) (bool, time.Duration) {
+	return IsTemporaryNetworkError(err), 0
+}
+
+// IsTemporaryNetworkError returns false unless the error implements
+// a Temporary() bool method such as url.Error and net.Error.
+// Otherwise, returns the value of the Temporary() method.
+func IsTemporaryNetworkError(err error) bool {
+	t, ok := err.(interface {
+		// Temporary is implemented by url.Error and net.Error
+		Temporary() bool
+	})
+
+	if !ok {
+		// Not a Temporary error.
+		return false
+	}
+
+	return t.Temporary()
 }
 
 type retry struct {
@@ -60,7 +67,8 @@ type retry struct {
 	// fn is a custom function that is called when an error occurs.
 	// It returns whether or not to retry, and if so, how long to
 	// delay before retrying.
-	fn RetryFunc
+	fn               RetryFunc
+	maxRetryAttempts int
 }
 
 // Retry wraps the specified soap.RoundTripper and invokes the
@@ -68,10 +76,16 @@ type retry struct {
 // retry the call, and if so, how long to wait before retrying. If
 // the result of this function is to not retry, the original error
 // is returned from the RoundTrip function.
-func Retry(roundTripper soap.RoundTripper, fn RetryFunc) soap.RoundTripper {
+// The soap.RoundTripper will return the original error if retryAttempts is specified and reached.
+func Retry(roundTripper soap.RoundTripper, fn RetryFunc, retryAttempts ...int) soap.RoundTripper {
 	r := &retry{
-		roundTripper: roundTripper,
-		fn:           fn,
+		roundTripper:     roundTripper,
+		fn:               fn,
+		maxRetryAttempts: 1,
+	}
+
+	if len(retryAttempts) == 1 {
+		r.maxRetryAttempts = retryAttempts[0]
 	}
 
 	return r
@@ -80,7 +94,7 @@ func Retry(roundTripper soap.RoundTripper, fn RetryFunc) soap.RoundTripper {
 func (r *retry) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
 	var err error
 
-	for {
+	for attempt := 0; attempt < r.maxRetryAttempts; attempt++ {
 		err = r.roundTripper.RoundTrip(ctx, req, res)
 		if err == nil {
 			break

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -560,7 +560,7 @@ type statusError struct {
 }
 
 // Temporary returns true for HTTP response codes that can be retried
-// See vim25.TemporaryNetworkError
+// See vim25.IsTemporaryNetworkError
 func (e *statusError) Temporary() bool {
 	switch e.res.StatusCode {
 	case http.StatusBadGateway:


### PR DESCRIPTION
To maintain backward compatibility introduced new optional
variable in retry struct and new function with parameter
retryAttempts.

- Add vim25.RetryTemporaryNetworkError to replace deprecated vim25.TemporaryNetworkError

- Export IsTemporaryNetworkError function

- Add test to retry network error

Fixes #2266