### PR TITLE
Update generated types to vCenter 7.0U2 HP4 (build 17986435)

### DIFF
--- a/eam/types/enum.go
+++ b/eam/types/enum.go
@@ -91,3 +91,14 @@ const (
 func init() {
 	types.Add("eam:EamObjectRuntimeInfoStatus", reflect.TypeOf((*EamObjectRuntimeInfoStatus)(nil)).Elem())
 }
+
+type EsxAgentManagerMaintenanceModePolicy string
+
+const (
+	EsxAgentManagerMaintenanceModePolicySingleHost    = EsxAgentManagerMaintenanceModePolicy("singleHost")
+	EsxAgentManagerMaintenanceModePolicyMultipleHosts = EsxAgentManagerMaintenanceModePolicy("multipleHosts")
+)
+
+func init() {
+	types.Add("eam:EsxAgentManagerMaintenanceModePolicy", reflect.TypeOf((*EsxAgentManagerMaintenanceModePolicy)(nil)).Elem())
+}

--- a/eam/types/types.go
+++ b/eam/types/types.go
@@ -610,12 +610,6 @@ func init() {
 	types.Add("eam:EamInvalidState", reflect.TypeOf((*EamInvalidState)(nil)).Elem())
 }
 
-type EamInvalidStateFault EamInvalidState
-
-func init() {
-	types.Add("eam:EamInvalidStateFault", reflect.TypeOf((*EamInvalidStateFault)(nil)).Elem())
-}
-
 type EamInvalidVibPackage struct {
 	EamRuntimeFault
 }
@@ -714,6 +708,14 @@ type ExtensibleIssue struct {
 
 func init() {
 	types.Add("eam:ExtensibleIssue", reflect.TypeOf((*ExtensibleIssue)(nil)).Elem())
+}
+
+type GetMaintenanceModePolicyRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("eam:GetMaintenanceModePolicyRequestType", reflect.TypeOf((*GetMaintenanceModePolicyRequestType)(nil)).Elem())
 }
 
 type HostInMaintenanceMode struct {
@@ -1309,6 +1311,15 @@ func init() {
 }
 
 type ScanForUnknownAgentVmResponse struct {
+}
+
+type SetMaintenanceModePolicyRequestType struct {
+	This   types.ManagedObjectReference `xml:"_this"`
+	Policy string                       `xml:"policy"`
+}
+
+func init() {
+	types.Add("eam:SetMaintenanceModePolicyRequestType", reflect.TypeOf((*SetMaintenanceModePolicyRequestType)(nil)).Elem())
 }
 
 type Uninstall UninstallRequestType

--- a/gen/gen.sh
+++ b/gen/gen.sh
@@ -47,16 +47,19 @@ generate() {
   done
 }
 
-# ./sdk/ contains the contents of wsdl.zip from vimbase build 17097359 (vSphere 7.0U1)
+#
+# All types derive from vCenter build 17986435, vSphere 7.0U2 Hot Patch 4
+#
+export COPYRIGHT_DATE_RANGE="2014-2021"
 
-generate "../vim25" "vim" "./rbvmomi/vmodl.db" # from github.com/vmware/rbvmomi@v2.4.1
+# ./sdk/ contains the contents of wsdl.zip from vimbase build 17354719
+generate "../vim25" "vim" "./rbvmomi/vmodl.db" # from github.com/vmware/rbvmomi@v3.0.0
 generate "../pbm" "pbm"
 generate "../vslm" "vslm"
 generate "../sms" "sms"
 
 # ./sdk/ contains the files eam-messagetypes.xsd and eam-types.xsd from
-# eam-wsdl.zip, from eam-vcenter build 17073099 (vSphere 7.0U1), a
-# dependency component of the aforementioned vimbase build 17097359.
+# eam-wsdl.zip, from eam-vcenter build 17490501.
 #
 # Please note the EAM files are also available at the following, public URL --
 # http://bit.ly/eam-sdk, therefore the WSDL resource for EAM are in fact

--- a/pbm/methods/methods.go
+++ b/pbm/methods/methods.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pbm/types/enum.go
+++ b/pbm/types/enum.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,6 +21,18 @@ import (
 
 	"github.com/vmware/govmomi/vim25/types"
 )
+
+type PbmAssociateAndApplyPolicyStatusPolicyStatus string
+
+const (
+	PbmAssociateAndApplyPolicyStatusPolicyStatusSuccess = PbmAssociateAndApplyPolicyStatusPolicyStatus("success")
+	PbmAssociateAndApplyPolicyStatusPolicyStatusFailed  = PbmAssociateAndApplyPolicyStatusPolicyStatus("failed")
+	PbmAssociateAndApplyPolicyStatusPolicyStatusInvalid = PbmAssociateAndApplyPolicyStatusPolicyStatus("invalid")
+)
+
+func init() {
+	types.Add("pbm:PbmAssociateAndApplyPolicyStatusPolicyStatus", reflect.TypeOf((*PbmAssociateAndApplyPolicyStatusPolicyStatus)(nil)).Elem())
+}
 
 type PbmBuiltinGenericType string
 

--- a/pbm/types/if.go
+++ b/pbm/types/if.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pbm/types/types.go
+++ b/pbm/types/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/sms/methods/methods.go
+++ b/sms/methods/methods.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/sms/types/enum.go
+++ b/sms/types/enum.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/sms/types/if.go
+++ b/sms/types/if.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/sms/types/types.go
+++ b/sms/types/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vim25/methods/methods.go
+++ b/vim25/methods/methods.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -4083,6 +4083,26 @@ func DeleteSnapshot_Task(ctx context.Context, r soap.RoundTripper, req *types.De
 	return resBody.Res, nil
 }
 
+type DeleteVStorageObjectEx_TaskBody struct {
+	Req    *types.DeleteVStorageObjectEx_Task         `xml:"urn:vim25 DeleteVStorageObjectEx_Task,omitempty"`
+	Res    *types.DeleteVStorageObjectEx_TaskResponse `xml:"DeleteVStorageObjectEx_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DeleteVStorageObjectEx_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DeleteVStorageObjectEx_Task(ctx context.Context, r soap.RoundTripper, req *types.DeleteVStorageObjectEx_Task) (*types.DeleteVStorageObjectEx_TaskResponse, error) {
+	var reqBody, resBody DeleteVStorageObjectEx_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type DeleteVStorageObject_TaskBody struct {
 	Req    *types.DeleteVStorageObject_Task         `xml:"urn:vim25 DeleteVStorageObject_Task,omitempty"`
 	Res    *types.DeleteVStorageObject_TaskResponse `xml:"DeleteVStorageObject_TaskResponse,omitempty"`
@@ -6543,6 +6563,26 @@ func HostCreateDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.Ho
 	return resBody.Res, nil
 }
 
+type HostDeleteVStorageObjectEx_TaskBody struct {
+	Req    *types.HostDeleteVStorageObjectEx_Task         `xml:"urn:vim25 HostDeleteVStorageObjectEx_Task,omitempty"`
+	Res    *types.HostDeleteVStorageObjectEx_TaskResponse `xml:"HostDeleteVStorageObjectEx_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostDeleteVStorageObjectEx_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostDeleteVStorageObjectEx_Task(ctx context.Context, r soap.RoundTripper, req *types.HostDeleteVStorageObjectEx_Task) (*types.HostDeleteVStorageObjectEx_TaskResponse, error) {
+	var reqBody, resBody HostDeleteVStorageObjectEx_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type HostDeleteVStorageObject_TaskBody struct {
 	Req    *types.HostDeleteVStorageObject_Task         `xml:"urn:vim25 HostDeleteVStorageObject_Task,omitempty"`
 	Res    *types.HostDeleteVStorageObject_TaskResponse `xml:"HostDeleteVStorageObject_TaskResponse,omitempty"`
@@ -6963,6 +7003,26 @@ func HostSpecGetUpdatedHosts(ctx context.Context, r soap.RoundTripper, req *type
 	return resBody.Res, nil
 }
 
+type HostUpdateVStorageObjectMetadataEx_TaskBody struct {
+	Req    *types.HostUpdateVStorageObjectMetadataEx_Task         `xml:"urn:vim25 HostUpdateVStorageObjectMetadataEx_Task,omitempty"`
+	Res    *types.HostUpdateVStorageObjectMetadataEx_TaskResponse `xml:"HostUpdateVStorageObjectMetadataEx_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostUpdateVStorageObjectMetadataEx_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostUpdateVStorageObjectMetadataEx_Task(ctx context.Context, r soap.RoundTripper, req *types.HostUpdateVStorageObjectMetadataEx_Task) (*types.HostUpdateVStorageObjectMetadataEx_TaskResponse, error) {
+	var reqBody, resBody HostUpdateVStorageObjectMetadataEx_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type HostUpdateVStorageObjectMetadata_TaskBody struct {
 	Req    *types.HostUpdateVStorageObjectMetadata_Task         `xml:"urn:vim25 HostUpdateVStorageObjectMetadata_Task,omitempty"`
 	Res    *types.HostUpdateVStorageObjectMetadata_TaskResponse `xml:"HostUpdateVStorageObjectMetadata_TaskResponse,omitempty"`
@@ -7133,6 +7193,26 @@ func (b *HttpNfcLeaseGetManifestBody) Fault() *soap.Fault { return b.Fault_ }
 
 func HttpNfcLeaseGetManifest(ctx context.Context, r soap.RoundTripper, req *types.HttpNfcLeaseGetManifest) (*types.HttpNfcLeaseGetManifestResponse, error) {
 	var reqBody, resBody HttpNfcLeaseGetManifestBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HttpNfcLeaseProbeUrlsBody struct {
+	Req    *types.HttpNfcLeaseProbeUrls         `xml:"urn:vim25 HttpNfcLeaseProbeUrls,omitempty"`
+	Res    *types.HttpNfcLeaseProbeUrlsResponse `xml:"HttpNfcLeaseProbeUrlsResponse,omitempty"`
+	Fault_ *soap.Fault                          `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HttpNfcLeaseProbeUrlsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HttpNfcLeaseProbeUrls(ctx context.Context, r soap.RoundTripper, req *types.HttpNfcLeaseProbeUrls) (*types.HttpNfcLeaseProbeUrlsResponse, error) {
+	var reqBody, resBody HttpNfcLeaseProbeUrlsBody
 
 	reqBody.Req = req
 
@@ -17753,6 +17833,26 @@ func (b *UploadKmipServerCertBody) Fault() *soap.Fault { return b.Fault_ }
 
 func UploadKmipServerCert(ctx context.Context, r soap.RoundTripper, req *types.UploadKmipServerCert) (*types.UploadKmipServerCertResponse, error) {
 	var reqBody, resBody UploadKmipServerCertBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VCenterUpdateVStorageObjectMetadataEx_TaskBody struct {
+	Req    *types.VCenterUpdateVStorageObjectMetadataEx_Task         `xml:"urn:vim25 VCenterUpdateVStorageObjectMetadataEx_Task,omitempty"`
+	Res    *types.VCenterUpdateVStorageObjectMetadataEx_TaskResponse `xml:"VCenterUpdateVStorageObjectMetadataEx_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VCenterUpdateVStorageObjectMetadataEx_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VCenterUpdateVStorageObjectMetadataEx_Task(ctx context.Context, r soap.RoundTripper, req *types.VCenterUpdateVStorageObjectMetadataEx_Task) (*types.VCenterUpdateVStorageObjectMetadataEx_TaskResponse, error) {
+	var reqBody, resBody VCenterUpdateVStorageObjectMetadataEx_TaskBody
 
 	reqBody.Req = req
 

--- a/vim25/mo/mo.go
+++ b/vim25/mo/mo.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vim25/types/enum.go
+++ b/vim25/types/enum.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -1131,6 +1131,20 @@ func init() {
 	t["GuestInfoAppStateType"] = reflect.TypeOf((*GuestInfoAppStateType)(nil)).Elem()
 }
 
+type GuestInfoCustomizationStatus string
+
+const (
+	GuestInfoCustomizationStatusTOOLSDEPLOYPKG_IDLE      = GuestInfoCustomizationStatus("TOOLSDEPLOYPKG_IDLE")
+	GuestInfoCustomizationStatusTOOLSDEPLOYPKG_PENDING   = GuestInfoCustomizationStatus("TOOLSDEPLOYPKG_PENDING")
+	GuestInfoCustomizationStatusTOOLSDEPLOYPKG_RUNNING   = GuestInfoCustomizationStatus("TOOLSDEPLOYPKG_RUNNING")
+	GuestInfoCustomizationStatusTOOLSDEPLOYPKG_SUCCEEDED = GuestInfoCustomizationStatus("TOOLSDEPLOYPKG_SUCCEEDED")
+	GuestInfoCustomizationStatusTOOLSDEPLOYPKG_FAILED    = GuestInfoCustomizationStatus("TOOLSDEPLOYPKG_FAILED")
+)
+
+func init() {
+	t["GuestInfoCustomizationStatus"] = reflect.TypeOf((*GuestInfoCustomizationStatus)(nil)).Elem()
+}
+
 type GuestOsDescriptorFirmwareType string
 
 const (
@@ -2101,6 +2115,18 @@ func init() {
 	t["HostRuntimeInfoNetStackInstanceRuntimeInfoState"] = reflect.TypeOf((*HostRuntimeInfoNetStackInstanceRuntimeInfoState)(nil)).Elem()
 }
 
+type HostRuntimeInfoStatelessNvdsMigrationState string
+
+const (
+	HostRuntimeInfoStatelessNvdsMigrationStateReady     = HostRuntimeInfoStatelessNvdsMigrationState("ready")
+	HostRuntimeInfoStatelessNvdsMigrationStateNotNeeded = HostRuntimeInfoStatelessNvdsMigrationState("notNeeded")
+	HostRuntimeInfoStatelessNvdsMigrationStateUnknown   = HostRuntimeInfoStatelessNvdsMigrationState("unknown")
+)
+
+func init() {
+	t["HostRuntimeInfoStatelessNvdsMigrationState"] = reflect.TypeOf((*HostRuntimeInfoStatelessNvdsMigrationState)(nil)).Elem()
+}
+
 type HostServicePolicy string
 
 const (
@@ -2470,6 +2496,7 @@ const (
 	KmipClusterInfoKmsManagementTypeUnknown        = KmipClusterInfoKmsManagementType("unknown")
 	KmipClusterInfoKmsManagementTypeVCenter        = KmipClusterInfoKmsManagementType("vCenter")
 	KmipClusterInfoKmsManagementTypeTrustAuthority = KmipClusterInfoKmsManagementType("trustAuthority")
+	KmipClusterInfoKmsManagementTypeNativeProvider = KmipClusterInfoKmsManagementType("nativeProvider")
 )
 
 func init() {
@@ -3141,6 +3168,7 @@ const (
 	RecommendationReasonCodeVmHostAffinityPolicy            = RecommendationReasonCode("vmHostAffinityPolicy")
 	RecommendationReasonCodeVmHostAntiAffinityPolicy        = RecommendationReasonCode("vmHostAntiAffinityPolicy")
 	RecommendationReasonCodeVmAntiAffinityPolicy            = RecommendationReasonCode("vmAntiAffinityPolicy")
+	RecommendationReasonCodeBalanceVsanUsage                = RecommendationReasonCode("balanceVsanUsage")
 )
 
 func init() {
@@ -3355,6 +3383,18 @@ const (
 
 func init() {
 	t["ScsiLunVStorageSupportStatus"] = reflect.TypeOf((*ScsiLunVStorageSupportStatus)(nil)).Elem()
+}
+
+type SessionManagerGenericServiceTicketTicketType string
+
+const (
+	SessionManagerGenericServiceTicketTicketTypeHttpNfcServiceTicket = SessionManagerGenericServiceTicketTicketType("HttpNfcServiceTicket")
+	SessionManagerGenericServiceTicketTicketTypeHostServiceTicket    = SessionManagerGenericServiceTicketTicketType("HostServiceTicket")
+	SessionManagerGenericServiceTicketTicketTypeVcServiceTicket      = SessionManagerGenericServiceTicketTicketType("VcServiceTicket")
+)
+
+func init() {
+	t["SessionManagerGenericServiceTicketTicketType"] = reflect.TypeOf((*SessionManagerGenericServiceTicketTicketType)(nil)).Elem()
 }
 
 type SessionManagerHttpServiceRequestSpecMethod string
@@ -3741,6 +3781,17 @@ func init() {
 	t["VMwareUplinkLacpMode"] = reflect.TypeOf((*VMwareUplinkLacpMode)(nil)).Elem()
 }
 
+type VMwareUplinkLacpTimeoutMode string
+
+const (
+	VMwareUplinkLacpTimeoutModeFast = VMwareUplinkLacpTimeoutMode("fast")
+	VMwareUplinkLacpTimeoutModeSlow = VMwareUplinkLacpTimeoutMode("slow")
+)
+
+func init() {
+	t["VMwareUplinkLacpTimeoutMode"] = reflect.TypeOf((*VMwareUplinkLacpTimeoutMode)(nil)).Elem()
+}
+
 type VStorageObjectConsumptionType string
 
 const (
@@ -4108,6 +4159,18 @@ const (
 
 func init() {
 	t["VirtualMachineConfigInfoSwapPlacementType"] = reflect.TypeOf((*VirtualMachineConfigInfoSwapPlacementType)(nil)).Elem()
+}
+
+type VirtualMachineConfigSpecEncryptedFtModes string
+
+const (
+	VirtualMachineConfigSpecEncryptedFtModesFtEncryptionDisabled      = VirtualMachineConfigSpecEncryptedFtModes("ftEncryptionDisabled")
+	VirtualMachineConfigSpecEncryptedFtModesFtEncryptionOpportunistic = VirtualMachineConfigSpecEncryptedFtModes("ftEncryptionOpportunistic")
+	VirtualMachineConfigSpecEncryptedFtModesFtEncryptionRequired      = VirtualMachineConfigSpecEncryptedFtModes("ftEncryptionRequired")
+)
+
+func init() {
+	t["VirtualMachineConfigSpecEncryptedFtModes"] = reflect.TypeOf((*VirtualMachineConfigSpecEncryptedFtModes)(nil)).Elem()
 }
 
 type VirtualMachineConfigSpecEncryptedVMotionModes string
@@ -5009,6 +5072,7 @@ const (
 	VmFaultToleranceConfigIssueReasonForIssueHasEFIFirmware                 = VmFaultToleranceConfigIssueReasonForIssue("hasEFIFirmware")
 	VmFaultToleranceConfigIssueReasonForIssueTooManyVCPUs                   = VmFaultToleranceConfigIssueReasonForIssue("tooManyVCPUs")
 	VmFaultToleranceConfigIssueReasonForIssueTooMuchMemory                  = VmFaultToleranceConfigIssueReasonForIssue("tooMuchMemory")
+	VmFaultToleranceConfigIssueReasonForIssueUnsupportedPMemHAFailOver      = VmFaultToleranceConfigIssueReasonForIssue("unsupportedPMemHAFailOver")
 )
 
 func init() {

--- a/vim25/types/if.go
+++ b/vim25/types/if.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -1528,6 +1528,18 @@ type BaseHostTargetTransport interface {
 
 func init() {
 	t["BaseHostTargetTransport"] = reflect.TypeOf((*HostTargetTransport)(nil)).Elem()
+}
+
+func (b *HostTpmBootSecurityOptionEventDetails) GetHostTpmBootSecurityOptionEventDetails() *HostTpmBootSecurityOptionEventDetails {
+	return b
+}
+
+type BaseHostTpmBootSecurityOptionEventDetails interface {
+	GetHostTpmBootSecurityOptionEventDetails() *HostTpmBootSecurityOptionEventDetails
+}
+
+func init() {
+	t["BaseHostTpmBootSecurityOptionEventDetails"] = reflect.TypeOf((*HostTpmBootSecurityOptionEventDetails)(nil)).Elem()
 }
 
 func (b *HostTpmEventDetails) GetHostTpmEventDetails() *HostTpmEventDetails { return b }

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ type AboutInfo struct {
 	FullName              string `xml:"fullName"`
 	Vendor                string `xml:"vendor"`
 	Version               string `xml:"version"`
+	PatchLevel            string `xml:"patchLevel,omitempty"`
 	Build                 string `xml:"build"`
 	LocaleVersion         string `xml:"localeVersion,omitempty"`
 	LocaleBuild           string `xml:"localeBuild,omitempty"`
@@ -2243,6 +2244,14 @@ func init() {
 	t["ArrayOfDatastoreVVolContainerFailoverPair"] = reflect.TypeOf((*ArrayOfDatastoreVVolContainerFailoverPair)(nil)).Elem()
 }
 
+type ArrayOfDesiredSoftwareSpecComponentSpec struct {
+	DesiredSoftwareSpecComponentSpec []DesiredSoftwareSpecComponentSpec `xml:"DesiredSoftwareSpecComponentSpec,omitempty"`
+}
+
+func init() {
+	t["ArrayOfDesiredSoftwareSpecComponentSpec"] = reflect.TypeOf((*ArrayOfDesiredSoftwareSpecComponentSpec)(nil)).Elem()
+}
+
 type ArrayOfDiagnosticManagerBundleInfo struct {
 	DiagnosticManagerBundleInfo []DiagnosticManagerBundleInfo `xml:"DiagnosticManagerBundleInfo,omitempty"`
 }
@@ -4033,6 +4042,14 @@ type ArrayOfHttpNfcLeaseManifestEntry struct {
 
 func init() {
 	t["ArrayOfHttpNfcLeaseManifestEntry"] = reflect.TypeOf((*ArrayOfHttpNfcLeaseManifestEntry)(nil)).Elem()
+}
+
+type ArrayOfHttpNfcLeaseProbeResult struct {
+	HttpNfcLeaseProbeResult []HttpNfcLeaseProbeResult `xml:"HttpNfcLeaseProbeResult,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHttpNfcLeaseProbeResult"] = reflect.TypeOf((*ArrayOfHttpNfcLeaseProbeResult)(nil)).Elem()
 }
 
 type ArrayOfHttpNfcLeaseSourceFile struct {
@@ -6414,6 +6431,8 @@ type BaseConfigInfo struct {
 	NativeSnapshotSupported     *bool                         `xml:"nativeSnapshotSupported"`
 	ChangedBlockTrackingEnabled *bool                         `xml:"changedBlockTrackingEnabled"`
 	Backing                     BaseBaseConfigInfoBackingInfo `xml:"backing,typeattr"`
+	Metadata                    []KeyValue                    `xml:"metadata,omitempty"`
+	Vclock                      *VslmVClockInfo               `xml:"vclock,omitempty"`
 	Iofilter                    []string                      `xml:"iofilter,omitempty"`
 }
 
@@ -7250,6 +7269,7 @@ type Capability struct {
 	ComputePolicyVersion             int32            `xml:"computePolicyVersion,omitempty"`
 	ClusterPlacementSupported        *bool            `xml:"clusterPlacementSupported"`
 	LifecycleManagementSupported     *bool            `xml:"lifecycleManagementSupported"`
+	HostSeedingSupported             *bool            `xml:"hostSeedingSupported"`
 	ScalableSharesSupported          *bool            `xml:"scalableSharesSupported"`
 	HadcsSupported                   *bool            `xml:"hadcsSupported"`
 }
@@ -8451,6 +8471,7 @@ type ClusterDasAdmissionControlPolicy struct {
 	DynamicData
 
 	ResourceReductionToToleratePercent *int32 `xml:"resourceReductionToToleratePercent"`
+	PMemAdmissionControlEnabled        *bool  `xml:"pMemAdmissionControlEnabled"`
 }
 
 func init() {
@@ -8920,6 +8941,7 @@ type ClusterFailoverResourcesAdmissionControlInfo struct {
 
 	CurrentCpuFailoverResourcesPercent    int32 `xml:"currentCpuFailoverResourcesPercent"`
 	CurrentMemoryFailoverResourcesPercent int32 `xml:"currentMemoryFailoverResourcesPercent"`
+	CurrentPMemFailoverResourcesPercent   int32 `xml:"currentPMemFailoverResourcesPercent,omitempty"`
 }
 
 func init() {
@@ -8929,10 +8951,12 @@ func init() {
 type ClusterFailoverResourcesAdmissionControlPolicy struct {
 	ClusterDasAdmissionControlPolicy
 
-	CpuFailoverResourcesPercent    int32 `xml:"cpuFailoverResourcesPercent"`
-	MemoryFailoverResourcesPercent int32 `xml:"memoryFailoverResourcesPercent"`
-	FailoverLevel                  int32 `xml:"failoverLevel,omitempty"`
-	AutoComputePercentages         *bool `xml:"autoComputePercentages"`
+	CpuFailoverResourcesPercent             int32 `xml:"cpuFailoverResourcesPercent"`
+	MemoryFailoverResourcesPercent          int32 `xml:"memoryFailoverResourcesPercent"`
+	FailoverLevel                           int32 `xml:"failoverLevel,omitempty"`
+	AutoComputePercentages                  *bool `xml:"autoComputePercentages"`
+	PMemFailoverResourcesPercent            int32 `xml:"pMemFailoverResourcesPercent,omitempty"`
+	AutoComputePMemFailoverResourcesPercent *bool `xml:"autoComputePMemFailoverResourcesPercent"`
 }
 
 func init() {
@@ -9527,6 +9551,7 @@ type ComputeResourceConfigInfo struct {
 	VmSwapPlacement           string `xml:"vmSwapPlacement"`
 	SpbmEnabled               *bool  `xml:"spbmEnabled"`
 	DefaultHardwareVersionKey string `xml:"defaultHardwareVersionKey,omitempty"`
+	MaximumHardwareVersionKey string `xml:"maximumHardwareVersionKey,omitempty"`
 }
 
 func init() {
@@ -9540,6 +9565,7 @@ type ComputeResourceConfigSpec struct {
 	SpbmEnabled               *bool                `xml:"spbmEnabled"`
 	DefaultHardwareVersionKey string               `xml:"defaultHardwareVersionKey,omitempty"`
 	DesiredSoftwareSpec       *DesiredSoftwareSpec `xml:"desiredSoftwareSpec,omitempty"`
+	MaximumHardwareVersionKey string               `xml:"maximumHardwareVersionKey,omitempty"`
 }
 
 func init() {
@@ -10393,6 +10419,7 @@ type CreateDirectoryRequestType struct {
 	Datastore   ManagedObjectReference `xml:"datastore"`
 	DisplayName string                 `xml:"displayName,omitempty"`
 	Policy      string                 `xml:"policy,omitempty"`
+	Size        int64                  `xml:"size,omitempty"`
 }
 
 func init() {
@@ -12952,6 +12979,7 @@ type DatacenterConfigInfo struct {
 	DynamicData
 
 	DefaultHardwareVersionKey string `xml:"defaultHardwareVersionKey,omitempty"`
+	MaximumHardwareVersionKey string `xml:"maximumHardwareVersionKey,omitempty"`
 }
 
 func init() {
@@ -12962,6 +12990,7 @@ type DatacenterConfigSpec struct {
 	DynamicData
 
 	DefaultHardwareVersionKey string `xml:"defaultHardwareVersionKey,omitempty"`
+	MaximumHardwareVersionKey string `xml:"maximumHardwareVersionKey,omitempty"`
 }
 
 func init() {
@@ -13672,6 +13701,26 @@ type DeleteSnapshot_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
+type DeleteVStorageObjectExRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["DeleteVStorageObjectExRequestType"] = reflect.TypeOf((*DeleteVStorageObjectExRequestType)(nil)).Elem()
+}
+
+type DeleteVStorageObjectEx_Task DeleteVStorageObjectExRequestType
+
+func init() {
+	t["DeleteVStorageObjectEx_Task"] = reflect.TypeOf((*DeleteVStorageObjectEx_Task)(nil)).Elem()
+}
+
+type DeleteVStorageObjectEx_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type DeleteVStorageObjectRequestType struct {
 	This      ManagedObjectReference `xml:"_this"`
 	Id        ID                     `xml:"id"`
@@ -13837,6 +13886,7 @@ type DesiredSoftwareSpec struct {
 
 	BaseImageSpec   DesiredSoftwareSpecBaseImageSpec    `xml:"baseImageSpec"`
 	VendorAddOnSpec *DesiredSoftwareSpecVendorAddOnSpec `xml:"vendorAddOnSpec,omitempty"`
+	Components      []DesiredSoftwareSpecComponentSpec  `xml:"components,omitempty"`
 }
 
 func init() {
@@ -13851,6 +13901,17 @@ type DesiredSoftwareSpecBaseImageSpec struct {
 
 func init() {
 	t["DesiredSoftwareSpecBaseImageSpec"] = reflect.TypeOf((*DesiredSoftwareSpecBaseImageSpec)(nil)).Elem()
+}
+
+type DesiredSoftwareSpecComponentSpec struct {
+	DynamicData
+
+	Name    string `xml:"name"`
+	Version string `xml:"version,omitempty"`
+}
+
+func init() {
+	t["DesiredSoftwareSpecComponentSpec"] = reflect.TypeOf((*DesiredSoftwareSpecComponentSpec)(nil)).Elem()
 }
 
 type DesiredSoftwareSpecVendorAddOnSpec struct {
@@ -19930,10 +19991,24 @@ type GuestInfo struct {
 	GuestStateChangeSupported       *bool                              `xml:"guestStateChangeSupported"`
 	GenerationInfo                  []GuestInfoNamespaceGenerationInfo `xml:"generationInfo,omitempty"`
 	HwVersion                       string                             `xml:"hwVersion,omitempty"`
+	CustomizationInfo               *GuestInfoCustomizationInfo        `xml:"customizationInfo,omitempty"`
 }
 
 func init() {
 	t["GuestInfo"] = reflect.TypeOf((*GuestInfo)(nil)).Elem()
+}
+
+type GuestInfoCustomizationInfo struct {
+	DynamicData
+
+	CustomizationStatus string     `xml:"customizationStatus"`
+	StartTime           *time.Time `xml:"startTime"`
+	EndTime             *time.Time `xml:"endTime"`
+	ErrorMsg            string     `xml:"errorMsg,omitempty"`
+}
+
+func init() {
+	t["GuestInfoCustomizationInfo"] = reflect.TypeOf((*GuestInfoCustomizationInfo)(nil)).Elem()
 }
 
 type GuestInfoNamespaceGenerationInfo struct {
@@ -21089,7 +21164,9 @@ type HostCapability struct {
 	Vmfs3EOLSupported                         *bool           `xml:"vmfs3EOLSupported"`
 	FtVmcpSupported                           *bool           `xml:"ftVmcpSupported"`
 	QuickBootSupported                        *bool           `xml:"quickBootSupported"`
+	EncryptedFtSupported                      *bool           `xml:"encryptedFtSupported"`
 	AssignableHardwareSupported               *bool           `xml:"assignableHardwareSupported"`
+	SuspendToMemorySupported                  *bool           `xml:"suspendToMemorySupported"`
 	UseFeatureReqsForOldHWv                   *bool           `xml:"useFeatureReqsForOldHWv"`
 	MarkPerenniallyReservedSupported          *bool           `xml:"markPerenniallyReservedSupported"`
 	HppPspSupported                           *bool           `xml:"hppPspSupported"`
@@ -21098,6 +21175,10 @@ type HostCapability struct {
 	PrecisionTimeProtocolSupported            *bool           `xml:"precisionTimeProtocolSupported"`
 	RemoteDeviceVMotionSupported              *bool           `xml:"remoteDeviceVMotionSupported"`
 	MaxSupportedVmMemory                      int32           `xml:"maxSupportedVmMemory,omitempty"`
+	AhDeviceHintsSupported                    *bool           `xml:"ahDeviceHintsSupported"`
+	AssignHwPciConfigSupported                *bool           `xml:"assignHwPciConfigSupported"`
+	PMemFailoverSupported                     *bool           `xml:"pMemFailoverSupported"`
+	HostConfigEncryptionSupported             *bool           `xml:"hostConfigEncryptionSupported"`
 }
 
 func init() {
@@ -21877,6 +21958,26 @@ type HostDateTimeSystemTimeZone struct {
 
 func init() {
 	t["HostDateTimeSystemTimeZone"] = reflect.TypeOf((*HostDateTimeSystemTimeZone)(nil)).Elem()
+}
+
+type HostDeleteVStorageObjectExRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["HostDeleteVStorageObjectExRequestType"] = reflect.TypeOf((*HostDeleteVStorageObjectExRequestType)(nil)).Elem()
+}
+
+type HostDeleteVStorageObjectEx_Task HostDeleteVStorageObjectExRequestType
+
+func init() {
+	t["HostDeleteVStorageObjectEx_Task"] = reflect.TypeOf((*HostDeleteVStorageObjectEx_Task)(nil)).Elem()
+}
+
+type HostDeleteVStorageObjectEx_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
 type HostDeleteVStorageObjectRequestType struct {
@@ -24026,6 +24127,7 @@ type HostNetworkConfig struct {
 	Nat                  []HostNatServiceConfig          `xml:"nat,omitempty"`
 	IpV6Enabled          *bool                           `xml:"ipV6Enabled"`
 	NetStackSpec         []HostNetworkConfigNetStackSpec `xml:"netStackSpec,omitempty"`
+	MigrationStatus      string                          `xml:"migrationStatus,omitempty"`
 }
 
 func init() {
@@ -24057,25 +24159,27 @@ func init() {
 type HostNetworkInfo struct {
 	DynamicData
 
-	Vswitch              []HostVirtualSwitch     `xml:"vswitch,omitempty"`
-	ProxySwitch          []HostProxySwitch       `xml:"proxySwitch,omitempty"`
-	Portgroup            []HostPortGroup         `xml:"portgroup,omitempty"`
-	Pnic                 []PhysicalNic           `xml:"pnic,omitempty"`
-	RdmaDevice           []HostRdmaDevice        `xml:"rdmaDevice,omitempty"`
-	Vnic                 []HostVirtualNic        `xml:"vnic,omitempty"`
-	ConsoleVnic          []HostVirtualNic        `xml:"consoleVnic,omitempty"`
-	DnsConfig            BaseHostDnsConfig       `xml:"dnsConfig,omitempty,typeattr"`
-	IpRouteConfig        BaseHostIpRouteConfig   `xml:"ipRouteConfig,omitempty,typeattr"`
-	ConsoleIpRouteConfig BaseHostIpRouteConfig   `xml:"consoleIpRouteConfig,omitempty,typeattr"`
-	RouteTableInfo       *HostIpRouteTableInfo   `xml:"routeTableInfo,omitempty"`
-	Dhcp                 []HostDhcpService       `xml:"dhcp,omitempty"`
-	Nat                  []HostNatService        `xml:"nat,omitempty"`
-	IpV6Enabled          *bool                   `xml:"ipV6Enabled"`
-	AtBootIpV6Enabled    *bool                   `xml:"atBootIpV6Enabled"`
-	NetStackInstance     []HostNetStackInstance  `xml:"netStackInstance,omitempty"`
-	OpaqueSwitch         []HostOpaqueSwitch      `xml:"opaqueSwitch,omitempty"`
-	OpaqueNetwork        []HostOpaqueNetworkInfo `xml:"opaqueNetwork,omitempty"`
-	NsxTransportNodeId   string                  `xml:"nsxTransportNodeId,omitempty"`
+	Vswitch                    []HostVirtualSwitch     `xml:"vswitch,omitempty"`
+	ProxySwitch                []HostProxySwitch       `xml:"proxySwitch,omitempty"`
+	Portgroup                  []HostPortGroup         `xml:"portgroup,omitempty"`
+	Pnic                       []PhysicalNic           `xml:"pnic,omitempty"`
+	RdmaDevice                 []HostRdmaDevice        `xml:"rdmaDevice,omitempty"`
+	Vnic                       []HostVirtualNic        `xml:"vnic,omitempty"`
+	ConsoleVnic                []HostVirtualNic        `xml:"consoleVnic,omitempty"`
+	DnsConfig                  BaseHostDnsConfig       `xml:"dnsConfig,omitempty,typeattr"`
+	IpRouteConfig              BaseHostIpRouteConfig   `xml:"ipRouteConfig,omitempty,typeattr"`
+	ConsoleIpRouteConfig       BaseHostIpRouteConfig   `xml:"consoleIpRouteConfig,omitempty,typeattr"`
+	RouteTableInfo             *HostIpRouteTableInfo   `xml:"routeTableInfo,omitempty"`
+	Dhcp                       []HostDhcpService       `xml:"dhcp,omitempty"`
+	Nat                        []HostNatService        `xml:"nat,omitempty"`
+	IpV6Enabled                *bool                   `xml:"ipV6Enabled"`
+	AtBootIpV6Enabled          *bool                   `xml:"atBootIpV6Enabled"`
+	NetStackInstance           []HostNetStackInstance  `xml:"netStackInstance,omitempty"`
+	OpaqueSwitch               []HostOpaqueSwitch      `xml:"opaqueSwitch,omitempty"`
+	OpaqueNetwork              []HostOpaqueNetworkInfo `xml:"opaqueNetwork,omitempty"`
+	NsxTransportNodeId         string                  `xml:"nsxTransportNodeId,omitempty"`
+	NvdsToVdsMigrationRequired *bool                   `xml:"nvdsToVdsMigrationRequired"`
+	MigrationStatus            string                  `xml:"migrationStatus,omitempty"`
 }
 
 func init() {
@@ -24666,6 +24770,7 @@ type HostPciPassthruConfig struct {
 	Id              string `xml:"id"`
 	PassthruEnabled bool   `xml:"passthruEnabled"`
 	ApplyNow        *bool  `xml:"applyNow"`
+	HardwareLabel   string `xml:"hardwareLabel,omitempty"`
 }
 
 func init() {
@@ -24680,6 +24785,7 @@ type HostPciPassthruInfo struct {
 	PassthruEnabled bool   `xml:"passthruEnabled"`
 	PassthruCapable bool   `xml:"passthruCapable"`
 	PassthruActive  bool   `xml:"passthruActive"`
+	HardwareLabel   string `xml:"hardwareLabel,omitempty"`
 }
 
 func init() {
@@ -25512,21 +25618,22 @@ type HostRetrieveVStorageObjectStateResponse struct {
 type HostRuntimeInfo struct {
 	DynamicData
 
-	ConnectionState            HostSystemConnectionState                   `xml:"connectionState"`
-	PowerState                 HostSystemPowerState                        `xml:"powerState"`
-	StandbyMode                string                                      `xml:"standbyMode,omitempty"`
-	InMaintenanceMode          bool                                        `xml:"inMaintenanceMode"`
-	InQuarantineMode           *bool                                       `xml:"inQuarantineMode"`
-	BootTime                   *time.Time                                  `xml:"bootTime"`
-	HealthSystemRuntime        *HealthSystemRuntime                        `xml:"healthSystemRuntime,omitempty"`
-	DasHostState               *ClusterDasFdmHostState                     `xml:"dasHostState,omitempty"`
-	TpmPcrValues               []HostTpmDigestInfo                         `xml:"tpmPcrValues,omitempty"`
-	VsanRuntimeInfo            *VsanHostRuntimeInfo                        `xml:"vsanRuntimeInfo,omitempty"`
-	NetworkRuntimeInfo         *HostRuntimeInfoNetworkRuntimeInfo          `xml:"networkRuntimeInfo,omitempty"`
-	VFlashResourceRuntimeInfo  *HostVFlashManagerVFlashResourceRunTimeInfo `xml:"vFlashResourceRuntimeInfo,omitempty"`
-	HostMaxVirtualDiskCapacity int64                                       `xml:"hostMaxVirtualDiskCapacity,omitempty"`
-	CryptoState                string                                      `xml:"cryptoState,omitempty"`
-	CryptoKeyId                *CryptoKeyId                                `xml:"cryptoKeyId,omitempty"`
+	ConnectionState             HostSystemConnectionState                   `xml:"connectionState"`
+	PowerState                  HostSystemPowerState                        `xml:"powerState"`
+	StandbyMode                 string                                      `xml:"standbyMode,omitempty"`
+	InMaintenanceMode           bool                                        `xml:"inMaintenanceMode"`
+	InQuarantineMode            *bool                                       `xml:"inQuarantineMode"`
+	BootTime                    *time.Time                                  `xml:"bootTime"`
+	HealthSystemRuntime         *HealthSystemRuntime                        `xml:"healthSystemRuntime,omitempty"`
+	DasHostState                *ClusterDasFdmHostState                     `xml:"dasHostState,omitempty"`
+	TpmPcrValues                []HostTpmDigestInfo                         `xml:"tpmPcrValues,omitempty"`
+	VsanRuntimeInfo             *VsanHostRuntimeInfo                        `xml:"vsanRuntimeInfo,omitempty"`
+	NetworkRuntimeInfo          *HostRuntimeInfoNetworkRuntimeInfo          `xml:"networkRuntimeInfo,omitempty"`
+	VFlashResourceRuntimeInfo   *HostVFlashManagerVFlashResourceRunTimeInfo `xml:"vFlashResourceRuntimeInfo,omitempty"`
+	HostMaxVirtualDiskCapacity  int64                                       `xml:"hostMaxVirtualDiskCapacity,omitempty"`
+	CryptoState                 string                                      `xml:"cryptoState,omitempty"`
+	CryptoKeyId                 *CryptoKeyId                                `xml:"cryptoKeyId,omitempty"`
+	StatelessNvdsMigrationReady string                                      `xml:"statelessNvdsMigrationReady,omitempty"`
 }
 
 func init() {
@@ -26358,6 +26465,14 @@ func init() {
 	t["HostTpmEventLogEntry"] = reflect.TypeOf((*HostTpmEventLogEntry)(nil)).Elem()
 }
 
+type HostTpmNvTagEventDetails struct {
+	HostTpmBootSecurityOptionEventDetails
+}
+
+func init() {
+	t["HostTpmNvTagEventDetails"] = reflect.TypeOf((*HostTpmNvTagEventDetails)(nil)).Elem()
+}
+
 type HostTpmOptionEventDetails struct {
 	HostTpmEventDetails
 
@@ -26470,6 +26585,28 @@ type HostUnresolvedVmfsVolumeResolveStatus struct {
 
 func init() {
 	t["HostUnresolvedVmfsVolumeResolveStatus"] = reflect.TypeOf((*HostUnresolvedVmfsVolumeResolveStatus)(nil)).Elem()
+}
+
+type HostUpdateVStorageObjectMetadataExRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	Id         ID                     `xml:"id"`
+	Datastore  ManagedObjectReference `xml:"datastore"`
+	Metadata   []KeyValue             `xml:"metadata,omitempty"`
+	DeleteKeys []string               `xml:"deleteKeys,omitempty"`
+}
+
+func init() {
+	t["HostUpdateVStorageObjectMetadataExRequestType"] = reflect.TypeOf((*HostUpdateVStorageObjectMetadataExRequestType)(nil)).Elem()
+}
+
+type HostUpdateVStorageObjectMetadataEx_Task HostUpdateVStorageObjectMetadataExRequestType
+
+func init() {
+	t["HostUpdateVStorageObjectMetadataEx_Task"] = reflect.TypeOf((*HostUpdateVStorageObjectMetadataEx_Task)(nil)).Elem()
+}
+
+type HostUpdateVStorageObjectMetadataEx_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
 type HostUpdateVStorageObjectMetadataRequestType struct {
@@ -27369,6 +27506,36 @@ type HttpNfcLeaseManifestEntry struct {
 
 func init() {
 	t["HttpNfcLeaseManifestEntry"] = reflect.TypeOf((*HttpNfcLeaseManifestEntry)(nil)).Elem()
+}
+
+type HttpNfcLeaseProbeResult struct {
+	DynamicData
+
+	ServerAccessible bool `xml:"serverAccessible"`
+}
+
+func init() {
+	t["HttpNfcLeaseProbeResult"] = reflect.TypeOf((*HttpNfcLeaseProbeResult)(nil)).Elem()
+}
+
+type HttpNfcLeaseProbeUrls HttpNfcLeaseProbeUrlsRequestType
+
+func init() {
+	t["HttpNfcLeaseProbeUrls"] = reflect.TypeOf((*HttpNfcLeaseProbeUrls)(nil)).Elem()
+}
+
+type HttpNfcLeaseProbeUrlsRequestType struct {
+	This    ManagedObjectReference   `xml:"_this"`
+	Files   []HttpNfcLeaseSourceFile `xml:"files,omitempty"`
+	Timeout int32                    `xml:"timeout,omitempty"`
+}
+
+func init() {
+	t["HttpNfcLeaseProbeUrlsRequestType"] = reflect.TypeOf((*HttpNfcLeaseProbeUrlsRequestType)(nil)).Elem()
+}
+
+type HttpNfcLeaseProbeUrlsResponse struct {
+	Returnval []HttpNfcLeaseProbeResult `xml:"returnval,omitempty"`
 }
 
 type HttpNfcLeaseProgress HttpNfcLeaseProgressRequestType
@@ -29814,6 +29981,9 @@ type KmipClusterInfo struct {
 	UseAsDefault       bool                     `xml:"useAsDefault"`
 	ManagementType     string                   `xml:"managementType,omitempty"`
 	UseAsEntityDefault []ManagedObjectReference `xml:"useAsEntityDefault,omitempty"`
+	HasBackup          *bool                    `xml:"hasBackup"`
+	TpmRequired        *bool                    `xml:"tpmRequired"`
+	KeyId              string                   `xml:"keyId,omitempty"`
 }
 
 func init() {
@@ -44412,6 +44582,7 @@ type SessionManagerGenericServiceTicket struct {
 	Id            string `xml:"id"`
 	HostName      string `xml:"hostName,omitempty"`
 	SslThumbprint string `xml:"sslThumbprint,omitempty"`
+	TicketType    string `xml:"ticketType,omitempty"`
 }
 
 func init() {
@@ -49786,6 +49957,28 @@ func init() {
 	t["VAppTaskInProgressFault"] = reflect.TypeOf((*VAppTaskInProgressFault)(nil)).Elem()
 }
 
+type VCenterUpdateVStorageObjectMetadataExRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	Id         ID                     `xml:"id"`
+	Datastore  ManagedObjectReference `xml:"datastore"`
+	Metadata   []KeyValue             `xml:"metadata,omitempty"`
+	DeleteKeys []string               `xml:"deleteKeys,omitempty"`
+}
+
+func init() {
+	t["VCenterUpdateVStorageObjectMetadataExRequestType"] = reflect.TypeOf((*VCenterUpdateVStorageObjectMetadataExRequestType)(nil)).Elem()
+}
+
+type VCenterUpdateVStorageObjectMetadataEx_Task VCenterUpdateVStorageObjectMetadataExRequestType
+
+func init() {
+	t["VCenterUpdateVStorageObjectMetadataEx_Task"] = reflect.TypeOf((*VCenterUpdateVStorageObjectMetadataEx_Task)(nil)).Elem()
+}
+
+type VCenterUpdateVStorageObjectMetadataEx_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type VFlashCacheHotConfigNotSupported struct {
 	VmConfigFault
 }
@@ -50083,6 +50276,7 @@ type VMwareDVSFeatureCapability struct {
 	VspanCapability            *VMwareDVSVspanCapability `xml:"vspanCapability,omitempty"`
 	LacpCapability             *VMwareDvsLacpCapability  `xml:"lacpCapability,omitempty"`
 	NsxSupported               *bool                     `xml:"nsxSupported"`
+	MtuCapability              *VMwareDvsMtuCapability   `xml:"mtuCapability,omitempty"`
 }
 
 func init() {
@@ -50256,6 +50450,7 @@ type VMwareDvsLacpCapability struct {
 
 	LacpSupported           *bool `xml:"lacpSupported"`
 	MultiLacpGroupSupported *bool `xml:"multiLacpGroupSupported"`
+	LacpFastModeSupported   *bool `xml:"lacpFastModeSupported"`
 }
 
 func init() {
@@ -50274,6 +50469,7 @@ type VMwareDvsLacpGroupConfig struct {
 	Ipfix                *VMwareDvsLagIpfixConfig `xml:"ipfix,omitempty"`
 	UplinkName           []string                 `xml:"uplinkName,omitempty"`
 	UplinkPortKey        []string                 `xml:"uplinkPortKey,omitempty"`
+	TimeoutMode          string                   `xml:"timeoutMode,omitempty"`
 }
 
 func init() {
@@ -50309,6 +50505,17 @@ type VMwareDvsLagVlanConfig struct {
 
 func init() {
 	t["VMwareDvsLagVlanConfig"] = reflect.TypeOf((*VMwareDvsLagVlanConfig)(nil)).Elem()
+}
+
+type VMwareDvsMtuCapability struct {
+	DynamicData
+
+	MinMtuSupported int32 `xml:"minMtuSupported"`
+	MaxMtuSupported int32 `xml:"maxMtuSupported"`
+}
+
+func init() {
+	t["VMwareDvsMtuCapability"] = reflect.TypeOf((*VMwareDvsMtuCapability)(nil)).Elem()
 }
 
 type VMwareIpfixConfig struct {
@@ -52216,8 +52423,10 @@ type VirtualMachineCapability struct {
 	VirtualMmuUsageIgnored                 *bool `xml:"virtualMmuUsageIgnored"`
 	VirtualExecUsageIgnored                *bool `xml:"virtualExecUsageIgnored"`
 	DiskOnlySnapshotOnSuspendedVMSupported *bool `xml:"diskOnlySnapshotOnSuspendedVMSupported"`
+	SuspendToMemorySupported               *bool `xml:"suspendToMemorySupported"`
 	ToolsSyncTimeAllowSupported            *bool `xml:"toolsSyncTimeAllowSupported"`
 	SevSupported                           *bool `xml:"sevSupported"`
+	PmemFailoverSupported                  *bool `xml:"pmemFailoverSupported"`
 }
 
 func init() {
@@ -52321,8 +52530,10 @@ type VirtualMachineConfigInfo struct {
 	MigrateEncryption            string                                     `xml:"migrateEncryption,omitempty"`
 	SgxInfo                      *VirtualMachineSgxInfo                     `xml:"sgxInfo,omitempty"`
 	ContentLibItemInfo           *VirtualMachineContentLibraryItemInfo      `xml:"contentLibItemInfo,omitempty"`
+	FtEncryptionMode             string                                     `xml:"ftEncryptionMode,omitempty"`
 	GuestMonitoringModeInfo      *VirtualMachineGuestMonitoringModeInfo     `xml:"guestMonitoringModeInfo,omitempty"`
 	SevEnabled                   *bool                                      `xml:"sevEnabled"`
+	PmemFailoverEnabled          *bool                                      `xml:"pmemFailoverEnabled"`
 }
 
 func init() {
@@ -52453,8 +52664,10 @@ type VirtualMachineConfigSpec struct {
 	Crypto                       BaseCryptoSpec                         `xml:"crypto,omitempty,typeattr"`
 	MigrateEncryption            string                                 `xml:"migrateEncryption,omitempty"`
 	SgxInfo                      *VirtualMachineSgxInfo                 `xml:"sgxInfo,omitempty"`
+	FtEncryptionMode             string                                 `xml:"ftEncryptionMode,omitempty"`
 	GuestMonitoringModeInfo      *VirtualMachineGuestMonitoringModeInfo `xml:"guestMonitoringModeInfo,omitempty"`
 	SevEnabled                   *bool                                  `xml:"sevEnabled"`
+	PmemFailoverEnabled          *bool                                  `xml:"pmemFailoverEnabled"`
 }
 
 func init() {
@@ -53271,6 +53484,7 @@ type VirtualMachineRuntimeInfo struct {
 	Host                      *ManagedObjectReference                      `xml:"host,omitempty"`
 	ConnectionState           VirtualMachineConnectionState                `xml:"connectionState"`
 	PowerState                VirtualMachinePowerState                     `xml:"powerState"`
+	VmFailoverInProgress      *bool                                        `xml:"vmFailoverInProgress"`
 	FaultToleranceState       VirtualMachineFaultToleranceState            `xml:"faultToleranceState,omitempty"`
 	DasVmProtection           *VirtualMachineRuntimeInfoDasProtectionState `xml:"dasVmProtection,omitempty"`
 	ToolsInstallerMounted     bool                                         `xml:"toolsInstallerMounted"`
@@ -53297,6 +53511,7 @@ type VirtualMachineRuntimeInfo struct {
 	QuiescedForkParent        *bool                                        `xml:"quiescedForkParent"`
 	InstantCloneFrozen        *bool                                        `xml:"instantCloneFrozen"`
 	CryptoState               string                                       `xml:"cryptoState,omitempty"`
+	SuspendedToMemory         *bool                                        `xml:"suspendedToMemory"`
 }
 
 func init() {
@@ -53671,7 +53886,8 @@ func init() {
 type VirtualNVDIMM struct {
 	VirtualDevice
 
-	CapacityInMB int64 `xml:"capacityInMB"`
+	CapacityInMB           int64 `xml:"capacityInMB"`
+	ConfiguredCapacityInMB int64 `xml:"configuredCapacityInMB,omitempty"`
 }
 
 func init() {
@@ -53871,7 +54087,8 @@ func init() {
 type VirtualPCIPassthroughVmiopBackingInfo struct {
 	VirtualPCIPassthroughPluginBackingInfo
 
-	Vgpu string `xml:"vgpu,omitempty"`
+	Vgpu             string `xml:"vgpu,omitempty"`
+	MigrateSupported *bool  `xml:"migrateSupported"`
 }
 
 func init() {
@@ -57953,4 +58170,14 @@ type VslmInfrastructureObjectPolicySpec struct {
 
 func init() {
 	t["vslmInfrastructureObjectPolicySpec"] = reflect.TypeOf((*VslmInfrastructureObjectPolicySpec)(nil)).Elem()
+}
+
+type VslmVClockInfo struct {
+	DynamicData
+
+	VClockTime int64 `xml:"vClockTime"`
+}
+
+func init() {
+	t["vslmVClockInfo"] = reflect.TypeOf((*VslmVClockInfo)(nil)).Elem()
 }

--- a/vslm/methods/methods.go
+++ b/vslm/methods/methods.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vslm/types/enum.go
+++ b/vslm/types/enum.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vslm/types/if.go
+++ b/vslm/types/if.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vslm/types/types.go
+++ b/vslm/types/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -1212,7 +1212,10 @@ func init() {
 type VslmVsoVStorageObjectSnapshotResult struct {
 	types.DynamicData
 
-	BackingObjectId types.ID `xml:"backingObjectId"`
+	BackingObjectId types.ID  `xml:"backingObjectId"`
+	Description     string    `xml:"description,omitempty"`
+	SnapshotId      *types.ID `xml:"snapshotId,omitempty"`
+	DiskPath        string    `xml:"diskPath,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

This patch updates the file `gen/gen.sh` to use vCenter 7.0U2 HotPatch 4 (build `17986435`) as the source for generating types and client bindings for the following packages:

* `eam`
* `pbm`
* `sms`
* `vlsm`
* `vim25`

Please note that all of the packages sans `eam` have also had their copyright headers updated to reflect `2014-2021`.

Closes: _NA_

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The following commands were executed locally:

* `make lint`
* `make install`
* `make test`

None of the above checks produced any errors.

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged