### PR TITLE
vcsim: use 'domain-c' prefix for cluster moids

### DIFF
--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -573,7 +573,7 @@ EOF
 
   run govc find -l -i /
   assert_success
-  assert_matches :domain- # ClusterComputeResource moid value
+  assert_matches :domain-c # ClusterComputeResource moid value
   assert_matches :group- # Folder moid value
   assert_matches :resgroup- # ResourcePool moid value
   assert_matches :dvs- # DistributedVirtualSwitch moid value

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -45,8 +45,9 @@ var refValueMap = map[string]string{
 	"VirtualMachineSnapshot":         "snapshot",
 	"VmwareDistributedVirtualSwitch": "dvs",
 	"DistributedVirtualSwitch":       "dvs",
-	"ClusterComputeResource":         "domain",
+	"ClusterComputeResource":         "domain-c",
 	"Folder":                         "group",
+	"StoragePod":                     "group-p",
 }
 
 // Map is the default Registry instance.
@@ -113,11 +114,16 @@ func typeName(item mo.Reference) string {
 
 // valuePrefix returns the value name prefix of a given object
 func valuePrefix(typeName string) string {
-	if v, ok := refValueMap[typeName]; ok {
-		return v
+	v, ok := refValueMap[typeName]
+	if ok {
+		if strings.Contains(v, "-") {
+			return v
+		}
+	} else {
+		v = strings.ToLower(typeName)
 	}
 
-	return strings.ToLower(typeName)
+	return v + "-"
 }
 
 // newReference returns a new MOR, where Type defaults to type of the given item
@@ -131,7 +137,7 @@ func (r *Registry) newReference(item mo.Reference) types.ManagedObjectReference 
 
 	if ref.Value == "" {
 		n := atomic.AddInt64(&r.counter, 1)
-		ref.Value = fmt.Sprintf("%s-%d", valuePrefix(ref.Type), n)
+		ref.Value = fmt.Sprintf("%s%d", valuePrefix(ref.Type), n)
 	}
 
 	return ref


### PR DESCRIPTION
## Description

Real vCenter uses a `domain-c` prefix, rather than just `domain-`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Adjusted test in object.bats

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged