### PR TITLE
vcsim: propagate CustomizeVM MacAddress to Virtual NIC

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -3,32 +3,36 @@
 load test_helper
 
 @test "vm.ip" {
-  esx_env
+  vcsim_env -autostart=false
 
-  id=$(new_ttylinux_vm)
+  id=/DC0/vm/DC0_H0_VM0
+
+  mac=00:50:56:83:3a:5d
+  run govc vm.customize -vm $id -mac $mac -ip 10.0.0.1 -netmask 255.255.0.0 -type Linux
+  assert_success
 
   run govc vm.power -on $id
   assert_success
 
-  run govc vm.ip $id
+  run govc vm.ip -wait 5s $id
   assert_success
 
-  run govc vm.ip -a -v4 $id
+  run govc vm.ip -wait 5s -a -v4 $id
   assert_success
 
-  run govc vm.ip -n $(vm_mac $id) $id
+  run govc vm.ip -wait 5s -n $mac $id
   assert_success
 
-  run govc vm.ip -n ethernet-0 $id
+  run govc vm.ip -wait 5s -n ethernet-0 $id
   assert_success
 
-  ip=$(govc vm.ip $id)
+  ip=$(govc vm.ip -wait 5s $id)
 
   # add a second nic
   run govc vm.network.add -vm $id "VM Network"
   assert_success
 
-  res=$(govc vm.ip -n ethernet-0 $id)
+  res=$(govc vm.ip -wait 5s -n ethernet-0 $id)
   assert_equal $ip $res
 }
 

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1888,10 +1888,15 @@ func (vm *VirtualMachine) customize(ctx *Context) {
 		hostname = customizeName(vm, c.UserData.ComputerName)
 	}
 
+	cards := object.VirtualDeviceList(vm.Config.Hardware.Device).SelectByType((*types.VirtualEthernetCard)(nil))
+
 	for i, s := range vm.imc.NicSettingMap {
 		nic := &vm.Guest.Net[i]
 		if s.MacAddress != "" {
-			nic.MacAddress = s.MacAddress
+			nic.MacAddress = strings.ToLower(s.MacAddress) // MacAddress in guest will always be lowercase
+			card := cards[i].(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+			card.MacAddress = s.MacAddress // MacAddress in Virtual NIC can be any case
+			card.AddressType = string(types.VirtualEthernetCardMacTypeManual)
 		}
 		if nic.DnsConfig == nil {
 			nic.DnsConfig = new(types.NetDnsConfigInfo)


### PR DESCRIPTION
## Description

The object.VirtualMachine.WaitForNetIP method depends on both the Virtual NIC's MacAddress and
the MacAddress reported by vmware-tools (guest.net[].macaddress property).

With this we can enable WaitForNetIP testing (govc vm.ip) against vcsim.

Related: #2510

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

`vm.ip` bats test enabled against vcsim

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged