### PR TITLE
Add CNS Snapshot APIs in govmomi/cns

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -228,3 +228,31 @@ func (c *Client) ConfigureVolumeACLs(ctx context.Context, aclConfigSpecs ...cnst
 	}
 	return object.NewTask(c.vim25Client, res.Returnval), nil
 }
+
+// Cns Snapshot API client
+
+func (c *Client) CreateSnapshots(ctx context.Context, snapshotCreateSpecList []cnstypes.CnsSnapshotCreateSpec) (*object.Task, error) {
+	req := cnstypes.CnsCreateSnapshots{
+		This:          CnsVolumeManagerInstance,
+		SnapshotSpecs: snapshotCreateSpecList,
+	}
+	res, err := methods.CnsCreateSnapshots(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(c.vim25Client, res.Returnval), nil
+}
+
+// DeleteSnapshot calls the CNS Snapshot API.
+func (c *Client) DeleteSnapshots(ctx context.Context, snapshotDeleteSpecList []cnstypes.CnsSnapshotDeleteSpec) (*object.Task, error) {
+	req := cnstypes.CnsDeleteSnapshots{
+		This:                CnsVolumeManagerInstance,
+		SnapshotDeleteSpecs: snapshotDeleteSpecList,
+	}
+	res, err := methods.CnsDeleteSnapshots(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(c.vim25Client, res.Returnval), nil
+}

--- a/cns/methods/methods.go
+++ b/cns/methods/methods.go
@@ -260,3 +260,45 @@ func CnsQueryAsync(ctx context.Context, r soap.RoundTripper, req *types.CnsQuery
 
 	return resBody.Res, nil
 }
+
+// Cns Snapshot Methods
+
+type CnsCreateSnapshotsBody struct {
+	Req    *types.CnsCreateSnapshots         `xml:"urn:vsan CnsCreateSnapshots,omitempty"`
+	Res    *types.CnsCreateSnapshotsResponse `xml:"urn:vsan CnsCreateSnapshotsResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsCreateSnapshotsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsCreateSnapshots(ctx context.Context, r soap.RoundTripper, req *types.CnsCreateSnapshots) (*types.CnsCreateSnapshotsResponse, error) {
+	var reqBody, resBody CnsCreateSnapshotsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CnsDeleteSnapshotBody struct {
+	Req    *types.CnsDeleteSnapshots         `xml:"urn:vsan CnsDeleteSnapshots,omitempty"`
+	Res    *types.CnsDeleteSnapshotsResponse `xml:"urn:vsan CnsDeleteSnapshotsResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsDeleteSnapshotBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsDeleteSnapshots(ctx context.Context, r soap.RoundTripper, req *types.CnsDeleteSnapshots) (*types.CnsDeleteSnapshotsResponse, error) {
+	var reqBody, resBody CnsDeleteSnapshotBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/cns/types/if.go
+++ b/cns/types/if.go
@@ -105,3 +105,13 @@ type BaseCnsVolumeOperationResult interface {
 func init() {
 	types.Add("BaseCnsVolumeOperationResult", reflect.TypeOf((*CnsVolumeOperationResult)(nil)).Elem())
 }
+
+func (b *CnsVolumeSource) GetCnsVolumeSource() *CnsVolumeSource { return b }
+
+type BaseCnsVolumeSource interface {
+	GetCnsVolumeSource() *CnsVolumeSource
+}
+
+func init() {
+	types.Add("BaseCnsVolumeSource", reflect.TypeOf((*CnsVolumeSource)(nil)).Elem())
+}

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/vmware/govmomi/vim25/types"
 	vsanfstypes "github.com/vmware/govmomi/vsan/vsanfs/types"
@@ -95,6 +96,7 @@ type CnsVolumeCreateSpec struct {
 	BackingObjectDetails BaseCnsBackingObjectDetails           `xml:"backingObjectDetails,typeattr"`
 	Profile              []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
 	CreateSpec           BaseCnsBaseCreateSpec                 `xml:"createSpec,omitempty,typeattr"`
+	VolumeSource         BaseCnsVolumeSource                   `xml:"volumeSource,omitempty,typeattr"`
 }
 
 func init() {
@@ -669,4 +671,134 @@ type CnsAsyncQueryResult struct {
 
 func init() {
 	types.Add("CnsAsyncQueryResult", reflect.TypeOf((*CnsAsyncQueryResult)(nil)).Elem())
+}
+
+// Cns Snapshot Types
+
+type CnsCreateSnapshotsRequestType struct {
+	This          types.ManagedObjectReference `xml:"_this"`
+	SnapshotSpecs []CnsSnapshotCreateSpec      `xml:"snapshotSpecs,omitempty"`
+}
+
+func init() {
+	types.Add("CnsCreateSnapshotsRequestType", reflect.TypeOf((*CnsCreateSnapshotsRequestType)(nil)).Elem())
+}
+
+type CnsCreateSnapshots CnsCreateSnapshotsRequestType
+
+func init() {
+	types.Add("CnsCreateSnapshots", reflect.TypeOf((*CnsCreateSnapshots)(nil)).Elem())
+}
+
+type CnsCreateSnapshotsResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type CnsSnapshotCreateSpec struct {
+	types.DynamicData
+
+	VolumeId    CnsVolumeId `xml:"volumeId"`
+	Description string      `xml:"description"`
+}
+
+func init() {
+	types.Add("CnsSnapshotCreateSpec", reflect.TypeOf((*CnsSnapshotCreateSpec)(nil)).Elem())
+}
+
+type CnsDeleteSnapshotsRequestType struct {
+	This                types.ManagedObjectReference `xml:"_this"`
+	SnapshotDeleteSpecs []CnsSnapshotDeleteSpec      `xml:"snapshotDeleteSpecs,omitempty"`
+}
+
+func init() {
+	types.Add("CnsDeleteSnapshotsRequestType", reflect.TypeOf((*CnsDeleteSnapshotsRequestType)(nil)).Elem())
+}
+
+type CnsDeleteSnapshots CnsDeleteSnapshotsRequestType
+
+func init() {
+	types.Add("CnsDeleteSnapshots", reflect.TypeOf((*CnsDeleteSnapshots)(nil)).Elem())
+}
+
+type CnsDeleteSnapshotsResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type CnsSnapshotId struct {
+	types.DynamicData
+
+	Id string `xml:"id"`
+}
+
+func init() {
+	types.Add("CnsSnapshotId", reflect.TypeOf((*CnsSnapshotId)(nil)).Elem())
+}
+
+type CnsSnapshotDeleteSpec struct {
+	types.DynamicData
+
+	VolumeId   CnsVolumeId   `xml:"volumeId"`
+	SnapshotId CnsSnapshotId `xml:"snapshotId"`
+}
+
+func init() {
+	types.Add("CnsSnapshotDeleteSpec", reflect.TypeOf((*CnsSnapshotDeleteSpec)(nil)).Elem())
+}
+
+type CnsSnapshot struct {
+	types.DynamicData
+
+	SnapshotId  CnsSnapshotId `xml:"snapshotId"`
+	VolumeId    CnsVolumeId   `xml:"volumeId"`
+	Description string        `xml:"description,omitempty"`
+	CreateTime  time.Time     `xml:"createTime"`
+}
+
+func init() {
+	types.Add("CnsSnapshot", reflect.TypeOf((*CnsSnapshot)(nil)).Elem())
+}
+
+type CnsSnapshotOperationResult struct {
+	CnsVolumeOperationResult
+}
+
+func init() {
+	types.Add("CnsSnapshotOperationResult", reflect.TypeOf((*CnsSnapshotOperationResult)(nil)).Elem())
+}
+
+type CnsSnapshotCreateResult struct {
+	CnsSnapshotOperationResult
+	Snapshot CnsSnapshot `xml:"snapshot,omitempty"`
+}
+
+func init() {
+	types.Add("CnsSnapshotCreateResult", reflect.TypeOf((*CnsSnapshotCreateResult)(nil)).Elem())
+}
+
+type CnsSnapshotDeleteResult struct {
+	CnsSnapshotOperationResult
+	SnapshotId CnsSnapshotId `xml:"snapshotId,omitempty"`
+}
+
+func init() {
+	types.Add("CnsSnapshotDeleteResult", reflect.TypeOf((*CnsSnapshotDeleteResult)(nil)).Elem())
+}
+
+type CnsVolumeSource struct {
+	types.DynamicData
+}
+
+func init() {
+	types.Add("CnsVolumeSource", reflect.TypeOf((*CnsVolumeSource)(nil)).Elem())
+}
+
+type CnsSnapshotVolumeSource struct {
+	CnsVolumeSource
+
+	VolumeId   CnsVolumeId   `xml:"volumeId,omitempty"`
+	SnapshotId CnsSnapshotId `xml:"snapshotId,omitempty"`
+}
+
+func init() {
+	types.Add("CnsSnapshotVolumeSource", reflect.TypeOf((*CnsSnapshotVolumeSource)(nil)).Elem())
 }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

Closes: #(issue-number)

Add CNS Snapshot APIs binding in govmomi. It works with vSphere 7.0 and above. 

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

Testing Done:
- Run the integration test with latest vSphere version
- Run the integration test with previous vSphere version (>= 7.0)

Before running the integration test, please make sure the following ENVs are exported properly.

```
export CNS_DATACENTER=<datacenter name>
export CNS_DATASTORE=<datastore name>
export CNS_VC_URL=https://<username>:<password>@<VCIP>/sdk
```

```
$ go test -v
=== RUN   TestClient
    TestClient: client_test.go:276: Creating snapshot using the spec: []types.CnsSnapshotCreateSpec{
            {
                VolumeId: types.CnsVolumeId{
                    Id: "5a2c17fc-2220-4b5b-92a5-3ada9f5036ea",
                },
                Description: "example-vanilla-block-snapshot",
            },
        }
    TestClient: client_test.go:300: CreateSnapshots: Snapshot created successfully. volumeId: "5a2c17fc-2220-4b5b-92a5-3ada9f5036ea", snapshot id "53fb2a0a-dd51-4f68-ada4-5490eb04ab3f", time stamp 2021-05-21 17:35:58.251 +0000 UTC, opId: "8e8c4071"
    TestClient: client_test.go:307: CreateVolumeFromSnapshot: calling QueryVolume using queryFilter: types.CnsQueryFilter{
            VolumeIds: []types.CnsVolumeId{
                {
                    Id: "5a2c17fc-2220-4b5b-92a5-3ada9f5036ea",
                },
            },
            Names:                        nil,
            ContainerClusterIds:          nil,
            StoragePolicyId:              "",
            Datastores:                   nil,
            Labels:                       nil,
            ComplianceStatus:             "",
            DatastoreAccessibilityStatus: "",
            Cursor:                       (*types.CnsCursor)(nil),
            healthStatus:                 "",
        }
    TestClient: client_test.go:320: CreateVolumeFromSnapshot: Successfully Queried Volumes. queryResult: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "5a2c17fc-2220-4b5b-92a5-3ada9f5036ea",
                    },
                    DatastoreUrl:    "ds:///vmfs/volumes/vsan:529214ad781f54f6-89fbb152add68b67/",
                    Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:      "BLOCK",
                    StoragePolicyId: "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:        types.CnsVolumeMetadata{
                        ContainerCluster: types.CnsContainerCluster{
                            ClusterType:         "KUBERNETES",
                            ClusterId:           "demo-cluster-id",
                            VSphereUser:         "Administrator@vsphere.local",
                            ClusterFlavor:       "VANILLA",
                            ClusterDistribution: "OpenShift",
                        },
                        EntityMetadata:        nil,
                        ContainerClusterArray: []types.CnsContainerCluster{
                            {
                                ClusterType:         "KUBERNETES",
                                ClusterId:           "demo-cluster-id",
                                VSphereUser:         "Administrator@vsphere.local",
                                ClusterFlavor:       "VANILLA",
                                ClusterDistribution: "OpenShift",
                            },
                        },
                    },
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 5120,
                        },
                        BackingDiskId:      "5a2c17fc-2220-4b5b-92a5-3ada9f5036ea",
                        BackingDiskUrlPath: "",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "green",
                },
            },
            Cursor: types.CnsCursor{
                Offset:       1,
                Limit:        100,
                TotalRecords: 1,
            },
        }
    TestClient: client_test.go:346: Creating volume from snapshot using the spec: types.CnsVolumeCreateSpec{
            Name:       "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0-create-from-snapshot",
            VolumeType: "BLOCK",
            Datastores: []types.ManagedObjectReference{
                {Type:"Datastore", Value:"datastore-52"},
            },
            Metadata: types.CnsVolumeMetadata{
                ContainerCluster: types.CnsContainerCluster{
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "OpenShift",
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    CapacityInMb: 5120,
                },
                BackingDiskId:      "",
                BackingDiskUrlPath: "",
            },
            Profile:      nil,
            CreateSpec:   nil,
            VolumeSource: &types.CnsSnapshotVolumeSource{
                CnsVolumeSource: types.CnsVolumeSource{},
                VolumeId:        types.CnsVolumeId{
                    Id: "5a2c17fc-2220-4b5b-92a5-3ada9f5036ea",
                },
                SnapshotId: types.CnsSnapshotId{
                    Id: "53fb2a0a-dd51-4f68-ada4-5490eb04ab3f",
                },
            },
        }
    TestClient: client_test.go:372: createVolumeFromSnapshotResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:c524e2e6-936d-4a45-afc7-24819c820c9b} Fault:<nil>} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0-create-from-snapshot PlacementResults:[{Datastore:Datastore:datastore-52 PlacementFaults:[]}]}
    TestClient: client_test.go:373: Volume created from snapshot 53fb2a0a-dd51-4f68-ada4-5490eb04ab3f sucessfully. volumeId: c524e2e6-936d-4a45-afc7-24819c820c9b
    TestClient: client_test.go:378: Deleting volume: [{DynamicData:{} Id:c524e2e6-936d-4a45-afc7-24819c820c9b}]
    TestClient: client_test.go:402: Volume: "c524e2e6-936d-4a45-afc7-24819c820c9b" deleted sucessfully
    TestClient: client_test.go:416: Deleting snapshot using the spec: []types.CnsSnapshotDeleteSpec{
            {
                VolumeId: types.CnsVolumeId{
                    Id: "5a2c17fc-2220-4b5b-92a5-3ada9f5036ea",
                },
                SnapshotId: types.CnsSnapshotId{
                    Id: "53fb2a0a-dd51-4f68-ada4-5490eb04ab3f",
                },
            },
        }
    TestClient: client_test.go:440: DeleteSnapshots: Snapshot deleted successfully. volumeId: "5a2c17fc-2220-4b5b-92a5-3ada9f5036ea", snapshot id {{} "53fb2a0a-dd51-4f68-ada4-5490eb04ab3f"}, opId: "8e8c408e"
    TestClient: client_test.go:482: Extending volume using the spec: []types.CnsVolumeExtendSpec{
            {
                VolumeId: types.CnsVolumeId{
                    Id: "5a2c17fc-2220-4b5b-92a5-3ada9f5036ea",
                },
                CapacityInMb: 10240,
            },
        }
...
--- PASS: TestClient (71.01s)
PASS
ok  	github.com/vmware/govmomi/cns	71.396s
```


**Test Configuration**:
* Toolchain:
* SDK:
* (add more if needed)

## Checklist:

- [ x ] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] Any dependent changes have been merged