### PR TITLE
govc: add vsan info and change commands

### DIFF
--- a/govc/main.go
+++ b/govc/main.go
@@ -98,6 +98,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/vm/rdm"
 	_ "github.com/vmware/govmomi/govc/vm/snapshot"
 	_ "github.com/vmware/govmomi/govc/volume"
+	_ "github.com/vmware/govmomi/govc/vsan"
 )
 
 func main() {

--- a/govc/test/vsan.bats
+++ b/govc/test/vsan.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "vsan.change" {
+  vcsim_env -cluster 2
+
+  run govc vsan.info -json DC0_C0
+  assert_success
+  config=$(jq .Clusters[].Info.UnmapConfig <<<"$output")
+  assert_equal null "$config"
+
+  run govc vsan.change DC0_C0
+  assert_failure # no flags specified
+
+  run govc vsan.change -unmap-enabled DC0_C0
+  assert_success
+
+  run govc vsan.info -json DC0_C0
+  assert_success
+
+  config=$(jq .Clusters[].Info.UnmapConfig.Enable <<<"$output")
+  assert_equal true "$config"
+}

--- a/govc/vsan/change.go
+++ b/govc/vsan/change.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsan
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vsan"
+	"github.com/vmware/govmomi/vsan/types"
+)
+
+type change struct {
+	*flags.DatacenterFlag
+
+	unmap *bool
+}
+
+func init() {
+	cli.Register("vsan.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.Var(flags.NewOptionalBool(&cmd.unmap), "unmap-enabled", "Enable Unmap")
+}
+
+func (cmd *change) Usage() string {
+	return "CLUSTER"
+}
+
+func (cmd *change) Description() string {
+	return `Change vSAN configuration.
+
+Examples:
+  govc vsan.change -unmap-enabled ClusterA # enable unmap
+  govc vsan.change -unmap-enabled=false ClusterA # disable unmap`
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	vc, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	cluster, err := finder.ClusterComputeResourceOrDefault(ctx, f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	c, err := vsan.NewClient(ctx, vc)
+	if err != nil {
+		return err
+	}
+
+	c.RoundTripper = cmd.RoundTripper(c.Client)
+
+	var spec types.VimVsanReconfigSpec
+
+	if cmd.unmap != nil {
+		spec.UnmapConfig = &types.VsanUnmapConfig{Enable: *cmd.unmap}
+	} else {
+		return flag.ErrHelp
+	}
+
+	task, err := c.VsanClusterReconfig(ctx, cluster.Reference(), spec)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger("Updating vSAN...")
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}

--- a/govc/vsan/info.go
+++ b/govc/vsan/info.go
@@ -1,0 +1,124 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsan
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vsan"
+	"github.com/vmware/govmomi/vsan/types"
+)
+
+type info struct {
+	*flags.DatacenterFlag
+}
+
+func init() {
+	cli.Register("vsan.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+}
+
+func (cmd *info) Usage() string {
+	return "CLUSTER..."
+}
+
+func (cmd *info) Description() string {
+	return `Display vSAN configuration.
+
+Examples:
+  govc vsan.info
+  govc vsan.info ClusterA
+  govc vsan.info -json`
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	vc, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	c, err := vsan.NewClient(ctx, vc)
+	if err != nil {
+		return err
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	args := f.Args()
+	if len(args) == 0 {
+		args = []string{"*"}
+	}
+
+	var res []Cluster
+
+	for _, arg := range args {
+		clusters, err := finder.ClusterComputeResourceList(ctx, arg)
+		if err != nil {
+			return err
+		}
+
+		for _, cluster := range clusters {
+			info, err := c.VsanClusterGetConfig(ctx, cluster.Reference())
+			if err != nil {
+				return err
+			}
+			res = append(res, Cluster{cluster.InventoryPath, info})
+		}
+	}
+
+	return cmd.WriteResult(&infoResult{res})
+}
+
+type Cluster struct {
+	Path string
+	Info *types.VsanConfigInfoEx
+}
+
+type infoResult struct {
+	Clusters []Cluster
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for _, cluster := range r.Clusters {
+		fmt.Fprintf(tw, "Path:\t%s\n", cluster.Path)
+		fmt.Fprintf(tw, "  Enabled:\t%t\n", *cluster.Info.Enabled)
+		unmapEnabled := false
+		if unmap := cluster.Info.UnmapConfig; unmap != nil {
+			unmapEnabled = unmap.Enable
+		}
+
+		fmt.Fprintf(tw, "  Unmap Enabled:\t%t\n", unmapEnabled)
+	}
+
+	return tw.Flush()
+}

--- a/vsan/client.go
+++ b/vsan/client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -62,12 +63,14 @@ type Client struct {
 	*soap.Client
 
 	RoundTripper soap.RoundTripper
+
+	vim25Client *vim25.Client
 }
 
 // NewClient creates a new VsanHealth client
 func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
 	sc := c.Client.NewServiceClient(Path, Namespace)
-	return &Client{sc, sc}, nil
+	return &Client{sc, sc, c}, nil
 }
 
 // RoundTrip dispatches to the RoundTripper field.
@@ -87,6 +90,22 @@ func (c *Client) VsanClusterGetConfig(ctx context.Context, cluster vimtypes.Mana
 		return nil, err
 	}
 	return &res.Returnval, nil
+}
+
+// VsanClusterReconfig calls the Vsan health's VsanClusterReconfig API.
+func (c *Client) VsanClusterReconfig(ctx context.Context, cluster vimtypes.ManagedObjectReference, spec vsantypes.VimVsanReconfigSpec) (*object.Task, error) {
+	req := vsantypes.VsanClusterReconfig{
+		This:             VsanVcClusterConfigSystemInstance,
+		Cluster:          cluster,
+		VsanReconfigSpec: spec,
+	}
+
+	res, err := methods.VsanClusterReconfig(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(c.vim25Client, res.Returnval), nil
 }
 
 // VsanPerfQueryPerf calls the vsan performance manager API


### PR DESCRIPTION
- vsan.change command adds the ability to set VsanUnmapConfig

- vsan.info command adds the ability to inspect vSAN cluster config

- vcsim: add support for VsanClusterGetConfig and VsanClusterReconfig methods

Fixes #1965

Co-authored-by: Tanay Kothari <tkothari@vmware.com>
Co-authored-by: Doug MacEachern <dougm@vmware.com>