### PR TITLE
install bin doc: permalink to latest version

### DIFF
--- a/govc/README.md
+++ b/govc/README.md
@@ -17,12 +17,9 @@ You can find prebuilt `govc` binaries on the [releases page](https://github.com/
 You can download and install a binary locally like this:
 
 ```console
-# get version from https://github.com/vmware/govmomi/releases/latest
-$ VERSION=v0.25.0
-$ URL=https://github.com/vmware/govmomi/releases/download/${VERSION}/govc_$(uname -s)_$(uname -m).tar.gz
-
 # extract govc binary to /usr/local/bin
-$ curl -L -o - $URL | tar -C /usr/local/bin -xvzf - govc
+# note: the "tar" command must run with root permissions
+$ curl -L -o - "https://github.com/vmware/govmomi/releases/latest/download/govc_$(uname -s)_$(uname -m).tar.gz" | tar -C /usr/local/bin -xvzf - govc
 ```
 
 ### Source

--- a/vcsim/README.md
+++ b/vcsim/README.md
@@ -16,12 +16,9 @@ You can find prebuilt `vcsim` binaries on the [releases page](https://github.com
 You can download and install a binary locally like this:
 
 ``` console
-# get version from https://github.com/vmware/govmomi/releases/latest
-$ VERSION=v0.25.0
-$ URL=https://github.com/vmware/govmomi/releases/download/${VERSION}/vcsim_$(uname -s)_$(uname -m).tar.gz
-
 # extract vcsim binary to /usr/local/bin
-$ curl -L -o - $URL | tar -C /usr/local/bin -xvzf - vcsim
+# note: the "tar" command must run with root permissions
+$ curl -L -o - https://github.com/vmware/govmomi/releases/latest/download/vcsim_$(uname -s)_$(uname -m).tar.gz | tar -C /usr/local/bin -xvzf - vcsim
 ```
 
 ### Source


### PR DESCRIPTION
Github has a (non-obvious) way to link to the latest release files. I also added a note about the `tar` command requiring root permissions.