### PR TITLE
explicitly import eam/simulator in test

### DIFF
--- a/eam/simulator/simulator_test.go
+++ b/eam/simulator/simulator_test.go
@@ -36,6 +36,9 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 	vim "github.com/vmware/govmomi/vim25/types"
+
+	// making sure the SDK endpoint is registered
+	_ "github.com/vmware/govmomi/eam/simulator"
 )
 
 const waitLoopMessage = `


### PR DESCRIPTION
## Description

This is a bit of an exotic issue.
The current implementation of eam simulator test assumes the specific behavior of the standard go test runner: that both the `simulator` and `simulator_test` packages are linked into a single binary. This way, the test module can implicitly rely on the fact that the simulator module's `init()` function has run, registering the SDK endpoint that the test uses.

In a different, non-standard, test runner model where potentially 2 binaries are used instead, that assumption breaks, leading to a test failure. (requests on /eam/sdk then get a 404)

This change makes it explicit that there's a dependency to that `init()` function, but doesn't have any functional impact on the tests as run in `go test`

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] validated that the test runs correctly in all cases

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A)
- [x] I have added tests that prove my fix is effective or that my feature works (NOOP)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged (N/A)