### PR TITLE
Fix events example

### DIFF
--- a/examples/events/main.go
+++ b/examples/events/main.go
@@ -30,9 +30,11 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-// example use: go run main.go -url $GOVC_URL -b 8h -f VmEvent
 func main() {
-	begin := flag.Duration("b", time.Hour, "Begin time") // default BeginTime is 1h ago
+	// example use against simulator: go run main.go -b 8h -f
+	// example use against vCenter with optional event filters:
+	// go run main.go -url $GOVMOMI_URL -insecure $GOVMOMI_INSECURE -b 8h -f VmEvent UserLoginSessionEvent
+	begin := flag.Duration("b", 10*time.Minute, "Begin time") // default BeginTime is 10min ago
 	end := flag.Duration("e", 0, "End time")
 	follow := flag.Bool("f", false, "Follow event stream")
 

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -133,11 +133,13 @@ func Run(f func(context.Context, *vim25.Client) error) {
 	flag.Parse()
 
 	var err error
+	var c *vim25.Client
+
 	if *urlFlag == "" {
 		err = simulator.VPX().Run(f)
 	} else {
 		ctx := context.Background()
-		c, err := NewClient(ctx)
+		c, err = NewClient(ctx)
 		if err == nil {
 			err = f(ctx, c)
 		}


### PR DESCRIPTION
Fixes err variable shadowed in example.go which caused the examples to
fail silently on some errors, e.g. TLS issues when not passing
`-insecure`.

Minor documentation improvements on the example and start stream from
-10min instead of -1h to reduce load on vCenter backend.

Signed-off-by: Michael Gasch <mgasch@vmware.com>
Closes: #2322 

Signed-off-by: Michael Gasch <mgasch@vmware.com>