### PR TITLE
Add chore section to CHANGELOG

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -9,10 +9,12 @@ options:
       Type:
         - govc
         - vcsim
+        - chore
   commit_groups:
     title_maps:
       govc: 💫 `govc` (CLI)
       vcsim: 💫 `vcsim` (Simulator)
+      chore: 🧹 Chore
   header:
     pattern: "^(\\w*)\\:\\s(.*)$"
     pattern_maps:

--- a/.github/comment-template.md
+++ b/.github/comment-template.md
@@ -1,1 +1,3 @@
 Howdy 🖐 &nbsp; {{ .author }} ! Thank you for your interest in this project. We value your feedback and will respond soon.
+
+If you want to contribute to this project, please make yourself familiar with the `CONTRIBUTION` [guidelines](./../CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,24 @@ Message](http://chris.beams.io/posts/git-commit/).
 Be sure to include any related GitHub issue references in the commit message,
 e.g. `Closes: #<number>`.
 
+The [`CHANGELOG.md`](./CHANGELOG.md) and release page uses commit message
+prefixes for grouping and highlighting. A commit message that
+starts with `[prefix:] ` will place this commit under the respective
+section in the `CHANGELOG`. 
+
+The following example creates a commit referencing the `issue: 1234` and puts
+the commit message in the `govc` `CHANGELOG` section:
+
+```console
+$ git commit -s -m "govc: Add CLI command X" -m "Closes: #1234"
+```
+
+Currently the following prefixes are used:
+
+- `govc:` - CLI
+- `vcsim:` - Simulator
+- `chore:` - Repository related activities
+
 ### Running CI Checks and Tests
 You can run both `make check` and `make test` from the top level of the
 repository. 


### PR DESCRIPTION
Will add this to CHANGELOG.md (and every release) highlighting all commits with `chore: ...` prefix.

Example:

<a name="v0.25.0-next"></a>
## [Release v0.25.0-next](https://github.com/vmware/govmomi/compare/v0.26.0...v0.25.0-next)

> Release Date: 2021-05-05

### 💫 `vcsim` (Simulator)

- add guest operations process support

### 🧹 Chore

- Add issue greeting
- Add WIP Action
- Remove dep files
- Clean up documentation
- Remove unused release script
- Automate CHANGELOG

### 📖 Commits

- Add chore section to CHANGELOG [e39dfdc8]
- chore: Add issue greeting [cac1d8d7]
- chore: Add WIP Action [0f1c3f89]
- chore: Remove dep files [921ad37a]
- docs: Document linker and GOFLAGS for build vars [2719c229]
- Clarify SetRootCAs behavior [f3645a96]
- toolbox: add hgfs freebsd stub [c368e57f]
- vcsim: add guest operations process support [35a42af5]
- Set RoundTripper in ssoadmin.NewClient [64e55d81]
- chore: Clean up documentation [1d4ce94a]
- chore: Remove unused release script [991278b9]
- chore: Automate CHANGELOG [16d8add5]
- Add NotFoundFault in cns types [e8805c92]


Closes: #2410
Signed-off-by: Michael Gasch <mgasch@vmware.com>