### PR TITLE
Use "vcsim uuidgen" for bats tests

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -142,7 +142,7 @@ EOF
   run govc vm.info -vm.dns localhost.localdomain
   assert_success
 
-  uuid=$(uuidgen)
+  uuid=$(vcsim uuidgen)
   run govc vm.change -vm $vm -e SET.config.uuid="$uuid"
   assert_success
 

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -134,7 +134,7 @@ load test_helper
   run govc object.collect -s "vm/$id" config.annotation
   assert_success $$
 
-  uuid=$(uuidgen)
+  uuid=$(vcsim uuidgen)
   run govc vm.change -vm $id -uuid "$uuid"
   assert_success
   run govc object.collect -s "vm/$id" config.uuid


### PR DESCRIPTION
This patch fixes an issue where some bats tests fail because the `uuidgen` command is not present. The `vcsim` binary includes `uuidgen` for this reason, and thus the two locations where `uuidgen` was used directly have been updated to call `vcsim uuidgen` instead.