### PR TITLE
vcsim: check if VM host InMaintenanceMode

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -1093,4 +1093,20 @@ load test_helper
 
   run govc object.collect -s vm/DC0_H0_VM0 guest.ipAddress
   assert_success 10.0.0.45
+
+  run govc vm.power -off DC0_H0_VM0
+  assert_success
+
+  host=$(govc ls -L "$(govc object.collect -s vm/DC0_H0_VM0 runtime.host)")
+  run govc host.maintenance.enter "$host"
+  assert_success
+
+  run govc vm.customize -vm DC0_H0_VM0 -ip 10.0.0.45 -netmask 255.255.0.0 -type Linux
+  assert_failure # InvalidState
+
+  run govc host.maintenance.exit "$host"
+  assert_success
+
+  run govc vm.customize -vm DC0_H0_VM0 -ip 10.0.0.45 -netmask 255.255.0.0 -type Linux
+  assert_success
 }


### PR DESCRIPTION
## Description

If a VM's host is InMaintenanceMode, certain tasks should return InvalidState,
such as CustomizeVM and PowerOnVM.

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

`vm.customize` test puts the vm host in MM and attempts to customize the vm, expecting failure (InvalidState)

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged