### PR TITLE
Added UpdateServiceMessage to Session Manager

### DIFF
--- a/session/manager.go
+++ b/session/manager.go
@@ -281,3 +281,14 @@ func (sm *Manager) CloneSession(ctx context.Context, ticket string) error {
 	sm.userSession = &res.Returnval
 	return nil
 }
+
+func (sm *Manager) UpdateServiceMessage(ctx context.Context, message string) error {
+	req := types.UpdateServiceMessage{
+		This:    sm.Reference(),
+		Message: message,
+	}
+
+	_, err := methods.UpdateServiceMessage(ctx, sm.client, &req)
+
+	return err
+}


### PR DESCRIPTION
Added an extra method to the Session Manager to expose the `UpdateServiceMessage` method.

It was already defined as part of the vim25 methods & types, just missing from the session manager wrapper.

Let me know if there is anything else I need to submit with this PR.