### PR TITLE
Adding MOB client and global Permission CRUD operations.

### DIFF
--- a/mob/globalpermissions/global_permission.go
+++ b/mob/globalpermissions/global_permission.go
@@ -1,0 +1,228 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package globalpermissions
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"github.com/vmware/govmomi/mob/internal"
+	"github.com/vmware/govmomi/mob/mobclient"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const globalPermissionsServiceMoid = "authorizationService"
+const voidMethodResultMessage = "Method Invocation Result: void"
+
+// Manager extends rest.Client, adding tag related methods.
+type Manager struct {
+	client *mobclient.Client
+}
+
+// NewManager creates a new Manager instance with the given client.
+func NewManager(client *mobclient.Client) *Manager {
+	return &Manager{
+		client: client,
+	}
+}
+
+type GlobalPermission struct {
+	Principal string
+	Group     bool
+	Propagate bool
+	RoleId    int64
+}
+
+func (m *Manager) CreateGlobalPermission(principalName string, isGroup bool, propagate bool, roleId int64) error {
+	if principalName == "" {
+		return fmt.Errorf("error while creating global permission, principal name can't be empty")
+	}
+	method := "AuthorizationService.AddGlobalAccessControlList"
+	sessionCallRes := m.client.Resource(internal.SessionPath)
+	sessionCallRes.WithParam(internal.Moid, globalPermissionsServiceMoid)
+	sessionCallRes.WithParam(internal.Method, method)
+	req := sessionCallRes.Request(http.MethodGet)
+	out := ""
+	xsrfToken, err := m.client.Do(context.Background(), req, &out)
+	if err != nil {
+		return err
+	}
+	if xsrfToken == "" {
+		return fmt.Errorf("error while creating session for %s %s", method, err)
+	}
+
+	type principal struct {
+		XMLName xml.Name `xml:"principal"`
+		Name    string   `xml:"name"`
+		Group   bool     `xml:"group"`
+	}
+	type permissions struct {
+		XMLName   xml.Name  `xml:"permissions"`
+		Principal principal `xml:"principal"`
+		Propagate bool      `xml:"propagate"`
+		Role      int64     `xml:"roles"`
+		Version   int64     `xml:"version"`
+	}
+
+	createPermissionBody := permissions{Principal: principal{Name: principalName, Group: isGroup}, Propagate: propagate, Role: roleId}
+	createPermissionBodyXml, _ := xml.MarshalIndent(createPermissionBody, "  ", "    ")
+
+	form := url.Values{}
+	form.Add(internal.XsrfToken, xsrfToken)
+	form.Add("permissions", string(createPermissionBodyXml))
+	postReq := sessionCallRes.Request(http.MethodPost, form.Encode())
+
+	_, err = m.client.Do(context.Background(), postReq, &out)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(out, voidMethodResultMessage) {
+		return nil
+	}
+	errorIndex := strings.Index(out, "Method Invocation Result:")
+	if errorIndex > 0 {
+		out = out[errorIndex:]
+	}
+	return fmt.Errorf("error while creating global permission for user %s %s", principalName, out)
+}
+
+func (m *Manager) ListGlobalPermission() (map[string]GlobalPermission, error) {
+	method := "AuthorizationService.GetPermissions"
+	sessionCallRes := m.client.Resource(internal.SessionPath)
+	sessionCallRes.WithParam(internal.Moid, globalPermissionsServiceMoid)
+	sessionCallRes.WithParam(internal.Method, method)
+	req := sessionCallRes.Request(http.MethodGet)
+	out := ""
+	xsrfToken, err := m.client.Do(context.Background(), req, &out)
+	if err != nil {
+		return nil, err
+	}
+	if xsrfToken == "" {
+		return nil, fmt.Errorf("error while creating session for %s %s", method, err)
+	}
+
+	form := url.Values{}
+	form.Add(internal.XsrfToken, xsrfToken)
+	form.Add("docUri", "https://vmware.com")
+	postReq := sessionCallRes.Request(http.MethodPost, form.Encode())
+
+	_, err = m.client.Do(context.Background(), postReq, &out)
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, fmt.Errorf("error while getting all global permissions, no response from server")
+	}
+
+	result := map[string]GlobalPermission{}
+	permissionsObjs := strings.Split(out, "version")
+	for i, permissionsObj := range permissionsObjs {
+		if i == 0 {
+			//trim for 1st value
+			permissionsObj = permissionsObj[len(permissionsObj)-450:]
+		}
+		principalRegex, _ := regexp.Compile("<tr><td class=\"c2\">name</td><td class=\"c1\">string</td><td>(.+?)</td></tr>")
+		matches := principalRegex.FindStringSubmatch(permissionsObj)
+		if len(matches) < 2 {
+			continue
+		}
+		principal := matches[1]
+
+		groupRegex, _ := regexp.Compile("<tr><td class=\"c2\">group</td><td class=\"c1\">boolean</td><td>(.+?)</td></tr>")
+		matches = groupRegex.FindStringSubmatch(permissionsObj)
+		if len(matches) < 2 {
+			continue
+		}
+		isGroup, err := strconv.ParseBool(matches[1])
+		if err != nil {
+			continue
+		}
+
+		propagateRegex, _ := regexp.Compile("<tr><td class=\"c2\">propagate</td><td class=\"c1\">boolean</td><td>(.+?)</td></tr>")
+		matches = propagateRegex.FindStringSubmatch(permissionsObj)
+		if len(matches) < 2 {
+			continue
+		}
+		propagate, err := strconv.ParseBool(matches[1])
+		if err != nil {
+			continue
+		}
+
+		roleRegex, _ := regexp.Compile("<td class=\"c2\">roles</td><td class=\"c1\">ArrayOfLong</td><td><ul class=\"noindent\"><li>(.+?)</li></ul></td></tr><tr>")
+		matches = roleRegex.FindStringSubmatch(permissionsObj)
+		if len(matches) < 2 {
+			continue
+		}
+		role, err := strconv.ParseInt(matches[1], 10, 64)
+		if err != nil {
+			continue
+		}
+
+		result[principal] = GlobalPermission{principal, isGroup, propagate, role}
+	}
+	return result, nil
+}
+
+func (m *Manager) DeleteGlobalPermission(ctx context.Context, principalName string, isGroup bool) error {
+	if principalName == "" {
+		return fmt.Errorf("error while deleting global permission, principal name can't be empty")
+	}
+	method := "AuthorizationService.RemoveGlobalAccess"
+	sessionCallRes := m.client.Resource(internal.SessionPath)
+	sessionCallRes.WithParam(internal.Moid, globalPermissionsServiceMoid)
+	sessionCallRes.WithParam(internal.Method, method)
+	req := sessionCallRes.Request(http.MethodGet)
+	out := ""
+	xsrfToken, err := m.client.Do(context.Background(), req, &out)
+	if err != nil {
+		return err
+	}
+	if xsrfToken == "" {
+		return fmt.Errorf("error while creating session for %s %s", method, err)
+	}
+
+	type principal struct {
+		XMLName xml.Name `xml:"principals"`
+		Name    string   `xml:"name"`
+		Group   bool     `xml:"group"`
+	}
+
+	deletePermissionBody := principal{Name: principalName, Group: isGroup}
+	deletePermissionBodyXml, _ := xml.MarshalIndent(deletePermissionBody, "  ", "    ")
+
+	form := url.Values{}
+	form.Add(internal.XsrfToken, xsrfToken)
+	form.Add("principals", string(deletePermissionBodyXml))
+	postReq := sessionCallRes.Request(http.MethodPost, form.Encode())
+
+	_, err = m.client.Do(context.Background(), postReq, &out)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(out, voidMethodResultMessage) {
+		return nil
+	}
+	errorIndex := strings.Index(out, "Method Invocation Result:")
+	if errorIndex > 0 {
+		out = out[errorIndex:]
+	}
+	return fmt.Errorf("error while deleting global permission for user %s %s", principalName, out)
+}

