### PR TITLE
Only greet unassociated users

### DIFF
--- a/.github/workflows/issue-greeting.yaml
+++ b/.github/workflows/issue-greeting.yaml
@@ -8,8 +8,9 @@ jobs:
   greeting:
     name: Send Greeting
     runs-on: ubuntu-latest
-    # only send message to first-time contributors
-    if: github.event.issue.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # only send message to users not (yet) associated with repo
+    # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
+    if: github.event.issue.author_association == 'NONE'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This change will send greetings only to users currently not associated with the repo, i.e. no previous commits, no members of the org, no owners, etc. which seems to be a better option for this behavior.

Closes: #2412
Signed-off-by: Michael Gasch <mgasch@vmware.com>