### PR TITLE
vcsim: add moid value mapping mappings

### DIFF
--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -573,6 +573,10 @@ EOF
 
   run govc find -l -i /
   assert_success
+  assert_matches :domain- # ClusterComputeResource moid value
+  assert_matches :group- # Folder moid value
+  assert_matches :resgroup- # ResourcePool moid value
+  assert_matches :dvs- # DistributedVirtualSwitch moid value
 }
 
 @test "object.method" {

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -45,6 +45,8 @@ var refValueMap = map[string]string{
 	"VirtualMachineSnapshot":         "snapshot",
 	"VmwareDistributedVirtualSwitch": "dvs",
 	"DistributedVirtualSwitch":       "dvs",
+	"ClusterComputeResource":         "domain",
+	"Folder":                         "group",
 }
 
 // Map is the default Registry instance.


### PR DESCRIPTION
cluster moid values have "domain" prefix in real VC, not "clustercomputeresource"

folder moid values have "group" prefix.