### PR TITLE
Include commit details in BREAKING section

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -26,7 +26,7 @@
 {{ if .Notes -}}
 {{ if not .Merge -}}
 {{ if not (contains .Header "Update CHANGELOG for" ) -}}
-{{ range .Notes }}{{ .Body }}
+{{ .Subject }} [{{ .Hash.Short }}]:{{"\n"}}{{ range .Notes }}{{ .Body }}
 {{ end }}
 {{ end -}}
 {{ end -}}

--- a/.chglog/RELEASE.tpl.md
+++ b/.chglog/RELEASE.tpl.md
@@ -26,7 +26,7 @@
 {{ if .Notes -}}
 {{ if not .Merge -}}
 {{ if not (contains .Header "Update CHANGELOG for" ) -}}
-{{ range .Notes }}{{ .Body }}
+{{ .Subject }} [{{ .Hash.Short }}]:{{"\n"}}{{ range .Notes }}{{ .Body }}
 {{ end }}
 {{ end -}}
 {{ end -}}


### PR DESCRIPTION
## Description

The `BREAKING` section in the corresponding CHANGELOG/release notes lacked details on the actual commit introducing a breaking change. See below for an example how this PR addresses this.

### Example

<a name="v0.26.1"></a>
## [Release v0.26.1](https://github.com/vmware/govmomi/compare/v0.26.0...v0.26.1)

> Release Date: 2021-06-07

### 🧹 Chore

- [0736a32a]    Include commit details in BREAKING section (#2482)

### ⚠️ BREAKING

Add a context to funcXYZ [3ba9cc21]:
`funcXYZ()` now requires passing a `context.Context`

### 📖 Commits

- [3ba9cc21]    feat: Add a context to funcXYZ
- [0736a32a]    chore: Include commit details in BREAKING section (#2482)


Closes: #2482
Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Run `git-chglog` to create the example output above.

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged