### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. 
+1.
+1.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Affected version**
+Please provide details on the version used, e.g. release tag, commit, module version, etc.
+
+**Screenshots/Debug Output**
+If applicable, add screenshots or debug output to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'kind/feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I cannot do X because [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+## Description
+
+Please include a summary of the change and which issue is fixed. Please also
+include relevant motivation and context. List any dependencies that are required
+for this change.
+
+Closes: #(issue-number)
+
+## Type of change
+
+Please mark options that are relevant:
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to
+  not work as expected)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide
+instructions so we can reproduce. If applicable, please also list any relevant
+details for your test configuration.
+
+- [ ] Test Description 1
+- [ ] Test Description 2
+
+**Test Configuration**:
+* Toolchain:
+* SDK:
+* (add more if needed)
+
+## Checklist:
+
+- [ ] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
+  this project
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged


### PR DESCRIPTION
@dougm proposal for discussion:

Add two issue templates (for [BUG]s and feature requests) and PR template for contributions.

Examples follow https://github.com/cloudevents/sdk-powershell

Closes: #2431 
Signed-off-by: Michael Gasch <mgasch@vmware.com>