### PR TITLE
Add godoc and mod version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [![Build](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-build.yaml/badge.svg)](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-build.yaml)
 [![Test](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-test.yaml/badge.svg)](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/vmware/govmomi)](https://goreportcard.com/report/github.com/vmware/govmomi)
+[![Latest Release](https://img.shields.io/github/release/vmware/govmomi.svg?logo=github&style=flat-square)](https://github.com/vmware/govmomi/releases/latest)
+[![Go Reference](https://pkg.go.dev/badge/github.com/vmware/govmomi.svg)](https://pkg.go.dev/github.com/vmware/govmomi)
+[![go.mod Go version](https://img.shields.io/github/go-mod/go-version/vmware/govmomi)](https://github.com/vmware/govmomi)
 
 # govmomi
 


### PR DESCRIPTION
Adds badges and links to:

- latest release
- godoc
- go modules version used

New layout:

![image](https://user-images.githubusercontent.com/15986659/112764720-3c429000-900a-11eb-9fbc-81b7dcba6a51.png)


Closes #2334 

Signed-off-by: Michael Gasch <mgasch@vmware.com>