### PR TITLE
Fixes in SOAP download progress

### DIFF
--- a/vim25/progress/reader.go
+++ b/vim25/progress/reader.go
@@ -36,6 +36,9 @@ type readerReport struct {
 }
 
 func (r readerReport) Percentage() float32 {
+	if r.size <= 0 {
+		return 0
+	}
 	return 100.0 * float32(r.pos) / float32(r.size)
 }
 

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -828,7 +828,7 @@ func (c *Client) WriteFile(ctx context.Context, file string, src io.Reader, size
 
 	if s != nil {
 		pr := progress.NewReader(ctx, s, src, size)
-		src = pr
+		r = pr
 
 		// Mark progress reader as done when returning from this function.
 		defer func() {


### PR DESCRIPTION
Fixing a bug that caused a progress reader to be created but never used in soap.client.WriteFile.
In addition, treating the situation in which a reader size is invalid and returning 0 as the progress in those cases. I suppose -1 might also work here.