### PR TITLE
Update GitHub Test Action to use Makefile

### DIFF
--- a/.github/workflows/govmomi-go-tests.yaml
+++ b/.github/workflows/govmomi-go-tests.yaml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Run Tests
         env:
-          TIMEOUT: 5m
+          TEST_COUNT: 1
+          TEST_RACE_HISTORY_SIZE: 5
+          TEST_TIMEOUT: 5m
           TEST_OPTS: ""
-        run: go test -timeout $TIMEOUT -count 1 -race -v $TEST_OPTS ./...
+        run: make go-test

--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,32 @@ doc: ## Generates govc USAGE.md
 ## Tests
 ## --------------------------------------
 
+# Test options
+TEST_COUNT ?= 1
+TEST_TIMEOUT ?= 5m
+TEST_RACE_HISTORY_SIZE ?= 5
+GORACE ?= history_size=$(TEST_RACE_HISTORY_SIZE)
+
+ifeq (-count,$(findstring -count,$(TEST_OPTS)))
+$(error Use TEST_COUNT to override this option)
+endif
+
+ifeq (-race,$(findstring -race,$(TEST_OPTS)))
+$(error The -race flag is enabled by default & cannot be specified in TEST_OPTS)
+endif
+
+ifeq (-timeout,$(findstring -timeout,$(TEST_OPTS)))
+$(error Use TEST_TIMEOUT to override this option)
+endif
+
 .PHONY: go-test
 go-test: ## Runs go unit tests with race detector enabled
-	GORACE=history_size=5 $(GO) test -timeout 5m -count 1 -race -v $(TEST_OPTS) ./...
+	GORACE=$(GORACE) $(GO) test \
+  -count $(TEST_COUNT) \
+  -race \
+  -timeout $(TEST_TIMEOUT) \
+  -v $(TEST_OPTS) \
+  ./...
 
 .PHONY: govc-test
 govc-test: install


### PR DESCRIPTION
## Description

This patch updates the GitHub Test Action to use the Makefile for running the tests. New options are included in the Makefile to make it easy to parameterize certain values, such as:

  * test count
  * test timeout
  * race history size

The Makefile has also been updated so that certain options that are parameterized independently, ex. TEST_COUNT, will force an error if a person tries to specify them in the raw via TEST_OPTS. For example:

```shell
$ TEST_OPTS=-race make test
Makefile:126: *** The -race flag is enabled by default & cannot be specified in TEST_OPTS.  Stop.

$ TEST_OPTS="-count 1" make test
Makefile:122: *** Use TEST_COUNT to override this option.  Stop.

$ TEST_OPTS="-timeout 5m" make test
Makefile:130: *** Use TEST_TIMEOUT to override this option.  Stop.
```

Closes: _NA_

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Executed the following commands:

* `make lint`
* `make install`
* `make test`

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~Any dependent changes have been merged~~