### PR TITLE
vcsim: add vsan simulator

### DIFF
--- a/govc/test/cluster.bats
+++ b/govc/test/cluster.bats
@@ -269,3 +269,16 @@ _EOF_
   memory=$(govc cluster.usage -json DC0_C0 | jq -r .Memory.Summary.Usage)
   [ "$memory" = "34.3" ]
 }
+
+@test "cluster.stretch" {
+  vcsim_env -host 4
+
+  run govc cluster.stretch -witness DC0_H0 -first-fault-domain-hosts=DC0_C0_H1,DC0_C0_H2 -second-fault-domain-hosts DC0_C0_H2,DC0_C0_H3
+  assert_failure # no cluster specified
+
+  run govc cluster.stretch -witness DC0_H0 -first-fault-domain-hosts=DC0_C0_H1,DC0_C0_H2 DC0_C0
+  assert_failure # no second-fault-domain-hosts specified
+
+  run govc cluster.stretch -witness DC0_H0 -first-fault-domain-hosts=DC0_C0_H1,DC0_C0_H2 -second-fault-domain-hosts DC0_C0_H2,DC0_C0_H3 DC0_C0
+  assert_success
+}

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -408,7 +408,15 @@ func (s *Service) HandleFunc(pattern string, handler func(http.ResponseWriter, *
 }
 
 // RegisterSDK adds an HTTP handler for the Registry's Path and Namespace.
+// If r.Path is already registered, r's objects are added to the existing Registry.
 func (s *Service) RegisterSDK(r *Registry) {
+	if existing, ok := s.sdk[r.Path]; ok {
+		for id, obj := range r.objects {
+			existing.objects[id] = obj
+		}
+		return
+	}
+
 	if s.ServeMux == nil {
 		s.ServeMux = http.NewServeMux()
 	}

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -46,6 +46,7 @@ import (
 	_ "github.com/vmware/govmomi/vapi/cluster/simulator"
 	_ "github.com/vmware/govmomi/vapi/namespace/simulator"
 	_ "github.com/vmware/govmomi/vapi/simulator"
+	_ "github.com/vmware/govmomi/vsan/simulator"
 )
 
 func main() {

--- a/vsan/simulator/simulator.go
+++ b/vsan/simulator/simulator.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/soap"
+	vim "github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vsan"
+	"github.com/vmware/govmomi/vsan/methods"
+	"github.com/vmware/govmomi/vsan/types"
+)
+
+func init() {
+	simulator.RegisterEndpoint(func(s *simulator.Service, r *simulator.Registry) {
+		if r.IsVPX() {
+			s.RegisterSDK(New())
+		}
+	})
+}
+
+func New() *simulator.Registry {
+	r := simulator.NewRegistry()
+	r.Namespace = vsan.Namespace
+	r.Path = vsan.Path
+
+	r.Put(&StretchedClusterSystem{
+		ManagedObjectReference: vsan.VsanVcStretchedClusterSystem,
+	})
+
+	return r
+}
+
+type StretchedClusterSystem struct {
+	vim.ManagedObjectReference
+}
+
+func (s *StretchedClusterSystem) VSANVcConvertToStretchedCluster(ctx *simulator.Context, req *types.VSANVcConvertToStretchedCluster) soap.HasFault {
+	task := simulator.CreateTask(s, "convertToStretchedCluster", func(*simulator.Task) (vim.AnyType, vim.BaseMethodFault) {
+		// TODO: validate req fields
+		return nil, nil
+	})
+
+	return &methods.VSANVcConvertToStretchedClusterBody{
+		Res: &types.VSANVcConvertToStretchedClusterResponse{
+			Returnval: task.Run(),
+		},
+	}
+}


### PR DESCRIPTION
cns/simulator implements a subset of the vsan namespace.
Add vsan/simulator to implement other vsan related methods,
starting with the ConvertToStretchedCluster method.

Add cluster.stretch bats test.

Issue #2235