### PR TITLE
Add action to block WIP PRs

### DIFF
--- a/.github/workflows/govmomi-check-wip.yaml
+++ b/.github/workflows/govmomi-check-wip.yaml
@@ -1,0 +1,31 @@
+#  Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Perform "exit 1" if PR title starts with "WIP" to block accidental merges
+name: Check "WIP" in PR Title
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, edited ]
+
+jobs:
+  WIP:
+    name: "Check WIP in title"
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.title, 'WIP')
+    steps:
+      - name: Must Exit
+        run: |
+          echo "::error ::PR marked as Work in Progress!"
+          exit 1


### PR DESCRIPTION
Any PR title starting with `WIP` will fail this status check to prevent accidental merges.

Closes: #2341

Signed-off-by: Michael Gasch <mgasch@vmware.com>