### PR TITLE
simulator: Wait until VM creation completes before adding to folder

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -58,10 +58,9 @@ func asVirtualMachineMO(obj mo.Reference) (*mo.VirtualMachine, bool) {
 func NewVirtualMachine(ctx *Context, parent types.ManagedObjectReference, spec *types.VirtualMachineConfigSpec) (*VirtualMachine, types.BaseMethodFault) {
 	vm := &VirtualMachine{}
 	vm.Parent = &parent
+	Map.reference(vm)
 
 	folder := Map.Get(parent)
-	f, _ := asFolderMO(folder)
-	folderPutChild(ctx, f, vm)
 
 	if spec.Name == "" {
 		return vm, &types.InvalidVmConfig{Property: "configSpec.name"}
@@ -163,6 +162,9 @@ func NewVirtualMachine(ctx *Context, parent types.ManagedObjectReference, spec *
 	vm.Summary.QuickStats.GuestHeartbeatStatus = types.ManagedEntityStatusGray
 	vm.Summary.OverallStatus = types.ManagedEntityStatusGreen
 	vm.ConfigStatus = types.ManagedEntityStatusGreen
+
+	f, _ := asFolderMO(folder)
+	folderPutChild(ctx, f, vm)
 
 	return vm, nil
 }


### PR DESCRIPTION
If something like finder is used to retrieve the list of VMs in a
folder, it is possible that the list may include VMs that are not yet
fully constructed.

In this case, property.Wait() might observe theoretically-impossible
values, like <nil> for a VM's powerState.

This can cause TestRace (race_test.go) to hang.

The solution is to wait until the VM is fully initialized before adding
it to the folder. Because some initialization code expects the VM to
have a real MO reference, we have to use Registry.reference(vm) to
assign the new VM a reference (this is normally called by the
add-to-folder code; so thankfully it is idempotent).