### PR TITLE
vcsim: fix Task.Info.Entity in RevertToSnapshot_Task

### DIFF
--- a/govc/test/snapshot.bats
+++ b/govc/test/snapshot.bats
@@ -75,6 +75,11 @@ test_vm_snapshot() {
 
   # set current to grand
   run govc snapshot.revert -vm "$vm" grand
+  assert_success
+
+  vm_id=$(govc find -i vm -name "$vm")
+  entity=$(govc object.collect -s TaskManager:TaskManager recentTask | awk -F, '{print $NF}' | xargs -I% govc object.collect -s % info.entity)
+  assert_equal "$vm_id" "$entity"
 
   # name is unique
   run govc snapshot.remove -vm "$vm" grand

--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -147,7 +147,7 @@ func (v *VirtualMachineSnapshot) RemoveSnapshotTask(ctx *Context, req *types.Rem
 }
 
 func (v *VirtualMachineSnapshot) RevertToSnapshotTask(req *types.RevertToSnapshot_Task) soap.HasFault {
-	task := CreateTask(v, "revertToSnapshot", func(t *Task) (types.AnyType, types.BaseMethodFault) {
+	task := CreateTask(v.Vm, "revertToSnapshot", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		vm := Map.Get(v.Vm).(*VirtualMachine)
 
 		Map.WithLock(vm, func() {


### PR DESCRIPTION
Fixes #2281