### PR TITLE
fix: Isolate SSO govc tests

### DIFF
--- a/.github/workflows/govmomi-govc-tests.yaml
+++ b/.github/workflows/govmomi-govc-tests.yaml
@@ -27,11 +27,25 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.15", "1.16"]
-        # tests randomly hang on ubuntu-20.04 go v1.16
         platform: ["ubuntu-18.04"]
+        cmd: ["govc-test"]
+        experimental: [false]
+        timeout: [10]
+        include:
+          - go-version: "1.15"
+            platform: "ubuntu-18.04"
+            cmd: "govc-test-sso"
+            experimental: true
+            timeout: 3
+          - go-version: "1.15"
+            platform: "ubuntu-18.04"
+            cmd: "govc-test-sso-assert-cert"
+            experimental: true
+            timeout: 3
 
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 20
+    continue-on-error: ${{ matrix.experimental }}
+    timeout-minutes: ${{ matrix.timeout }}
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -43,5 +57,5 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Run govc Tests
-        run: make govc-test
+      - name: Run ${{ matrix.cmd }}
+        run: make ${{ matrix.cmd }}

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,13 @@ govc-test: install
 	./govc/test/images/update.sh
 	(cd govc/test && ./vendor/github.com/sstephenson/bats/libexec/bats -t .)
 
+govc-test-sso: install
+	./govc/test/images/update.sh
+	(cd govc/test && SSO_BATS=1 ./vendor/github.com/sstephenson/bats/libexec/bats -t sso.bats)
+
+govc-test-sso-assert-cert:
+	SSO_BATS_ASSERT_CERT=1 $(MAKE) govc-test-sso
+
 .PHONY: test
 test: go-test govc-test
 

--- a/govc/test/sso.bats
+++ b/govc/test/sso.bats
@@ -3,6 +3,10 @@
 load test_helper
 
 @test "sso.service.ls" {
+  if [ ! "${SSO_BATS}" = "1" ]; then
+    skip "skip sso.service.ls by default"
+  fi
+
   vcsim_env
 
   sts=$(govc option.ls config.vpxd.sso.sts.uri | awk '{print $2}')
@@ -30,9 +34,11 @@ load test_helper
   run govc sso.service.ls -t sso:sts -U
   assert_success "$sts"
 
-  cert=$(govc about.cert -show | grep -v CERTIFICATE | tr -d '\n')
-  trust=$(govc sso.service.ls -json -t sso:sts | jq -r .[].ServiceEndpoints[].SslTrust[0])
-  assert_equal "$cert" "$trust"
+  if [ "${SSO_BATS_ASSERT_CERT}" = "1" ]; then
+    cert=$(govc about.cert -show | grep -v CERTIFICATE | tr -d '\n')
+    trust=$(govc sso.service.ls -json -t sso:sts | jq -r .[].ServiceEndpoints[].SslTrust[0])
+    assert_equal "$cert" "$trust"
+  fi
 
   govc sso.service.ls -t cs.identity | grep com.vmware.cis | grep -v https:
   govc sso.service.ls -t cs.identity -l | grep https:


### PR DESCRIPTION
Isolate `govc` SSO-related tests as separate workflows, marked as experimental so they don't fail the run in case of cancellation.

Note: Only running the SSO-related tests with one go version (1.15) for now and timeout of 3m.
Kudos to @akutz for pinning the issue down to the SSO tests and making the relevant Makefile/tests changes.

Closes: #2425
Signed-off-by: Michael Gasch <mgasch@vmware.com>