### PR TITLE
govc: metric command enhancements and fixes

### DIFF
--- a/govc/metric/interval/info.go
+++ b/govc/metric/interval/info.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -76,9 +77,17 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 			continue
 		}
 
+		period := (time.Duration(i.SamplingPeriod) * time.Second).String()
+		period = strings.TrimSuffix(period, "0s")
+		if strings.Contains(period, "h") {
+			period = strings.TrimSuffix(period, "0m")
+		}
+		samples := i.Length / i.SamplingPeriod
+
 		fmt.Fprintf(cmd.Out, "ID:\t%d\n", i.SamplingPeriod)
 		fmt.Fprintf(cmd.Out, "  Enabled:\t%t\n", i.Enabled)
-		fmt.Fprintf(cmd.Out, "  Interval:\t%s\n", time.Duration(i.SamplingPeriod)*time.Second)
+		fmt.Fprintf(cmd.Out, "  Interval:\t%s\n", period)
+		fmt.Fprintf(cmd.Out, "  Available Samples:\t%d\n", samples)
 		fmt.Fprintf(cmd.Out, "  Name:\t%s\n", i.Name)
 		fmt.Fprintf(cmd.Out, "  Level:\t%d\n", i.Level)
 	}

--- a/govc/metric/sample.go
+++ b/govc/metric/sample.go
@@ -54,7 +54,7 @@ func (cmd *sample) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.PerformanceFlag.Register(ctx, f)
 
 	f.IntVar(&cmd.d, "d", 30, "Limit object display name to D chars")
-	f.IntVar(&cmd.n, "n", 6, "Max number of samples")
+	f.IntVar(&cmd.n, "n", 5, "Max number of samples")
 	f.StringVar(&cmd.plot, "plot", "", "Plot data using gnuplot")
 	f.BoolVar(&cmd.t, "t", false, "Include sample times")
 	f.StringVar(&cmd.instance, "instance", "*", "Instance")

--- a/govc/test/metric.bats
+++ b/govc/test/metric.bats
@@ -25,7 +25,7 @@ load test_helper
 }
 
 @test "metric.sample" {
-  esx_env
+  vcsim_env
 
   host=$(govc ls -t HostSystem ./... | head -n 1)
   metrics=($(govc metric.ls "$host"))
@@ -42,26 +42,17 @@ load test_helper
   run govc metric.sample -json "$host" "${metrics[@]}"
   assert_success
 
-  vm=$(new_ttylinux_vm)
-
-  run govc metric.ls "$vm"
-  assert_output ""
-
-  run govc vm.power -on "$vm"
-  assert_success
-
-  run govc vm.ip "$vm"
-  assert_success
+  vm=vm/DC0_H0_VM0
 
   metrics=($(govc metric.ls "$vm"))
 
-  run govc metric.sample "$vm" "${metrics[@]}"
+  run govc metric.sample -i day "$vm" "${metrics[@]}"
   assert_success
 
-  run govc metric.sample -json "$vm" "${metrics[@]}"
+  run govc metric.sample -i 300 -json "$vm" "${metrics[@]}"
   assert_success
 
-  run govc metric.sample "govc-test-*" "${metrics[@]}"
+  run govc metric.sample $vm "${metrics[@]}"
   assert_success
 }
 


### PR DESCRIPTION
- Add '-g' group flag to metric.info

- Support interval name in '-i' switch

- metric.interval.info: format Interval, add Available Samples

- Include per-instance-only metrics in metric.info and metric.ls (#704)

- Fix metric.sample '-n' flag

Fixes #704