### PR TITLE
[feature] govc: Allow cluster.change to set ClusterDrsConfigInfo.vmotionRate

### DIFF
--- a/govc/cluster/change.go
+++ b/govc/cluster/change.go
@@ -60,6 +60,8 @@ func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
 
 	f.StringVar((*string)(&cmd.DrsConfig.DefaultVmBehavior), "drs-mode", "", DrsBehaviorUsage())
 
+	f.Var(flags.NewInt32(&cmd.DrsConfig.VmotionRate), "drs-vmotion-rate", "Aggressiveness of vMotions (1-5)")
+
 	// HA
 	f.Var(flags.NewOptionalBool(&cmd.DasConfig.Enabled), "ha-enabled", "Enable HA")
 
@@ -84,7 +86,8 @@ func (cmd *change) Description() string {
 
 Examples:
   govc cluster.change -drs-enabled -vsan-enabled -vsan-autoclaim ClusterA
-  govc cluster.change -drs-enabled=false ClusterB`
+  govc cluster.change -drs-enabled=false ClusterB
+  govc cluster.change -drs-vmotion-rate=4 ClusterC`
 }
 
 func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {


### PR DESCRIPTION
Closes: #2506

## Description

The govc's `cluster.change` command allows enabling DRS on a cluster and also setting the automation level. However, it doesn't allow changing the vmotionRate on the DRS Config.

I'm automating some stuff where I want to dynamically change the vmotionRate and this change allows me to add it to my automation.

Closes: #2506 

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have a vCenter on which I tested the CLI and verified from the MOB the value did reflect. I also tested some negative cases giving the value > 5 and < 1. And the command obviously fails.

I also tested the command locally to ensure the help message does print out info about how to use the new option:
```
~/c/l/s/g/a/govmomi (issue-2506) go run govc/main.go cluster.change -h
Usage: /var/folders/n_/0xw1_2wd5r9bh3mx0kcr9tyh0000gr/T/go-build822536017/b001/exe/main cluster.change [OPTIONS] CLUSTER...

Change configuration of the given clusters.

Examples:
  govc cluster.change -drs-enabled -vsan-enabled -vsan-autoclaim ClusterA
  govc cluster.change -drs-enabled=false ClusterB
  govc cluster.change -drs-vmotion-rate=4 ClusterC
..
..
```

## Checklist:

- [X] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works **(N/A ..?)**
I don't know how to write tests for such govc cli changes.

- [X] New and existing unit tests pass locally with my changes
`make check` and `make test` both pass locally

- [X] Any dependent changes have been merged: **N/A**