### PR TITLE
Support pre-auth handlers in vC Sim

### DIFF
--- a/eam/simulator/agent.go
+++ b/eam/simulator/agent.go
@@ -161,9 +161,8 @@ func NewAgent(
 	}
 
 	// Start watching this VM and updating the agent's information about the VM.
-	go func(eamReg, vimReg *simulator.Registry) {
+	go func(ctx *simulator.Context, eamReg, vimReg *simulator.Registry) {
 		var (
-			ctx    = simulator.SpoofContext()
 			ticker = time.NewTicker(1 * time.Second)
 			vmName string
 		)
@@ -229,7 +228,7 @@ func NewAgent(
 				})
 			})
 		}
-	}(ctx.Map, vimMap)
+	}(simulator.SpoofContext(), ctx.Map, vimMap)
 
 	return agent, nil
 }

--- a/eam/simulator/simulator.go
+++ b/eam/simulator/simulator.go
@@ -18,7 +18,10 @@ package simulator
 
 import (
 	"github.com/vmware/govmomi/eam"
+	"github.com/vmware/govmomi/eam/types"
 	"github.com/vmware/govmomi/simulator"
+	vimmo "github.com/vmware/govmomi/vim25/mo"
+	vim "github.com/vmware/govmomi/vim25/types"
 )
 
 func init() {
@@ -33,6 +36,7 @@ func New() *simulator.Registry {
 	r := simulator.NewRegistry()
 	r.Namespace = eam.Namespace
 	r.Path = eam.Path
+	r.Handler = invalidLoginForNilSessionFn
 
 	r.Put(&EsxAgentManager{
 		EamObject: EamObject{
@@ -41,4 +45,17 @@ func New() *simulator.Registry {
 	})
 
 	return r
+}
+
+// invalidLoginForNilSessionFn returns EamInvalidLogin if the provided
+// ctx.Session is nil. This is for validating all calls to EAM methods
+// have a valid credential.
+func invalidLoginForNilSessionFn(
+	ctx *simulator.Context,
+	_ *simulator.Method) (vimmo.Reference, vim.BaseMethodFault) {
+
+	if ctx.Session == nil {
+		return nil, new(types.EamInvalidLogin)
+	}
+	return nil, nil
 }

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -70,6 +70,7 @@ type Registry struct {
 
 	Namespace string
 	Path      string
+	Handler   func(*Context, *Method) (mo.Reference, types.BaseMethodFault)
 
 	tagManager tagManager
 }

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -140,6 +140,16 @@ func (s *Service) call(ctx *Context, method *Method) soap.HasFault {
 	session := ctx.Session
 	ctx.Caller = &method.This
 
+	if ctx.Map.Handler != nil {
+		h, fault := ctx.Map.Handler(ctx, method)
+		if fault != nil {
+			return &serverFaultBody{Reason: Fault("", fault)}
+		}
+		if h != nil {
+			handler = h
+		}
+	}
+
 	if session == nil {
 		switch method.Name {
 		case "RetrieveServiceContent", "PbmRetrieveServiceContent", "Fetch", "List", "Login", "LoginByToken", "LoginExtensionByCertificate", "RetrieveProperties", "RetrievePropertiesEx", "CloneSession":


### PR DESCRIPTION
## Description

This patch adds support for pre-auth handlers in vC Sim. This enables SDKs registered with vC Sim to return their own errors if a session does not exist.

This patch includes a validation of this behavior by asserting the EAM simulator should return `EamInvalidLogin` when a session is not present instead of `vim.NotAuthenticated`.

Closes: _NA_

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```shell
$ go test -v -run TestNotAuthenticated -count 1 ./eam/simulator
=== RUN   TestNotAuthenticated
=== RUN   TestNotAuthenticated/TerminateSession
=== RUN   TestNotAuthenticated/ValidateFaults
=== RUN   TestNotAuthenticated/ValidateFaults/vim.NotAuthenticated
=== PAUSE TestNotAuthenticated/ValidateFaults/vim.NotAuthenticated
=== RUN   TestNotAuthenticated/ValidateFaults/eam.EamInvalidLogin
=== PAUSE TestNotAuthenticated/ValidateFaults/eam.EamInvalidLogin
=== CONT  TestNotAuthenticated/ValidateFaults/vim.NotAuthenticated
=== CONT  TestNotAuthenticated/ValidateFaults/eam.EamInvalidLogin
--- PASS: TestNotAuthenticated (0.40s)
    --- PASS: TestNotAuthenticated/TerminateSession (0.00s)
    --- PASS: TestNotAuthenticated/ValidateFaults (0.00s)
        --- PASS: TestNotAuthenticated/ValidateFaults/vim.NotAuthenticated (0.00s)
        --- PASS: TestNotAuthenticated/ValidateFaults/eam.EamInvalidLogin (0.00s)
PASS
ok  	github.com/vmware/govmomi/eam/simulator	0.757s
```

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] ~~Any dependent changes have been merged~~