### PR TITLE
Update vcsim Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile*
+.*ignore

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,7 +68,7 @@ brews:
   - name: govc
     ids:
       - govc
-    github:
+    tap:
       owner: govmomi
       name: homebrew-tap
     commit_author:
@@ -84,7 +84,7 @@ brews:
   - name: vcsim
     ids:
       - vcsim
-    github:
+    tap:
       owner: govmomi
       name: homebrew-tap
     commit_author:

--- a/Dockerfile.govc
+++ b/Dockerfile.govc
@@ -1,4 +1,43 @@
+# Create a builder container
+# golang:1.16.0-buster amd64
+FROM golang@sha256:f254180c5defa2653955e963fb0626e3d4fbbb162f7cff6490e94607d1d867ff AS build
+WORKDIR /go/src/app
+
+# Create appuser to isolate potential vulnerabilities
+# See https://stackoverflow.com/a/55757473/12429735
+ENV USER=appuser
+ENV UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    "${USER}"
+
+# Create a new tmp directory so no bad actors can manipulate it
+RUN mkdir /temporary-tmp-directory && chmod 777 /temporary-tmp-directory
+
+###############################################################################
+# Final stage
 FROM scratch
-LABEL maintainer="fabio@vmware.com"
-COPY govc /
-ENTRYPOINT [ "/govc" ]
+
+# Run all commands as non-root
+USER appuser:appuser
+
+# Allow container to use latest TLS certificates
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy over appuser to run as non-root
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/group /etc/group
+
+# Copy over the /tmp directory for golang/os.TmpDir
+COPY --chown=appuser --from=build /temporary-tmp-directory /tmp
+
+# Copy application from external build
+COPY govc /govc
+
+# Set CMD to application with container defaults
+CMD ["/govc"]

--- a/Dockerfile.vcsim
+++ b/Dockerfile.vcsim
@@ -1,4 +1,46 @@
+# Create a builder container
+# golang:1.16.0-buster amd64
+FROM golang@sha256:f254180c5defa2653955e963fb0626e3d4fbbb162f7cff6490e94607d1d867ff AS build
+WORKDIR /go/src/app
+
+# Create appuser to isolate potential vulnerabilities
+# See https://stackoverflow.com/a/55757473/12429735
+ENV USER=appuser
+ENV UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    "${USER}"
+
+# Create a new tmp directory so no bad actors can manipulate it
+RUN mkdir /temporary-tmp-directory && chmod 777 /temporary-tmp-directory
+
+###############################################################################
+# Final stage
 FROM scratch
-LABEL maintainer="fabio@vmware.com"
-COPY vcsim /
-ENTRYPOINT [ "/vcsim" ]
+
+# Run all commands as non-root
+USER appuser:appuser
+
+# Allow container to use latest TLS certificates
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy over appuser to run as non-root
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/group /etc/group
+
+# Copy over the /tmp directory for golang/os.TmpDir
+COPY --chown=appuser --from=build /temporary-tmp-directory /tmp
+
+# Expose application port
+EXPOSE 8989
+
+# Copy application from external build
+COPY vcsim /vcsim
+
+# Set entrypoint to application with container defaults
+ENTRYPOINT ["/vcsim", "-l", "0.0.0.0:8989"]


### PR DESCRIPTION
Fixes #2045
Allows vcsim to be built within the docker container rather than built externally and copied in.