### PR TITLE
Fix race in simulator's PropertyCollector

### DIFF
--- a/simulator/property_collector.go
+++ b/simulator/property_collector.go
@@ -667,9 +667,9 @@ func (pc *PropertyCollector) WaitForUpdatesEx(ctx *Context, r *types.WaitForUpda
 	}
 
 	if r.Version == "" {
+		ctx.Map.AddHandler(pc) // Listen for create, update, delete of managed objects
 		apply()                // Collect current state
 		set.Version = "-"      // Next request with Version set will wait via loop below
-		ctx.Map.AddHandler(pc) // Listen for create, update, delete of managed objects
 		return body
 	}
 


### PR DESCRIPTION
When WaitForUpdatesEx() finds an empty Version string, it collects the
current state and then installs the PC as a "RegisterObject" handler
with the registry. If the object is updated after collecting its state
but before the PC is installed as a handler, those updates will be
missed.

This ordering addresses the issue of missing updates, but it introduces
a separate potential issue: that an update would be delivered twice if
the update happens after installing the PC as a RegisterObject but
before the object state is collected. The update would appear in the
initial state, but also be collected by the update callbacks.