### PR TITLE
govc: implement vSphere HA additional delay and ready condition

### DIFF
--- a/govc/cluster/override/change.go
+++ b/govc/cluster/override/change.go
@@ -79,11 +79,11 @@ func (cmd *change) Description() string {
 	return `Change cluster VM overrides.
 	
 Examples:
-	govc cluster.override.change -cluster cluster_1 -vm vm_1 -drs-enabled=false
-	govc cluster.override.change -cluster cluster_1 -vm vm_2 -drs-enabled -drs-mode fullyAutomated
-	govc cluster.override.change -cluster cluster_1 -vm vm_3 -ha-restart-priority high
-	govc cluster.override.change -cluster cluster_1 -vm vm_4 -ha-additional-delay 30
-	govc cluster.override.change -cluster cluster_1 -vm vm_5 -ha-ready-condition poweredOn`
+  govc cluster.override.change -cluster cluster_1 -vm vm_1 -drs-enabled=false
+  govc cluster.override.change -cluster cluster_1 -vm vm_2 -drs-enabled -drs-mode fullyAutomated
+  govc cluster.override.change -cluster cluster_1 -vm vm_3 -ha-restart-priority high
+  govc cluster.override.change -cluster cluster_1 -vm vm_4 -ha-additional-delay 30
+  govc cluster.override.change -cluster cluster_1 -vm vm_5 -ha-ready-condition poweredOn`
 }
 
 func (cmd *change) Process(ctx context.Context) error {

--- a/govc/cluster/override/info.go
+++ b/govc/cluster/override/info.go
@@ -56,11 +56,12 @@ func (cmd *info) Process(ctx context.Context) error {
 }
 
 type Override struct {
-	id   types.ManagedObjectReference
-	Name string
-	Host string                        `json:",omitempty"`
-	DRS  *types.ClusterDrsVmConfigInfo `json:",omitempty"`
-	DAS  *types.ClusterDasVmConfigInfo `json:",omitempty"`
+	id              types.ManagedObjectReference
+	Name            string
+	Host            string                            `json:",omitempty"`
+	DRS             *types.ClusterDrsVmConfigInfo     `json:",omitempty"`
+	DAS             *types.ClusterDasVmConfigInfo     `json:",omitempty"`
+	VmOrchestration *types.ClusterVmOrchestrationInfo `json:",omitempty"`
 }
 
 type infoResult struct {
@@ -83,9 +84,15 @@ func (r *infoResult) Write(w io.Writer) error {
 			priority = entry.DAS.DasSettings.RestartPriority
 		}
 
+		additionalDelay := fmt.Sprintf("Default (%d seconds)", 0)
+		if entry.VmOrchestration != nil {
+			additionalDelay = fmt.Sprintf("%d seconds", int(entry.VmOrchestration.VmReadiness.PostReadyDelay))
+		}
+
 		fmt.Fprintf(tw, "Name:\t%s\n", entry.Name)
 		fmt.Fprintf(tw, "  DRS Automation Level:\t%s\n", strings.Title(behavior))
 		fmt.Fprintf(tw, "  HA Restart Priority:\t%s\n", strings.Title(priority))
+		fmt.Fprintf(tw, "  HA Additional Delay:\t%s\n", strings.Title(additionalDelay))
 		fmt.Fprintf(tw, "  Host:\t%s\n", entry.Host)
 	}
 
@@ -127,6 +134,12 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 		vm := res.entry(config.DrsVmConfig[i].Key)
 
 		vm.DRS = &config.DrsVmConfig[i]
+	}
+
+	for i := range config.VmOrchestration {
+		vm := res.entry(config.VmOrchestration[i].Vm)
+
+		vm.VmOrchestration = &config.VmOrchestration[i]
 	}
 
 	for _, o := range res.Overrides {

--- a/govc/cluster/override/remove.go
+++ b/govc/cluster/override/remove.go
@@ -106,5 +106,19 @@ func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 	}
 
+	for _, c := range config.VmOrchestration {
+		if c.Vm == ref {
+			spec.VmOrchestrationSpec = []types.ClusterVmOrchestrationSpec{
+				{
+					ArrayUpdateSpec: types.ArrayUpdateSpec{
+						Operation: types.ArrayUpdateOperationRemove,
+						RemoveKey: ref,
+					},
+				},
+			}
+			break
+		}
+	}
+
 	return cmd.Reconfigure(ctx, spec)
 }

--- a/simulator/cluster_compute_resource.go
+++ b/simulator/cluster_compute_resource.go
@@ -263,7 +263,6 @@ func (c *ClusterComputeResource) updateOverridesDRS(cfg *types.ClusterConfigInfo
 	return nil
 }
 
-
 func (c *ClusterComputeResource) updateOverridesVmOrchestration(cfg *types.ClusterConfigInfoEx, cspec *types.ClusterConfigSpecEx) types.BaseMethodFault {
 	for _, spec := range cspec.VmOrchestrationSpec {
 		var i int

--- a/simulator/cluster_compute_resource.go
+++ b/simulator/cluster_compute_resource.go
@@ -263,6 +263,53 @@ func (c *ClusterComputeResource) updateOverridesDRS(cfg *types.ClusterConfigInfo
 	return nil
 }
 
+
+func (c *ClusterComputeResource) updateOverridesVmOrchestration(cfg *types.ClusterConfigInfoEx, cspec *types.ClusterConfigSpecEx) types.BaseMethodFault {
+	for _, spec := range cspec.VmOrchestrationSpec {
+		var i int
+		var key types.ManagedObjectReference
+		exists := false
+
+		if spec.Operation == types.ArrayUpdateOperationRemove {
+			key = spec.RemoveKey.(types.ManagedObjectReference)
+		} else {
+			key = spec.Info.Vm
+		}
+
+		for i = range cfg.VmOrchestration {
+			if cfg.VmOrchestration[i].Vm == key {
+				exists = true
+				break
+			}
+		}
+
+		switch spec.Operation {
+		case types.ArrayUpdateOperationAdd:
+			if exists {
+				return new(types.InvalidArgument)
+			}
+			cfg.VmOrchestration = append(cfg.VmOrchestration, *spec.Info)
+		case types.ArrayUpdateOperationEdit:
+			if !exists {
+				return new(types.InvalidArgument)
+			}
+			if spec.Info.VmReadiness.ReadyCondition != "" {
+				cfg.VmOrchestration[i].VmReadiness.ReadyCondition = spec.Info.VmReadiness.ReadyCondition
+			}
+			if spec.Info.VmReadiness.PostReadyDelay != 0 {
+				cfg.VmOrchestration[i].VmReadiness.PostReadyDelay = spec.Info.VmReadiness.PostReadyDelay
+			}
+		case types.ArrayUpdateOperationRemove:
+			if !exists {
+				return new(types.InvalidArgument)
+			}
+			cfg.VmOrchestration = append(cfg.VmOrchestration[:i], cfg.VmOrchestration[i+1:]...)
+		}
+	}
+
+	return nil
+}
+
 func (c *ClusterComputeResource) ReconfigureComputeResourceTask(req *types.ReconfigureComputeResource_Task) soap.HasFault {
 	task := CreateTask(c, "reconfigureCluster", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		spec, ok := req.Spec.(*types.ClusterConfigSpecEx)
@@ -275,6 +322,7 @@ func (c *ClusterComputeResource) ReconfigureComputeResourceTask(req *types.Recon
 			c.updateGroups,
 			c.updateOverridesDAS,
 			c.updateOverridesDRS,
+			c.updateOverridesVmOrchestration,
 		}
 
 		for _, update := range updates {


### PR DESCRIPTION
This PR implements a new feature in configuring VM HA overrides with govc by adding `-ha-additional-delay` that configures `vSphere HA Additional Delay`:

![image](https://user-images.githubusercontent.com/18685317/109116030-2f4b2c00-7740-11eb-9ab6-4386b295d705.png)
