### PR TITLE
Added CNS QuerySnapshots binding, simulator testcases and client testcases

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -229,7 +229,7 @@ func (c *Client) ConfigureVolumeACLs(ctx context.Context, aclConfigSpecs ...cnst
 	return object.NewTask(c.vim25Client, res.Returnval), nil
 }
 
-// Cns Snapshot API client
+// CreateSnapshots calls the CNS CreateSnapshots API
 
 func (c *Client) CreateSnapshots(ctx context.Context, snapshotCreateSpecList []cnstypes.CnsSnapshotCreateSpec) (*object.Task, error) {
 	req := cnstypes.CnsCreateSnapshots{
@@ -244,13 +244,26 @@ func (c *Client) CreateSnapshots(ctx context.Context, snapshotCreateSpecList []c
 	return object.NewTask(c.vim25Client, res.Returnval), nil
 }
 
-// DeleteSnapshot calls the CNS Snapshot API.
+// DeleteSnapshots calls the CNS DeleteSnapshots API
 func (c *Client) DeleteSnapshots(ctx context.Context, snapshotDeleteSpecList []cnstypes.CnsSnapshotDeleteSpec) (*object.Task, error) {
 	req := cnstypes.CnsDeleteSnapshots{
 		This:                CnsVolumeManagerInstance,
 		SnapshotDeleteSpecs: snapshotDeleteSpecList,
 	}
 	res, err := methods.CnsDeleteSnapshots(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(c.vim25Client, res.Returnval), nil
+}
+
+// QuerySnapshots calls the CNS QuerySnapshots API
+func (c *Client) QuerySnapshots(ctx context.Context, snapshotQueryFilter cnstypes.CnsSnapshotQueryFilter) (*object.Task, error) {
+	req := cnstypes.CnsQuerySnapshots{
+		This:                CnsVolumeManagerInstance,
+		SnapshotQueryFilter: snapshotQueryFilter,
+	}
+	res, err := methods.CnsQuerySnapshots(ctx, c, &req)
 	if err != nil {
 		return nil, err
 	}

--- a/cns/cns_util.go
+++ b/cns/cns_util.go
@@ -34,6 +34,21 @@ func GetTaskInfo(ctx context.Context, task *object.Task) (*vim25types.TaskInfo, 
 	return taskInfo, nil
 }
 
+// GetQuerySnapshotsTaskResult gets the task result of QuerySnapshots given a task info
+func GetQuerySnapshotsTaskResult(ctx context.Context, taskInfo *vim25types.TaskInfo) (*cnstypes.CnsSnapshotQueryResult, error) {
+	if taskInfo == nil {
+		return nil, errors.New("TaskInfo is empty")
+	}
+	if taskInfo.Result != nil {
+		snapshotQueryResult := taskInfo.Result.(cnstypes.CnsSnapshotQueryResult)
+		if &snapshotQueryResult == nil {
+			return nil, errors.New("Cannot get SnapshotQueryResult")
+		}
+		return &snapshotQueryResult, nil
+	}
+	return nil, errors.New("TaskInfo result is empty")
+}
+
 // GetTaskResult gets the task result given a task info
 func GetTaskResult(ctx context.Context, taskInfo *vim25types.TaskInfo) (cnstypes.BaseCnsVolumeOperationResult, error) {
 	if taskInfo == nil {

--- a/cns/methods/methods.go
+++ b/cns/methods/methods.go
@@ -261,7 +261,7 @@ func CnsQueryAsync(ctx context.Context, r soap.RoundTripper, req *types.CnsQuery
 	return resBody.Res, nil
 }
 
-// Cns Snapshot Methods
+// CNS CreateSnapshots API
 
 type CnsCreateSnapshotsBody struct {
 	Req    *types.CnsCreateSnapshots         `xml:"urn:vsan CnsCreateSnapshots,omitempty"`
@@ -283,6 +283,8 @@ func CnsCreateSnapshots(ctx context.Context, r soap.RoundTripper, req *types.Cns
 	return resBody.Res, nil
 }
 
+// CNS DeleteSnapshot API
+
 type CnsDeleteSnapshotBody struct {
 	Req    *types.CnsDeleteSnapshots         `xml:"urn:vsan CnsDeleteSnapshots,omitempty"`
 	Res    *types.CnsDeleteSnapshotsResponse `xml:"urn:vsan CnsDeleteSnapshotsResponse,omitempty"`
@@ -293,6 +295,28 @@ func (b *CnsDeleteSnapshotBody) Fault() *soap.Fault { return b.Fault_ }
 
 func CnsDeleteSnapshots(ctx context.Context, r soap.RoundTripper, req *types.CnsDeleteSnapshots) (*types.CnsDeleteSnapshotsResponse, error) {
 	var reqBody, resBody CnsDeleteSnapshotBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+// CNS QuerySnapshots API
+
+type CnsQuerySnapshotsBody struct {
+	Req    *types.CnsQuerySnapshots         `xml:"urn:vsan CnsQuerySnapshots,omitempty"`
+	Res    *types.CnsQuerySnapshotsResponse `xml:"urn:vsan CnsQuerySnapshotsResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsQuerySnapshotsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsQuerySnapshots(ctx context.Context, r soap.RoundTripper, req *types.CnsQuerySnapshots) (*types.CnsQuerySnapshotsResponse, error) {
+	var reqBody, resBody CnsQuerySnapshotsBody
 
 	reqBody.Req = req
 

--- a/cns/simulator/simulator_test.go
+++ b/cns/simulator/simulator_test.go
@@ -401,6 +401,70 @@ func TestSimulator(t *testing.T) {
 		t.Fatalf("Failed to create volume: fault=%+v", updateVolumeOperationRes.Fault)
 	}
 
+	// Create Snapshots
+	desc := "simulator-snapshot"
+	var cnsSnapshotCreateSpecList []cnstypes.CnsSnapshotCreateSpec
+	cnsSnapshotCreateSpec := cnstypes.CnsSnapshotCreateSpec{
+		VolumeId: cnstypes.CnsVolumeId{
+			Id: volumeId,
+		},
+		Description: desc,
+	}
+	cnsSnapshotCreateSpecList = append(cnsSnapshotCreateSpecList, cnsSnapshotCreateSpec)
+	createSnapshotsTask, err := cnsClient.CreateSnapshots(ctx, cnsSnapshotCreateSpecList)
+	if err != nil {
+		t.Fatalf("Failed to get the task of CreateSnapshots. Error: %+v \n", err)
+	}
+	createSnapshotsTaskInfo, err := cns.GetTaskInfo(ctx, createSnapshotsTask)
+	if err != nil {
+		t.Fatalf("Failed to get the task info of CreateSnapshots. Error: %+v \n", err)
+	}
+	createSnapshotsTaskResult, err := cns.GetTaskResult(ctx, createSnapshotsTaskInfo)
+	if err != nil {
+		t.Fatalf("Failed to get the task result of CreateSnapshots. Error: %+v \n", err)
+	}
+	createSnapshotsOperationRes := createSnapshotsTaskResult.GetCnsVolumeOperationResult()
+	if createSnapshotsOperationRes.Fault != nil {
+		t.Fatalf("Failed to create snapshots: fault=%+v", createSnapshotsOperationRes.Fault)
+	}
+
+	snapshotCreateResult := interface{}(createSnapshotsTaskResult).(*cnstypes.CnsSnapshotCreateResult)
+	snapshotId := snapshotCreateResult.Snapshot.SnapshotId.Id
+	t.Logf("snapshotCreateResult %+v", snapshotCreateResult)
+
+	// Delete Snapshots
+	var cnsSnapshotDeleteSpecList []cnstypes.CnsSnapshotDeleteSpec
+	cnsSnapshotDeleteSpec := cnstypes.CnsSnapshotDeleteSpec{
+		VolumeId: cnstypes.CnsVolumeId{
+			Id: volumeId,
+		},
+		SnapshotId: cnstypes.CnsSnapshotId{
+			Id: snapshotId,
+		},
+	}
+	cnsSnapshotDeleteSpecList = append(cnsSnapshotDeleteSpecList, cnsSnapshotDeleteSpec)
+	deleteSnapshotsTask, err := cnsClient.DeleteSnapshots(ctx, cnsSnapshotDeleteSpecList)
+	if err != nil {
+		t.Fatalf("Failed to get the task of DeleteSnapshots. Error: %+v \n", err)
+	}
+	deleteSnapshotsTaskInfo, err := cns.GetTaskInfo(ctx, deleteSnapshotsTask)
+	if err != nil {
+		t.Fatalf("Failed to get the task info of DeleteSnapshots. Error: %+v \n", err)
+	}
+
+	deleteSnapshotsTaskResult, err := cns.GetTaskResult(ctx, deleteSnapshotsTaskInfo)
+	if err != nil {
+		t.Fatalf("Failed to get the task result of DeleteSnapshots. Error: %+v \n", err)
+	}
+
+	deleteSnapshotsOperationRes := deleteSnapshotsTaskResult.GetCnsVolumeOperationResult()
+	if deleteSnapshotsOperationRes.Fault != nil {
+		t.Fatalf("Failed to delete snapshots: fault=%+v", deleteSnapshotsOperationRes.Fault)
+	}
+
+	snapshotDeleteResult := interface{}(deleteSnapshotsTaskResult).(*cnstypes.CnsSnapshotDeleteResult)
+	t.Logf("snapshotDeleteResult %+v", snapshotDeleteResult)
+
 	// Delete
 	deleteVolumeList = []cnstypes.CnsVolumeId{
 		{

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -607,6 +607,17 @@ func init() {
 	types.Add("CnsAlreadyRegisteredFault", reflect.TypeOf((*CnsAlreadyRegisteredFault)(nil)).Elem())
 }
 
+type CnsSnapshotNotFoundFault struct {
+	CnsFault
+
+	VolumeId   CnsVolumeId   `xml:"volumeId,omitempty"`
+	SnapshotId CnsSnapshotId `xml:"snapshotId"`
+}
+
+func init() {
+	types.Add("CnsSnapshotNotFoundFault", reflect.TypeOf((*CnsSnapshotNotFoundFault)(nil)).Elem())
+}
+
 type CnsConfigureVolumeACLs CnsConfigureVolumeACLsRequestType
 
 func init() {
@@ -801,4 +812,69 @@ type CnsSnapshotVolumeSource struct {
 
 func init() {
 	types.Add("CnsSnapshotVolumeSource", reflect.TypeOf((*CnsSnapshotVolumeSource)(nil)).Elem())
+}
+
+// CNS QuerySnapshots related types
+
+type CnsQuerySnapshotsRequestType struct {
+	This                types.ManagedObjectReference `xml:"_this"`
+	SnapshotQueryFilter CnsSnapshotQueryFilter       `xml:"snapshotQueryFilter"`
+}
+
+func init() {
+	types.Add("CnsQuerySnapshotsRequestType", reflect.TypeOf((*CnsQuerySnapshotsRequestType)(nil)).Elem())
+}
+
+type CnsQuerySnapshots CnsQuerySnapshotsRequestType
+
+func init() {
+	types.Add("CnsQuerySnapshots", reflect.TypeOf((*CnsQuerySnapshots)(nil)).Elem())
+}
+
+type CnsQuerySnapshotsResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}
+
+type CnsSnapshotQueryResult struct {
+	types.DynamicData
+
+	Entries []CnsSnapshotQueryResultEntry `xml:"entries,omitempty"`
+	Cursor  CnsCursor                     `xml:"cursor"`
+}
+
+func init() {
+	types.Add("CnsSnapshotQueryResult", reflect.TypeOf((*CnsSnapshotQueryResult)(nil)).Elem())
+}
+
+type CnsSnapshotQueryResultEntry struct {
+	types.DynamicData
+
+	Snapshot CnsSnapshot                 `xml:"snapshot,omitempty"`
+	Error    *types.LocalizedMethodFault `xml:"error,omitempty"`
+}
+
+func init() {
+	types.Add("CnsSnapshotQueryResultEntry", reflect.TypeOf((*CnsSnapshotQueryResultEntry)(nil)).Elem())
+}
+
+type CnsSnapshotQueryFilter struct {
+	types.DynamicData
+
+	SnapshotQuerySpecs []CnsSnapshotQuerySpec `xml:"snapshotQuerySpecs,omitempty"`
+	Cursor             *CnsCursor             `xml:"cursor,omitempty"`
+}
+
+func init() {
+	types.Add("CnsSnapshotQueryFilter", reflect.TypeOf((*CnsSnapshotQueryFilter)(nil)).Elem())
+}
+
+type CnsSnapshotQuerySpec struct {
+	types.DynamicData
+
+	VolumeId   CnsVolumeId    `xml:"volumeId"`
+	SnapshotId *CnsSnapshotId `xml:"snapshotId,omitempty"`
+}
+
+func init() {
+	types.Add("CnsSnapshotQuerySpec", reflect.TypeOf((*CnsSnapshotQuerySpec)(nil)).Elem())
 }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

Closes: #(issue-number)

**Summary**: Added CNS QuerySnapshots binding, simulator testcases and client testcases and added the simulator test cases for CreateSnapshots and DeleteSnapshots APIs as well.

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

Testing Done:

- Unit test using govmomi simulator

```
=== RUN   TestSimulator
    TestSimulator: simulator_test.go:121: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:fake-volume-Handle} Fault:<nil>} Name:test PlacementResults:[{Datastore:Datastore:/var/folders/8p/rbwb3z456fxfd1vj02y7g5w800_y48/T/govcsim-DC0-LocalDS_0-865553809@group-5 PlacementFaults:[]}]}
    TestSimulator: simulator_test.go:190: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:cde92f3b-f26a-4551-a5f5-60fbbb2cede0} Fault:<nil>} Name:test PlacementResults:[{Datastore:Datastore:/var/folders/8p/rbwb3z456fxfd1vj02y7g5w800_y48/T/govcsim-DC0-LocalDS_0-865553809@group-5 PlacementFaults:[]}]}
    TestSimulator: simulator_test.go:434: snapshotCreateResult &{CnsSnapshotOperationResult:{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:cde92f3b-f26a-4551-a5f5-60fbbb2cede0} Fault:<nil>}} Snapshot:{DynamicData:{} SnapshotId:{DynamicData:{} Id:8c83ad91-6529-49c1-b9af-d0f63f56858e} VolumeId:{DynamicData:{} Id:cde92f3b-f26a-4551-a5f5-60fbbb2cede0} Description:simulator-snapshot CreateTime:2021-06-11 22:42:32.352747 -0700 PDT}}
    TestSimulator: simulator_test.go:458: snapshotQueryFilter with empty SnapshotQuerySpecs: {DynamicData:{} SnapshotQuerySpecs:[] Cursor:<nil>}
    TestSimulator: simulator_test.go:460: snapshotQueryResult &{DynamicData:{} Entries:[{DynamicData:{} Snapshot:{DynamicData:{} SnapshotId:{DynamicData:{} Id:8c83ad91-6529-49c1-b9af-d0f63f56858e} VolumeId:{DynamicData:{} Id:cde92f3b-f26a-4551-a5f5-60fbbb2cede0} Description:simulator-snapshot CreateTime:2021-06-11 22:42:32.352747 -0700 PDT} Error:<nil>}] Cursor:{DynamicData:{} Offset:0 Limit:0 TotalRecords:0}}
    TestSimulator: simulator_test.go:470: snapshotQueryFilter with unknown volumeId in SnapshotQuerySpecs: {DynamicData:{} SnapshotQuerySpecs:[{DynamicData:{} VolumeId:{DynamicData:{} Id:unknown-volume-id} SnapshotId:<nil>}] Cursor:<nil>}
    TestSimulator: simulator_test.go:476: snapshotQueryResult with expected CnsVolumeNotFoundFault &{DynamicData:{} Entries:[{DynamicData:{} Snapshot:{DynamicData:{} SnapshotId:{DynamicData:{} Id:} VolumeId:{DynamicData:{} Id:} Description: CreateTime:0001-01-01 00:00:00 +0000 UTC} Error:0xc000222fe0}] Cursor:{DynamicData:{} Offset:0 Limit:0 TotalRecords:0}}
    TestSimulator: simulator_test.go:487: snapshotQueryFilter with unknown snapshotId in SnapshotQuerySpecs: {DynamicData:{} SnapshotQuerySpecs:[{DynamicData:{} VolumeId:{DynamicData:{} Id:cde92f3b-f26a-4551-a5f5-60fbbb2cede0} SnapshotId:0xc0003ceee0}] Cursor:<nil>}
    TestSimulator: simulator_test.go:493: snapshotQueryResult with expected CnsSnapshotNotFoundFault &{DynamicData:{} Entries:[{DynamicData:{} Snapshot:{DynamicData:{} SnapshotId:{DynamicData:{} Id:} VolumeId:{DynamicData:{} Id:} Description: CreateTime:0001-01-01 00:00:00 +0000 UTC} Error:0xc0003f1b40}] Cursor:{DynamicData:{} Offset:0 Limit:0 TotalRecords:0}}
    TestSimulator: simulator_test.go:503: snapshotQueryFilter with expected volumeId and empty snapshotId in SnapshotQuerySpecs: {DynamicData:{} SnapshotQuerySpecs:[{DynamicData:{} VolumeId:{DynamicData:{} Id:cde92f3b-f26a-4551-a5f5-60fbbb2cede0} SnapshotId:<nil>}] Cursor:<nil>}
    TestSimulator: simulator_test.go:505: snapshotQueryResult &{DynamicData:{} Entries:[{DynamicData:{} Snapshot:{DynamicData:{} SnapshotId:{DynamicData:{} Id:8c83ad91-6529-49c1-b9af-d0f63f56858e} VolumeId:{DynamicData:{} Id:cde92f3b-f26a-4551-a5f5-60fbbb2cede0} Description:simulator-snapshot CreateTime:2021-06-11 22:42:32.352747 -0700 PDT} Error:<nil>}] Cursor:{DynamicData:{} Offset:0 Limit:0 TotalRecords:0}}
    TestSimulator: simulator_test.go:516: snapshotQueryFilter with expected volumeId and snapshotId in SnapshotQuerySpecs: {DynamicData:{} SnapshotQuerySpecs:[{DynamicData:{} VolumeId:{DynamicData:{} Id:cde92f3b-f26a-4551-a5f5-60fbbb2cede0} SnapshotId:0xc0005b6230}] Cursor:<nil>}
    TestSimulator: simulator_test.go:518: snapshotQueryResult &{DynamicData:{} Entries:[{DynamicData:{} Snapshot:{DynamicData:{} SnapshotId:{DynamicData:{} Id:8c83ad91-6529-49c1-b9af-d0f63f56858e} VolumeId:{DynamicData:{} Id:cde92f3b-f26a-4551-a5f5-60fbbb2cede0} Description:simulator-snapshot CreateTime:2021-06-11 22:42:32.352747 -0700 PDT} Error:<nil>}] Cursor:{DynamicData:{} Offset:0 Limit:0 TotalRecords:0}}
    TestSimulator: simulator_test.go:552: snapshotDeleteResult &{CnsSnapshotOperationResult:{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:cde92f3b-f26a-4551-a5f5-60fbbb2cede0} Fault:<nil>}} SnapshotId:{DynamicData:{} Id:8c83ad91-6529-49c1-b9af-d0f63f56858e}}
```

- Integration test 

Before running the integration test, please make sure the following ENVs are exported properly.

```
export CNS_DATACENTER=<datacenter name>
export CNS_DATASTORE=<datastore name>
export CNS_VC_URL=https://<username>:<password>@<VCIP>/sdk
```
```
$ go test -v
=== RUN   TestClient
 ...
 TestClient: client_test.go:296: QuerySnapshots before CreateSnapshots, snapshotQueryFilter {DynamicData:{} SnapshotQuerySpecs:[{DynamicData:{} VolumeId:{DynamicData:{} Id:36f7f3b4-f9ad-4eaa-b9d1-3ab13ff34ebf} SnapshotId:<nil>}] Cursor:<nil>}
    TestClient: client_test.go:298: snapshotQueryResult &{DynamicData:{} Entries:[] Cursor:{DynamicData:{} Offset:0 Limit:128 TotalRecords:0}}
    TestClient: client_test.go:312: Creating snapshot using the spec: []types.CnsSnapshotCreateSpec{
            {
                VolumeId: types.CnsVolumeId{
                    Id: "36f7f3b4-f9ad-4eaa-b9d1-3ab13ff34ebf",
                },
                Description: "example-vanilla-block-snapshot",
            },
        }
    TestClient: client_test.go:336: CreateSnapshots: Snapshot created successfully. volumeId: "36f7f3b4-f9ad-4eaa-b9d1-3ab13ff34ebf", snapshot id "7c7b8861-9ad3-4415-86d7-9b786408a501", time stamp 2021-06-14 22:39:39.992 +0000 UTC, opId: "39a8d72c"
    TestClient: client_test.go:349: QuerySnapshots after CreateSnapshots, snapshotQueryFilter {DynamicData:{} SnapshotQuerySpecs:[{DynamicData:{} VolumeId:{DynamicData:{} Id:36f7f3b4-f9ad-4eaa-b9d1-3ab13ff34ebf} SnapshotId:0xc0000a2a50}] Cursor:<nil>}
    TestClient: client_test.go:351: snapshotQueryResult &{DynamicData:{} Entries:[{DynamicData:{} Snapshot:{DynamicData:{} SnapshotId:{DynamicData:{} Id:7c7b8861-9ad3-4415-86d7-9b786408a501} VolumeId:{DynamicData:{} Id:36f7f3b4-f9ad-4eaa-b9d1-3ab13ff34ebf} Description:example-vanilla-block-snapshot CreateTime:2021-06-14 22:39:39.991999 +0000 UTC} Error:<nil>}] Cursor:{DynamicData:{} Offset:1 Limit:128 TotalRecords:1}}
 ...
```

**Test Configuration**:
* Toolchain:
* SDK:
* (add more if needed)

## Checklist:

- [ x ] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] Any dependent changes have been merged