--- a/mob/globalpermissions/globalpermissions_test.go
+++ b/mob/globalpermissions/globalpermissions_test.go
@@ -1,0 +1,37 @@
+package globalpermissions_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/vmware/govmomi/mob/globalpermissions"
+	"github.com/vmware/govmomi/mob/mobclient"
+	"github.com/vmware/govmomi/vim25/soap"
+	"net/url"
+	"testing"
+)
+
+func TestManager_GlobalPermissionsWorkflow(t *testing.T) {
+
+	userinfo := url.UserPassword("user", "pass")
+	url := url.URL{Host: "vc_ip", Scheme: "https"}
+
+	mob := mobclient.NewClient(soap.NewClient(&url, true))
+	err := mob.Login(context.Background(), userinfo)
+	if err != nil {
+		t.Fatal("error while logging in ", err)
+	}
+
+	manager := globalpermissions.NewManager(mob)
+	permissions, err := manager.ListGlobalPermission()
+	if err != nil {
+		t.Error(err)
+	}
+	for _, val := range permissions {
+		fmt.Println(val)
+	}
+
+	err = manager.CreateGlobalPermission("user/group", true, false, 100)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/mob/internal/internal.go
+++ b/mob/internal/internal.go
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+const (
+	SessionPath       = "/invsvc/mob3"
+	SessionCookieName = "vmware_debug_session"
+	Moid              = "moid"
+	Method            = "method"
+	XsrfToken         = "vmware-session-nonce"
+)

--- a/mob/mobclient/client.go
+++ b/mob/mobclient/client.go
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mobclient
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/vmware/govmomi/mob/internal"
+	"github.com/vmware/govmomi/vim25/soap"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sync"
+	"time"
+)
+
+type Client struct {
+	mu sync.Mutex
+	*soap.Client
+	Cookie *http.Cookie
+}
+
+// Session information
+type Session struct {
+	User         string    `json:"user"`
+	Created      time.Time `json:"created_time"`
+	LastAccessed time.Time `json:"last_accessed_time"`
+}
+
+func NewClient(c *soap.Client) *Client {
+	return &Client{Client: c}
+}
+
+type statusError struct {
+	res *http.Response
+}
+
+func (e *statusError) Error() string {
+	return fmt.Sprintf("%s %s: %s", e.res.Request.Method, e.res.Request.URL, e.res.Status)
+}
+
+// Resource helper for the given path.
+func (c *Client) Resource(path string) *Resource {
+	r := &Resource{u: c.URL()}
+	r.u.Path = path
+	return r
+}
+
+// Do sends the http.Request, decoding resBody if provided.
+func (c *Client) Do(ctx context.Context, req *http.Request, resBody *string) (string, error) {
+	switch req.Method {
+	case http.MethodPost, http.MethodPatch:
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	if c.Cookie != nil {
+		req.AddCookie(c.Cookie)
+	}
+	err := c.Client.Do(ctx, req, func(res *http.Response) error {
+		switch res.StatusCode {
+		case http.StatusOK:
+		case http.StatusCreated:
+		case http.StatusNoContent:
+		case http.StatusBadRequest:
+			// TODO: structured error types
+			detail, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("%s: %s", res.Status, bytes.TrimSpace(detail))
+		default:
+			return &statusError{res}
+		}
+
+		for _, cookie := range res.Cookies() {
+			if cookie.Name == internal.SessionCookieName {
+				c.Cookie = cookie
+			}
+		}
+
+		if resBody == nil {
+			return nil
+		}
+
+		output, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+
+		*resBody = string(output)
+		return nil
+	})
+	return c.extractXsrfToken(*resBody), err
+
+}
+
+// Login creates a new session via Basic Authentication with the given url.Userinfo.
+func (c *Client) Login(ctx context.Context, user *url.Userinfo) error {
+	sessionCallRes := c.Resource(internal.SessionPath)
+	req := sessionCallRes.Request(http.MethodGet)
+	if user != nil {
+		if password, ok := user.Password(); ok {
+			req.SetBasicAuth(user.Username(), password)
+		}
+	}
+
+	responseBody := ""
+	_, err := c.Do(ctx, req, &responseBody)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) extractXsrfToken(out string) string {
+	regex, _ := regexp.Compile("<input name=\"vmware-session-nonce\" type=\"hidden\" value=\"(.+?)\">")
+	loc := regex.FindStringSubmatch(out)
+	if len(loc) < 2 {
+		return ""
+	}
+	return loc[1]
+}

--- a/mob/mobclient/resource.go
+++ b/mob/mobclient/resource.go
@@ -1,0 +1,91 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mobclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	Path = "/rest"
+)
+
+// Resource wraps url.URL with helpers
+type Resource struct {
+	u *url.URL
+}
+
+func (r *Resource) String() string {
+	return r.u.String()
+}
+
+// WithID appends id to the URL.Path
+func (r *Resource) WithID(id string) *Resource {
+	r.u.Path += "/id:" + id
+	return r
+}
+
+// WithAction sets adds action to the URL.RawQuery
+func (r *Resource) WithAction(action string) *Resource {
+	return r.WithParam("~action", action)
+}
+
+// WithParam adds one parameter on the URL.RawQuery
+func (r *Resource) WithParam(name string, value string) *Resource {
+	// ParseQuery handles empty case, and we control access to query string so shouldn't encounter an error case
+	params, _ := url.ParseQuery(r.u.RawQuery)
+	params[name] = []string{value}
+	r.u.RawQuery = params.Encode()
+	return r
+}
+
+// Request returns a new http.Request for the given method.
+// An optional body can be provided for POST and PATCH methods.
+func (r *Resource) Request(method string, body ...string) *http.Request {
+	rdr := "" // empty body by default
+	if len(body) != 0 {
+		rdr = body[0]
+	}
+	req, err := http.NewRequest(method, r.u.String(), strings.NewReader(rdr))
+	if err != nil {
+		panic(err)
+	}
+	return req
+}
+
+type errorReader struct {
+	e error
+}
+
+func (e errorReader) Read([]byte) (int, error) {
+	return -1, e.e
+}
+
+// encode body as JSON, deferring any errors until io.Reader is used.
+func encode(body interface{}) io.Reader {
+	var b bytes.Buffer
+	err := json.NewEncoder(&b).Encode(body)
+	if err != nil {
+		return errorReader{err}
+	}
+	return &b
+}


### PR DESCRIPTION
## Description

Adding Global Permissions Create/Update/Delete feature by this PR.
The Soap APIs for these operations are not public, hence using MOB(Managed Object Browser) to call the methods and
parsing the response. Reference as described here by William Lam : https://williamlam.com/2017/03/automating-vsphere-global-permissions-with-powercli.html

Internally I have raised a feature request with the Authmanager team to make these APIs public. If they accept the request, I will replace these operations with the officially supported Soap APIs.


Closes: #2107

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] globalpermissions_test


**Test Configuration**:
*  To be Run with the VC IP, VC userName and Password to login and create/manage global permissions.

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged