### PR TITLE
fix: generate negative device key

### DIFF
--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -68,7 +68,13 @@ func EthernetCardTypes() VirtualDeviceList {
 		&types.VirtualSriovEthernetCard{},
 	}).Select(func(device types.BaseVirtualDevice) bool {
 		c := device.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-		c.GetVirtualDevice().Key = int32(rand.Uint32()) * -1
+
+		key := rand.Int31() * -1
+		if key == 0 {
+			key = -1
+		}
+
+		c.GetVirtualDevice().Key = key
 		return true
 	})
 }

--- a/object/virtual_device_list_test.go
+++ b/object/virtual_device_list_test.go
@@ -688,9 +688,13 @@ func TestCreateEthernetCard(t *testing.T) {
 	}
 
 	for _, name := range []string{"", "e1000", "e1000e", "vmxnet2", "vmxnet3", "pcnet32", "sriov"} {
-		_, err := EthernetCardTypes().CreateEthernetCard(name, nil)
+		c, err := EthernetCardTypes().CreateEthernetCard(name, nil)
 		if err != nil {
 			t.Error(err)
+		}
+
+		if key := c.GetVirtualDevice().Key; key >= 0 {
+			t.Errorf("device key %d should be negative", key)
 		}
 	}
 }


### PR DESCRIPTION
## Description

Fix `VirtualDeviceList#CreateEthernetCard()` to always generate negative device keys so that they will not collide with existing keys.

Closes: #2536

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- ensure all device have negative device keys in CreateEthernetCard unittest

**Test Configuration**:
* Toolchain:
* SDK:
* (add more if needed)

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged