### PR TITLE
vcsim: add guest operations process support

### DIFF
--- a/govc/test/guest.bats
+++ b/govc/test/guest.bats
@@ -1,0 +1,183 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+vcsim_guest() {
+  require_docker
+  vcsim_env -autostart=false
+
+  vm=DC0_H0_VM0
+
+  name=$(docker_name $vm)
+
+  if docker inspect "$name" ; then
+    flunk "$vm container still exists"
+  fi
+
+  export GOVC_VM=$vm GOVC_GUEST_LOGIN=user:pass
+
+  run govc object.collect -s vm/$vm guest.toolsStatus
+  assert_success toolsNotInstalled
+
+  run govc object.collect -s vm/$vm guest.toolsRunningStatus
+  assert_success guestToolsNotRunning
+
+  govc vm.change -vm $vm -e "RUN.container=--tmpfs /tmp nginx"
+
+  govc vm.power -on $vm
+
+  if ! docker inspect "$name" ; then
+    flunk "$vm container does not exist"
+  fi
+
+  run govc object.collect -s vm/$vm guest.toolsStatus
+  assert_success toolsOk
+
+  run govc object.collect -s vm/$vm guest.toolsRunningStatus
+  assert_success guestToolsRunning
+}
+
+@test "guest file manager" {
+  vcsim_guest
+
+  run govc guest.mkdir /tmp/foo
+  assert_success
+
+  run govc guest.mkdir /tmp/foo/bar/baz
+  assert_failure
+
+  run govc guest.mkdir -p /tmp/foo/bar/baz
+  assert_success
+
+  run govc guest.rmdir /tmp/foo
+  assert_failure # not empty
+
+  run govc guest.rmdir -r /tmp/foo
+  assert_success
+
+  run govc guest.mktemp -d
+  assert_success
+  tmp="$output"
+
+  run govc guest.rmdir "$tmp"
+  assert_success
+
+  run govc guest.rmdir "$tmp"
+  assert_failure # does not exist
+
+  run govc guest.mktemp
+  assert_success
+  tmp="$output"
+
+  run govc guest.ls
+  assert_failure # InvalidArgument
+
+  run govc guest.ls /enoent
+  assert_failure # InvalidArgument
+
+  run govc guest.ls "$tmp"
+  assert_success
+  assert_matches "$tmp"
+  assert_matches "rw-------" # 0600
+
+
+  run govc guest.chmod 0644 "$tmp"
+  assert_success
+
+  run govc guest.chown 0:0 "$tmp"
+  assert_success
+
+  run govc guest.ls "$tmp"
+  assert_success
+  assert_matches "$tmp"
+  assert_matches "rw-r--r--" # 0644
+
+  run govc guest.ls "$(dirname "$tmp")"
+  assert_success
+  assert_matches "$tmp"
+
+  run govc guest.mv "$tmp" "$tmp-new"
+  assert_success
+
+  run govc guest.ls "$tmp"
+  assert_failure
+
+  run govc guest.ls "$tmp-new"
+  assert_success
+
+  run govc guest.upload -l '' README.md "$tmp"
+  assert_failure # unauthenticated
+
+  run govc guest.upload README.md "$tmp"
+  assert_success
+
+  run govc guest.download "$tmp" -
+  assert_success "$(cat README.md)"
+
+  run govc guest.rmdir "$tmp"
+  assert_failure # not a directory
+
+  run govc guest.rm "$tmp"
+  assert_success
+
+  run govc guest.rm "$tmp"
+  assert_failure # does not exist
+}
+
+@test "guest process manager" {
+  vcsim_guest
+
+  run govc guest.kill -p 123456
+  assert_failure # process does not exist
+
+  run govc guest.start -l '' /bin/df
+  assert_failure # unauthenticated
+
+  run govc guest.start /bin/df -h
+  assert_success
+  pid="$output"
+
+  run govc guest.ps -p "$pid"
+  assert_success
+  assert_matches /bin/df
+
+  run govc guest.ps -x
+  assert_success
+
+  run govc guest.kill -p "$pid"
+  assert_success
+
+  run govc guest.run uname -a
+  assert_success
+  assert_matches Linux
+
+  run govc guest.run -e FOO=bar -C /tmp env
+  assert_success
+  assert_matches FOO=bar
+  assert_matches PWD=/tmp
+}
+
+@test "guest tools status" {
+  vcsim_guest
+
+  run govc vm.power -r $GOVC_VM
+  assert_success
+
+  run govc object.collect -s vm/$vm guest.toolsStatus
+  assert_success toolsOk
+
+  run govc object.collect -s vm/$vm guest.toolsRunningStatus
+  assert_success guestToolsRunning
+
+  run govc vm.power -off $GOVC_VM
+  assert_success
+
+  run govc object.collect -s vm/$vm guest.toolsStatus
+  assert_success toolsNotRunning
+
+  run govc object.collect -s vm/$vm guest.toolsRunningStatus
+  assert_success guestToolsNotRunning
+
+  run govc guest.run uname -a
+  assert_failure # powered off
+}

--- a/govc/test/test_helper.bash
+++ b/govc/test/test_helper.bash
@@ -45,6 +45,10 @@ require_docker() {
   fi
 }
 
+docker_name() {
+  echo "vcsim-$1-$(govc object.collect -s "vm/$1" config.uuid)"
+}
+
 vcsim_start() {
     GOVC_SIM_ENV="$BATS_TMPDIR/$(new_id)"
     export GOVC_SIM_ENV

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -228,10 +228,6 @@ EOF
   wait $pid
 }
 
-docker_name() {
-  echo "vcsim-$1-$(govc object.collect -s "vm/$1" config.uuid)"
-}
-
 @test "vcsim run container" {
   require_docker
 

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -1045,37 +1045,3 @@ load test_helper
   run govc object.collect -s vm/DC0_H0_VM0 guest.ipAddress
   assert_success 10.0.0.45
 }
-
-@test "guest fileops" {
-  require_docker
-
-  vcsim_env -autostart=false
-
-  export GOVC_VM=DC0_H0_VM0
-  name="vcsim-$GOVC_VM-$(govc object.collect -s "vm/$GOVC_VM" config.uuid)"
-
-  if docker inspect "$name" ; then
-    flunk "$GOVC_VM container still exists"
-  fi
-
-  run govc vm.change -e RUN.container=nginx
-  assert_success
-
-  run govc vm.power -on $GOVC_VM
-  assert_success
-
-  if ! docker inspect "$name" ; then
-    flunk "$GOVC_VM container does not exist"
-  fi
-
-  run govc guest.upload README.md /tmp/README.md
-  assert_failure # unauthenticated
-
-  export GOVC_GUEST_LOGIN=user:pass
-
-  run govc guest.upload README.md /tmp/README.md
-  assert_success
-
-  run govc guest.download /tmp/README.md -
-  assert_success "$(cat README.md)"
-}

--- a/simulator/guest_operations_manager.go
+++ b/simulator/guest_operations_manager.go
@@ -17,9 +17,15 @@ limitations under the License.
 package simulator
 
 import (
+	"bufio"
+	"fmt"
 	"net/url"
 	"strings"
+	"syscall"
+	"time"
 
+	"github.com/vmware/govmomi/toolbox/process"
+	"github.com/vmware/govmomi/toolbox/vix"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -49,6 +55,7 @@ func (m *GuestOperationsManager) init(r *Registry) {
 		}
 	}
 	pm.Self = *m.ProcessManager
+	pm.Manager = process.NewManager()
 	r.Put(pm)
 }
 
