### PR TITLE
Add bindings for CnsQueryAsyncVolume API

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -189,6 +189,20 @@ func (c *Client) QueryAllVolume(ctx context.Context, queryFilter cnstypes.CnsQue
 	return &res.Returnval, nil
 }
 
+// QueryVolumeAsync calls the CNS QueryAsync API and return a task, from which we can extract CnsQueryResult
+func (c *Client) QueryVolumeAsync(ctx context.Context, queryFilter cnstypes.CnsQueryFilter, querySelection cnstypes.CnsQuerySelection) (*object.Task, error) {
+	req := cnstypes.CnsQueryAsync{
+		This:      CnsVolumeManagerInstance,
+		Filter:    queryFilter,
+		Selection: &querySelection,
+	}
+	res, err := methods.CnsQueryAsync(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(c.vim25Client, res.Returnval), nil
+}
+
 // RelocateVolume calls the CNS Relocate API.
 func (c *Client) RelocateVolume(ctx context.Context, relocateSpecs ...cnstypes.BaseCnsVolumeRelocateSpec) (*object.Task, error) {
 	req := cnstypes.CnsRelocateVolume{

--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -962,4 +962,27 @@ func TestClient(t *testing.T) {
 		}
 		t.Logf("volume:%q deleted sucessfully", volumeID)
 	}
+	// Test QueryVolumeAsync API
+	queryVolumeAsyncTask, err := cnsClient.QueryVolumeAsync(ctx, queryFilter, querySelection)
+	if err != nil {
+		t.Errorf("Failed to query volumes with QueryVolumeAsync. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	queryVolumeAsyncTaskInfo, err := GetTaskInfo(ctx, queryVolumeAsyncTask)
+	if err != nil {
+		t.Errorf("Failed to query volumes with QueryVolumeAsync. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	queryVolumeAsyncTaskResults, err := GetTaskResultArray(ctx, queryVolumeAsyncTaskInfo)
+	if err != nil {
+		t.Errorf("Failed to query volumes with QueryVolumeAsync. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	for _, queryVolumeAsyncTaskResult := range queryVolumeAsyncTaskResults {
+		queryVolumeAsyncOperationRes := queryVolumeAsyncTaskResult.GetCnsVolumeOperationResult()
+		if queryVolumeAsyncOperationRes.Fault != nil {
+			t.Fatalf("Failed to query volumes with QueryVolumeAsync. fault=%+v", queryVolumeAsyncOperationRes.Fault)
+		}
+		t.Logf("Successfully queried Volume using queryAsync API. queryVolumeAsyncTaskResult: %+v", pretty.Sprint(queryVolumeAsyncTaskResult))
+	}
 }

--- a/cns/methods/methods.go
+++ b/cns/methods/methods.go
@@ -240,3 +240,23 @@ func CnsConfigureVolumeACLs(ctx context.Context, r soap.RoundTripper, req *types
 
 	return resBody.Res, nil
 }
+
+type CnsQueryAsyncBody struct {
+	Req    *types.CnsQueryAsync         `xml:"urn:vsan CnsQueryAsync,omitempty"`
+	Res    *types.CnsQueryAsyncResponse `xml:"urn:vsan CnsQueryAsyncResponse,omitempty"`
+	Fault_ *soap.Fault                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsQueryAsyncBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsQueryAsync(ctx context.Context, r soap.RoundTripper, req *types.CnsQueryAsync) (*types.CnsQueryAsyncResponse, error) {
+	var reqBody, resBody CnsQueryAsyncBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -630,3 +630,33 @@ type CnsNFSAccessControlSpec struct {
 func init() {
 	types.Add("CnsNFSAccessControlSpec", reflect.TypeOf((*CnsNFSAccessControlSpec)(nil)).Elem())
 }
+
+type CnsQueryAsync CnsQueryAsyncRequestType
+
+func init() {
+	types.Add("CnsQueryAsync", reflect.TypeOf((*CnsQueryAsync)(nil)).Elem())
+}
+
+type CnsQueryAsyncRequestType struct {
+	This      types.ManagedObjectReference `xml:"_this"`
+	Filter    CnsQueryFilter               `xml:"filter"`
+	Selection *CnsQuerySelection           `xml:"selection,omitempty"`
+}
+
+func init() {
+	types.Add("CnsQueryAsyncRequestType", reflect.TypeOf((*CnsQueryAsyncRequestType)(nil)).Elem())
+}
+
+type CnsQueryAsyncResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type CnsAsyncQueryResult struct {
+	CnsVolumeOperationResult
+
+	QueryResult CnsQueryResult `xml:"queryResult,omitempty"`
+}
+
+func init() {
+	types.Add("CnsAsyncQueryResult", reflect.TypeOf((*CnsAsyncQueryResult)(nil)).Elem())
+}


### PR DESCRIPTION
This PR is adding go bindings for `QueryAsync` API which helps in retrieving volume information.
Invoking `QueryAsync` API in `cns/client_test.go`

```
=== RUN   TestClient
    client_test.go:133: Successfully queried Volume using queryAsync API. queryVolumeAsyncTaskResult: &types.CnsAsyncQueryResult{
            CnsVolumeOperationResult: types.CnsVolumeOperationResult{},
            QueryResult:              types.CnsQueryResult{
                Volumes: []types.CnsVolume{
                    {
                        VolumeId: types.CnsVolumeId{
                            Id: "233bfd99-3a92-410c-962d-2351dba5f702",
                        },
                        DatastoreUrl:         "",
                        Name:                 "pvc-12d9a1f1-238a-42a6-83ee-9e47f406636c",
                        VolumeType:           "BLOCK",
                        StoragePolicyId:      "",
                        Metadata:             types.CnsVolumeMetadata{},
                        BackingObjectDetails: &types.CnsBlockBackingDetails{
                            CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                                CapacityInMb: 2048,
                            },
                            BackingDiskId:      "233bfd99-3a92-410c-962d-2351dba5f702",
                            BackingDiskUrlPath: "",
                        },
                        ComplianceStatus:             "compliant",
                        DatastoreAccessibilityStatus: "accessible",
                        HealthStatus:                 "",
                    },
                },
                Cursor: types.CnsCursor{
                    Offset:       1,
                    Limit:        100,
                    TotalRecords: 1,
                },
            },
        }
--- PASS: TestClient (2.51s)
PASS
ok      github.com/vmware/govmomi/cns   2.699s
```