### PR TITLE
govc: fix vm.migrate search index flags

### DIFF
--- a/govc/flags/host_system.go
+++ b/govc/flags/host_system.go
@@ -86,7 +86,7 @@ func (flag *HostSystemFlag) HostSystemIfSpecified() (*object.HostSystem, error) 
 	}
 
 	// Use search flags if specified.
-	if flag.SearchFlag.IsSet() {
+	if flag.SearchFlag.IsSet() && flag.SearchFlag.t == SearchHosts {
 		host, err := flag.SearchFlag.HostSystem()
 		if err != nil {
 			return nil, err

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -817,7 +817,8 @@ load test_helper
   run govc object.collect -s "vm/$vm" parent
   assert_success
 
-  run govc vm.migrate -folder vm/new-folder "$vm"
+  uuid=$(govc object.collect -s "vm/$vm" config.uuid)
+  run govc vm.migrate -folder vm/new-folder -vm.uuid "$uuid"
   assert_success
 
   run govc object.collect -s "vm/new-folder/$vm" parent


### PR DESCRIPTION
vm.migrate combines the use of VM SearchFlag (-vm.uuid, -vm.path, etc) with HostSystemFlag.
When a -vm.* flag is used, it causes the error:

  expected HostSystem entity, got VirtualMachine

Add a check for the SearchFlag type to avoid this.