### PR TITLE
vcsim: fix panic in QueryPerfCounter method

### DIFF
--- a/performance/manager.go
+++ b/performance/manager.go
@@ -271,6 +271,21 @@ func (m *Manager) Query(ctx context.Context, spec []types.PerfQuerySpec) ([]type
 	return res.Returnval, nil
 }
 
+// QueryCounter wraps the QueryPerfCounter method.
+func (m *Manager) QueryCounter(ctx context.Context, ids []int32) ([]types.PerfCounterInfo, error) {
+	req := types.QueryPerfCounter{
+		This:      m.Reference(),
+		CounterId: ids,
+	}
+
+	res, err := methods.QueryPerfCounter(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
 // SampleByName uses the spec param as a template, constructing a []types.PerfQuerySpec for the given metrics and entities
 // and invoking the Query method.
 // The spec template can specify instances using the MetricId.Instance field, by default all instances are collected.

--- a/simulator/performance_manager.go
+++ b/simulator/performance_manager.go
@@ -78,7 +78,7 @@ func (m *PerformanceManager) init(r *Registry) {
 
 func (p *PerformanceManager) QueryPerfCounter(ctx *Context, req *types.QueryPerfCounter) soap.HasFault {
 	body := new(methods.QueryPerfCounterBody)
-	body.Req = req
+	body.Res = new(types.QueryPerfCounterResponse)
 	body.Res.Returnval = make([]types.PerfCounterInfo, len(req.CounterId))
 	for i, id := range req.CounterId {
 		if info, ok := p.perfCounterIndex[id]; !ok {
@@ -95,7 +95,6 @@ func (p *PerformanceManager) QueryPerfCounter(ctx *Context, req *types.QueryPerf
 
 func (p *PerformanceManager) QueryPerfProviderSummary(ctx *Context, req *types.QueryPerfProviderSummary) soap.HasFault {
 	body := new(methods.QueryPerfProviderSummaryBody)
-	body.Req = req
 	body.Res = new(types.QueryPerfProviderSummaryResponse)
 
 	// The entity must exist
@@ -169,7 +168,6 @@ func (p *PerformanceManager) queryAvailablePerfMetric(entity types.ManagedObject
 
 func (p *PerformanceManager) QueryAvailablePerfMetric(ctx *Context, req *types.QueryAvailablePerfMetric) soap.HasFault {
 	body := new(methods.QueryAvailablePerfMetricBody)
-	body.Req = req
 	body.Res = p.queryAvailablePerfMetric(req.Entity, req.IntervalId)
 
 	return body
@@ -177,7 +175,6 @@ func (p *PerformanceManager) QueryAvailablePerfMetric(ctx *Context, req *types.Q
 
 func (p *PerformanceManager) QueryPerf(ctx *Context, req *types.QueryPerf) soap.HasFault {
 	body := new(methods.QueryPerfBody)
-	body.Req = req
 	body.Res = new(types.QueryPerfResponse)
 	body.Res.Returnval = make([]types.BasePerfEntityMetricBase, len(req.QuerySpec))
 

--- a/simulator/performance_manager_test.go
+++ b/simulator/performance_manager_test.go
@@ -193,6 +193,17 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 		if len(info) == 0 {
 			t.Fatal("Expected non-empty list of host")
 		}
+		var ids []int32
+		for i := range info {
+			ids = append(ids, info[i].CounterId)
+		}
+		perf, err := p.QueryCounter(ctx, ids)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(perf) != len(ids) {
+			t.Errorf("%d counters", len(perf))
+		}
 	}
 
 	pool := Map.Any("ResourcePool").(*ResourcePool)


### PR DESCRIPTION
## Description

- Add performance.Manager.QueryCounter method

Fixes #2440

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

New test added to cover the `QueryPerfCounter` method.

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged