### PR TITLE
Add NotFoundFault in cns types

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -585,6 +585,16 @@ func init() {
 	types.Add("CnsFault", reflect.TypeOf((*CnsFault)(nil)).Elem())
 }
 
+type CnsVolumeNotFoundFault struct {
+	CnsFault
+
+	VolumeId CnsVolumeId `xml:"volumeId"`
+}
+
+func init() {
+	types.Add("CnsVolumeNotFoundFault", reflect.TypeOf((*CnsVolumeNotFoundFault)(nil)).Elem())
+}
+
 type CnsAlreadyRegisteredFault struct {
 	CnsFault `xml:"fault,typeattr"`
 


### PR DESCRIPTION
This PR is adding bindings for `CnsVolumeNotFoundFault` in cns types. This is useful to determine if Cns Delete Volume returned `notFound` fault.