### PR TITLE
vcsim: Modify Usage of README

### DIFF
--- a/vcsim/README.md
+++ b/vcsim/README.md
@@ -80,28 +80,66 @@ itself uses the vSphere API generate its inventory.
 ```console
 $ vcsim -h # pruned to model type flags used in the Examples section
 Usage of vcsim:
+  -E string
+        Output vcsim variables to the given fifo or stdout (default "-")
+  -api-version string
+        API version (default "6.5")
   -app int
         Number of virtual apps per compute resource
+  -autostart
+        Autostart model created VMs (default true)
   -cluster int
         Number of clusters (default 1)
   -dc int
         Number of datacenters (default 1)
+  -delay int
+        Method response delay across all methods
+  -delay-jitter float
+        Delay jitter coefficient of variation (tip: 0.5 is a good starting value)
   -ds int
         Number of local datastores (default 1)
+  -esx
+        Simulate standalone ESX
   -folder int
         Number of folders
   -host int
         Number of hosts per cluster (default 3)
+  -l string
+        Listen address for vcsim (default "127.0.0.1:8989")
+  -load string
+        Load model from directory
+  -method-delay string
+        Delay per method on the form 'method1:delay1,method2:delay2...'
   -nsx int
         Number of NSX backed opaque networks
+  -password string
+        Login password for vcsim (any password allowed by default)
   -pg int
         Number of port groups (default 1)
+  -pg-nsx int
+        Number of NSX backed port groups
   -pod int
         Number of storage pods per datacenter
   -pool int
         Number of resource pools per compute resource
   -standalone-host int
         Number of standalone hosts (default 1)
+  -stdinexit
+        Press any key to exit
+  -tls
+        Enable TLS (default true)
+  -tlscert string
+        Path to TLS certificate file
+  -tlskey string
+        Path to TLS key file
+  -trace
+        Trace SOAP to -trace-file
+  -trace-file string
+        Trace output file (defaults to stderr)
+  -tunnel int
+        SDK tunnel port (default -1)
+  -username string
+        Login username for vcsim (any username allowed by default)
   -vm int
         Number of virtual machines per resource pool (default 2)
 ```


### PR DESCRIPTION
## Description

I modified uasge of vcsim readme. 
Because it is old.

Closes: na

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

I download vcsim v0.25.0 & ran `vcsim -h` 

```
$ uname -a
Darwin volaaanja 19.6.0 Darwin Kernel Version 19.6.0: Mon Apr 12 20:57:45 PDT 2021; root:xnu-6153.141.28.1~1/RELEASE_X86_64 x86_64
$ ~/local/go/bin/vcsim version
Build Version: 0.25.0
Build Commit: bb0307eb
Build Date: 2021-04-16T16:00:59Z
```

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged