### PR TITLE
toolbox: move process management to its own package

### DIFF
--- a/toolbox/command_test.go
+++ b/toolbox/command_test.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/vmware/govmomi/toolbox/hgfs"
+	"github.com/vmware/govmomi/toolbox/process"
 	"github.com/vmware/govmomi/toolbox/vix"
 )
 
@@ -188,7 +189,7 @@ func TestVixRelayedCommandHandler(t *testing.T) {
 		t.Fatalf("%q", reply)
 	}
 
-	cmd.ProcessStartCommand = func(pm *ProcessManager, r *vix.StartProgramRequest) (int64, error) {
+	cmd.ProcessStartCommand = func(pm *process.Manager, r *vix.StartProgramRequest) (int64, error) {
 		return -1, nil
 	}
 
@@ -443,13 +444,12 @@ func TestVixProcessHgfsPacket(t *testing.T) {
 
 func TestVixListProcessesEx(t *testing.T) {
 	c := NewCommandClient()
-	pm := c.Service.Command.ProcessManager
 
-	c.Service.Command.ProcessStartCommand = func(pm *ProcessManager, r *vix.StartProgramRequest) (int64, error) {
-		var p *Process
+	c.Service.Command.ProcessStartCommand = func(pm *process.Manager, r *vix.StartProgramRequest) (int64, error) {
+		var p *process.Process
 		switch r.ProgramPath {
 		case "foo":
-			p = NewProcessFunc(func(ctx context.Context, arg string) error {
+			p = process.NewFunc(func(ctx context.Context, arg string) error {
 				return nil
 			})
 		default:
@@ -483,7 +483,7 @@ func TestVixListProcessesEx(t *testing.T) {
 		t.Fatalf("rc: %d", rc)
 	}
 
-	pm.wg.Wait()
+	<-time.Tick(time.Millisecond * 100)
 
 	ps := new(vix.ListProcessesRequest)
 

--- a/toolbox/service_test.go
+++ b/toolbox/service_test.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/vmware/govmomi/toolbox/hgfs"
+	"github.com/vmware/govmomi/toolbox/process"
 	"github.com/vmware/govmomi/toolbox/vix"
 	"github.com/vmware/govmomi/vim25/types"
 )
@@ -413,7 +414,7 @@ func TestServiceRunESX(t *testing.T) {
 	}
 
 	if *testPID != 0 {
-		service.Command.ProcessStartCommand = func(m *ProcessManager, r *vix.StartProgramRequest) (int64, error) {
+		service.Command.ProcessStartCommand = func(m *process.Manager, r *vix.StartProgramRequest) (int64, error) {
 			wg.Add(1)
 			defer wg.Done()
 
@@ -421,7 +422,7 @@ func TestServiceRunESX(t *testing.T) {
 			case "/bin/date":
 				return *testPID, nil
 			case "sleep":
-				p := NewProcessFunc(func(ctx context.Context, arg string) error {
+				p := process.NewFunc(func(ctx context.Context, arg string) error {
 					d, err := time.ParseDuration(arg)
 					if err != nil {
 						return err
@@ -429,7 +430,7 @@ func TestServiceRunESX(t *testing.T) {
 
 					select {
 					case <-ctx.Done():
-						return &ProcessError{Err: ctx.Err(), ExitCode: 42}
+						return &process.Error{Err: ctx.Err(), ExitCode: 42}
 					case <-time.After(d):
 					}
 


### PR DESCRIPTION
This allows vcsim to use the process manager without depending on the backdoor RPC package.