### PR TITLE
fix: Regenerated interface and type to include BaseAgencyConfigInfo. …

### DIFF
--- a/eam/object/agency.go
+++ b/eam/object/agency.go
@@ -61,7 +61,7 @@ func (m Agency) Config(ctx context.Context) (*types.AgencyConfigInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &resp.Returnval, nil
+	return resp.Returnval.GetAgencyConfigInfo(), nil
 }
 
 func (m Agency) Runtime(ctx context.Context) (*types.EamObjectRuntimeInfo, error) {

--- a/eam/object/esx_agent_manager.go
+++ b/eam/object/esx_agent_manager.go
@@ -47,7 +47,7 @@ func (m EsxAgentManager) CreateAgency(
 	var agency Agency
 	resp, err := methods.CreateAgency(ctx, m.c, &types.CreateAgency{
 		This:             m.r,
-		AgencyConfigInfo: config,
+		AgencyConfigInfo: config.GetAgencyConfigInfo(),
 		InitialGoalState: initialGoalState,
 	})
 	if err != nil {

--- a/eam/simulator/agency.go
+++ b/eam/simulator/agency.go
@@ -197,7 +197,7 @@ func (m *Agency) QueryConfig(
 
 	return &methods.QueryConfigBody{
 		Res: &types.QueryConfigResponse{
-			Returnval: m.Config,
+			Returnval: &m.Config,
 		},
 	}
 }
@@ -237,7 +237,7 @@ func (m *Agency) Update(
 	ctx *simulator.Context,
 	req *types.Update) soap.HasFault {
 
-	m.Config = req.Config
+	m.Config = *req.Config.GetAgencyConfigInfo()
 
 	return &methods.UpdateBody{
 		Res: &types.UpdateResponse{},

--- a/eam/simulator/esx_agent_manager.go
+++ b/eam/simulator/esx_agent_manager.go
@@ -39,7 +39,7 @@ func (m *EsxAgentManager) CreateAgency(
 
 	if agency, err := NewAgency(
 		ctx,
-		req.AgencyConfigInfo,
+		*req.AgencyConfigInfo.GetAgencyConfigInfo(),
 		req.InitialGoalState); err != nil {
 
 		res.Fault_ = simulator.Fault("", err)

--- a/eam/types/if.go
+++ b/eam/types/if.go
@@ -22,6 +22,16 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+func (b *AgencyConfigInfo) GetAgencyConfigInfo() *AgencyConfigInfo { return b }
+
+type BaseAgencyConfigInfo interface {
+	GetAgencyConfigInfo() *AgencyConfigInfo
+}
+
+func init() {
+	types.Add("BaseAgencyConfigInfo", reflect.TypeOf((*AgencyConfigInfo)(nil)).Elem())
+}
+
 func (b *AgencyIssue) GetAgencyIssue() *AgencyIssue { return b }
 
 type BaseAgencyIssue interface {

--- a/eam/types/types.go
+++ b/eam/types/types.go
@@ -500,7 +500,7 @@ func init() {
 
 type CreateAgencyRequestType struct {
 	This             types.ManagedObjectReference `xml:"_this"`
-	AgencyConfigInfo AgencyConfigInfo             `xml:"agencyConfigInfo"`
+	AgencyConfigInfo BaseAgencyConfigInfo         `xml:"agencyConfigInfo,typeattr"`
 	InitialGoalState string                       `xml:"initialGoalState"`
 }
 
@@ -1201,7 +1201,7 @@ func init() {
 }
 
 type QueryConfigResponse struct {
-	Returnval AgencyConfigInfo `xml:"returnval"`
+	Returnval BaseAgencyConfigInfo `xml:"returnval,typeattr"`
 }
 
 type QueryIssue QueryIssueRequestType
@@ -1375,7 +1375,7 @@ func init() {
 
 type UpdateRequestType struct {
 	This   types.ManagedObjectReference `xml:"_this"`
-	Config AgencyConfigInfo             `xml:"config"`
+	Config BaseAgencyConfigInfo         `xml:"config,typeattr"`
 }
 
 func init() {

--- a/gen/gen.sh
+++ b/gen/gen.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,13 @@ generate() {
 # All types derive from vCenter build 17986435, vSphere 7.0U2 Hot Patch 4
 #
 export COPYRIGHT_DATE_RANGE="2014-2021"
+
+#
+# FORCE_BASE_INTERFACE_FOR_TYPES defines the types that we want to
+# generate base interfaces for. The type names should be comma seperated -
+# e.g. "TypeA,TypeB,TypeC"
+#
+export FORCE_BASE_INTERFACE_FOR_TYPES="AgencyConfigInfo"
 
 # ./sdk/ contains the contents of wsdl.zip from vimbase build 17354719
 generate "../vim25" "vim" "./rbvmomi/vmodl.db" # from github.com/vmware/rbvmomi@v3.0.0

--- a/gen/vim_wsdl.rb
+++ b/gen/vim_wsdl.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2021 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ require "nokogiri"
 require "test/unit"
 
 $namespaces = %w(vim25)
+$force_base_interface_for_types = ENV['FORCE_BASE_INTERFACE_FOR_TYPES']
 
 def valid_ns?(t)
   $namespaces.include?(t)
@@ -62,7 +63,7 @@ class Peek
       # VrpResourceAllocationInfo is removed in 6.7, so base will no longer generated
       return false if ["ResourceAllocationInfo", "FaultDomainId"].include?(@name)
 
-      return !children.empty?
+      return !children.empty? || $force_base_interface_for_types.split(",").include?(@name)
     end
   end
 
@@ -193,7 +194,7 @@ class Simple
   end
 
   def base_type?
-    vim_type? && Peek.base?(vim_type)
+    vim_type? && (Peek.base?(vim_type) || $force_base_interface_for_types.split(",").include?(vim_type))
   end
 
   def enum_type?


### PR DESCRIPTION
## Description
fix: Regenerated interface and type to include BaseAgencyConfigInfo.
Closes: #2545.
    1- Introduced a new environment variable as a comma-seperated string to indicate the types, which we will consume to force generate the corresponding base interfaces and types;
    2- Regenerated EAM interfaces and types;
    3- Modified code where necessary to consume the change in interfaces and types.

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

Closes: #2545

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

Ran unit tests in the package
```
(base) yuyin-a01:govmomi yueyin$ go test
PASS
ok  	github.com/vmware/govmomi	0.425s
```

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged