### PR TITLE
Marshal soapFaultError as JSON

### DIFF
--- a/vim25/soap/error.go
+++ b/vim25/soap/error.go
@@ -17,6 +17,7 @@ limitations under the License.
 package soap
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -47,6 +48,15 @@ func (s soapFaultError) Error() string {
 	}
 
 	return fmt.Sprintf("%s: %s", s.fault.Code, msg)
+}
+
+func (s soapFaultError) MarshalJSON() ([]byte, error) {
+	out := struct {
+		Fault *Fault
+	}{
+		Fault: s.fault,
+	}
+	return json.Marshal(out)
 }
 
 type vimFaultError struct {


### PR DESCRIPTION
govc optionally allows JSON formatted output. In certain cases, e.g.
when a SOAP error is thrown, that causes the JSON output to be empty due
to unexported fields in the struct.

Closes: #2278

Signed-off-by: Michael Gasch <mgasch@vmware.com>