### PR TITLE
Add action to automate release

### DIFF
--- a/.github/workflows/govmomi-build.yaml
+++ b/.github/workflows/govmomi-build.yaml
@@ -29,22 +29,30 @@ jobs:
   artifacts:
     name: Build Snapshot Release (no upload)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
-      - name: GoReleaser Snapshot
+
+      - name: Docker Login (verify only)
+        run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
+          
+      - name: Build Artifacts
         uses: goreleaser/goreleaser-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           version: latest
           args: release --rm-dist --snapshot # snapshot will disable push/release
+          
       - name: Verify git clean
         shell: bash
         run: |
@@ -55,6 +63,7 @@ jobs:
             echo "::error:: $(git status)"
             exit 1
           fi
+
       # make artifacts available for inspection
       # https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts
       - name: Archive run artifacts

--- a/.github/workflows/govmomi-release.yaml
+++ b/.github/workflows/govmomi-release.yaml
@@ -1,0 +1,48 @@
+#  Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*" # Push events to matching v*, i.e. v0.25.0, v1.15.1
+
+jobs:
+  artifacts:
+    name: Create Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+          
+      - name: Docker Login
+        run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
+        
+      - name: Build and push Artifacts
+        uses: goreleaser/goreleaser-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: latest
+          args: release --rm-dist # will push artefacts and container images

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,9 @@
 ---
 project_name: govmomi
+before:
+  hooks:
+  - go mod vendor
+  
 builds:
   - id: govc
     goos: &goos-defs
@@ -32,6 +36,7 @@ builds:
     binary: vcsim
     ldflags:
       - "-X main.buildVersion={{.Version}} -X main.buildCommit={{.ShortCommit}} -X main.buildDate={{.Date}}"
+
 archives:
   - id: govcbuild
     builds:
@@ -43,7 +48,7 @@ archives:
       windows: Windows
       freebsd: FreeBSD
       amd64: x86_64
-    format_overrides:
+    format_overrides: &overrides
       - goos: windows
         format: zip
   - id: vcsimbuild
@@ -51,13 +56,14 @@ archives:
       - vcsim
     name_template: "vcsim_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     replacements: *replacements
-    format_overrides:
-      - goos: windows
-        format: zip
+    format_overrides: *overrides
+        
 snapshot:
   name_template: "{{ .Tag }}-next"
+  
 checksum:
   name_template: "checksums.txt"
+  
 changelog:
   sort: asc
   filters:
@@ -66,6 +72,8 @@ changelog:
       - "^test:"
       - Merge pull request
       - Merge branch
+      
+# upload disabled since it is maintained in homebrew-core
 brews:
   - name: govc
     ids:
@@ -107,6 +115,7 @@ brews:
       system "#{bin}/vcsim -h"
     install: |
       bin.install "vcsim"
+      
 dockers:
   - image_templates:
       - "vmware/govc:{{ .Tag }}"


### PR DESCRIPTION
This PR marks the final changes towards fully utilizing Github Actions for CI in govmomi.
Changes:

On **any** push (commit) to this repo using a tag starting with "v", e.g. `v0.25.0` a release action will be triggered.
Binaries and Docker images for govc/vcsim will be created and uploaded to a new release on this repo (binaries) respectively Docker hub (container images). A CHANGELOG with the commits since the previous tag will be added to the release notes (can be modified afterwards). The same goreleaser configuration is used as during the build verification action to avoid inconsistencies and early catch regressions.

Note: the following error in the release check is due to this PR run not being able to read the secrets from the repo (which is by design to protect repos):

```
Run docker login -u  -p 
Error: Cannot perform an interactive login from a non TTY device
Error: Process completed with exit code 1.
```

Closes #2356, closes #1844, closes #2295
Signed-off-by: Michael Gasch <mgasch@vmware.com>