### PR TITLE
Update cluster.override.change help message

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -509,7 +509,7 @@ Options:
   -cluster=              Cluster [GOVC_CLUSTER]
   -drs-enabled=<nil>     Enable DRS
   -drs-mode=             DRS behavior for virtual machines: manual, partiallyAutomated, fullyAutomated
-  -ha-restart-priority=  HA restart priority: disabled, low, medium, high
+  -ha-restart-priority=  HA restart priority: disabled, lowest, low, medium, high, highest
   -vm=                   Virtual machine [GOVC_VM]
 ```
 

--- a/govc/cluster/override/change.go
+++ b/govc/cluster/override/change.go
@@ -53,9 +53,11 @@ func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
 	// HA
 	rp := []string{
 		string(types.DasVmPriorityDisabled),
+		string(types.DasVmPriorityLowest),
 		string(types.DasVmPriorityLow),
 		string(types.DasVmPriorityMedium),
 		string(types.DasVmPriorityHigh),
+		string(types.DasVmPriorityHighest),
 	}
 	cmd.das.DasSettings = new(types.ClusterDasVmSettings)
 

--- a/vim25/types/enum.go
+++ b/vim25/types/enum.go
@@ -650,9 +650,11 @@ type DasVmPriority string
 
 const (
 	DasVmPriorityDisabled = DasVmPriority("disabled")
+	DasVmPriorityLowest   = DasVmPriority("lowest")
 	DasVmPriorityLow      = DasVmPriority("low")
 	DasVmPriorityMedium   = DasVmPriority("medium")
 	DasVmPriorityHigh     = DasVmPriority("high")
+	DasVmPriorityHighest  = DasVmPriority("highest")
 )
 
 func init() {


### PR DESCRIPTION
Since vSphere API 6.5 it is possible to set cluster HA restart priority also to `lowest` and `highest` (see [API ref](https://vdc-download.vmware.com/vmwb-repository/dcr-public/da47f910-60ac-438b-8b9b-6122f4d14524/16b7274a-bf8b-4b4c-a05e-746f2aa93c8c/doc/vim.cluster.DasVmSettings.RestartPriority.html)). 

This is only missing in the CLI help message and in the usage documentation, the command itself using `highest` or `lowest` is already working.