### PR TITLE
vcsim: Implement VSLM ExtendDisk_Task

### DIFF
--- a/simulator/vstorage_object_manager.go
+++ b/simulator/vstorage_object_manager.go
@@ -350,6 +350,23 @@ func (m *VcenterVStorageObjectManager) VStorageObjectCreateSnapshotTask(ctx *Con
 	}
 }
 
+func (m *VcenterVStorageObjectManager) ExtendDiskTask(ctx *Context, req *types.ExtendDisk_Task) soap.HasFault {
+	task := CreateTask(m, "extendDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
+		obj := m.object(req.Datastore, req.Id)
+		if obj == nil {
+			return nil, new(types.InvalidArgument)
+		}
+
+		obj.Config.CapacityInMB = req.NewCapacityInMB
+		return nil, nil
+	})
+	return &methods.ExtendDisk_TaskBody{
+		Res: &types.ExtendDisk_TaskResponse{
+			Returnval: task.Run(ctx),
+		},
+	}
+}
+
 func (m *VcenterVStorageObjectManager) DeleteSnapshotTask(ctx *Context, req *types.DeleteSnapshot_Task) soap.HasFault {
 	task := CreateTask(m, "deleteSnapshot", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		obj := m.object(req.Datastore, req.Id)


### PR DESCRIPTION
Add support to vcsim for ExtendDisk_Task in VSLM. This allows you to
change the capcity of a FCD when using vcsim without the simulator
throwing an error.

## Description

Fixes part of #2480

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

1. Start vcsim
2. Create a first class disk with govc (`govc disk.create -size 24G test-disk`)
3. Make note of the UUID and write code similar to the following:
```go
task, err := manager.ExtendDisk(ctx, ds, 40*1024)
if err != nil {
  log.Fatal(err)
}
err = task.Wait(ctx)
if err != nil {
  log.Fatal(err)
}
dsk, err := manager.Retrieve(ctx, ds, diskUUID)
if err != nil {
  log.Fatal(err)
}
fmt.Println(dsk.Config.CapacityInMB / 1024)
```

**Test Configuration**:
* Toolchain:
* SDK:
* (add more if needed)

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged