### PR TITLE
Add Cron Docker Login Action

### DIFF
--- a/.github/workflows/govmomi-build.yaml
+++ b/.github/workflows/govmomi-build.yaml
@@ -42,9 +42,6 @@ jobs:
         with:
           go-version: 1.16
 
-      - name: Docker Login (verify only)
-        run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
-          
       - name: Build Artifacts
         uses: goreleaser/goreleaser-action@v2
         env:

--- a/.github/workflows/verify-docker-login.yaml
+++ b/.github/workflows/verify-docker-login.yaml
@@ -1,0 +1,29 @@
+#  Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Verify Docker Login
+
+on:
+  schedule:
+    - cron: "0 1 * * *" # daily
+
+jobs:
+  login:
+    name: Verify Docker Login
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Docker Login
+        run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
Runs every night to verify Docker credentials and avoid surprises during release. Removed from build Action since PR runs don't have access to secrets (for good reason).

Closes: #2361
Signed-off-by: Michael Gasch <mgasch@vmware.com>