@@ -108,4 +115,343 @@ func (m *GuestFileManager) InitiateFileTransferFromGuest(ctx *Context, req *type
 
 type GuestProcessManager struct {
 	mo.GuestProcessManager
+	*process.Manager
+}
+
+func (m *GuestProcessManager) StartProgramInGuest(ctx *Context, req *types.StartProgramInGuest) soap.HasFault {
+	body := new(methods.StartProgramInGuestBody)
+
+	spec := req.Spec.(*types.GuestProgramSpec)
+	auth := req.Auth.(*types.NamePasswordAuthentication)
+
+	vm := ctx.Map.Get(req.Vm).(*VirtualMachine)
+
+	fault := vm.run.prepareGuestOperation(vm, auth)
+	if fault != nil {
+		body.Fault_ = Fault("", fault)
+	}
+
+	args := []string{"exec"}
+
+	if spec.WorkingDirectory != "" {
+		args = append(args, "-w", spec.WorkingDirectory)
+	}
+
+	for _, e := range spec.EnvVariables {
+		args = append(args, "-e", e)
+	}
+
+	args = append(args, vm.run.id, spec.ProgramPath, spec.Arguments)
+
+	spec.ProgramPath = "docker"
+	spec.Arguments = strings.Join(args, " ")
+
+	start := &vix.StartProgramRequest{
+		ProgramPath: spec.ProgramPath,
+		Arguments:   spec.Arguments,
+	}
+
+	proc := process.New()
+	proc.Owner = auth.Username
+
+	pid, err := m.Start(start, proc)
+	if err != nil {
+		panic(err) // only happens if LookPath("docker") fails, which it should't at this point
+	}
+
+	body.Res = &types.StartProgramInGuestResponse{
+		Returnval: pid,
+	}
+
+	return body
+}
+
+func (m *GuestProcessManager) ListProcessesInGuest(ctx *Context, req *types.ListProcessesInGuest) soap.HasFault {
+	body := &methods.ListProcessesInGuestBody{
+		Res: new(types.ListProcessesInGuestResponse),
+	}
+
+	procs := m.List(req.Pids)
+
+	for _, proc := range procs {
+		var end *time.Time
+		if proc.EndTime != 0 {
+			end = types.NewTime(time.Unix(proc.EndTime, 0))
+		}
+
+		body.Res.Returnval = append(body.Res.Returnval, types.GuestProcessInfo{
+			Name:      proc.Name,
+			Pid:       proc.Pid,
+			Owner:     proc.Owner,
+			CmdLine:   proc.Name + " " + proc.Args,
+			StartTime: time.Unix(proc.StartTime, 0),
+			EndTime:   end,
+			ExitCode:  proc.ExitCode,
+		})
+	}
+
+	return body
+}
+
+func (m *GuestProcessManager) TerminateProcessInGuest(ctx *Context, req *types.TerminateProcessInGuest) soap.HasFault {
+	body := new(methods.TerminateProcessInGuestBody)
+
+	if m.Kill(req.Pid) {
+		body.Res = new(types.TerminateProcessInGuestResponse)
+	} else {
+		body.Fault_ = Fault("", &types.GuestProcessNotFound{Pid: req.Pid})
+	}
+
+	return body
+}
+
+func (m *GuestFileManager) mktemp(ctx *Context, req *types.CreateTemporaryFileInGuest, dir bool) (string, types.BaseMethodFault) {
+	args := []string{"mktemp", fmt.Sprintf("--tmpdir=%s", req.DirectoryPath), req.Prefix + "vcsim-XXXXX" + req.Suffix}
+	if dir {
+		args = append(args, "-d")
+	}
+
+	vm := ctx.Map.Get(req.Vm).(*VirtualMachine)
+
+	return vm.run.exec(ctx, vm, req.Auth, args)
+}
+
+func (m *GuestFileManager) CreateTemporaryFileInGuest(ctx *Context, req *types.CreateTemporaryFileInGuest) soap.HasFault {
+	body := new(methods.CreateTemporaryFileInGuestBody)
+
+	res, fault := m.mktemp(ctx, req, false)
+	if fault != nil {
+		body.Fault_ = Fault("", fault)
+		return body
+	}
+
+	body.Res = &types.CreateTemporaryFileInGuestResponse{Returnval: res}
+
+	return body
+}
+
+func (m *GuestFileManager) CreateTemporaryDirectoryInGuest(ctx *Context, req *types.CreateTemporaryDirectoryInGuest) soap.HasFault {
+	body := new(methods.CreateTemporaryDirectoryInGuestBody)
+
+	dir := types.CreateTemporaryFileInGuest(*req)
+	res, fault := m.mktemp(ctx, &dir, true)
+	if fault != nil {
+		body.Fault_ = Fault("", fault)
+		return body
+	}
+
+	body.Res = &types.CreateTemporaryDirectoryInGuestResponse{Returnval: res}
+
+	return body
+}
+
+func listFiles(req *types.ListFilesInGuest) []string {
+	args := []string{"find", req.FilePath}
+	if req.MatchPattern != "" {
+		args = append(args, "-name", req.MatchPattern)
+	}
+	return append(args, "-maxdepth", "1", "-exec", "stat", "-c", "%s %u %g %f %X %Y %n", "{}", "+")
+}
+
+func toFileInfo(s string) []types.GuestFileInfo {
+	var res []types.GuestFileInfo
+
+	scanner := bufio.NewScanner(strings.NewReader(s))
+
+	for scanner.Scan() {
+		var mode, atime, mtime int64
+		attr := &types.GuestPosixFileAttributes{OwnerId: new(int32), GroupId: new(int32)}
+		info := types.GuestFileInfo{Attributes: attr}
+
+		_, err := fmt.Sscanf(scanner.Text(), "%d %d %d %x %d %d %s",
+			&info.Size, attr.OwnerId, attr.GroupId, &mode, &atime, &mtime, &info.Path)
+		if err != nil {
+			panic(err)
+		}
+
+		attr.AccessTime = types.NewTime(time.Unix(atime, 0))
+		attr.ModificationTime = types.NewTime(time.Unix(mtime, 0))
+		attr.Permissions = mode & 0777
+
+		switch mode & syscall.S_IFMT {
+		case syscall.S_IFDIR:
+			info.Type = string(types.GuestFileTypeDirectory)
+		case syscall.S_IFLNK:
+			info.Type = string(types.GuestFileTypeSymlink)
+		default:
+			info.Type = string(types.GuestFileTypeFile)
+		}
+
+		res = append(res, info)
+	}
+
+	return res
+}
+
+func (m *GuestFileManager) ListFilesInGuest(ctx *Context, req *types.ListFilesInGuest) soap.HasFault {
+	body := new(methods.ListFilesInGuestBody)
+
+	vm := ctx.Map.Get(req.Vm).(*VirtualMachine)
+
+	if req.FilePath == "" {
+		body.Fault_ = Fault("", new(types.InvalidArgument))
+		return body
+	}
+
+	res, fault := vm.run.exec(ctx, vm, req.Auth, listFiles(req))
+	if fault != nil {
+		body.Fault_ = Fault("", fault)
+		return body
+	}
+
+	body.Res = new(types.ListFilesInGuestResponse)
+	body.Res.Returnval.Files = toFileInfo(res)
+
+	return body
+}
+
+func (m *GuestFileManager) DeleteFileInGuest(ctx *Context, req *types.DeleteFileInGuest) soap.HasFault {
+	body := new(methods.DeleteFileInGuestBody)
+
+	args := []string{"rm", req.FilePath}
+
+	vm := ctx.Map.Get(req.Vm).(*VirtualMachine)
+
+	_, fault := vm.run.exec(ctx, vm, req.Auth, args)
+	if fault != nil {
+		body.Fault_ = Fault("", fault)
+		return body
+	}
+
+	body.Res = new(types.DeleteFileInGuestResponse)
+
+	return body
+}
+
+func (m *GuestFileManager) DeleteDirectoryInGuest(ctx *Context, req *types.DeleteDirectoryInGuest) soap.HasFault {
+	body := new(methods.DeleteDirectoryInGuestBody)
+
+	args := []string{"rmdir", req.DirectoryPath}
+	if req.Recursive {
+		args = []string{"rm", "-rf", req.DirectoryPath}
+	}
+
+	vm := ctx.Map.Get(req.Vm).(*VirtualMachine)
+
+	_, fault := vm.run.exec(ctx, vm, req.Auth, args)
+	if fault != nil {
+		body.Fault_ = Fault("", fault)
+		return body
+	}
+
+	body.Res = new(types.DeleteDirectoryInGuestResponse)
+
+	return body
+}
+
+func (m *GuestFileManager) MakeDirectoryInGuest(ctx *Context, req *types.MakeDirectoryInGuest) soap.HasFault {
+	body := new(methods.MakeDirectoryInGuestBody)
+
+	args := []string{"mkdir", req.DirectoryPath}
+	if req.CreateParentDirectories {
+		args = []string{"mkdir", "-p", req.DirectoryPath}
+	}
+
+	vm := ctx.Map.Get(req.Vm).(*VirtualMachine)
+
+	_, fault := vm.run.exec(ctx, vm, req.Auth, args)
+	if fault != nil {
+		body.Fault_ = Fault("", fault)
+		return body
+	}
+
+	body.Res = new(types.MakeDirectoryInGuestResponse)
+
+	return body
+}
+
+func (m *GuestFileManager) MoveFileInGuest(ctx *Context, req *types.MoveFileInGuest) soap.HasFault {
+	body := new(methods.MoveFileInGuestBody)
+
+	args := []string{"mv"}
+	if !req.Overwrite {
+		args = append(args, "-n")
+	}
+	args = append(args, req.SrcFilePath, req.DstFilePath)
+
+	vm := ctx.Map.Get(req.Vm).(*VirtualMachine)
+
+	_, fault := vm.run.exec(ctx, vm, req.Auth, args)
+	if fault != nil {
+		body.Fault_ = Fault("", fault)
+		return body
+	}
+
+	body.Res = new(types.MoveFileInGuestResponse)
+
+	return body
+}
+
+func (m *GuestFileManager) MoveDirectoryInGuest(ctx *Context, req *types.MoveDirectoryInGuest) soap.HasFault {
+	body := new(methods.MoveDirectoryInGuestBody)
+
+	args := []string{"mv", req.SrcDirectoryPath, req.DstDirectoryPath}
+
+	vm := ctx.Map.Get(req.Vm).(*VirtualMachine)
+
+	_, fault := vm.run.exec(ctx, vm, req.Auth, args)
+	if fault != nil {
+		body.Fault_ = Fault("", fault)
+		return body
+	}
+
+	body.Res = new(types.MoveDirectoryInGuestResponse)
+
+	return body
+}
+
+func (m *GuestFileManager) ChangeFileAttributesInGuest(ctx *Context, req *types.ChangeFileAttributesInGuest) soap.HasFault {
+	body := new(methods.ChangeFileAttributesInGuestBody)
+
+	vm := ctx.Map.Get(req.Vm).(*VirtualMachine)
+
+	attr, ok := req.FileAttributes.(*types.GuestPosixFileAttributes)
+	if !ok {
+		body.Fault_ = Fault("", new(types.OperationNotSupportedByGuest))
+		return body
+	}
+
+	if attr.Permissions != 0 {
+		args := []string{"chmod", fmt.Sprintf("%#o", attr.Permissions), req.GuestFilePath}
+
+		_, fault := vm.run.exec(ctx, vm, req.Auth, args)
+		if fault != nil {
+			body.Fault_ = Fault("", fault)
+			return body
+		}
+	}
+
+	change := []struct {
+		cmd string
+		id  *int32
+	}{
+		{"chown", attr.OwnerId},
+		{"chgrp", attr.GroupId},
+	}
+
+	for _, c := range change {
+		if c.id != nil {
+			args := []string{c.cmd, fmt.Sprintf("%d", *c.id), req.GuestFilePath}
+
+			_, fault := vm.run.exec(ctx, vm, req.Auth, args)
+			if fault != nil {
+				body.Fault_ = Fault("", fault)
+				return body
+			}
+		}
+	}
+
+	body.Res = new(types.ChangeFileAttributesInGuestResponse)
+
+	return body
 }

--- a/simulator/guest_operations_manager_test.go
+++ b/simulator/guest_operations_manager_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestFileInfo(t *testing.T) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := &types.ListFilesInGuest{
+		FilePath:     pwd,
+		MatchPattern: "*_test.go",
+	}
+
+	args := listFiles(req)
+	path, err := exec.LookPath(args[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Cmd{Path: path, Args: args}
+	res, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, info := range toFileInfo(string(res)) {
+		if info.Path == "" {
+			t.Fail()
+		}
+		if !strings.HasSuffix(info.Path, "_test.go") {
+			t.Fail()
+		}
+		if info.Type == "" {
+			t.Fail()
+		}
+		if info.Size == 0 {
+			t.Fail()
+		}
+		attr, ok := info.Attributes.(*types.GuestPosixFileAttributes)
+		if !ok {
+			t.Fail()
+		}
+		if attr.ModificationTime == nil {
+			t.Fail()
+		}
+		if attr.AccessTime == nil {
+			t.Fail()
+		}
+		if attr.Permissions == 0 {
+			t.Fail()
+		}
+	}
+}

--- a/toolbox/hgfs/hgfs_freebsd.go
+++ b/toolbox/hgfs/hgfs_freebsd.go
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hgfs
+
+import (
+	"os"
+)
+
+func (a *AttrV2) sysStat(info os.FileInfo) {
+}


### PR DESCRIPTION
The original plan was to run govmomi/toolbox inside the container.
  Pros: toolbox uses Go's stdlib for process and file ops, no shelling out and parsing command output.
  Cons: would require binary added to containers, manage the process lifecycle and transport (e.g. unix socket).
With this change, we instead use a hybrid of the toolbox.ProcessManager and docker exec.
  Pros: negates the cons listed above.
  Cons: shelling out to docker exec and having to parse output in some cases (e.g. ListFiles)