### PR TITLE
make processing of mac addresses case insensitive

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -36,6 +36,40 @@ load test_helper
   assert_equal $ip $res
 }
 
+@test "vm.ip capital MAC" {
+  vcsim_env -autostart=false
+
+  id=/DC0/vm/DC0_H0_VM0
+
+  mac=00:50:56:83:3A:5D
+  run govc vm.customize -vm $id -mac $mac -ip 10.0.0.1 -netmask 255.255.0.0 -type Linux
+  assert_success
+
+  run govc vm.power -on $id
+  assert_success
+
+  run govc vm.ip -wait 5s $id
+  assert_success
+
+  run govc vm.ip -wait 5s -a -v4 $id
+  assert_success
+
+  run govc vm.ip -wait 5s -n $mac $id
+  assert_success
+
+  run govc vm.ip -wait 5s -n ethernet-0 $id
+  assert_success
+
+  ip=$(govc vm.ip -wait 5s $id)
+
+  # add a second nic
+  run govc vm.network.add -vm $id "VM Network"
+  assert_success
+
+  res=$(govc vm.ip -wait 5s -n ethernet-0 $id)
+  assert_equal $ip $res
+}
+
 @test "vm.ip -esxcli" {
   esx_env
 

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"path"
+	"strings"
 
 	"github.com/vmware/govmomi/nfc"
 	"github.com/vmware/govmomi/property"
@@ -333,7 +334,9 @@ func (v VirtualMachine) WaitForNetIP(ctx context.Context, v4 bool, device ...str
 			devices := VirtualDeviceList(c.Val.(types.ArrayOfVirtualDevice).VirtualDevice)
 			for _, d := range devices {
 				if nic, ok := d.(types.BaseVirtualEthernetCard); ok {
-					mac := nic.GetVirtualEthernetCard().MacAddress
+					// Convert to lower so that e.g. 00:50:56:83:3A:5D is treated the
+					// same as 00:50:56:83:3a:5d
+					mac := strings.ToLower(nic.GetVirtualEthernetCard().MacAddress)
 					if mac == "" {
 						return false
 					}
@@ -369,7 +372,9 @@ func (v VirtualMachine) WaitForNetIP(ctx context.Context, v4 bool, device ...str
 
 			nics := c.Val.(types.ArrayOfGuestNicInfo).GuestNicInfo
 			for _, nic := range nics {
-				mac := nic.MacAddress
+				// Convert to lower so that e.g. 00:50:56:83:3A:5D is treated the
+				// same as 00:50:56:83:3a:5d
+				mac := strings.ToLower(nic.MacAddress)
 				if mac == "" || nic.IpConfig == nil {
 					continue
 				}


### PR DESCRIPTION
## Description

Fixes WaitForNetIP when the vm contains a manual mac address which may contain uppercase characters.

Closes: #2509 

## Type of change

Please mark options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged