### PR TITLE
govc: remove device.boot -firmware default

### DIFF
--- a/govc/device/boot.go
+++ b/govc/device/boot.go
@@ -54,7 +54,7 @@ func (cmd *boot) Register(ctx context.Context, f *flag.FlagSet) {
 	f.BoolVar(cmd.EnterBIOSSetup, "setup", false, "If true, enter BIOS setup on next boot")
 
 	f.Var(flags.NewOptionalBool(&cmd.EfiSecureBootEnabled), "secure", "Enable EFI secure boot")
-	f.StringVar(&cmd.firmware, "firmware", vm.FirmwareTypes[0], vm.FirmwareUsage)
+	f.StringVar(&cmd.firmware, "firmware", "", vm.FirmwareUsage)
 }
 
 func (cmd *boot) Description() string {

--- a/govc/test/device.bats
+++ b/govc/test/device.bats
@@ -77,6 +77,12 @@ load test_helper
 
   run govc device.boot -vm $vm -secure -firmware efi
   assert_success
+
+  run govc device.boot -vm $vm -order -
+  assert_success
+
+  firmware=$(govc object.collect -s vm/$vm config.firmware)
+  assert_equal efi "$firmware"
 }
 
 @test "device.cdrom" {


### PR DESCRIPTION
Avoid reverting from efi to bios when device.boot is used without specifiying the -firmware option