### PR TITLE
Set RoundTripper in ssoadmin.NewClient

### DIFF
--- a/ssoadmin/client.go
+++ b/ssoadmin/client.go
@@ -79,9 +79,10 @@ func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
 	sc.Version = Version
 
 	admin := &Client{
-		Client: sc,
-		Domain: "vsphere.local", // Default
-		Limit:  100,
+		Client:       sc,
+		RoundTripper: sc,
+		Domain:       "vsphere.local", // Default
+		Limit:        100,
 	}
 	if url != Path {
 		admin.Domain = path.Base(url)


### PR DESCRIPTION
Commit 4ed615f6 added RoundTripper to support govc '-verbose', with govc sso.* commands setting RoundTripper,
but NewClient needs to set the default.