### PR TITLE
Add queryAsyncVolume in simulator

### DIFF
--- a/cns/simulator/simulator_test.go
+++ b/cns/simulator/simulator_test.go
@@ -287,6 +287,38 @@ func TestSimulator(t *testing.T) {
 		t.Fatal("Number of volumes mismatches after creating a single volume")
 	}
 
+	// QueryAsync
+	queryFilter = cnstypes.CnsQueryFilter{}
+	querySelection := cnstypes.CnsQuerySelection{}
+	queryVolumeAsyncTask, err := cnsClient.QueryVolumeAsync(ctx, queryFilter, querySelection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queryVolumeAsyncTaskInfo, err := cns.GetTaskInfo(ctx, queryVolumeAsyncTask)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queryVolumeAsyncTaskResult, err := cns.GetTaskResult(ctx, queryVolumeAsyncTaskInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if queryVolumeAsyncTaskResult == nil {
+		t.Fatalf("Empty queryVolumeAsync Task Result")
+	}
+	queryVolumeAsyncOperationRes := queryVolumeAsyncTaskResult.GetCnsVolumeOperationResult()
+	if queryVolumeAsyncOperationRes.Fault != nil {
+		t.Fatalf("Failed to query volume detail using queryVolumeAsync: fault=%+v", queryVolumeAsyncOperationRes.Fault)
+	}
+
+	// QueryVolume
+	queryFilter = cnstypes.CnsQueryFilter{}
+	queryResult, err = cnsClient.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Fatalf("Failed to query volume with QueryFilter: err=%+v", err)
+	}
+	if len(queryResult.Volumes) != existingNumDisks+1 {
+		t.Fatal("Number of volumes mismatches after deleting a single volume")
+	}
 	// QueryVolumeInfo
 	queryVolumeInfoTask, err := cnsClient.QueryVolumeInfo(ctx, []cnstypes.CnsVolumeId{{Id: createVolumeOperationRes.VolumeId.Id}})
 	if err != nil {
@@ -310,7 +342,7 @@ func TestSimulator(t *testing.T) {
 
 	// QueryAll
 	queryFilter = cnstypes.CnsQueryFilter{}
-	querySelection := cnstypes.CnsQuerySelection{}
+	querySelection = cnstypes.CnsQuerySelection{}
 	queryResult, err = cnsClient.QueryAllVolume(ctx, queryFilter, querySelection)
 
 	if len(queryResult.Volumes) != existingNumDisks+1 {


### PR DESCRIPTION
This PR is adding queryAsync API in simulator. This is helpful for clients to simulate QueryAsync API mostly in their unit tests

```
simulator chethanv$ go test -v
=== RUN   TestSimulator
    simulator_test.go:120: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:fake-volume-Handle} Fault:<nil>} Name:test PlacementResults:[{Datastore:Datastore:/var/folders/lp/5y1nj2ss6jg588yfj874lspw0000gq/T/govcsim-DC0-LocalDS_0-370437992@group-5 PlacementFaults:[]}]}
    simulator_test.go:189: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:686c9835-c98d-43ce-abd0-f956b2fcbf93} Fault:<nil>} Name:test PlacementResults:[{Datastore:Datastore:/var/folders/lp/5y1nj2ss6jg588yfj874lspw0000gq/T/govcsim-DC0-LocalDS_0-370437992@group-5 PlacementFaults:[]}]}
--- PASS: TestSimulator (0.41s)
PASS
ok      github.com/vmware/govmomi/cns/simulator 0.608s
```