### PR TITLE
govc: fix default guest.run path for unsupported Windows guests

### DIFF
--- a/govc/vm/guest/guest.go
+++ b/govc/vm/guest/guest.go
@@ -88,12 +88,18 @@ func (flag *GuestFlag) Toolbox() (*toolbox.Client, error) {
 
 	family := ""
 	var props mo.VirtualMachine
-	err = vm.Properties(context.Background(), vm.Reference(), []string{"guest.guestFamily"}, &props)
+	err = vm.Properties(context.Background(), vm.Reference(), []string{"guest.guestFamily", "guest.toolsInstallType"}, &props)
 	if err != nil {
 		return nil, err
 	}
 	if props.Guest != nil {
 		family = props.Guest.GuestFamily
+		if family == string(types.VirtualMachineGuestOsFamilyOtherGuestFamily) {
+			if props.Guest.ToolsInstallType == string(types.VirtualMachineToolsInstallTypeGuestToolsTypeMSI) {
+				// The case of Windows version not supported by the ESX version
+				family = string(types.VirtualMachineGuestOsFamilyWindowsGuest)
+			}
+		}
 	}
 
 	return &toolbox.Client{

--- a/govc/vm/guest/run.go
+++ b/govc/vm/guest/run.go
@@ -58,6 +58,11 @@ The guest.run command starts a program in the VM with i/o redirected, waits for 
 propagates the exit code to the govc process exit code.  Note that stdout and stderr are redirected by default,
 stdin is only redirected when the '-d' flag is specified.
 
+Note that vmware-tools requires program PATH to be absolute.
+If PATH is not absolute and vm guest family is Windows,
+guest.run changes the command to: 'c:\\Windows\\System32\\cmd.exe /c "PATH [ARG]..."'
+Otherwise the command is changed to: '/bin/bash -c "PATH [ARG]..."'
+
 Examples:
   govc guest.run -vm $name ifconfig
   govc guest.run -vm $name ifconfig eth0
@@ -65,7 +70,8 @@ Examples:
   govc guest.run -vm $name -d "hello $USER" cat
   govc guest.run -vm $name curl -s :invalid: || echo $? # exit code 6
   govc guest.run -vm $name -e FOO=bar -e BIZ=baz -C /tmp env
-  govc guest.run -l root:'mypassword' -vm my_vm_hostname "ntpdate -u pool.ntp.org"`
+  govc guest.run -vm $name -l root:mypassword ntpdate -u pool.ntp.org
+  govc guest.run -vm $name powershell C:\\network_refresh.ps1`
 }
 
 func (cmd *run) Run(ctx context.Context, f *flag.FlagSet) error {


### PR DESCRIPTION
- Add '-w' flag to guest.run

Closes: #2446
