### PR TITLE
Use Github Actions

### DIFF
--- a/.github/workflows/govmomi-go-build.yaml
+++ b/.github/workflows/govmomi-go-build.yaml
@@ -1,0 +1,57 @@
+#  Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Build
+
+on:
+  push:
+    branches: [ 'main', 'master' ]
+
+  pull_request:
+    branches: [ 'main', 'master' ]
+
+jobs:
+
+  build:
+    name: Build
+    strategy:
+      matrix:
+        go-version: [ '1.15', '1.16']
+        buildOS: [ 'linux', 'darwin', 'freebsd', 'windows' ]
+        platform: [ 'ubuntu-latest']
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build govc
+        env:
+          GOOS: ${{ matrix.buildOS }}
+        run: |
+          make -C govc install
+
+      - name: Build vcsim
+        env:
+          GOOS: ${{ matrix.buildOS }}
+        run: |
+          make -C vcsim install

--- a/.github/workflows/govmomi-go-lint.yaml
+++ b/.github/workflows/govmomi-go-lint.yaml
@@ -1,0 +1,98 @@
+#  Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Code Style
+
+on:
+  push:
+    branches: [ 'main', 'master' ]
+
+  pull_request:
+    branches: [ 'main', 'master' ]
+
+jobs:
+
+  autoformat:
+    name: Auto-format and Check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Keep running if one leg fails.
+      matrix:
+        tool:
+          - goimports
+
+        include:
+          - tool: goimports
+            importpath: golang.org/x/tools/cmd/goimports
+
+    steps:
+      - name: Set up Go 1.15.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        if: ${{ matrix.importpath != '' }}
+        run: |
+          cd $(mktemp -d)
+          GO111MODULE=on go get ${{ matrix.importpath }}
+
+      - name: ${{ matrix.tool }} ${{ matrix.options }}
+        shell: bash
+        run: >
+          ${{ matrix.tool }} ${{ matrix.options }} -w
+          $(find .
+          -path 'github.com/vmware/govmomi/vim25/xml' -prune
+          -o -path './vendor' -prune
+          -o -type f -name '*.go' -print)
+
+      - name: Verify ${{ matrix.tool }}
+        shell: bash
+        run: |
+          # From: https://backreference.org/2009/12/23/how-to-match-newlines-in-sed/
+          # This is to leverage this workaround:
+          # https://github.com/actions/toolkit/issues/193#issuecomment-605394935
+          function urlencode() {
+            sed ':begin;$!N;s/\n/%0A/;tbegin'
+          }
+          if [[ $(git diff-index --name-only HEAD --) ]]; then
+              for x in $(git diff-index --name-only HEAD --); do
+                echo "::error file=$x::Please run ${{ matrix.tool }} ${{ matrix.options }}.%0A$(git diff $x | urlencode)"
+              done
+              echo "${{ github.repository }} is out of style. Please run ${{ matrix.tool }} ${{ matrix.options }}."
+              exit 1
+          fi
+          echo "${{ github.repository }} is formatted correctly."
+
+  lint:
+    name: Lint Files
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go 1.15.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Go Lint
+        run: |
+          go vet -structtag=false -methods=false $(go list ./... | grep -v 'github.com/vmware/govmomi/vim25/xml')

--- a/.github/workflows/govmomi-go-test.yaml
+++ b/.github/workflows/govmomi-go-test.yaml
@@ -1,0 +1,50 @@
+#  Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Test
+
+on:
+  push:
+    branches: [ 'main', 'master' ]
+
+  pull_request:
+    branches: [ 'main', 'master' ]
+
+jobs:
+
+  test:
+    name: Unit Tests
+    strategy:
+      matrix:
+        go-version: [ '1.15', '1.16' ]
+        platform: [ 'ubuntu-latest' ]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Run Tests
+        env:
+          TIMEOUT: 5m
+          GORACE: history_size=5
+          TEST_OPTS: ''
+        run: go test -timeout $TIMEOUT -race -v $TEST_OPTS ./...

--- a/.github/workflows/govmomi-stale.yaml
+++ b/.github/workflows/govmomi-stale.yaml
@@ -1,0 +1,48 @@
+#  Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Close Stale
+
+on:
+  schedule:
+    - cron: '0 1 * * *' # daily
+
+jobs:
+
+  stale:
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - uses: 'actions/stale@v3'
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}' # No need to setup
+
+          stale-issue-message: |-
+            This issue is stale because it has been open for 90 days with no
+            activity. It will automatically close after 30 more days of
+            inactivity. Reopen the issue with `/reopen`. Mark the issue as
+            fresh by adding the comment `/remove-lifecycle stale`.
+          stale-issue-label: 'lifecycle/stale'
+          exempt-issue-labels: 'lifecycle/frozen'
+
+          stale-pr-message: |-
+            This Pull Request is stale because it has been open for 90 days with
+            no activity. It will automatically close after 30 more days of
+            inactivity. Reopen with `/reopen`. Mark as fresh by adding the
+            comment `/remove-lifecycle stale`.
+          stale-pr-label: 'lifecycle/stale'
+          exempt-pr-labels: 'lifecycle/frozen'
+
+          days-before-stale: 90
+          days-before-close: 30


### PR DESCRIPTION
First step towards migrating from Travis to Github Actions.
This PR adds four actions:

- Code style (linting and vetting)
- Tests with matrix (different Go versions)
- Build with matrix (different platforms and Go versions)
- Close stale issues (warn after 90d, close after another 30d of
  inactivity)

Code style, tests and build are 1:1 copies of the Travis CI jobs (with
added matrix tests). 

**Note:** These actions will run on every push/PR against main/master. The Travis pipeline will be kept for some transition period thus users will see multiple checks in their PRs.


Credit to the Knative team as source of inspiration.

Signed-off-by: Michael Gasch <mgasch@vmware.com>