### PR TITLE
Add client_test for vslm package to validate register disk method

### DIFF
--- a/vslm/client_test.go
+++ b/vslm/client_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package vslm
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/kr/pretty"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/cns"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+func TestClient(t *testing.T) {
+	url := os.Getenv("VSLM_VC_URL")            // export VC_URL='https://administrator@vsphere.local:Admin!23@10.184.69.227/sdk'
+	datacenter := os.Getenv("VSLM_DATACENTER") // export DATACENTER='test-vpx-1614463083-15492-hostpool'
+	volumePath := os.Getenv("VOLUME_PATH")     // export VOLUME_PATH='https://10.186.43.166/folder/27b74660-98cd-3fe5-514f-02009d24d7ab/vm-1.vmdk?dcPath=datacenter&dsName=vsanDatastore'
+	if url == "" || datacenter == "" || volumePath == "" {
+		t.Skip("VC_URL or DATACENTER is not set")
+	}
+
+	u, err := soap.ParseURL(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	c, err := govmomi.NewClient(ctx, u, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vslmClient, err := NewClient(ctx, c.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	globalObjectManager := NewGlobalObjectManager(vslmClient)
+	vStorageObject, err := globalObjectManager.RegisterDisk(ctx, volumePath, "volume-name1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Successfully registered disk with path %s as FCD with storage object id %s", volumePath, vStorageObject.Config.Id.Id)
+
+	containerCluster := cnstypes.CnsContainerCluster{
+		ClusterType:         string(cnstypes.CnsClusterTypeKubernetes),
+		ClusterId:           "demo-cluster-id",
+		VSphereUser:         "Administrator@vsphere.local",
+		ClusterFlavor:       string(cnstypes.CnsClusterFlavorVanilla),
+		ClusterDistribution: "KUBERNETES",
+	}
+
+	// Test CreateVolume API
+	var cnsVolumeCreateSpecList []cnstypes.CnsVolumeCreateSpec
+	cnsVolumeCreateSpec := cnstypes.CnsVolumeCreateSpec{
+		Name:       "pvc-abc123",
+		VolumeType: string(cnstypes.CnsVolumeTypeBlock),
+		Metadata: cnstypes.CnsVolumeMetadata{
+			ContainerCluster: containerCluster,
+		},
+		BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+			CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{
+				CapacityInMb: 5120,
+			},
+			BackingDiskId: vStorageObject.Config.Id.Id,
+		},
+	}
+	c.UseServiceVersion("vsan")
+	cnsClient, err := cns.NewClient(ctx, c.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cnsVolumeCreateSpecList = append(cnsVolumeCreateSpecList, cnsVolumeCreateSpec)
+	t.Logf("Creating volume using the spec: %+v", pretty.Sprint(cnsVolumeCreateSpec))
+	createTask, err := cnsClient.CreateVolume(ctx, cnsVolumeCreateSpecList)
+	if err != nil {
+		t.Errorf("Failed to create volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	createTaskInfo, err := cns.GetTaskInfo(ctx, createTask)
+	if err != nil {
+		t.Errorf("Failed to create volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	createTaskResult, err := cns.GetTaskResult(ctx, createTaskInfo)
+	if err != nil {
+		t.Errorf("Failed to create volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	if createTaskResult == nil {
+		t.Fatalf("Empty create task results")
+		t.FailNow()
+	}
+	createVolumeOperationRes := createTaskResult.GetCnsVolumeOperationResult()
+	if createVolumeOperationRes.Fault != nil {
+		t.Fatalf("Failed to create volume: fault=%+v", createVolumeOperationRes.Fault)
+	}
+	volumeId := createVolumeOperationRes.VolumeId.Id
+	volumeCreateResult := (createTaskResult).(*cnstypes.CnsVolumeCreateResult)
+	t.Logf("volumeCreateResult %+v", volumeCreateResult)
+	t.Logf("Volume created sucessfully. volumeId: %s", volumeId)
+}


### PR DESCRIPTION
The client_test validates register disk method in globalobjectmanager and invokes cnscreatevolume 
```
$ export VOLUME_PATH="https://10.186.43.166/folder/04c14d60-ce81-e7b1-0d7a-02009d67ced5/vm-12.vmdk?dcPath=datacenter&dsName=vsanDatastore"
chethanv-a01:vslm chethanv$ go test -v
=== RUN   TestClient
    client_test.go:75: Successfully registered disk with path https://10.186.43.166/folder/04c14d60-ce81-e7b1-0d7a-02009d67ced5/vm-12.vmdk?dcPath=datacenter&dsName=vsanDatastore as FCD with storage object id 99c12eef-b5c5-49cf-873a-d6e380e2bc7a
    client_test.go:106: Creating volume using the spec: types.CnsVolumeCreateSpec{
            Name:       "pvc-abc123",
            VolumeType: "BLOCK",
            Datastores: nil,
            Metadata:   types.CnsVolumeMetadata{
                ContainerCluster: types.CnsContainerCluster{
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "KUBERNETES",
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    CapacityInMb: 5120,
                },
                BackingDiskId:      "99c12eef-b5c5-49cf-873a-d6e380e2bc7a",
                BackingDiskUrlPath: "",
            },
            Profile:    nil,
            CreateSpec: nil,
        }
    client_test.go:132: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:99c12eef-b5c5-49cf-873a-d6e380e2bc7a} Fault:<nil>} Name:pvc-abc123 PlacementResults:[]}
    client_test.go:133: Volume created sucessfully. volumeId: 99c12eef-b5c5-49cf-873a-d6e380e2bc7a
--- PASS: TestClient (7.62s)
PASS
ok      github.com/vmware/govmomi/vslm  7.631s
```