### PR TITLE
vcsim: avoid race when fetching object Locker

### DIFF
--- a/simulator/task.go
+++ b/simulator/task.go
@@ -86,11 +86,11 @@ type TaskRunner interface {
 
 // taskReference is a helper struct so we can call AcquireLock in Run()
 type taskReference struct {
-	ref types.ManagedObjectReference
+	Self types.ManagedObjectReference
 }
 
 func (tr *taskReference) Reference() types.ManagedObjectReference {
-	return tr.ref
+	return tr.Self
 }
 
 func (t *Task) Run(ctx *Context) types.ManagedObjectReference {
@@ -101,7 +101,7 @@ func (t *Task) Run(ctx *Context) types.ManagedObjectReference {
 	})
 
 	tr := &taskReference{
-		ref: *t.Info.Entity,
+		Self: *t.Info.Entity,
 	}
 	// in most cases, the caller already holds this lock, and we would like
 	// the lock to be held across the "hand off" to the async goroutine.


### PR DESCRIPTION
## Description

The use of an interface method (mo.Reference) to get an object's lock can cause a read race.
The race detector doesn't follow what happens in the interface impl (most impls just return the `Self` field).
Prefer the mo 'Self' field via reflection to avoid this race.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Existing tests pass, in particular simulator/race_test.go after removing the special case for use of `*ListView.Self` in the `Registry.locker()` method.

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged