### PR TITLE
Isolate the SSO bats test that times out

### DIFF
--- a/.github/workflows/govmomi-govc-tests.yaml
+++ b/.github/workflows/govmomi-govc-tests.yaml
@@ -45,3 +45,51 @@ jobs:
 
       - name: Run govc Tests
         run: make govc-test
+
+  govc-tests-sso:
+    name: Run govc Tests - sso
+    strategy:
+      matrix:
+        go-version: ["1.15", "1.16"]
+        # tests randomly hang on ubuntu-20.04 go v1.16
+        platform: ["ubuntu-18.04"]
+
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 20
+
+    steps:
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Run govc Tests - sso
+        run: make govc-test-sso
+
+  govc-tests-sso-assert-cert:
+    name: Run govc Tests - sso - assert cert
+    strategy:
+      matrix:
+        go-version: ["1.15", "1.16"]
+        # tests randomly hang on ubuntu-20.04 go v1.16
+        platform: ["ubuntu-18.04"]
+
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 20
+
+    steps:
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Run govc Tests - sso - assert cert
+        run: make govc-test-sso-assert-cert

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,13 @@ govc-test: install
 	./govc/test/images/update.sh
 	(cd govc/test && ./vendor/github.com/sstephenson/bats/libexec/bats -t .)
 
+govc-test-sso: install
+	./govc/test/images/update.sh
+	(cd govc/test && SSO_BATS=1 ./vendor/github.com/sstephenson/bats/libexec/bats -t sso.bats)
+
+govc-test-sso-assert-cert:
+	SSO_BATS_ASSERT_CERT=1 $(MAKE) govc-test-sso
+
 .PHONY: test
 test: go-test govc-test
 

--- a/govc/test/sso.bats
+++ b/govc/test/sso.bats
@@ -3,6 +3,10 @@
 load test_helper
 
 @test "sso.service.ls" {
+  if [ ! "${SSO_BATS}" = "1" ]; then
+    skip "skip sso.service.ls by default"
+  fi
+
   vcsim_env
 
   sts=$(govc option.ls config.vpxd.sso.sts.uri | awk '{print $2}')
@@ -30,9 +34,11 @@ load test_helper
   run govc sso.service.ls -t sso:sts -U
   assert_success "$sts"
 
-  cert=$(govc about.cert -show | grep -v CERTIFICATE | tr -d '\n')
-  trust=$(govc sso.service.ls -json -t sso:sts | jq -r .[].ServiceEndpoints[].SslTrust[0])
-  assert_equal "$cert" "$trust"
+  if [ "${SSO_BATS_ASSERT_CERT}" = "1" ]; then
+    cert=$(govc about.cert -show | grep -v CERTIFICATE | tr -d '\n')
+    trust=$(govc sso.service.ls -json -t sso:sts | jq -r .[].ServiceEndpoints[].SslTrust[0])
+    assert_equal "$cert" "$trust"
+  fi
 
   govc sso.service.ls -t cs.identity | grep com.vmware.cis | grep -v https:
   govc sso.service.ls -t cs.identity -l | grep https:


### PR DESCRIPTION
This patch isolates the govc test for `sso.bats` -- the test that often times out when run as part of GitHub actions. This change is to determine whether or not the issue is specific to `sso.bats` or if the timeout occurs at that point during the 200+ test run for the uber-bats test. This patch also excludes the `sso.bats` test from the uber run.

To enable `sso.bats`, it must be run with `SSO_BATS=1`. The make target `govc-test-sso` can be used to run `sso.bats`.