### PR TITLE
govc: add library.clone '-e' and '-m' options

### DIFF
--- a/govc/library/clone.go
+++ b/govc/library/clone.go
@@ -36,6 +36,8 @@ type clone struct {
 
 	profile string
 	ovf     bool
+	extra   bool
+	mac     bool
 }
 
 func init() {
@@ -62,6 +64,8 @@ func (cmd *clone) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.VirtualMachineFlag.Register(ctx, f)
 
 	f.BoolVar(&cmd.ovf, "ovf", false, "Clone as OVF (default is VM Template)")
+	f.BoolVar(&cmd.extra, "e", false, "Include extra configuration")
+	f.BoolVar(&cmd.mac, "m", false, "Preserve MAC-addresses on network adapters")
 	f.StringVar(&cmd.profile, "profile", "", "Storage profile")
 }
 
@@ -157,6 +161,12 @@ func (cmd *clone) Run(ctx context.Context, f *flag.FlagSet) error {
 			Target: vcenter.LibraryTarget{
 				LibraryID: l.ID,
 			},
+		}
+		if cmd.extra {
+			ovf.Spec.Flags = append(ovf.Spec.Flags, "EXTRA_CONFIG")
+		}
+		if cmd.mac {
+			ovf.Spec.Flags = append(ovf.Spec.Flags, "PRESERVE_MAC")
 		}
 		id, err := vcenter.NewManager(c).CreateOVF(ctx, ovf)
 		if err != nil {

--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -253,7 +253,7 @@ EOF
   run govc library.create my-content
   assert_success
 
-  run govc library.clone -vm $vm -ovf my-content $item
+  run govc library.clone -vm $vm -ovf -e -m my-content $item
   assert_success
 
   run govc vm.destroy $vm


### PR DESCRIPTION
## Description

New `library.clone` flags provide parity with the UI options:

```console
% govc library.clone -h | grep -E 'MAC|extra'
  -e=false                                                     Include extra configuration
  -m=false                                                    Preserve MAC-addresses on network adapters
```

Closes: #2528

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Adjusted library.bats test to clone with these options and tested against real VC manually.

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged