### PR TITLE
Add the vSAN stretched cluster reference.

### DIFF
--- a/vsan/client.go
+++ b/vsan/client.go
@@ -51,6 +51,10 @@ var (
 		Type:  "PropertyCollector",
 		Value: "vsan-property-collector",
 	}
+	VsanVcStretchedClusterSystem = vimtypes.ManagedObjectReference{
+		Type:  "VimClusterVsanVcStretchedClusterSystem",
+		Value: "vsan-stretched-cluster-system",
+	}
 )
 
 // Client used for accessing vsan health APIs.


### PR DESCRIPTION
Add a well-known ManagedObjectReference constant to allow access
to the vSAN stretched cluster management system.

Signed-off-by: James Peach <jpeach@vmware.com>