### PR TITLE
vcsim: Fix Data race in unprotected simulator.Map

### DIFF
--- a/cns/simulator/simulator.go
+++ b/cns/simulator/simulator.go
@@ -74,7 +74,7 @@ func (m *CnsVolumeManager) CnsCreateVolume(ctx *simulator.Context, req *cnstypes
 		for _, createSpec := range req.CreateSpecs {
 			staticProvisionedSpec, ok := interface{}(createSpec.BackingObjectDetails).(*cnstypes.CnsBlockBackingDetails)
 			if ok && staticProvisionedSpec.BackingDiskId != "" {
-				datastore := simulator.Map.Any("Datastore").(*simulator.Datastore)
+				datastore := simulator.Map().Any("Datastore").(*simulator.Datastore)
 				volumes, ok := m.volumes[datastore.Self]
 				if !ok {
 					volumes = make(map[cnstypes.CnsVolumeId]*cnstypes.CnsVolume)
@@ -109,7 +109,7 @@ func (m *CnsVolumeManager) CnsCreateVolume(ctx *simulator.Context, req *cnstypes
 
 			} else {
 				for _, datastoreRef := range createSpec.Datastores {
-					datastore := simulator.Map.Get(datastoreRef).(*simulator.Datastore)
+					datastore := simulator.Map().Get(datastoreRef).(*simulator.Datastore)
 
 					volumes, ok := m.volumes[datastore.Self]
 					if !ok {
@@ -306,7 +306,7 @@ func (m *CnsVolumeManager) CnsAttachVolume(ctx *simulator.Context, req *cnstypes
 		}
 		operationResult := []cnstypes.BaseCnsVolumeOperationResult{}
 		for _, attachSpec := range req.AttachSpecs {
-			node := simulator.Map.Get(attachSpec.Vm).(*simulator.VirtualMachine)
+			node := simulator.Map().Get(attachSpec.Vm).(*simulator.VirtualMachine)
 			if _, ok := m.attachments[attachSpec.VolumeId]; !ok {
 				m.attachments[attachSpec.VolumeId] = node.Self
 			} else {
@@ -427,7 +427,7 @@ func (m *CnsVolumeManager) CnsQueryVolumeInfo(ctx *simulator.Context, req *cnsty
 			vstorageObject.Config.Backing = &vim25types.BaseConfigInfoDiskFileBackingInfo{
 				BaseConfigInfoFileBackingInfo: vim25types.BaseConfigInfoFileBackingInfo{
 					BaseConfigInfoBackingInfo: vim25types.BaseConfigInfoBackingInfo{
-						Datastore: simulator.Map.Any("Datastore").(*simulator.Datastore).Self,
+						Datastore: simulator.Map().Any("Datastore").(*simulator.Datastore).Self,
 					},
 					FilePath:        "[vsanDatastore] 6785a85e-268e-6352-a2e8-02008b7afadd/kubernetes-dynamic-pvc-68734c9f-a679-42e6-a694-39632c51e31f.vmdk",
 					BackingObjectId: volumeId.Id,

--- a/cns/simulator/simulator_test.go
+++ b/cns/simulator/simulator_test.go
@@ -69,8 +69,11 @@ func TestSimulator(t *testing.T) {
 	}
 	existingNumDisks := len(queryResult.Volumes)
 
+	// alias the default registry
+	vimMap := simulator.Map()
+
 	// Get a simulator DS
-	datastore := simulator.Map().Any("Datastore").(*simulator.Datastore)
+	datastore := vimMap.Any("Datastore").(*simulator.Datastore)
 
 	// Create volume for static provisioning
 	var capacityInMb int64 = 1024
@@ -220,7 +223,7 @@ func TestSimulator(t *testing.T) {
 	}
 
 	// Attach
-	nodeVM := simulator.Map().Any("VirtualMachine").(*simulator.VirtualMachine)
+	nodeVM := vimMap.Any("VirtualMachine").(*simulator.VirtualMachine)
 	attachSpecList := []cnstypes.CnsVolumeAttachDetachSpec{
 		{
 			VolumeId: createVolumeOperationRes.VolumeId,

--- a/cns/simulator/simulator_test.go
+++ b/cns/simulator/simulator_test.go
@@ -70,7 +70,7 @@ func TestSimulator(t *testing.T) {
 	existingNumDisks := len(queryResult.Volumes)
 
 	// Get a simulator DS
-	datastore := simulator.Map.Any("Datastore").(*simulator.Datastore)
+	datastore := simulator.Map().Any("Datastore").(*simulator.Datastore)
 
 	// Create volume for static provisioning
 	var capacityInMb int64 = 1024
@@ -220,7 +220,7 @@ func TestSimulator(t *testing.T) {
 	}
 
 	// Attach
-	nodeVM := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	nodeVM := simulator.Map().Any("VirtualMachine").(*simulator.VirtualMachine)
 	attachSpecList := []cnstypes.CnsVolumeAttachDetachSpec{
 		{
 			VolumeId: createVolumeOperationRes.VolumeId,

--- a/eam/simulator/agency.go
+++ b/eam/simulator/agency.go
@@ -75,7 +75,7 @@ func NewAgency(
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	// Alias the registry that contains the vim25 objects.
-	vimMap := simulator.Map
+	vimMap := simulator.Map()
 
 	// Create the agents.
 	for i, agentConfig := range agencyConfig.AgentConfig {

--- a/eam/simulator/agent.go
+++ b/eam/simulator/agent.go
@@ -61,7 +61,7 @@ func NewAgent(
 	vmName string,
 	vmPlacement AgentVMPlacementOptions) (*Agent, vim.BaseMethodFault) {
 
-	vimMap := simulator.Map
+	vimMap := simulator.Map()
 
 	agent := &Agent{
 		EamObject: EamObject{

--- a/guest/file_manager_test.go
+++ b/guest/file_manager_test.go
@@ -27,8 +27,9 @@ import (
 
 func TestTranferURL(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		vm := simulator.Map().Any("VirtualMachine").(*simulator.VirtualMachine)
-		host := simulator.Map().Get(*vm.Runtime.Host).(*simulator.HostSystem)
+		vimMap := simulator.Map()
+		vm := vimMap.Any("VirtualMachine").(*simulator.VirtualMachine)
+		host := vimMap.Get(*vm.Runtime.Host).(*simulator.HostSystem)
 
 		ops := guest.NewOperationsManager(c, vm.Reference())
 		m, err := ops.FileManager(ctx)

--- a/guest/file_manager_test.go
+++ b/guest/file_manager_test.go
@@ -27,8 +27,8 @@ import (
 
 func TestTranferURL(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
-		host := simulator.Map.Get(*vm.Runtime.Host).(*simulator.HostSystem)
+		vm := simulator.Map().Any("VirtualMachine").(*simulator.VirtualMachine)
+		host := simulator.Map().Get(*vm.Runtime.Host).(*simulator.HostSystem)
 
 		ops := guest.NewOperationsManager(c, vm.Reference())
 		m, err := ops.FileManager(ctx)

--- a/lookup/simulator/registration_info.go
+++ b/lookup/simulator/registration_info.go
@@ -32,9 +32,10 @@ var (
 // registrationInfo returns a ServiceRegistration populated with vcsim's OptionManager settings.
 // The complete list can be captured using: govc sso.service.ls -dump
 func registrationInfo() []types.LookupServiceRegistrationInfo {
-	vc := simulator.Map().Get(vim25.ServiceInstance).(*simulator.ServiceInstance)
-	setting := simulator.Map().OptionManager().Setting
-	sm := simulator.Map().SessionManager()
+	vimMap := simulator.Map()
+	vc := vimMap.Get(vim25.ServiceInstance).(*simulator.ServiceInstance)
+	setting := vimMap.OptionManager().Setting
+	sm := vimMap.SessionManager()
 	opts := make(map[string]string, len(setting))
 
 	for _, o := range setting {

--- a/lookup/simulator/registration_info.go
+++ b/lookup/simulator/registration_info.go
@@ -32,9 +32,9 @@ var (
 // registrationInfo returns a ServiceRegistration populated with vcsim's OptionManager settings.
 // The complete list can be captured using: govc sso.service.ls -dump
 func registrationInfo() []types.LookupServiceRegistrationInfo {
-	vc := simulator.Map.Get(vim25.ServiceInstance).(*simulator.ServiceInstance)
-	setting := simulator.Map.OptionManager().Setting
-	sm := simulator.Map.SessionManager()
+	vc := simulator.Map().Get(vim25.ServiceInstance).(*simulator.ServiceInstance)
+	setting := simulator.Map().OptionManager().Setting
+	sm := simulator.Map().SessionManager()
 	opts := make(map[string]string, len(setting))
 
 	for _, o := range setting {

--- a/object/common_test.go
+++ b/object/common_test.go
@@ -49,7 +49,7 @@ func TestObjectName(t *testing.T) {
 		kinds := []string{"VirtualMachine", "Network", "DistributedVirtualPortgroup"}
 
 		for _, kind := range kinds {
-			ref := simulator.Map.Any(kind)
+			ref := simulator.Map().Any(kind)
 			obj := object.NewReference(c, ref.Reference())
 
 			name, err := obj.(common).ObjectName(ctx)

--- a/object/common_test.go
+++ b/object/common_test.go
@@ -48,8 +48,9 @@ func TestObjectName(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
 		kinds := []string{"VirtualMachine", "Network", "DistributedVirtualPortgroup"}
 
+		vimMap := simulator.Map()
 		for _, kind := range kinds {
-			ref := simulator.Map().Any(kind)
+			ref := vimMap.Any(kind)
 			obj := object.NewReference(c, ref.Reference())
 
 			name, err := obj.(common).ObjectName(ctx)

--- a/object/distributed_virtual_portgroup_test.go
+++ b/object/distributed_virtual_portgroup_test.go
@@ -33,7 +33,7 @@ var _ object.NetworkReference = object.DistributedVirtualPortgroup{}
 
 func TestDistributedVirtualPortgroupEthernetCardBackingInfo(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		obj := simulator.Map.Any("DistributedVirtualPortgroup").(*simulator.DistributedVirtualPortgroup)
+		obj := simulator.Map().Any("DistributedVirtualPortgroup").(*simulator.DistributedVirtualPortgroup)
 
 		pg := object.NewDistributedVirtualPortgroup(c, obj.Self)
 		_, err := pg.EthernetCardBackingInfo(ctx)

--- a/object/distributed_virtual_switch_test.go
+++ b/object/distributed_virtual_switch_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestDistributedVirtualSwitchEthernetCardBackingInfo(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		obj := simulator.Map.Any("DistributedVirtualSwitch").(*simulator.DistributedVirtualSwitch)
+		obj := simulator.Map().Any("DistributedVirtualSwitch").(*simulator.DistributedVirtualSwitch)
 
 		dvs := object.NewDistributedVirtualSwitch(c, obj.Self)
 

--- a/object/host_config_manager_test.go
+++ b/object/host_config_manager_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestHostConfigManager(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		obj := simulator.Map.Any("HostSystem").(*simulator.HostSystem)
+		obj := simulator.Map().Any("HostSystem").(*simulator.HostSystem)
 		host := object.NewHostSystem(c, obj.Self)
 
 		m := host.ConfigManager()

--- a/object/vm_guest_test.go
+++ b/object/vm_guest_test.go
@@ -37,7 +37,8 @@ func TestVirtualMachineWaitForIP(t *testing.T) {
 			return err
 		}
 
-		obj := simulator.Map().Get(vm.Reference()).(*simulator.VirtualMachine)
+		vimMap := simulator.Map()
+		obj := vimMap.Get(vm.Reference()).(*simulator.VirtualMachine)
 		obj.Guest.IpAddress = "fe80::250:56ff:fe97:2458"
 
 		ip, err := vm.WaitForIP(ctx)
@@ -58,8 +59,8 @@ func TestVirtualMachineWaitForIP(t *testing.T) {
 			t.Logf("delaying map update for %v", delay)
 			time.Sleep(delay)
 
-			simulator.Map().WithLock(simulator.SpoofContext(), obj.Reference(), func() {
-				simulator.Map().Update(obj, []types.PropertyChange{
+			vimMap.WithLock(simulator.SpoofContext(), obj.Reference(), func() {
+				vimMap.Update(obj, []types.PropertyChange{
 					{Name: "guest.ipAddress", Val: "10.0.0.1"},
 				})
 			})

--- a/object/vm_guest_test.go
+++ b/object/vm_guest_test.go
@@ -37,7 +37,7 @@ func TestVirtualMachineWaitForIP(t *testing.T) {
 			return err
 		}
 
-		obj := simulator.Map.Get(vm.Reference()).(*simulator.VirtualMachine)
+		obj := simulator.Map().Get(vm.Reference()).(*simulator.VirtualMachine)
 		obj.Guest.IpAddress = "fe80::250:56ff:fe97:2458"
 
 		ip, err := vm.WaitForIP(ctx)
@@ -58,8 +58,8 @@ func TestVirtualMachineWaitForIP(t *testing.T) {
 			t.Logf("delaying map update for %v", delay)
 			time.Sleep(delay)
 
-			simulator.Map.WithLock(simulator.SpoofContext(), obj.Reference(), func() {
-				simulator.Map.Update(obj, []types.PropertyChange{
+			simulator.Map().WithLock(simulator.SpoofContext(), obj.Reference(), func() {
+				simulator.Map().Update(obj, []types.PropertyChange{
 					{Name: "guest.ipAddress", Val: "10.0.0.1"},
 				})
 			})

--- a/pbm/simulator/simulator.go
+++ b/pbm/simulator/simulator.go
@@ -217,7 +217,7 @@ func (m *PlacementSolver) PbmCheckRequirements(req *types.PbmCheckRequirements) 
 	body := new(methods.PbmCheckRequirementsBody)
 	body.Res = new(types.PbmCheckRequirementsResponse)
 
-	for _, ds := range simulator.Map.All("Datastore") {
+	for _, ds := range simulator.Map().All("Datastore") {
 		// TODO: filter
 		ref := ds.Reference()
 		body.Res.Returnval = append(body.Res.Returnval, types.PbmPlacementCompatibilityResult{

--- a/property/wait_test.go
+++ b/property/wait_test.go
@@ -93,7 +93,7 @@ func TestWaitPermissionFault(t *testing.T) {
 
 	pc := new(PropertyCollector)
 	pc.Self = model.ServiceContent.PropertyCollector
-	simulator.Map.Put(pc)
+	simulator.Map().Put(pc)
 
 	dm := object.NewVirtualDiskManager(c.Client)
 

--- a/simulator/authorization_manager.go
+++ b/simulator/authorization_manager.go
@@ -67,7 +67,7 @@ func (m *AuthorizationManager) init(r *Registry) {
 }
 
 func (m *AuthorizationManager) RetrieveEntityPermissions(req *types.RetrieveEntityPermissions) soap.HasFault {
-	e := Map.Get(req.Entity).(mo.Entity)
+	e := Map().Get(req.Entity).(mo.Entity)
 
 	p := m.permissions[e.Reference()]
 
@@ -78,7 +78,7 @@ func (m *AuthorizationManager) RetrieveEntityPermissions(req *types.RetrieveEnti
 				break
 			}
 
-			e = Map.Get(parent.Reference()).(mo.Entity)
+			e = Map().Get(parent.Reference()).(mo.Entity)
 
 			p = append(p, m.permissions[e.Reference()]...)
 		}

--- a/simulator/authorization_manager.go
+++ b/simulator/authorization_manager.go
@@ -67,7 +67,8 @@ func (m *AuthorizationManager) init(r *Registry) {
 }
 
 func (m *AuthorizationManager) RetrieveEntityPermissions(req *types.RetrieveEntityPermissions) soap.HasFault {
-	e := Map().Get(req.Entity).(mo.Entity)
+	vimMap := Map()
+	e := vimMap.Get(req.Entity).(mo.Entity)
 
 	p := m.permissions[e.Reference()]
 
@@ -78,7 +79,7 @@ func (m *AuthorizationManager) RetrieveEntityPermissions(req *types.RetrieveEnti
 				break
 			}
 
-			e = Map().Get(parent.Reference()).(mo.Entity)
+			e = vimMap.Get(parent.Reference()).(mo.Entity)
 
 			p = append(p, m.permissions[e.Reference()]...)
 		}

--- a/simulator/authorization_manager_test.go
+++ b/simulator/authorization_manager_test.go
@@ -29,7 +29,7 @@ func TestAuthorizationManager(t *testing.T) {
 
 		_ = New(NewServiceInstance(SpoofContext(), model.ServiceContent, model.RootFolder)) // 2nd pass panics w/o copying RoleList
 
-		authz := Map.Get(*vpx.ServiceContent.AuthorizationManager).(*AuthorizationManager)
+		authz := Map().Get(*vpx.ServiceContent.AuthorizationManager).(*AuthorizationManager)
 		authz.RemoveAuthorizationRole(&types.RemoveAuthorizationRole{
 			RoleId: -2, // ReadOnly
 		})

--- a/simulator/cluster_compute_resource.go
+++ b/simulator/cluster_compute_resource.go
@@ -398,7 +398,8 @@ func (c *ClusterComputeResource) PlaceVm(ctx *Context, req *types.PlaceVm) soap.
 }
 
 func CreateClusterComputeResource(ctx *Context, f *Folder, name string, spec types.ClusterConfigSpecEx) (*ClusterComputeResource, types.BaseMethodFault) {
-	if e := Map().FindByName(name, f.ChildEntity); e != nil {
+	vimMap := Map()
+	if e := vimMap.FindByName(name, f.ChildEntity); e != nil {
 		return nil, &types.DuplicateName{
 			Name:   e.Entity().Name,
 			Object: e.Reference(),
@@ -408,7 +409,7 @@ func CreateClusterComputeResource(ctx *Context, f *Folder, name string, spec typ
 	cluster := &ClusterComputeResource{}
 	cluster.EnvironmentBrowser = newEnvironmentBrowser()
 	cluster.Name = name
-	cluster.Network = Map().getEntityDatacenter(f).defaultNetwork()
+	cluster.Network = vimMap.getEntityDatacenter(f).defaultNetwork()
 	cluster.Summary = &types.ClusterComputeResourceSummary{
 		UsageSummary: new(types.ClusterUsageSummary),
 	}
@@ -420,7 +421,7 @@ func CreateClusterComputeResource(ctx *Context, f *Folder, name string, spec typ
 	config.DrsConfig.Enabled = types.NewBool(true)
 
 	pool := NewResourcePool()
-	Map().PutEntity(cluster, Map().NewEntity(pool))
+	vimMap.PutEntity(cluster, vimMap.NewEntity(pool))
 	cluster.ResourcePool = &pool.Self
 
 	folderPutChild(ctx, &f.Folder, cluster)

--- a/simulator/cluster_compute_resource.go
+++ b/simulator/cluster_compute_resource.go
@@ -58,7 +58,7 @@ func (add *addHost) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	host.configure(spec, add.req.AsConnected)
 
 	cr := add.ClusterComputeResource
-	Map.PutEntity(cr, Map.NewEntity(host))
+	Map().PutEntity(cr, Map().NewEntity(host))
 	host.Summary.Host = &host.Self
 
 	cr.Host = append(cr.Host, host.Reference())
@@ -398,7 +398,7 @@ func (c *ClusterComputeResource) PlaceVm(ctx *Context, req *types.PlaceVm) soap.
 }
 
 func CreateClusterComputeResource(ctx *Context, f *Folder, name string, spec types.ClusterConfigSpecEx) (*ClusterComputeResource, types.BaseMethodFault) {
-	if e := Map.FindByName(name, f.ChildEntity); e != nil {
+	if e := Map().FindByName(name, f.ChildEntity); e != nil {
 		return nil, &types.DuplicateName{
 			Name:   e.Entity().Name,
 			Object: e.Reference(),
@@ -408,7 +408,7 @@ func CreateClusterComputeResource(ctx *Context, f *Folder, name string, spec typ
 	cluster := &ClusterComputeResource{}
 	cluster.EnvironmentBrowser = newEnvironmentBrowser()
 	cluster.Name = name
-	cluster.Network = Map.getEntityDatacenter(f).defaultNetwork()
+	cluster.Network = Map().getEntityDatacenter(f).defaultNetwork()
 	cluster.Summary = &types.ClusterComputeResourceSummary{
 		UsageSummary: new(types.ClusterUsageSummary),
 	}
@@ -420,7 +420,7 @@ func CreateClusterComputeResource(ctx *Context, f *Folder, name string, spec typ
 	config.DrsConfig.Enabled = types.NewBool(true)
 
 	pool := NewResourcePool()
-	Map.PutEntity(cluster, Map.NewEntity(pool))
+	Map().PutEntity(cluster, Map().NewEntity(pool))
 	cluster.ResourcePool = &pool.Self
 
 	folderPutChild(ctx, &f.Folder, cluster)

--- a/simulator/custom_fields_manager.go
+++ b/simulator/custom_fields_manager.go
@@ -32,7 +32,7 @@ type CustomFieldsManager struct {
 // Iterates through all entities of passed field type;
 // Removes found field from their custom field properties.
 func entitiesFieldRemove(ctx *Context, field types.CustomFieldDef) {
-	entities := Map.All(field.ManagedObjectType)
+	entities := Map().All(field.ManagedObjectType)
 	for _, e := range entities {
 		entity := e.Entity()
 		ctx.WithLock(entity, func() {
@@ -66,7 +66,7 @@ func entitiesFieldRemove(ctx *Context, field types.CustomFieldDef) {
 // Iterates through all entities of passed field type;
 // Renames found field in entity's AvailableField property.
 func entitiesFieldRename(ctx *Context, field types.CustomFieldDef) {
-	entities := Map.All(field.ManagedObjectType)
+	entities := Map().All(field.ManagedObjectType)
 	for _, e := range entities {
 		entity := e.Entity()
 		ctx.WithLock(entity, func() {
@@ -123,7 +123,7 @@ func (c *CustomFieldsManager) AddCustomFieldDef(ctx *Context, req *types.AddCust
 		FieldInstancePrivileges: req.FieldPolicy,
 	}
 
-	entities := Map.All(req.MoType)
+	entities := Map().All(req.MoType)
 	for _, e := range entities {
 		entity := e.Entity()
 		ctx.WithLock(entity, func() {
@@ -188,7 +188,7 @@ func (c *CustomFieldsManager) SetField(ctx *Context, req *types.SetField) soap.H
 		Value:            req.Value,
 	}
 
-	entity := Map.Get(req.Entity).(mo.Entity).Entity()
+	entity := Map().Get(req.Entity).(mo.Entity).Entity()
 	ctx.WithLock(entity, func() {
 		entity.CustomValue = append(entity.CustomValue, newValue)
 		entity.Value = append(entity.Value, newValue)

--- a/simulator/custom_fields_manager_test.go
+++ b/simulator/custom_fields_manager_test.go
@@ -92,7 +92,7 @@ func TestCustomFieldsManager(t *testing.T) {
 		t.Fatalf("expect field.name to be %s; got %s", "new_field_name", fields[0].Name)
 	}
 
-	vm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vm := Map().Any("VirtualMachine").(*VirtualMachine)
 	err = fieldsManager.Set(ctx, vm.Reference(), field.Key, "value")
 	if err != nil {
 		t.Fatal(err)

--- a/simulator/datacenter.go
+++ b/simulator/datacenter.go
@@ -77,10 +77,10 @@ func (dc *Datacenter) createFolders(ctx *Context) {
 		if dc.isESX {
 			folder.ChildType = f.types[:1]
 			folder.Self = *f.ref
-			Map.PutEntity(dc, folder)
+			Map().PutEntity(dc, folder)
 		} else {
 			folder.ChildType = f.types
-			e := Map.PutEntity(dc, folder)
+			e := Map().PutEntity(dc, folder)
 
 			// propagate the generated morefs to Datacenter
 			ref := e.Reference()
@@ -89,7 +89,7 @@ func (dc *Datacenter) createFolders(ctx *Context) {
 		}
 	}
 
-	net := Map.Get(dc.NetworkFolder).(*Folder)
+	net := Map().Get(dc.NetworkFolder).(*Folder)
 
 	for _, ref := range esx.Datacenter.Network {
 		// Add VM Network by default to each Datacenter
@@ -121,7 +121,7 @@ func (dc *Datacenter) folder(obj mo.Entity) *mo.Folder {
 	rtype := obj.Reference().Type
 
 	for i := range folders {
-		folder, _ := asFolderMO(Map.Get(folders[i]))
+		folder, _ := asFolderMO(Map().Get(folders[i]))
 		for _, kind := range folder.ChildType {
 			if rtype == kind {
 				return folder
@@ -139,7 +139,7 @@ func (dc *Datacenter) folder(obj mo.Entity) *mo.Folder {
 func datacenterEventArgument(obj mo.Entity) *types.DatacenterEventArgument {
 	dc, ok := obj.(*Datacenter)
 	if !ok {
-		dc = Map.getEntityDatacenter(obj)
+		dc = Map().getEntityDatacenter(obj)
 	}
 	return &types.DatacenterEventArgument{
 		Datacenter:          dc.Self,
@@ -154,7 +154,7 @@ func (dc *Datacenter) PowerOnMultiVMTask(ctx *Context, req *types.PowerOnMultiVM
 		}
 
 		for _, ref := range req.Vm {
-			vm := Map.Get(ref).(*VirtualMachine)
+			vm := Map().Get(ref).(*VirtualMachine)
 			ctx.WithLock(vm, func() {
 				vm.PowerOnVMTask(ctx, &types.PowerOnVM_Task{})
 			})
@@ -178,13 +178,13 @@ func (d *Datacenter) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.Has
 		}
 
 		for _, ref := range folders {
-			f, _ := asFolderMO(Map.Get(ref))
+			f, _ := asFolderMO(Map().Get(ref))
 			if len(f.ChildEntity) != 0 {
 				return nil, &types.ResourceInUse{}
 			}
 		}
 
-		p, _ := asFolderMO(Map.Get(*d.Parent))
+		p, _ := asFolderMO(Map().Get(*d.Parent))
 		folderRemoveChild(ctx, p, d.Self)
 
 		return nil, nil

--- a/simulator/datacenter_test.go
+++ b/simulator/datacenter_test.go
@@ -39,10 +39,11 @@ func TestDatacenterCreateFolders(t *testing.T) {
 		},
 	}
 
+	vimMap := Map()
 	for _, model := range models {
 		_ = model.Create()
 
-		dc := Map().Any("Datacenter").(*Datacenter)
+		dc := vimMap.Any("Datacenter").(*Datacenter)
 
 		folders := []types.ManagedObjectReference{
 			dc.VmFolder,
@@ -56,7 +57,7 @@ func TestDatacenterCreateFolders(t *testing.T) {
 				t.Errorf("invalid moref=%#v", ref)
 			}
 
-			e := Map().Get(ref).(mo.Entity)
+			e := vimMap.Get(ref).(mo.Entity)
 
 			if e.Entity().Name == "" {
 				t.Error("empty name")
@@ -71,7 +72,7 @@ func TestDatacenterCreateFolders(t *testing.T) {
 				t.Fatalf("unexpected type (%T) for %#v", e, ref)
 			}
 
-			if Map().IsVPX() {
+			if vimMap.IsVPX() {
 				if len(f.ChildType) < 2 {
 					t.Fail()
 				}

--- a/simulator/datacenter_test.go
+++ b/simulator/datacenter_test.go
@@ -42,7 +42,7 @@ func TestDatacenterCreateFolders(t *testing.T) {
 	for _, model := range models {
 		_ = model.Create()
 
-		dc := Map.Any("Datacenter").(*Datacenter)
+		dc := Map().Any("Datacenter").(*Datacenter)
 
 		folders := []types.ManagedObjectReference{
 			dc.VmFolder,
@@ -56,7 +56,7 @@ func TestDatacenterCreateFolders(t *testing.T) {
 				t.Errorf("invalid moref=%#v", ref)
 			}
 
-			e := Map.Get(ref).(mo.Entity)
+			e := Map().Get(ref).(mo.Entity)
 
 			if e.Entity().Name == "" {
 				t.Error("empty name")
@@ -71,7 +71,7 @@ func TestDatacenterCreateFolders(t *testing.T) {
 				t.Fatalf("unexpected type (%T) for %#v", e, ref)
 			}
 
-			if Map.IsVPX() {
+			if Map().IsVPX() {
 				if len(f.ChildType) < 2 {
 					t.Fail()
 				}

--- a/simulator/datastore.go
+++ b/simulator/datastore.go
@@ -88,14 +88,15 @@ func (ds *Datastore) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.Has
 			}
 		}
 
+		vimMap := Map()
 		for _, mount := range ds.Host {
-			host := Map().Get(mount.Key).(*HostSystem)
-			Map().RemoveReference(ctx, host, &host.Datastore, ds.Self)
+			host := vimMap.Get(mount.Key).(*HostSystem)
+			vimMap.RemoveReference(ctx, host, &host.Datastore, ds.Self)
 			parent := hostParent(&host.HostSystem)
-			Map().RemoveReference(ctx, parent, &parent.Datastore, ds.Self)
+			vimMap.RemoveReference(ctx, parent, &parent.Datastore, ds.Self)
 		}
 
-		p, _ := asFolderMO(Map().Get(*ds.Parent))
+		p, _ := asFolderMO(vimMap.Get(*ds.Parent))
 		folderRemoveChild(ctx, p, ds.Self)
 
 		return nil, nil

--- a/simulator/datastore.go
+++ b/simulator/datastore.go
@@ -89,13 +89,13 @@ func (ds *Datastore) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.Has
 		}
 
 		for _, mount := range ds.Host {
-			host := Map.Get(mount.Key).(*HostSystem)
-			Map.RemoveReference(ctx, host, &host.Datastore, ds.Self)
+			host := Map().Get(mount.Key).(*HostSystem)
+			Map().RemoveReference(ctx, host, &host.Datastore, ds.Self)
 			parent := hostParent(&host.HostSystem)
-			Map.RemoveReference(ctx, parent, &parent.Datastore, ds.Self)
+			Map().RemoveReference(ctx, parent, &parent.Datastore, ds.Self)
 		}
 
-		p, _ := asFolderMO(Map.Get(*ds.Parent))
+		p, _ := asFolderMO(Map().Get(*ds.Parent))
 		folderRemoveChild(ctx, p, ds.Self)
 
 		return nil, nil

--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -34,7 +34,7 @@ type DistributedVirtualSwitch struct {
 
 func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.AddDVPortgroup_Task) soap.HasFault {
 	task := CreateTask(s, "addDVPortgroup", func(t *Task) (types.AnyType, types.BaseMethodFault) {
-		f := Map.getEntityParent(s, "Folder").(*Folder)
+		f := Map().getEntityParent(s, "Folder").(*Folder)
 
 		portgroups := s.Portgroup
 		portgroupNames := s.Summary.PortgroupName
@@ -47,7 +47,7 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.Add
 			// Standard AddDVPortgroupTask() doesn't allow duplicate names, but NSX 3.0 does create some DVPGs with the same name.
 			// Allow duplicate names using this prefix so we can reproduce and test this condition.
 			if !strings.HasPrefix(pg.Name, "NSX-") {
-				if obj := Map.FindByName(pg.Name, f.ChildEntity); obj != nil {
+				if obj := Map().FindByName(pg.Name, f.ChildEntity); obj != nil {
 					return nil, &types.DuplicateName{
 						Name:   pg.Name,
 						Object: obj.Reference(),
@@ -131,18 +131,18 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.Add
 			for _, h := range s.Summary.HostMember {
 				pg.Host = append(pg.Host, h)
 
-				host := Map.Get(h).(*HostSystem)
-				Map.AppendReference(ctx, host, &host.Network, pg.Reference())
+				host := Map().Get(h).(*HostSystem)
+				Map().AppendReference(ctx, host, &host.Network, pg.Reference())
 
-				parent := Map.Get(*host.HostSystem.Parent)
+				parent := Map().Get(*host.HostSystem.Parent)
 				computeNetworks := append(hostParent(&host.HostSystem).Network, pg.Reference())
-				Map.Update(parent, []types.PropertyChange{
+				Map().Update(parent, []types.PropertyChange{
 					{Name: "network", Val: computeNetworks},
 				})
 			}
 		}
 
-		Map.Update(s, []types.PropertyChange{
+		Map().Update(s, []types.PropertyChange{
 			{Name: "portgroup", Val: portgroups},
 			{Name: "summary.portgroupName", Val: portgroupNames},
 		})
@@ -164,7 +164,7 @@ func (s *DistributedVirtualSwitch) ReconfigureDvsTask(ctx *Context, req *types.R
 		members := s.Summary.HostMember
 
 		for _, member := range spec.Host {
-			h := Map.Get(member.Host)
+			h := Map().Get(member.Host)
 			if h == nil {
 				return nil, &types.ManagedObjectNotFound{Obj: member.Host}
 			}
@@ -178,26 +178,26 @@ func (s *DistributedVirtualSwitch) ReconfigureDvsTask(ctx *Context, req *types.R
 				}
 
 				hostNetworks := append(host.Network, s.Portgroup...)
-				Map.Update(host, []types.PropertyChange{
+				Map().Update(host, []types.PropertyChange{
 					{Name: "network", Val: hostNetworks},
 				})
 				members = append(members, member.Host)
-				parent := Map.Get(*host.HostSystem.Parent)
+				parent := Map().Get(*host.HostSystem.Parent)
 
 				var pgs []types.ManagedObjectReference
 				for _, ref := range s.Portgroup {
-					pg := Map.Get(ref).(*DistributedVirtualPortgroup)
+					pg := Map().Get(ref).(*DistributedVirtualPortgroup)
 					pgs = append(pgs, ref)
 
 					pgHosts := append(pg.Host, member.Host)
-					Map.Update(pg, []types.PropertyChange{
+					Map().Update(pg, []types.PropertyChange{
 						{Name: "host", Val: pgHosts},
 					})
 
 					cr := hostParent(&host.HostSystem)
 					if FindReference(cr.Network, ref) == nil {
 						computeNetworks := append(cr.Network, ref)
-						Map.Update(parent, []types.PropertyChange{
+						Map().Update(parent, []types.PropertyChange{
 							{Name: "network", Val: computeNetworks},
 						})
 					}
@@ -205,7 +205,7 @@ func (s *DistributedVirtualSwitch) ReconfigureDvsTask(ctx *Context, req *types.R
 
 			case types.ConfigSpecOperationRemove:
 				for _, ref := range host.Vm {
-					vm := Map.Get(ref).(*VirtualMachine)
+					vm := Map().Get(ref).(*VirtualMachine)
 					if pg := FindReference(vm.Network, s.Portgroup...); pg != nil {
 						return nil, &types.ResourceInUse{
 							Type: pg.Type,
@@ -220,7 +220,7 @@ func (s *DistributedVirtualSwitch) ReconfigureDvsTask(ctx *Context, req *types.R
 			}
 		}
 
-		Map.Update(s, []types.PropertyChange{
+		Map().Update(s, []types.PropertyChange{
 			{Name: "summary.hostMember", Val: members},
 		})
 
@@ -244,7 +244,7 @@ func (s *DistributedVirtualSwitch) FetchDVPorts(req *types.FetchDVPorts) soap.Ha
 
 func (s *DistributedVirtualSwitch) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.HasFault {
 	task := CreateTask(s, "destroy", func(t *Task) (types.AnyType, types.BaseMethodFault) {
-		f := Map.getEntityParent(s, "Folder").(*Folder)
+		f := Map().getEntityParent(s, "Folder").(*Folder)
 		folderRemoveChild(ctx, &f.Folder, s.Reference())
 		return nil, nil
 	})
@@ -264,7 +264,7 @@ func (s *DistributedVirtualSwitch) dvPortgroups(_ *types.DistributedVirtualSwitc
 	}
 
 	for _, ref := range s.Portgroup {
-		pg := Map.Get(ref).(*DistributedVirtualPortgroup)
+		pg := Map().Get(ref).(*DistributedVirtualPortgroup)
 		res = append(res, types.DistributedVirtualPort{
 			DvsUuid: s.Uuid,
 			Key:     pg.Key,

--- a/simulator/dvs_test.go
+++ b/simulator/dvs_test.go
@@ -45,7 +45,7 @@ func TestDVS(t *testing.T) {
 	finder.SetDatacenter(dc[0])
 	folders, _ := dc[0].Folders(ctx)
 	hosts, _ := finder.HostSystemList(ctx, "*/*")
-	vswitch := Map.Any("DistributedVirtualSwitch").(*DistributedVirtualSwitch)
+	vswitch := Map().Any("DistributedVirtualSwitch").(*DistributedVirtualSwitch)
 	dvs0 := object.NewDistributedVirtualSwitch(c, vswitch.Reference())
 
 	if len(vswitch.Summary.HostMember) == 0 {
@@ -53,7 +53,7 @@ func TestDVS(t *testing.T) {
 	}
 
 	for _, ref := range vswitch.Summary.HostMember {
-		host := Map.Get(ref).(*HostSystem)
+		host := Map().Get(ref).(*HostSystem)
 		if len(host.Network) == 0 {
 			t.Fatalf("%s.Network=%v", ref, host.Network)
 		}

--- a/simulator/dvs_test.go
+++ b/simulator/dvs_test.go
@@ -39,13 +39,14 @@ func TestDVS(t *testing.T) {
 
 	ctx := context.Background()
 	c := m.Service.client
+	vimMap := Map()
 
 	finder := find.NewFinder(c, false)
 	dc, _ := finder.DatacenterList(ctx, "*")
 	finder.SetDatacenter(dc[0])
 	folders, _ := dc[0].Folders(ctx)
 	hosts, _ := finder.HostSystemList(ctx, "*/*")
-	vswitch := Map().Any("DistributedVirtualSwitch").(*DistributedVirtualSwitch)
+	vswitch := vimMap.Any("DistributedVirtualSwitch").(*DistributedVirtualSwitch)
 	dvs0 := object.NewDistributedVirtualSwitch(c, vswitch.Reference())
 
 	if len(vswitch.Summary.HostMember) == 0 {
@@ -53,7 +54,7 @@ func TestDVS(t *testing.T) {
 	}
 
 	for _, ref := range vswitch.Summary.HostMember {
-		host := Map().Get(ref).(*HostSystem)
+		host := vimMap.Get(ref).(*HostSystem)
 		if len(host.Network) == 0 {
 			t.Fatalf("%s.Network=%v", ref, host.Network)
 		}

--- a/simulator/entity.go
+++ b/simulator/entity.go
@@ -25,15 +25,15 @@ import (
 
 func RenameTask(ctx *Context, e mo.Entity, r *types.Rename_Task) soap.HasFault {
 	task := CreateTask(e, "rename", func(t *Task) (types.AnyType, types.BaseMethodFault) {
-		obj := Map.Get(r.This).(mo.Entity).Entity()
+		obj := Map().Get(r.This).(mo.Entity).Entity()
 
-		if parent, ok := asFolderMO(Map.Get(*obj.Parent)); ok {
-			if Map.FindByName(r.NewName, parent.ChildEntity) != nil {
+		if parent, ok := asFolderMO(Map().Get(*obj.Parent)); ok {
+			if Map().FindByName(r.NewName, parent.ChildEntity) != nil {
 				return nil, &types.InvalidArgument{InvalidProperty: "name"}
 			}
 		}
 
-		Map.Update(e, []types.PropertyChange{{Name: "name", Val: r.NewName}})
+		Map().Update(e, []types.PropertyChange{{Name: "name", Val: r.NewName}})
 
 		return nil, nil
 	})

--- a/simulator/entity.go
+++ b/simulator/entity.go
@@ -25,15 +25,16 @@ import (
 
 func RenameTask(ctx *Context, e mo.Entity, r *types.Rename_Task) soap.HasFault {
 	task := CreateTask(e, "rename", func(t *Task) (types.AnyType, types.BaseMethodFault) {
-		obj := Map().Get(r.This).(mo.Entity).Entity()
+		vimMap := Map()
+		obj := vimMap.Get(r.This).(mo.Entity).Entity()
 
-		if parent, ok := asFolderMO(Map().Get(*obj.Parent)); ok {
-			if Map().FindByName(r.NewName, parent.ChildEntity) != nil {
+		if parent, ok := asFolderMO(vimMap.Get(*obj.Parent)); ok {
+			if vimMap.FindByName(r.NewName, parent.ChildEntity) != nil {
 				return nil, &types.InvalidArgument{InvalidProperty: "name"}
 			}
 		}
 
-		Map().Update(e, []types.PropertyChange{{Name: "name", Val: r.NewName}})
+		vimMap.Update(e, []types.PropertyChange{{Name: "name", Val: r.NewName}})
 
 		return nil, nil
 	})

--- a/simulator/entity_test.go
+++ b/simulator/entity_test.go
@@ -38,17 +38,19 @@ func TestRename(t *testing.T) {
 	s := m.Service.NewServer()
 	defer s.Close()
 
-	dc := Map().Any("Datacenter").(*Datacenter)
-	vmFolder := Map().Get(dc.VmFolder).(*Folder)
+	vimMap := Map()
 
-	f1 := Map().Get(vmFolder.ChildEntity[0]).(*Folder) // "F1"
+	dc := vimMap.Any("Datacenter").(*Datacenter)
+	vmFolder := vimMap.Get(dc.VmFolder).(*Folder)
+
+	f1 := vimMap.Get(vmFolder.ChildEntity[0]).(*Folder) // "F1"
 
 	id := vmFolder.CreateFolder(SpoofContext(), &types.CreateFolder{
 		This: vmFolder.Reference(),
 		Name: "F2",
 	}).(*methods.CreateFolderBody).Res.Returnval
 
-	f2 := Map().Get(id).(*Folder) // "F2"
+	f2 := vimMap.Get(id).(*Folder) // "F2"
 
 	states := []types.TaskInfoState{types.TaskInfoStateError, types.TaskInfoStateSuccess}
 	name := f1.Name
@@ -59,7 +61,7 @@ func TestRename(t *testing.T) {
 			NewName: name,
 		}).(*methods.Rename_TaskBody).Res.Returnval
 
-		task := Map().Get(id).(*Task)
+		task := vimMap.Get(id).(*Task)
 		task.Wait()
 
 		if task.Info.State != expect {

--- a/simulator/entity_test.go
+++ b/simulator/entity_test.go
@@ -38,17 +38,17 @@ func TestRename(t *testing.T) {
 	s := m.Service.NewServer()
 	defer s.Close()
 
-	dc := Map.Any("Datacenter").(*Datacenter)
-	vmFolder := Map.Get(dc.VmFolder).(*Folder)
+	dc := Map().Any("Datacenter").(*Datacenter)
+	vmFolder := Map().Get(dc.VmFolder).(*Folder)
 
-	f1 := Map.Get(vmFolder.ChildEntity[0]).(*Folder) // "F1"
+	f1 := Map().Get(vmFolder.ChildEntity[0]).(*Folder) // "F1"
 
 	id := vmFolder.CreateFolder(SpoofContext(), &types.CreateFolder{
 		This: vmFolder.Reference(),
 		Name: "F2",
 	}).(*methods.CreateFolderBody).Res.Returnval
 
-	f2 := Map.Get(id).(*Folder) // "F2"
+	f2 := Map().Get(id).(*Folder) // "F2"
 
 	states := []types.TaskInfoState{types.TaskInfoStateError, types.TaskInfoStateSuccess}
 	name := f1.Name
@@ -59,7 +59,7 @@ func TestRename(t *testing.T) {
 			NewName: name,
 		}).(*methods.Rename_TaskBody).Res.Returnval
 
-		task := Map.Get(id).(*Task)
+		task := Map().Get(id).(*Task)
 		task.Wait()
 
 		if task.Info.State != expect {

--- a/simulator/environment_browser.go
+++ b/simulator/environment_browser.go
@@ -34,7 +34,7 @@ type EnvironmentBrowser struct {
 
 func newEnvironmentBrowser() *types.ManagedObjectReference {
 	env := new(EnvironmentBrowser)
-	Map.Put(env)
+	Map().Put(env)
 	return &env.Self
 }
 

--- a/simulator/event_manager.go
+++ b/simulator/event_manager.go
@@ -99,7 +99,7 @@ func (m *EventManager) CreateCollectorForEvents(ctx *Context, req *types.CreateC
 }
 
 func (m *EventManager) QueryEvents(ctx *Context, req *types.QueryEvents) soap.HasFault {
-	if Map.IsESX() {
+	if Map().IsESX() {
 		return &methods.QueryEventsBody{
 			Fault_: Fault("", new(types.NotImplemented)),
 		}
@@ -171,7 +171,7 @@ func (m *EventManager) PostEvent(ctx *Context, req *types.PostEvent) soap.HasFau
 		ctx.WithLock(c, func() {
 			if c.eventMatches(req.EventToPost) {
 				pushEvent(c.page, req.EventToPost)
-				Map.Update(c, []types.PropertyChange{{Name: "latestPage", Val: c.GetLatestPage()}})
+				Map().Update(c, []types.PropertyChange{{Name: "latestPage", Val: c.GetLatestPage()}})
 			}
 		})
 	}

--- a/simulator/event_manager.go
+++ b/simulator/event_manager.go
@@ -167,11 +167,12 @@ func (m *EventManager) PostEvent(ctx *Context, req *types.PostEvent) soap.HasFau
 
 	pushEvent(m.history, req.EventToPost)
 
+	vimMap := Map()
 	for _, c := range m.collectors {
 		ctx.WithLock(c, func() {
 			if c.eventMatches(req.EventToPost) {
 				pushEvent(c.page, req.EventToPost)
-				Map().Update(c, []types.PropertyChange{{Name: "latestPage", Val: c.GetLatestPage()}})
+				vimMap.Update(c, []types.PropertyChange{{Name: "latestPage", Val: c.GetLatestPage()}})
 			}
 		})
 	}

--- a/simulator/event_manager_test.go
+++ b/simulator/event_manager_test.go
@@ -52,8 +52,8 @@ func TestEventManagerVPX(t *testing.T) {
 	count := m.Count()
 
 	root := c.ServiceContent.RootFolder
-	vm := Map.Any("VirtualMachine").(*VirtualMachine)
-	host := Map.Get(vm.Runtime.Host.Reference()).(*HostSystem)
+	vm := Map().Any("VirtualMachine").(*VirtualMachine)
+	host := Map().Get(vm.Runtime.Host.Reference()).(*HostSystem)
 
 	vmEvents := 6 // BeingCreated + InstanceUuid + Uuid + Created + Starting + PoweredOn
 	tests := []struct {

--- a/simulator/event_manager_test.go
+++ b/simulator/event_manager_test.go
@@ -52,8 +52,9 @@ func TestEventManagerVPX(t *testing.T) {
 	count := m.Count()
 
 	root := c.ServiceContent.RootFolder
-	vm := Map().Any("VirtualMachine").(*VirtualMachine)
-	host := Map().Get(vm.Runtime.Host.Reference()).(*HostSystem)
+	vimMap := Map()
+	vm := vimMap.Any("VirtualMachine").(*VirtualMachine)
+	host := vimMap.Get(vm.Runtime.Host.Reference()).(*HostSystem)
 
 	vmEvents := 6 // BeingCreated + InstanceUuid + Uuid + Created + Starting + PoweredOn
 	tests := []struct {

--- a/simulator/example_extend_test.go
+++ b/simulator/example_extend_test.go
@@ -79,14 +79,14 @@ func Example() {
 	c, _ := govmomi.NewClient(ctx, s.URL, true)
 
 	// Shortcut to choose any VM, rather than using the more verbose Finder or ContainerView.
-	obj := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	obj := simulator.Map().Any("VirtualMachine").(*simulator.VirtualMachine)
 	// Validate VM is powered on
 	if obj.Runtime.PowerState != "poweredOn" {
 		log.Fatal(obj.Runtime.PowerState)
 	}
 
 	// Wrap the existing vm object, using the same vm.Self (ManagedObjectReference) value as the Map key.
-	simulator.Map.Put(&BusyVM{obj})
+	simulator.Map().Put(&BusyVM{obj})
 
 	vm := object.NewVirtualMachine(c.Client, obj.Reference())
 

--- a/simulator/example_extend_test.go
+++ b/simulator/example_extend_test.go
@@ -78,15 +78,18 @@ func Example() {
 	// NewClient connects to s.URL over https and invokes 2 SOAP methods (RetrieveServiceContent + Login)
 	c, _ := govmomi.NewClient(ctx, s.URL, true)
 
+	// Create a local reference the default registry
+	vimMap := simulator.Map()
+
 	// Shortcut to choose any VM, rather than using the more verbose Finder or ContainerView.
-	obj := simulator.Map().Any("VirtualMachine").(*simulator.VirtualMachine)
+	obj := vimMap.Any("VirtualMachine").(*simulator.VirtualMachine)
 	// Validate VM is powered on
 	if obj.Runtime.PowerState != "poweredOn" {
 		log.Fatal(obj.Runtime.PowerState)
 	}
 
 	// Wrap the existing vm object, using the same vm.Self (ManagedObjectReference) value as the Map key.
-	simulator.Map().Put(&BusyVM{obj})
+	vimMap.Put(&BusyVM{obj})
 
 	vm := object.NewVirtualMachine(c.Client, obj.Reference())
 

--- a/simulator/example_test.go
+++ b/simulator/example_test.go
@@ -141,7 +141,7 @@ func ExampleFolder_AddOpaqueNetwork() {
 		}
 
 		// Get vcsim's network Folder object
-		folder := simulator.Map.Get(obj.Reference()).(*simulator.Folder)
+		folder := simulator.Map().Get(obj.Reference()).(*simulator.Folder)
 
 		spec := types.OpaqueNetworkSummary{
 			NetworkSummary: types.NetworkSummary{

--- a/simulator/file_manager.go
+++ b/simulator/file_manager.go
@@ -44,7 +44,7 @@ func (f *FileManager) findDatastore(ref mo.Reference, name string) (*Datastore, 
 	}
 
 	for _, ref := range refs {
-		obj := Map.Get(ref)
+		obj := Map().Get(ref)
 
 		if ds, ok := obj.(*Datastore); ok && ds.Name == name {
 			return ds, nil
@@ -73,16 +73,16 @@ func (f *FileManager) resolve(dc *types.ManagedObjectReference, name string) (st
 	}
 
 	if dc == nil {
-		if Map.IsESX() {
+		if Map().IsESX() {
 			dc = &esx.Datacenter.Self
 		} else {
 			return "", &types.InvalidArgument{InvalidProperty: "dc"}
 		}
 	}
 
-	folder := Map.Get(*dc).(*Datacenter).DatastoreFolder
+	folder := Map().Get(*dc).(*Datacenter).DatastoreFolder
 
-	ds, fault := f.findDatastore(Map.Get(folder), p.Datastore)
+	ds, fault := f.findDatastore(Map().Get(folder), p.Datastore)
 	if fault != nil {
 		return "", fault
 	}

--- a/simulator/file_manager.go
+++ b/simulator/file_manager.go
@@ -43,8 +43,9 @@ func (f *FileManager) findDatastore(ref mo.Reference, name string) (*Datastore, 
 		refs = p.ChildEntity
 	}
 
+	vimMap := Map()
 	for _, ref := range refs {
-		obj := Map().Get(ref)
+		obj := vimMap.Get(ref)
 
 		if ds, ok := obj.(*Datastore); ok && ds.Name == name {
 			return ds, nil
@@ -72,17 +73,18 @@ func (f *FileManager) resolve(dc *types.ManagedObjectReference, name string) (st
 		return "", fault
 	}
 
+	vimMap := Map()
 	if dc == nil {
-		if Map().IsESX() {
+		if vimMap.IsESX() {
 			dc = &esx.Datacenter.Self
 		} else {
 			return "", &types.InvalidArgument{InvalidProperty: "dc"}
 		}
 	}
 
-	folder := Map().Get(*dc).(*Datacenter).DatastoreFolder
+	folder := vimMap.Get(*dc).(*Datacenter).DatastoreFolder
 
-	ds, fault := f.findDatastore(Map().Get(folder), p.Datastore)
+	ds, fault := f.findDatastore(vimMap.Get(folder), p.Datastore)
 	if fault != nil {
 		return "", fault
 	}

--- a/simulator/folder_test.go
+++ b/simulator/folder_test.go
@@ -123,7 +123,7 @@ func TestFolderVC(t *testing.T) {
 	}
 
 	for _, ref := range []object.Reference{ff, dc} {
-		o := Map.Get(ref.Reference())
+		o := Map().Get(ref.Reference())
 		if o == nil {
 			t.Fatalf("failed to find %#v", ref)
 		}
@@ -190,7 +190,7 @@ func TestFolderVC(t *testing.T) {
 			if !ok {
 				t.Errorf("expected moref, got type=%T", res.Result)
 			}
-			host := Map.Get(ref).(*HostSystem)
+			host := Map().Get(ref).(*HostSystem)
 			if host.Name != test.name {
 				t.Fail()
 			}
@@ -202,7 +202,7 @@ func TestFolderVC(t *testing.T) {
 				t.Error("expected new host summary Self reference")
 			}
 
-			pool := Map.Get(*host.Parent).(*mo.ComputeResource).ResourcePool
+			pool := Map().Get(*host.Parent).(*mo.ComputeResource).ResourcePool
 			if *pool == esx.ResourcePool.Self {
 				t.Error("expected new pool Self reference")
 			}
@@ -270,7 +270,7 @@ func TestRegisterVm(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		vm := Map.Get(vms[0].Reference()).(*VirtualMachine)
+		vm := Map().Get(vms[0].Reference()).(*VirtualMachine)
 
 		req := types.RegisterVM_Task{
 			This:       vmFolder.Reference(),
@@ -297,7 +297,7 @@ func TestRegisterVm(t *testing.T) {
 				new(types.NotFound), func() { req.Path = vm.Config.Files.VmPathName },
 			},
 			{
-				new(types.AlreadyExists), func() { Map.Remove(SpoofContext(), vm.Reference()) },
+				new(types.AlreadyExists), func() { Map().Remove(SpoofContext(), vm.Reference()) },
 			},
 			{
 				nil, func() {},
@@ -313,7 +313,7 @@ func TestRegisterVm(t *testing.T) {
 			ct := object.NewTask(c.Client, res.Returnval)
 			_ = ct.Wait(ctx)
 
-			rt := Map.Get(res.Returnval).(*Task)
+			rt := Map().Get(res.Returnval).(*Task)
 
 			if step.e != nil {
 				fault := rt.Info.Error.Fault

--- a/simulator/host_datastore_browser.go
+++ b/simulator/host_datastore_browser.go
@@ -188,7 +188,7 @@ func (s *searchDatastore) Run(task *Task) (types.AnyType, types.BaseMethodFault)
 		return nil, fault
 	}
 
-	ref := Map.FindByName(p.Datastore, s.Datastore)
+	ref := Map().FindByName(p.Datastore, s.Datastore)
 	if ref == nil {
 		return nil, &types.InvalidDatastore{Name: p.Datastore}
 	}
@@ -196,7 +196,7 @@ func (s *searchDatastore) Run(task *Task) (types.AnyType, types.BaseMethodFault)
 	ds := ref.(*Datastore)
 
 	isolatedLockContext := &Context{} // we don't need/want to share the task lock
-	Map.WithLock(isolatedLockContext, task, func() {
+	Map().WithLock(isolatedLockContext, task, func() {
 		task.Info.Entity = &ds.Self // TODO: CreateTask() should require mo.Entity, rather than mo.Reference
 		task.Info.EntityName = ds.Name
 	})

--- a/simulator/host_datastore_browser.go
+++ b/simulator/host_datastore_browser.go
@@ -188,7 +188,8 @@ func (s *searchDatastore) Run(task *Task) (types.AnyType, types.BaseMethodFault)
 		return nil, fault
 	}
 
-	ref := Map().FindByName(p.Datastore, s.Datastore)
+	vimMap := Map()
+	ref := vimMap.FindByName(p.Datastore, s.Datastore)
 	if ref == nil {
 		return nil, &types.InvalidDatastore{Name: p.Datastore}
 	}
@@ -196,7 +197,7 @@ func (s *searchDatastore) Run(task *Task) (types.AnyType, types.BaseMethodFault)
 	ds := ref.(*Datastore)
 
 	isolatedLockContext := &Context{} // we don't need/want to share the task lock
-	Map().WithLock(isolatedLockContext, task, func() {
+	vimMap.WithLock(isolatedLockContext, task, func() {
 		task.Info.Entity = &ds.Self // TODO: CreateTask() should require mo.Entity, rather than mo.Reference
 		task.Info.EntityName = ds.Name
 	})

--- a/simulator/host_datastore_system.go
+++ b/simulator/host_datastore_system.go
@@ -38,7 +38,8 @@ func (dss *HostDatastoreSystem) add(ctx *Context, ds *Datastore) *soap.Fault {
 
 	info.Name = ds.Name
 
-	if e := Map().FindByName(ds.Name, dss.Datastore); e != nil {
+	r := Map()
+	if e := r.FindByName(ds.Name, dss.Datastore); e != nil {
 		return Fault(e.Reference().Value, &types.DuplicateName{
 			Name:   ds.Name,
 			Object: e.Reference(),
@@ -59,7 +60,7 @@ func (dss *HostDatastoreSystem) add(ctx *Context, ds *Datastore) *soap.Fault {
 		}
 	}
 
-	folder := Map().getEntityFolder(dss.Host, "datastore")
+	folder := r.getEntityFolder(dss.Host, "datastore")
 	ds.Self.Type = typeName(ds)
 	// Datastore is the only type where create methods do not include the parent (Folder in this case),
 	// but we need the moref to be unique per DC/datastoreFolder, but not per-HostSystem.

--- a/simulator/host_datastore_system.go
+++ b/simulator/host_datastore_system.go
@@ -38,7 +38,7 @@ func (dss *HostDatastoreSystem) add(ctx *Context, ds *Datastore) *soap.Fault {
 
 	info.Name = ds.Name
 
-	if e := Map.FindByName(ds.Name, dss.Datastore); e != nil {
+	if e := Map().FindByName(ds.Name, dss.Datastore); e != nil {
 		return Fault(e.Reference().Value, &types.DuplicateName{
 			Name:   ds.Name,
 			Object: e.Reference(),
@@ -59,7 +59,7 @@ func (dss *HostDatastoreSystem) add(ctx *Context, ds *Datastore) *soap.Fault {
 		}
 	}
 
-	folder := Map.getEntityFolder(dss.Host, "datastore")
+	folder := Map().getEntityFolder(dss.Host, "datastore")
 	ds.Self.Type = typeName(ds)
 	// Datastore is the only type where create methods do not include the parent (Folder in this case),
 	// but we need the moref to be unique per DC/datastoreFolder, but not per-HostSystem.
@@ -82,12 +82,12 @@ func (dss *HostDatastoreSystem) add(ctx *Context, ds *Datastore) *soap.Fault {
 	dss.Datastore = append(dss.Datastore, ds.Self)
 	dss.Host.Datastore = dss.Datastore
 	parent := hostParent(dss.Host)
-	Map.AddReference(ctx, parent, &parent.Datastore, ds.Self)
+	Map().AddReference(ctx, parent, &parent.Datastore, ds.Self)
 
-	if Map.Get(ds.Self) == nil {
+	if Map().Get(ds.Self) == nil {
 		browser := &HostDatastoreBrowser{}
 		browser.Datastore = dss.Datastore
-		ds.Browser = Map.Put(browser).Reference()
+		ds.Browser = Map().Put(browser).Reference()
 
 		ds.Summary.Capacity = int64(units.TB * 10)
 		ds.Summary.FreeSpace = ds.Summary.Capacity

--- a/simulator/host_datastore_system.go
+++ b/simulator/host_datastore_system.go
@@ -38,8 +38,8 @@ func (dss *HostDatastoreSystem) add(ctx *Context, ds *Datastore) *soap.Fault {
 
 	info.Name = ds.Name
 
-	r := Map()
-	if e := r.FindByName(ds.Name, dss.Datastore); e != nil {
+	vimMap := Map()
+	if e := vimMap.FindByName(ds.Name, dss.Datastore); e != nil {
 		return Fault(e.Reference().Value, &types.DuplicateName{
 			Name:   ds.Name,
 			Object: e.Reference(),
@@ -60,7 +60,7 @@ func (dss *HostDatastoreSystem) add(ctx *Context, ds *Datastore) *soap.Fault {
 		}
 	}
 
-	folder := r.getEntityFolder(dss.Host, "datastore")
+	folder := vimMap.getEntityFolder(dss.Host, "datastore")
 	ds.Self.Type = typeName(ds)
 	// Datastore is the only type where create methods do not include the parent (Folder in this case),
 	// but we need the moref to be unique per DC/datastoreFolder, but not per-HostSystem.
@@ -83,12 +83,12 @@ func (dss *HostDatastoreSystem) add(ctx *Context, ds *Datastore) *soap.Fault {
 	dss.Datastore = append(dss.Datastore, ds.Self)
 	dss.Host.Datastore = dss.Datastore
 	parent := hostParent(dss.Host)
-	Map().AddReference(ctx, parent, &parent.Datastore, ds.Self)
+	vimMap.AddReference(ctx, parent, &parent.Datastore, ds.Self)
 
-	if Map().Get(ds.Self) == nil {
+	if vimMap.Get(ds.Self) == nil {
 		browser := &HostDatastoreBrowser{}
 		browser.Datastore = dss.Datastore
-		ds.Browser = Map().Put(browser).Reference()
+		ds.Browser = vimMap.Put(browser).Reference()
 
 		ds.Summary.Capacity = int64(units.TB * 10)
 		ds.Summary.FreeSpace = ds.Summary.Capacity

--- a/simulator/host_local_account_manager.go
+++ b/simulator/host_local_account_manager.go
@@ -31,7 +31,7 @@ type HostLocalAccountManager struct {
 
 func (h *HostLocalAccountManager) CreateUser(req *types.CreateUser) soap.HasFault {
 	spec := req.User.GetHostAccountSpec()
-	userDirectory := Map.UserDirectory()
+	userDirectory := Map().UserDirectory()
 
 	found := userDirectory.search(true, false, compareFunc(spec.Id, true))
 	if len(found) > 0 {
@@ -48,7 +48,7 @@ func (h *HostLocalAccountManager) CreateUser(req *types.CreateUser) soap.HasFaul
 }
 
 func (h *HostLocalAccountManager) RemoveUser(req *types.RemoveUser) soap.HasFault {
-	userDirectory := Map.UserDirectory()
+	userDirectory := Map().UserDirectory()
 
 	found := userDirectory.search(true, false, compareFunc(req.UserName, true))
 

--- a/simulator/host_network_system.go
+++ b/simulator/host_network_system.go
@@ -57,8 +57,8 @@ func (s *HostNetworkSystem) init(r *Registry) {
 }
 
 func (s *HostNetworkSystem) folder() *Folder {
-	f := Map.getEntityDatacenter(s.Host).NetworkFolder
-	return Map.Get(f).(*Folder)
+	f := Map().getEntityDatacenter(s.Host).NetworkFolder
+	return Map().Get(f).(*Folder)
 }
 
 func (s *HostNetworkSystem) AddVirtualSwitch(c *types.AddVirtualSwitch) soap.HasFault {
@@ -126,7 +126,7 @@ func (s *HostNetworkSystem) AddPortGroup(ctx *Context, c *types.AddPortGroup) so
 
 	folder := s.folder()
 
-	if obj := Map.FindByName(c.Portgrp.Name, folder.ChildEntity); obj != nil {
+	if obj := Map().FindByName(c.Portgrp.Name, folder.ChildEntity); obj != nil {
 		r.Fault_ = Fault("", &types.DuplicateName{
 			Name:   c.Portgrp.Name,
 			Object: obj.Reference(),
@@ -170,7 +170,7 @@ func (s *HostNetworkSystem) RemovePortGroup(ctx *Context, c *types.RemovePortGro
 	}
 
 	folder := s.folder()
-	e := Map.FindByName(c.PgName, folder.ChildEntity)
+	e := Map().FindByName(c.PgName, folder.ChildEntity)
 	folderRemoveChild(ctx, &folder.Folder, e.Reference())
 
 	for i, pg := range s.NetworkInfo.Portgroup {

--- a/simulator/host_network_system.go
+++ b/simulator/host_network_system.go
@@ -57,8 +57,9 @@ func (s *HostNetworkSystem) init(r *Registry) {
 }
 
 func (s *HostNetworkSystem) folder() *Folder {
-	f := Map().getEntityDatacenter(s.Host).NetworkFolder
-	return Map().Get(f).(*Folder)
+	vimMap := Map()
+	f := vimMap.getEntityDatacenter(s.Host).NetworkFolder
+	return vimMap.Get(f).(*Folder)
 }
 
 func (s *HostNetworkSystem) AddVirtualSwitch(c *types.AddVirtualSwitch) soap.HasFault {

--- a/simulator/host_system.go
+++ b/simulator/host_system.go
@@ -79,8 +79,9 @@ func NewHostSystem(host mo.HostSystem) *HostSystem {
 		{&hs.ConfigManager.StorageSystem, NewHostStorageSystem(&hs.HostSystem)},
 	}
 
+	vimMap := Map()
 	for _, c := range config {
-		ref := Map().Put(c.obj).Reference()
+		ref := vimMap.Put(c.obj).Reference()
 
 		*c.ref = &ref
 	}
@@ -172,14 +173,16 @@ func CreateDefaultESX(ctx *Context, f *Folder) {
 	cr.Name = host.Name
 	cr.Host = append(cr.Host, host.Reference())
 	host.Network = cr.Network
-	Map().PutEntity(cr, host)
+
+	vimMap := Map()
+	vimMap.PutEntity(cr, host)
 
 	pool := NewResourcePool()
 	cr.ResourcePool = &pool.Self
-	Map().PutEntity(cr, pool)
+	vimMap.PutEntity(cr, pool)
 	pool.Owner = cr.Self
 
-	folderPutChild(ctx, &Map().Get(dc.HostFolder).(*Folder).Folder, cr)
+	folderPutChild(ctx, &vimMap.Get(dc.HostFolder).(*Folder).Folder, cr)
 }
 
 // CreateStandaloneHost uses esx.HostSystem as a template, applying the given spec

--- a/simulator/host_system.go
+++ b/simulator/host_system.go
@@ -80,7 +80,7 @@ func NewHostSystem(host mo.HostSystem) *HostSystem {
 	}
 
 	for _, c := range config {
-		ref := Map.Put(c.obj).Reference()
+		ref := Map().Put(c.obj).Reference()
 
 		*c.ref = &ref
 	}
@@ -131,7 +131,7 @@ func (h *HostSystem) eventArgumentParent() *types.ComputeResourceEventArgument {
 }
 
 func hostParent(host *mo.HostSystem) *mo.ComputeResource {
-	switch parent := Map.Get(*host.Parent).(type) {
+	switch parent := Map().Get(*host.Parent).(type) {
 	case *mo.ComputeResource:
 		return parent
 	case *ClusterComputeResource:
@@ -172,14 +172,14 @@ func CreateDefaultESX(ctx *Context, f *Folder) {
 	cr.Name = host.Name
 	cr.Host = append(cr.Host, host.Reference())
 	host.Network = cr.Network
-	Map.PutEntity(cr, host)
+	Map().PutEntity(cr, host)
 
 	pool := NewResourcePool()
 	cr.ResourcePool = &pool.Self
-	Map.PutEntity(cr, pool)
+	Map().PutEntity(cr, pool)
 	pool.Owner = cr.Self
 
-	folderPutChild(ctx, &Map.Get(dc.HostFolder).(*Folder).Folder, cr)
+	folderPutChild(ctx, &Map().Get(dc.HostFolder).(*Folder).Folder, cr)
 }
 
 // CreateStandaloneHost uses esx.HostSystem as a template, applying the given spec
@@ -204,13 +204,13 @@ func CreateStandaloneHost(ctx *Context, f *Folder, spec types.HostConnectSpec) (
 		EnvironmentBrowser: newEnvironmentBrowser(),
 	}
 
-	Map.PutEntity(cr, Map.NewEntity(host))
+	Map().PutEntity(cr, Map().NewEntity(host))
 	host.Summary.Host = &host.Self
 
-	Map.PutEntity(cr, Map.NewEntity(pool))
+	Map().PutEntity(cr, Map().NewEntity(pool))
 
 	cr.Name = host.Name
-	cr.Network = Map.getEntityDatacenter(f).defaultNetwork()
+	cr.Network = Map().getEntityDatacenter(f).defaultNetwork()
 	cr.Host = append(cr.Host, host.Reference())
 	cr.ResourcePool = &pool.Self
 
@@ -229,7 +229,7 @@ func (h *HostSystem) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.Has
 
 		ctx.postEvent(&types.HostRemovedEvent{HostEvent: h.event()})
 
-		f := Map.getEntityParent(h, "Folder").(*Folder)
+		f := Map().getEntityParent(h, "Folder").(*Folder)
 		folderRemoveChild(ctx, &f.Folder, h.Reference())
 
 		return nil, nil

--- a/simulator/host_system_test.go
+++ b/simulator/host_system_test.go
@@ -83,7 +83,7 @@ func TestMaintenanceMode(t *testing.T) {
 
 	c := m.Service.client
 
-	hs := Map.Get(esx.HostSystem.Reference()).(*HostSystem)
+	hs := Map().Get(esx.HostSystem.Reference()).(*HostSystem)
 	host := object.NewHostSystem(c, hs.Self)
 
 	task, err := host.EnterMaintenanceMode(ctx, 1, false, nil)
@@ -147,13 +147,13 @@ func TestDestroyHostSystem(t *testing.T) {
 
 	c := m.Service.client
 
-	vm := Map.Any("VirtualMachine").(*VirtualMachine)
-	hs := Map.Get(*vm.Runtime.Host).(*HostSystem)
+	vm := Map().Any("VirtualMachine").(*VirtualMachine)
+	hs := Map().Get(*vm.Runtime.Host).(*HostSystem)
 	host := object.NewHostSystem(c, hs.Self)
 
 	vms := []*VirtualMachine{}
 	for _, vmref := range hs.Vm {
-		vms = append(vms, Map.Get(vmref).(*VirtualMachine))
+		vms = append(vms, Map().Get(vmref).(*VirtualMachine))
 	}
 
 	task, err := host.Destroy(ctx)
@@ -167,7 +167,7 @@ func TestDestroyHostSystem(t *testing.T) {
 	}
 
 	for _, vmref := range hs.Vm {
-		vm := Map.Get(vmref).(*VirtualMachine)
+		vm := Map().Get(vmref).(*VirtualMachine)
 		vmo := object.NewVirtualMachine(c, vm.Self)
 
 		task, err := vmo.PowerOff(ctx)
@@ -201,7 +201,7 @@ func TestDestroyHostSystem(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hs2 := Map.Get(esx.HostSystem.Reference())
+	hs2 := Map().Get(esx.HostSystem.Reference())
 	if hs2 != nil {
 		t.Fatal("host should have been destroyed")
 	}

--- a/simulator/license_manager.go
+++ b/simulator/license_manager.go
@@ -67,7 +67,7 @@ func (m *LicenseManager) init(r *Registry) {
 	m.Licenses = []types.LicenseManagerLicenseInfo{EvalLicense}
 
 	if r.IsVPX() {
-		am := Map.Put(&LicenseAssignmentManager{}).Reference()
+		am := Map().Put(&LicenseAssignmentManager{}).Reference()
 		m.LicenseAssignmentManager = &am
 	}
 }
@@ -156,13 +156,13 @@ func (m *LicenseAssignmentManager) QueryAssignedLicenses(req *types.QueryAssigne
 
 	// EntityId can be a HostSystem or the vCenter InstanceUuid
 	if req.EntityId != "" {
-		if req.EntityId != Map.content().About.InstanceUuid {
+		if req.EntityId != Map().content().About.InstanceUuid {
 			id := types.ManagedObjectReference{
 				Type:  "HostSystem",
 				Value: req.EntityId,
 			}
 
-			if Map.Get(id) == nil {
+			if Map().Get(id) == nil {
 				return body
 			}
 		}

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -431,8 +431,8 @@ func (m *Model) Load(dir string) error {
 		if content.Obj == vim25.ServiceInstance {
 			s = new(ServiceInstance)
 			s.Self = content.Obj
-			NewMap()
-			Map().Put(s)
+			vimMap := NewMap()
+			vimMap.Put(s)
 			return mo.LoadObjectContent([]types.ObjectContent{content}, &s.ServiceInstance)
 		}
 

--- a/simulator/object.go
+++ b/simulator/object.go
@@ -30,7 +30,7 @@ import (
 func SetCustomValue(ctx *Context, req *types.SetCustomValue) soap.HasFault {
 	body := &methods.SetCustomValueBody{}
 
-	cfm := Map.CustomFieldsManager()
+	cfm := Map().CustomFieldsManager()
 
 	_, field := cfm.findByNameType(req.Key, req.This.Type)
 	if field == nil {

--- a/simulator/object_test.go
+++ b/simulator/object_test.go
@@ -49,7 +49,7 @@ func TestObjectCustomFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vm := Map().Any("VirtualMachine").(*VirtualMachine)
 	vmm := object.NewVirtualMachine(c.Client, vm.Reference())
 
 	fieldName := "testField"

--- a/simulator/performance_manager.go
+++ b/simulator/performance_manager.go
@@ -98,7 +98,7 @@ func (p *PerformanceManager) QueryPerfProviderSummary(ctx *Context, req *types.Q
 	body.Res = new(types.QueryPerfProviderSummaryResponse)
 
 	// The entity must exist
-	if Map.Get(req.Entity) == nil {
+	if Map().Get(req.Entity) == nil {
 		body.Fault_ = Fault("", &types.InvalidArgument{
 			InvalidProperty: "Entity",
 		})
@@ -141,10 +141,10 @@ func (p *PerformanceManager) buildAvailablePerfMetricsQueryResponse(ids []types.
 func (p *PerformanceManager) queryAvailablePerfMetric(entity types.ManagedObjectReference, interval int32) *types.QueryAvailablePerfMetricResponse {
 	switch entity.Type {
 	case "VirtualMachine":
-		vm := Map.Get(entity).(*VirtualMachine)
+		vm := Map().Get(entity).(*VirtualMachine)
 		return p.buildAvailablePerfMetricsQueryResponse(p.vmMetrics, int(vm.Summary.Config.NumCpu), vm.Datastore[0].Value)
 	case "HostSystem":
-		host := Map.Get(entity).(*HostSystem)
+		host := Map().Get(entity).(*HostSystem)
 		return p.buildAvailablePerfMetricsQueryResponse(p.hostMetrics, int(host.Hardware.CpuInfo.NumCpuThreads), host.Datastore[0].Value)
 	case "ResourcePool":
 		return p.buildAvailablePerfMetricsQueryResponse(p.rpMetrics, 0, "")

--- a/simulator/performance_manager_test.go
+++ b/simulator/performance_manager_test.go
@@ -108,7 +108,7 @@ func TestQueryProviderSummary(t *testing.T) {
 
 	p := performance.NewManager(c)
 
-	vm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vm := Map().Any("VirtualMachine").(*VirtualMachine)
 	if info, err := p.ProviderSummary(ctx, vm.Reference()); err != nil {
 		t.Fatal(err)
 	} else {
@@ -117,7 +117,7 @@ func TestQueryProviderSummary(t *testing.T) {
 		}
 	}
 
-	host := Map.Any("HostSystem").(*HostSystem)
+	host := Map().Any("HostSystem").(*HostSystem)
 	if info, err := p.ProviderSummary(ctx, host.Reference()); err != nil {
 		t.Fatal(err)
 	} else {
@@ -126,7 +126,7 @@ func TestQueryProviderSummary(t *testing.T) {
 		}
 	}
 
-	pool := Map.Any("ResourcePool").(*ResourcePool)
+	pool := Map().Any("ResourcePool").(*ResourcePool)
 	if info, err := p.ProviderSummary(ctx, pool.Reference()); err != nil {
 		t.Fatal(err)
 	} else {
@@ -135,7 +135,7 @@ func TestQueryProviderSummary(t *testing.T) {
 		}
 	}
 
-	cluster := Map.Any("ClusterComputeResource").(*ClusterComputeResource)
+	cluster := Map().Any("ClusterComputeResource").(*ClusterComputeResource)
 	if info, err := p.ProviderSummary(ctx, cluster.Reference()); err != nil {
 		t.Fatal(err)
 	} else {
@@ -144,7 +144,7 @@ func TestQueryProviderSummary(t *testing.T) {
 		}
 	}
 
-	datastore := Map.Any("Datastore").(*Datastore)
+	datastore := Map().Any("Datastore").(*Datastore)
 	if info, err := p.ProviderSummary(ctx, datastore.Reference()); err != nil {
 		t.Fatal(err)
 	} else {
@@ -177,7 +177,7 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 	c := m.Service.client
 	p := performance.NewManager(c)
 
-	vm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vm := Map().Any("VirtualMachine").(*VirtualMachine)
 	if info, err := p.AvailableMetric(ctx, vm.Reference(), 20); err != nil {
 		t.Fatal(err)
 	} else {
@@ -186,7 +186,7 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 		}
 	}
 
-	host := Map.Any("HostSystem").(*HostSystem)
+	host := Map().Any("HostSystem").(*HostSystem)
 	if info, err := p.AvailableMetric(ctx, host.Reference(), 20); err != nil {
 		t.Fatal(err)
 	} else {
@@ -206,7 +206,7 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 		}
 	}
 
-	pool := Map.Any("ResourcePool").(*ResourcePool)
+	pool := Map().Any("ResourcePool").(*ResourcePool)
 	if info, err := p.AvailableMetric(ctx, pool.Reference(), 20); err != nil {
 		t.Fatal(err)
 	} else {
@@ -215,7 +215,7 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 		}
 	}
 
-	cluster := Map.Any("ClusterComputeResource").(*ClusterComputeResource)
+	cluster := Map().Any("ClusterComputeResource").(*ClusterComputeResource)
 	if info, err := p.AvailableMetric(ctx, cluster.Reference(), 300); err != nil {
 		t.Fatal(err)
 	} else {
@@ -232,7 +232,7 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 		}
 	}
 
-	ds := Map.Any("Datastore").(*Datastore)
+	ds := Map().Any("Datastore").(*Datastore)
 	if info, err := p.AvailableMetric(ctx, ds.Reference(), 300); err != nil {
 		t.Fatal(err)
 	} else {
@@ -249,7 +249,7 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 		}
 	}
 
-	dc := Map.Any("Datacenter").(*Datacenter)
+	dc := Map().Any("Datacenter").(*Datacenter)
 	if info, err := p.AvailableMetric(ctx, dc.Reference(), 300); err != nil {
 		t.Fatal(err)
 	} else {
@@ -312,22 +312,22 @@ func TestQueryPerf(t *testing.T) {
 
 	defer m.Remove()
 
-	if err := testPerfQuery(ctx, m, Map.Any("VirtualMachine"), 20); err != nil {
+	if err := testPerfQuery(ctx, m, Map().Any("VirtualMachine"), 20); err != nil {
 		t.Fatal(err)
 	}
-	if err := testPerfQuery(ctx, m, Map.Any("HostSystem"), 20); err != nil {
+	if err := testPerfQuery(ctx, m, Map().Any("HostSystem"), 20); err != nil {
 		t.Fatal(err)
 	}
-	if err := testPerfQuery(ctx, m, Map.Any("ClusterComputeResource"), 300); err != nil {
+	if err := testPerfQuery(ctx, m, Map().Any("ClusterComputeResource"), 300); err != nil {
 		t.Fatal(err)
 	}
-	if err := testPerfQuery(ctx, m, Map.Any("Datastore"), 300); err != nil {
+	if err := testPerfQuery(ctx, m, Map().Any("Datastore"), 300); err != nil {
 		t.Fatal(err)
 	}
-	if err := testPerfQuery(ctx, m, Map.Any("Datacenter"), 300); err != nil {
+	if err := testPerfQuery(ctx, m, Map().Any("Datacenter"), 300); err != nil {
 		t.Fatal(err)
 	}
-	if err := testPerfQuery(ctx, m, Map.Any("ResourcePool"), 300); err != nil {
+	if err := testPerfQuery(ctx, m, Map().Any("ResourcePool"), 300); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/simulator/portgroup.go
+++ b/simulator/portgroup.go
@@ -54,11 +54,11 @@ func (s *DistributedVirtualPortgroup) ReconfigureDVPortgroupTask(ctx *Context, r
 
 func (s *DistributedVirtualPortgroup) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.HasFault {
 	task := CreateTask(s, "destroy", func(t *Task) (types.AnyType, types.BaseMethodFault) {
-		vswitch := Map.Get(*s.Config.DistributedVirtualSwitch).(*DistributedVirtualSwitch)
-		Map.RemoveReference(ctx, vswitch, &vswitch.Portgroup, s.Reference())
-		Map.removeString(ctx, vswitch, &vswitch.Summary.PortgroupName, s.Name)
+		vswitch := Map().Get(*s.Config.DistributedVirtualSwitch).(*DistributedVirtualSwitch)
+		Map().RemoveReference(ctx, vswitch, &vswitch.Portgroup, s.Reference())
+		Map().removeString(ctx, vswitch, &vswitch.Summary.PortgroupName, s.Name)
 
-		f := Map.getEntityParent(vswitch, "Folder").(*Folder)
+		f := Map().getEntityParent(vswitch, "Folder").(*Folder)
 		folderRemoveChild(ctx, &f.Folder, s.Reference())
 
 		return nil, nil

--- a/simulator/portgroup_test.go
+++ b/simulator/portgroup_test.go
@@ -43,7 +43,7 @@ func TestReconfigurePortgroup(t *testing.T) {
 	c := m.Service.client
 
 	dvs := object.NewDistributedVirtualSwitch(c,
-		Map.Any("DistributedVirtualSwitch").Reference())
+		Map().Any("DistributedVirtualSwitch").Reference())
 
 	spec := []types.DVPortgroupConfigSpec{
 		types.DVPortgroupConfigSpec{
@@ -63,7 +63,7 @@ func TestReconfigurePortgroup(t *testing.T) {
 	}
 
 	pg := object.NewDistributedVirtualPortgroup(c,
-		Map.Any("DistributedVirtualPortgroup").Reference())
+		Map().Any("DistributedVirtualPortgroup").Reference())
 	pgspec := types.DVPortgroupConfigSpec{
 		NumPorts: 5,
 		Name:     "pg1",
@@ -79,7 +79,7 @@ func TestReconfigurePortgroup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pge := Map.Get(pg.Reference()).(*DistributedVirtualPortgroup)
+	pge := Map().Get(pg.Reference()).(*DistributedVirtualPortgroup)
 	if pge.Config.Name != "pg1" || pge.Config.NumPorts != 5 {
 		t.Fatalf("expect pg.Name==pg1 && pg.Config.NumPort==5; got %s,%d",
 			pge.Config.Name, pge.Config.NumPorts)
@@ -110,7 +110,7 @@ func TestPortgroupBacking(t *testing.T) {
 
 	c := m.Service.client
 
-	pg := Map.Any("DistributedVirtualPortgroup").(*DistributedVirtualPortgroup)
+	pg := Map().Any("DistributedVirtualPortgroup").(*DistributedVirtualPortgroup)
 
 	net := object.NewDistributedVirtualPortgroup(c, pg.Reference())
 	t.Logf("pg=%s", net.Reference())
@@ -135,7 +135,7 @@ func TestPortgroupBackingWithNSX(t *testing.T) {
 	model.PortgroupNSX = 1
 
 	Test(func(context.Context, *vim25.Client) {
-		pgs := Map.All("DistributedVirtualPortgroup")
+		pgs := Map().All("DistributedVirtualPortgroup")
 		n := len(pgs) - 1
 		if model.PortgroupNSX != n {
 			t.Errorf("%d pgs", n)

--- a/simulator/property_collector.go
+++ b/simulator/property_collector.go
@@ -58,7 +58,7 @@ func getObject(ctx *Context, ref types.ManagedObjectReference) (reflect.Value, b
 	if ctx.Session == nil {
 		// Even without permissions to access an object or specific fields, RetrieveProperties
 		// returns an ObjectContent response as long as the object exists.  See retrieveResult.add()
-		obj = Map.Get(ref)
+		obj = Map().Get(ref)
 	} else {
 		obj = ctx.Session.Get(ref)
 	}
@@ -331,7 +331,7 @@ func (rr *retrieveResult) collect(ctx *Context, ref types.ManagedObjectReference
 
 	rval, ok := getObject(ctx, ref)
 	if !ok {
-		// Possible if a test uses Map.Remove instead of Destroy_Task
+		// Possible if a test uses Map().Remove instead of Destroy_Task
 		tracef("object %s no longer exists", ref)
 		return
 	}

--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -201,7 +201,7 @@ func TestRetrieveProperties(t *testing.T) {
 		}
 
 		// Retrieve a nested property
-		Map.Get(dc.Reference()).(*Datacenter).Configuration.DefaultHardwareVersionKey = "foo"
+		Map().Get(dc.Reference()).(*Datacenter).Configuration.DefaultHardwareVersionKey = "foo"
 		mdc = mo.Datacenter{}
 		err = client.RetrieveOne(ctx, dc.Reference(), []string{"configuration.defaultHardwareVersionKey"}, &mdc)
 		if err != nil {
@@ -232,7 +232,7 @@ func TestRetrieveProperties(t *testing.T) {
 		}
 
 		// Expect ManagedObjectNotFoundError
-		Map.Remove(SpoofContext(), dc.Reference())
+		Map().Remove(SpoofContext(), dc.Reference())
 		err = client.RetrieveOne(ctx, dc.Reference(), []string{"name"}, &mdc)
 		if err == nil {
 			t.Fatal("expected error")
@@ -299,7 +299,7 @@ func TestWaitForUpdates(t *testing.T) {
 	wg.Wait()
 
 	// test object not found
-	Map.Remove(SpoofContext(), folder.Reference())
+	Map().Remove(SpoofContext(), folder.Reference())
 
 	err = property.Wait(ctx, pc, folder.Reference(), props, cb(true))
 	if err == nil {
@@ -345,7 +345,7 @@ func TestIncrementalWaitForUpdates(t *testing.T) {
 	}
 
 	pc := property.DefaultCollector(c.Client)
-	obj := Map.Any("VirtualMachine").(*VirtualMachine)
+	obj := Map().Any("VirtualMachine").(*VirtualMachine)
 	ref := obj.Reference()
 	vm := object.NewVirtualMachine(c.Client, ref)
 
@@ -482,7 +482,7 @@ func TestWaitForUpdatesOneUpdateCalculation(t *testing.T) {
 
 	wait := make(chan bool)
 	pc := property.DefaultCollector(c.Client)
-	obj := Map.Any("VirtualMachine").(*VirtualMachine)
+	obj := Map().Any("VirtualMachine").(*VirtualMachine)
 	ref := obj.Reference()
 	vm := object.NewVirtualMachine(c.Client, ref)
 	filter := new(property.WaitFilter).Add(ref, ref.Type, []string{"runtime.powerState"})
@@ -584,7 +584,7 @@ func TestPropertyCollectorWithUnsetValues(t *testing.T) {
 
 	pc := property.DefaultCollector(client.Client)
 
-	vm := Map.Any("VirtualMachine")
+	vm := Map().Any("VirtualMachine")
 	vmRef := vm.Reference()
 
 	propSets := [][]string{
@@ -705,7 +705,7 @@ func TestExtractEmbeddedField(t *testing.T) {
 
 	x := new(MyResourcePool)
 
-	Map.Put(x)
+	Map().Put(x)
 
 	obj, ok := getObject(SpoofContext(), x.Reference())
 	if !ok {
@@ -737,8 +737,8 @@ func TestPropertyCollectorFold(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cluster := Map.Any("ClusterComputeResource")
-	compute := Map.Any("ComputeResource")
+	cluster := Map().Any("ClusterComputeResource")
+	compute := Map().Any("ComputeResource")
 
 	// Test that we fold duplicate properties (rbvmomi depends on this)
 	var content []types.ObjectContent
@@ -802,7 +802,7 @@ func TestPropertyCollectorFold(t *testing.T) {
 }
 
 func TestPropertyCollectorInvalidSpecName(t *testing.T) {
-	obj := Map.Put(new(Folder))
+	obj := Map().Put(new(Folder))
 	folderPutChild(SpoofContext(), &obj.(*Folder).Folder, new(Folder))
 
 	pc := &PropertyCollector{}

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -50,8 +50,30 @@ var refValueMap = map[string]string{
 	"StoragePod":                     "group-p",
 }
 
+var (
+	defaultRegistry      *Registry
+	defaultRegistryMutex sync.Mutex
+)
+
 // Map is the default Registry instance.
-var Map = NewRegistry()
+func Map() *Registry {
+	defaultRegistryMutex.Lock()
+	defer defaultRegistryMutex.Unlock()
+
+	if defaultRegistry == nil {
+		defaultRegistry = NewRegistry()
+	}
+	return defaultRegistry
+}
+
+// NewMap is used to create a new global default Registry.
+func NewMap() *Registry {
+	defaultRegistryMutex.Lock()
+	defer defaultRegistryMutex.Unlock()
+
+	defaultRegistry = NewRegistry()
+	return defaultRegistry
+}
 
 // RegisterObject interface supports callbacks when objects are created, updated and deleted from the Registry
 type RegisterObject interface {
@@ -355,7 +377,7 @@ func (r *Registry) getEntityDatacenter(item mo.Entity) *Datacenter {
 }
 
 func (r *Registry) getEntityFolder(item mo.Entity, kind string) *mo.Folder {
-	dc := Map.getEntityDatacenter(item)
+	dc := Map().getEntityDatacenter(item)
 
 	var ref types.ManagedObjectReference
 
@@ -369,7 +391,7 @@ func (r *Registry) getEntityFolder(item mo.Entity, kind string) *mo.Folder {
 	// If Model was created with Folder option, use that Folder; else use top-level folder
 	for _, child := range folder.ChildEntity {
 		if child.Type == "Folder" {
-			folder, _ = asFolderMO(Map.Get(child))
+			folder, _ = asFolderMO(Map().Get(child))
 			break
 		}
 	}

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -377,7 +377,7 @@ func (r *Registry) getEntityDatacenter(item mo.Entity) *Datacenter {
 }
 
 func (r *Registry) getEntityFolder(item mo.Entity, kind string) *mo.Folder {
-	dc := Map().getEntityDatacenter(item)
+	dc := r.getEntityDatacenter(item)
 
 	var ref types.ManagedObjectReference
 
@@ -391,7 +391,7 @@ func (r *Registry) getEntityFolder(item mo.Entity, kind string) *mo.Folder {
 	// If Model was created with Folder option, use that Folder; else use top-level folder
 	for _, child := range folder.ChildEntity {
 		if child.Type == "Folder" {
-			folder, _ = asFolderMO(Map().Get(child))
+			folder, _ = asFolderMO(r.Get(child))
 			break
 		}
 	}

--- a/simulator/resource_pool.go
+++ b/simulator/resource_pool.go
@@ -44,7 +44,7 @@ func NewResourcePool() *ResourcePool {
 		ResourcePool: esx.ResourcePool,
 	}
 
-	if Map.IsVPX() {
+	if Map().IsVPX() {
 		pool.DisabledMethod = nil // Enable VApp methods for VC
 	}
 
@@ -87,7 +87,7 @@ func allResourceFieldsValid(info *types.ResourceAllocationInfo) bool {
 }
 
 func (p *ResourcePool) createChild(name string, spec types.ResourceConfigSpec) (*ResourcePool, *soap.Fault) {
-	if e := Map.FindByName(name, p.ResourcePool.ResourcePool); e != nil {
+	if e := Map().FindByName(name, p.ResourcePool.ResourcePool); e != nil {
 		return nil, Fault("", &types.DuplicateName{
 			Name:   e.Entity().Name,
 			Object: e.Reference(),
@@ -127,7 +127,7 @@ func (p *ResourcePool) CreateResourcePool(c *types.CreateResourcePool) soap.HasF
 		return body
 	}
 
-	Map.PutEntity(p, Map.NewEntity(child))
+	Map().PutEntity(p, Map().NewEntity(child))
 
 	p.ResourcePool.ResourcePool = append(p.ResourcePool.ResourcePool, child.Reference())
 
@@ -164,7 +164,7 @@ func (p *ResourcePool) UpdateConfig(c *types.UpdateConfig) soap.HasFault {
 	body := &methods.UpdateConfigBody{}
 
 	if c.Name != "" {
-		if e := Map.FindByName(c.Name, p.ResourcePool.ResourcePool); e != nil {
+		if e := Map().FindByName(c.Name, p.ResourcePool.ResourcePool); e != nil {
 			body.Fault_ = Fault("", &types.DuplicateName{
 				Name:   e.Entity().Name,
 				Object: e.Reference(),
@@ -224,7 +224,7 @@ func (p *ResourcePool) ImportVApp(ctx *Context, req *types.ImportVApp) soap.HasF
 		Host:   req.Host,
 	})
 
-	ctask := Map.Get(res.(*methods.CreateVM_TaskBody).Res.Returnval).(*Task)
+	ctask := Map().Get(res.(*methods.CreateVM_TaskBody).Res.Returnval).(*Task)
 	ctask.Wait()
 
 	if ctask.Info.Error != nil {
@@ -320,7 +320,7 @@ func (p *ResourcePool) CreateVApp(req *types.CreateVApp) soap.HasFault {
 	child.ParentFolder = req.VmFolder
 
 	if child.ParentFolder == nil {
-		folder := Map.getEntityDatacenter(p).VmFolder
+		folder := Map().getEntityDatacenter(p).VmFolder
 		child.ParentFolder = &folder
 	}
 
@@ -333,7 +333,7 @@ func (p *ResourcePool) CreateVApp(req *types.CreateVApp) soap.HasFault {
 		child.VAppConfig.Product = append(child.VAppConfig.Product, *product.Info)
 	}
 
-	Map.PutEntity(p, Map.NewEntity(child))
+	Map().PutEntity(p, Map().NewEntity(child))
 
 	p.ResourcePool.ResourcePool = append(p.ResourcePool.ResourcePool, child.Reference())
 
@@ -347,7 +347,7 @@ func (p *ResourcePool) CreateVApp(req *types.CreateVApp) soap.HasFault {
 func (a *VirtualApp) CreateChildVMTask(ctx *Context, req *types.CreateChildVM_Task) soap.HasFault {
 	body := &methods.CreateChildVM_TaskBody{}
 
-	folder := Map.Get(*a.ParentFolder).(*Folder)
+	folder := Map().Get(*a.ParentFolder).(*Folder)
 
 	res := folder.CreateVMTask(ctx, &types.CreateVM_Task{
 		This:   folder.Self,
@@ -405,7 +405,7 @@ func (a *VirtualApp) CloneVAppTask(ctx *Context, req *types.CloneVApp_Task) soap
 				},
 			})
 
-			ctask := Map.Get(res.(*methods.CloneVM_TaskBody).Res.Returnval).(*Task)
+			ctask := Map().Get(res.(*methods.CloneVM_TaskBody).Res.Returnval).(*Task)
 			ctask.Wait()
 			if ctask.Info.Error != nil {
 				return nil, ctask.Info.Error.Fault

--- a/simulator/resource_pool_test.go
+++ b/simulator/resource_pool_test.go
@@ -208,7 +208,7 @@ func TestCreateVAppVPX(t *testing.T) {
 
 	c := m.Service.client
 
-	pool := Map.Any("ResourcePool")
+	pool := Map().Any("ResourcePool")
 	parent := object.NewResourcePool(c, pool.Reference())
 	rspec := types.DefaultResourceConfigSpec()
 	vspec := NewVAppConfigSpec()
@@ -260,7 +260,7 @@ func TestCreateVAppVPX(t *testing.T) {
 		t.Errorf("FindChild(%s)==nil", spec.Name)
 	}
 
-	ref := Map.Get(Map.getEntityDatacenter(pool).VmFolder).Reference()
+	ref := Map().Get(Map().getEntityDatacenter(pool).VmFolder).Reference()
 	folder, err := object.NewFolder(c, ref).CreateFolder(ctx, "myapp-clone")
 	if err != nil {
 		t.Fatal(err)

--- a/simulator/search_index.go
+++ b/simulator/search_index.go
@@ -32,10 +32,11 @@ type SearchIndex struct {
 func (s *SearchIndex) FindByDatastorePath(r *types.FindByDatastorePath) soap.HasFault {
 	res := &methods.FindByDatastorePathBody{Res: new(types.FindByDatastorePathResponse)}
 
-	Map().m.Lock()
-	defer Map().m.Unlock()
+	vimMap := Map()
+	vimMap.m.Lock()
+	defer vimMap.m.Unlock()
 
-	for ref, obj := range Map().objects {
+	for ref, obj := range vimMap.objects {
 		vm, ok := asVirtualMachineMO(obj)
 		if !ok {
 			continue
@@ -81,7 +82,8 @@ func (s *SearchIndex) FindByInventoryPath(req *types.FindByInventoryPath) soap.H
 func (s *SearchIndex) FindChild(req *types.FindChild) soap.HasFault {
 	body := &methods.FindChildBody{}
 
-	obj := Map().Get(req.Entity)
+	vimMap := Map()
+	obj := vimMap.Get(req.Entity)
 
 	if obj == nil {
 		body.Fault_ = Fault("", &types.ManagedObjectNotFound{Obj: req.Entity})
@@ -111,7 +113,7 @@ func (s *SearchIndex) FindChild(req *types.FindChild) soap.HasFault {
 		children = append(children, e.Vm...)
 	}
 
-	match := Map().FindByName(req.Name, children)
+	match := vimMap.FindByName(req.Name, children)
 
 	if match != nil {
 		ref := match.Reference()
@@ -124,12 +126,13 @@ func (s *SearchIndex) FindChild(req *types.FindChild) soap.HasFault {
 func (s *SearchIndex) FindByUuid(req *types.FindByUuid) soap.HasFault {
 	body := &methods.FindByUuidBody{Res: new(types.FindByUuidResponse)}
 
-	Map().m.Lock()
-	defer Map().m.Unlock()
+	vimMap := Map()
+	vimMap.m.Lock()
+	defer vimMap.m.Unlock()
 
 	if req.VmSearch {
 		// Find Virtual Machine using UUID
-		for ref, obj := range Map().objects {
+		for ref, obj := range vimMap.objects {
 			vm, ok := asVirtualMachineMO(obj)
 			if !ok {
 				continue
@@ -148,7 +151,7 @@ func (s *SearchIndex) FindByUuid(req *types.FindByUuid) soap.HasFault {
 		}
 	} else {
 		// Find Host System using UUID
-		for ref, obj := range Map().objects {
+		for ref, obj := range vimMap.objects {
 			host, ok := asHostSystemMO(obj)
 			if !ok {
 				continue
@@ -183,12 +186,13 @@ func (s *SearchIndex) FindByDnsName(req *types.FindByDnsName) soap.HasFault {
 func (s *SearchIndex) FindAllByDnsName(req *types.FindAllByDnsName) soap.HasFault {
 	body := &methods.FindAllByDnsNameBody{Res: new(types.FindAllByDnsNameResponse)}
 
-	Map().m.Lock()
-	defer Map().m.Unlock()
+	vimMap := Map()
+	vimMap.m.Lock()
+	defer vimMap.m.Unlock()
 
 	if req.VmSearch {
 		// Find Virtual Machine using DNS name
-		for ref, obj := range Map().objects {
+		for ref, obj := range vimMap.objects {
 			vm, ok := asVirtualMachineMO(obj)
 			if !ok {
 				continue
@@ -199,7 +203,7 @@ func (s *SearchIndex) FindAllByDnsName(req *types.FindAllByDnsName) soap.HasFaul
 		}
 	} else {
 		// Find Host System using DNS name
-		for ref, obj := range Map().objects {
+		for ref, obj := range vimMap.objects {
 			host, ok := asHostSystemMO(obj)
 			if !ok {
 				continue
@@ -235,12 +239,13 @@ func (s *SearchIndex) FindByIp(req *types.FindByIp) soap.HasFault {
 func (s *SearchIndex) FindAllByIp(req *types.FindAllByIp) soap.HasFault {
 	body := &methods.FindAllByIpBody{Res: new(types.FindAllByIpResponse)}
 
-	Map().m.Lock()
-	defer Map().m.Unlock()
+	vimMap := Map()
+	vimMap.m.Lock()
+	defer vimMap.m.Unlock()
 
 	if req.VmSearch {
 		// Find Virtual Machine using IP
-		for ref, obj := range Map().objects {
+		for ref, obj := range vimMap.objects {
 			vm, ok := asVirtualMachineMO(obj)
 			if !ok {
 				continue
@@ -251,7 +256,7 @@ func (s *SearchIndex) FindAllByIp(req *types.FindAllByIp) soap.HasFault {
 		}
 	} else {
 		// Find Host System using IP
-		for ref, obj := range Map().objects {
+		for ref, obj := range vimMap.objects {
 			host, ok := asHostSystemMO(obj)
 			if !ok {
 				continue

--- a/simulator/search_index.go
+++ b/simulator/search_index.go
@@ -32,10 +32,10 @@ type SearchIndex struct {
 func (s *SearchIndex) FindByDatastorePath(r *types.FindByDatastorePath) soap.HasFault {
 	res := &methods.FindByDatastorePathBody{Res: new(types.FindByDatastorePathResponse)}
 
-	Map.m.Lock()
-	defer Map.m.Unlock()
+	Map().m.Lock()
+	defer Map().m.Unlock()
 
-	for ref, obj := range Map.objects {
+	for ref, obj := range Map().objects {
 		vm, ok := asVirtualMachineMO(obj)
 		if !ok {
 			continue
@@ -61,7 +61,7 @@ func (s *SearchIndex) FindByInventoryPath(req *types.FindByInventoryPath) soap.H
 		return body
 	}
 
-	root := Map.content().RootFolder
+	root := Map().content().RootFolder
 	o := &root
 
 	for _, name := range path {
@@ -81,7 +81,7 @@ func (s *SearchIndex) FindByInventoryPath(req *types.FindByInventoryPath) soap.H
 func (s *SearchIndex) FindChild(req *types.FindChild) soap.HasFault {
 	body := &methods.FindChildBody{}
 
-	obj := Map.Get(req.Entity)
+	obj := Map().Get(req.Entity)
 
 	if obj == nil {
 		body.Fault_ = Fault("", &types.ManagedObjectNotFound{Obj: req.Entity})
@@ -111,7 +111,7 @@ func (s *SearchIndex) FindChild(req *types.FindChild) soap.HasFault {
 		children = append(children, e.Vm...)
 	}
 
-	match := Map.FindByName(req.Name, children)
+	match := Map().FindByName(req.Name, children)
 
 	if match != nil {
 		ref := match.Reference()
@@ -124,12 +124,12 @@ func (s *SearchIndex) FindChild(req *types.FindChild) soap.HasFault {
 func (s *SearchIndex) FindByUuid(req *types.FindByUuid) soap.HasFault {
 	body := &methods.FindByUuidBody{Res: new(types.FindByUuidResponse)}
 
-	Map.m.Lock()
-	defer Map.m.Unlock()
+	Map().m.Lock()
+	defer Map().m.Unlock()
 
 	if req.VmSearch {
 		// Find Virtual Machine using UUID
-		for ref, obj := range Map.objects {
+		for ref, obj := range Map().objects {
 			vm, ok := asVirtualMachineMO(obj)
 			if !ok {
 				continue
@@ -148,7 +148,7 @@ func (s *SearchIndex) FindByUuid(req *types.FindByUuid) soap.HasFault {
 		}
 	} else {
 		// Find Host System using UUID
-		for ref, obj := range Map.objects {
+		for ref, obj := range Map().objects {
 			host, ok := asHostSystemMO(obj)
 			if !ok {
 				continue
@@ -183,12 +183,12 @@ func (s *SearchIndex) FindByDnsName(req *types.FindByDnsName) soap.HasFault {
 func (s *SearchIndex) FindAllByDnsName(req *types.FindAllByDnsName) soap.HasFault {
 	body := &methods.FindAllByDnsNameBody{Res: new(types.FindAllByDnsNameResponse)}
 
-	Map.m.Lock()
-	defer Map.m.Unlock()
+	Map().m.Lock()
+	defer Map().m.Unlock()
 
 	if req.VmSearch {
 		// Find Virtual Machine using DNS name
-		for ref, obj := range Map.objects {
+		for ref, obj := range Map().objects {
 			vm, ok := asVirtualMachineMO(obj)
 			if !ok {
 				continue
@@ -199,7 +199,7 @@ func (s *SearchIndex) FindAllByDnsName(req *types.FindAllByDnsName) soap.HasFaul
 		}
 	} else {
 		// Find Host System using DNS name
-		for ref, obj := range Map.objects {
+		for ref, obj := range Map().objects {
 			host, ok := asHostSystemMO(obj)
 			if !ok {
 				continue
@@ -235,12 +235,12 @@ func (s *SearchIndex) FindByIp(req *types.FindByIp) soap.HasFault {
 func (s *SearchIndex) FindAllByIp(req *types.FindAllByIp) soap.HasFault {
 	body := &methods.FindAllByIpBody{Res: new(types.FindAllByIpResponse)}
 
-	Map.m.Lock()
-	defer Map.m.Unlock()
+	Map().m.Lock()
+	defer Map().m.Unlock()
 
 	if req.VmSearch {
 		// Find Virtual Machine using IP
-		for ref, obj := range Map.objects {
+		for ref, obj := range Map().objects {
 			vm, ok := asVirtualMachineMO(obj)
 			if !ok {
 				continue
@@ -251,7 +251,7 @@ func (s *SearchIndex) FindAllByIp(req *types.FindAllByIp) soap.HasFault {
 		}
 	} else {
 		// Find Host System using IP
-		for ref, obj := range Map.objects {
+		for ref, obj := range Map().objects {
 			host, ok := asHostSystemMO(obj)
 			if !ok {
 				continue

--- a/simulator/search_index_test.go
+++ b/simulator/search_index_test.go
@@ -59,7 +59,7 @@ func TestSearchIndex(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		vm := Map.Get(vms[0].Reference()).(*VirtualMachine)
+		vm := Map().Get(vms[0].Reference()).(*VirtualMachine)
 
 		si := object.NewSearchIndex(c.Client)
 
@@ -117,7 +117,7 @@ func TestSearchIndex(t *testing.T) {
 			t.Error("expected nil")
 		}
 
-		host := Map.Any("HostSystem").(*HostSystem)
+		host := Map().Any("HostSystem").(*HostSystem)
 
 		ref, err = si.FindByUuid(ctx, dc, host.Summary.Hardware.Uuid, false, nil)
 		if err != nil {

--- a/simulator/service_instance.go
+++ b/simulator/service_instance.go
@@ -34,17 +34,17 @@ type ServiceInstance struct {
 }
 
 func NewServiceInstance(ctx *Context, content types.ServiceContent, folder mo.Folder) *ServiceInstance {
-	Map = NewRegistry()
+	NewMap()
 
 	s := &ServiceInstance{}
 
 	s.Self = vim25.ServiceInstance
 	s.Content = content
 
-	Map.Put(s)
+	Map().Put(s)
 
 	f := &Folder{Folder: folder}
-	Map.Put(f)
+	Map().Put(f)
 
 	if content.About.ApiType == "HostAgent" {
 		CreateDefaultESX(ctx, f)
@@ -55,7 +55,7 @@ func NewServiceInstance(ctx *Context, content types.ServiceContent, folder mo.Fo
 	refs := mo.References(content)
 
 	for i := range refs {
-		if Map.Get(refs[i]) != nil {
+		if Map().Get(refs[i]) != nil {
 			continue
 		}
 		content := types.ObjectContent{Obj: refs[i]}
@@ -63,7 +63,7 @@ func NewServiceInstance(ctx *Context, content types.ServiceContent, folder mo.Fo
 		if err != nil {
 			panic(err)
 		}
-		Map.Put(o)
+		Map().Put(o)
 	}
 
 	return s

--- a/simulator/service_instance.go
+++ b/simulator/service_instance.go
@@ -34,7 +34,7 @@ type ServiceInstance struct {
 }
 
 func NewServiceInstance(ctx *Context, content types.ServiceContent, folder mo.Folder) *ServiceInstance {
-	NewMap()
+	vimMap := NewMap()
 
 	s := &ServiceInstance{}
 
@@ -63,7 +63,7 @@ func NewServiceInstance(ctx *Context, content types.ServiceContent, folder mo.Fo
 		if err != nil {
 			panic(err)
 		}
-		Map().Put(o)
+		vimMap.Put(o)
 	}
 
 	return s

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -99,7 +99,7 @@ type Server struct {
 func New(instance *ServiceInstance) *Service {
 	s := &Service{
 		readAll: ioutil.ReadAll,
-		sm:      Map.SessionManager(),
+		sm:      Map().SessionManager(),
 		sdk:     make(map[string]*Registry),
 	}
 
@@ -249,7 +249,7 @@ func (s *Service) RoundTrip(ctx context.Context, request, response soap.HasFault
 	}
 
 	res := s.call(&Context{
-		Map:     Map,
+		Map:     Map(),
 		Context: ctx,
 		Session: internalSession,
 	}, method)
@@ -557,7 +557,7 @@ func (s *Service) findDatastore(query url.Values) (*Datastore, error) {
 		return nil, err
 	}
 
-	return Map.Get(ds.Reference()).(*Datastore), nil
+	return Map().Get(ds.Reference()).(*Datastore), nil
 }
 
 const folderPrefix = "/folder/"
@@ -654,13 +654,13 @@ func defaultIP(addr *net.TCPAddr) string {
 
 // NewServer returns an http Server instance for the given service
 func (s *Service) NewServer() *Server {
-	s.RegisterSDK(Map)
+	s.RegisterSDK(Map())
 
 	mux := s.ServeMux
-	vim := Map.Path + "/vimService"
+	vim := Map().Path + "/vimService"
 	s.sdk[vim] = s.sdk[vim25.Path]
 	mux.HandleFunc(vim, s.ServeSDK)
-	mux.HandleFunc(Map.Path+"/vimServiceVersions.xml", s.ServiceVersions)
+	mux.HandleFunc(Map().Path+"/vimServiceVersions.xml", s.ServiceVersions)
 	mux.HandleFunc(folderPrefix, s.ServeDatastore)
 	mux.HandleFunc(guestPrefix, ServeGuest)
 	mux.HandleFunc(nfcPrefix, ServeNFC)
@@ -675,17 +675,17 @@ func (s *Service) NewServer() *Server {
 	u := &url.URL{
 		Scheme: "http",
 		Host:   net.JoinHostPort(defaultIP(addr), port),
-		Path:   Map.Path,
+		Path:   Map().Path,
 	}
 	if s.TLS != nil {
 		u.Scheme += "s"
 	}
 
 	// Redirect clients to this http server, rather than HostSystem.Name
-	Map.SessionManager().ServiceHostName = u.Host
+	Map().SessionManager().ServiceHostName = u.Host
 
 	// Add vcsim config to OptionManager for use by SDK handlers (see lookup/simulator for example)
-	m := Map.OptionManager()
+	m := Map().OptionManager()
 	for i := range m.Setting {
 		setting := m.Setting[i].GetOptionValue()
 
@@ -714,7 +714,7 @@ func (s *Service) NewServer() *Server {
 
 	if s.RegisterEndpoints {
 		for i := range endpoints {
-			endpoints[i](s, Map)
+			endpoints[i](s, Map())
 		}
 	}
 
@@ -732,7 +732,7 @@ func (s *Service) NewServer() *Server {
 	if s.TLS != nil {
 		ts.TLS = s.TLS
 		ts.TLS.ClientAuth = tls.RequestClientCert // Used by SessionManager.LoginExtensionByCertificate
-		Map.SessionManager().TLSCert = func() string {
+		Map().SessionManager().TLSCert = func() string {
 			return base64.StdEncoding.EncodeToString(ts.TLS.Certificates[0].Certificate[0])
 		}
 		ts.StartTLS()

--- a/simulator/simulator_test.go
+++ b/simulator/simulator_test.go
@@ -415,21 +415,21 @@ func TestServeHTTPErrors(t *testing.T) {
 	}
 
 	// cover the does not implement method error path
-	Map.objects[vim25.ServiceInstance] = &errorNoSuchMethod{}
+	Map().objects[vim25.ServiceInstance] = &errorNoSuchMethod{}
 	_, err = methods.GetCurrentTime(ctx, client)
 	if err == nil {
 		t.Error("expected error")
 	}
 
 	// cover the xml encode error path
-	Map.objects[vim25.ServiceInstance] = &errorMarshal{}
+	Map().objects[vim25.ServiceInstance] = &errorMarshal{}
 	_, err = methods.GetCurrentTime(ctx, client)
 	if err == nil {
 		t.Error("expected error")
 	}
 
 	// cover the no such object path
-	Map.Remove(SpoofContext(), vim25.ServiceInstance)
+	Map().Remove(SpoofContext(), vim25.ServiceInstance)
 	_, err = methods.GetCurrentTime(ctx, client)
 	if err == nil {
 		t.Error("expected error")
@@ -486,7 +486,7 @@ func TestDelay(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	simvm := Map.Any("VirtualMachine").(*VirtualMachine)
+	simvm := Map().Any("VirtualMachine").(*VirtualMachine)
 	vm := object.NewVirtualMachine(client.Client, simvm.Reference())
 
 	m.Service.delay.Delay = 1000
@@ -519,7 +519,7 @@ func TestDelayTask(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	simvm := Map.Any("VirtualMachine").(*VirtualMachine)
+	simvm := Map().Any("VirtualMachine").(*VirtualMachine)
 	vm := object.NewVirtualMachine(client.Client, simvm.Reference())
 
 	TaskDelay.Delay = 1000

--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -33,7 +33,7 @@ type VirtualMachineSnapshot struct {
 }
 
 func (v *VirtualMachineSnapshot) createSnapshotFiles() types.BaseMethodFault {
-	vm := Map.Get(v.Vm).(*VirtualMachine)
+	vm := Map().Get(v.Vm).(*VirtualMachine)
 
 	snapshotDirectory := vm.Config.Files.SnapshotDirectory
 	if snapshotDirectory == "" {
@@ -74,7 +74,7 @@ func (v *VirtualMachineSnapshot) createSnapshotFiles() types.BaseMethodFault {
 func (v *VirtualMachineSnapshot) removeSnapshotFiles(ctx *Context) types.BaseMethodFault {
 	// TODO: also remove delta disks that were created when snapshot was taken
 
-	vm := Map.Get(v.Vm).(*VirtualMachine)
+	vm := Map().Get(v.Vm).(*VirtualMachine)
 
 	for idx, sLayout := range vm.Layout.Snapshot {
 		if sLayout.Key == v.Self {
@@ -92,8 +92,8 @@ func (v *VirtualMachineSnapshot) removeSnapshotFiles(ctx *Context) types.BaseMet
 						return fault
 					}
 
-					host := Map.Get(*vm.Runtime.Host).(*HostSystem)
-					datastore := Map.FindByName(p.Datastore, host.Datastore).(*Datastore)
+					host := Map().Get(*vm.Runtime.Host).(*HostSystem)
+					datastore := Map().FindByName(p.Datastore, host.Datastore).(*Datastore)
 					dFilePath := path.Join(datastore.Info.GetDatastoreInfo().Url, p.Path)
 
 					_ = os.Remove(dFilePath)
@@ -113,7 +113,7 @@ func (v *VirtualMachineSnapshot) RemoveSnapshotTask(ctx *Context, req *types.Rem
 	task := CreateTask(v, "removeSnapshot", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		var changes []types.PropertyChange
 
-		vm := Map.Get(v.Vm).(*VirtualMachine)
+		vm := Map().Get(v.Vm).(*VirtualMachine)
 		ctx.WithLock(vm, func() {
 			if vm.Snapshot.CurrentSnapshot != nil && *vm.Snapshot.CurrentSnapshot == req.This {
 				parent := findParentSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This)
@@ -129,12 +129,12 @@ func (v *VirtualMachineSnapshot) RemoveSnapshotTask(ctx *Context, req *types.Rem
 				}
 			}
 
-			Map.Get(req.This).(*VirtualMachineSnapshot).removeSnapshotFiles(ctx)
+			Map().Get(req.This).(*VirtualMachineSnapshot).removeSnapshotFiles(ctx)
 
-			Map.Update(vm, changes)
+			Map().Update(vm, changes)
 		})
 
-		Map.Remove(ctx, req.This)
+		Map().Remove(ctx, req.This)
 
 		return nil, nil
 	})
@@ -148,10 +148,10 @@ func (v *VirtualMachineSnapshot) RemoveSnapshotTask(ctx *Context, req *types.Rem
 
 func (v *VirtualMachineSnapshot) RevertToSnapshotTask(ctx *Context, req *types.RevertToSnapshot_Task) soap.HasFault {
 	task := CreateTask(v.Vm, "revertToSnapshot", func(t *Task) (types.AnyType, types.BaseMethodFault) {
-		vm := Map.Get(v.Vm).(*VirtualMachine)
+		vm := Map().Get(v.Vm).(*VirtualMachine)
 
 		ctx.WithLock(vm, func() {
-			Map.Update(vm, []types.PropertyChange{
+			Map().Update(vm, []types.PropertyChange{
 				{Name: "snapshot.currentSnapshot", Val: v.Self},
 			})
 		})

--- a/simulator/storage_resource_manager.go
+++ b/simulator/storage_resource_manager.go
@@ -33,7 +33,7 @@ type StorageResourceManager struct {
 
 func (m *StorageResourceManager) ConfigureStorageDrsForPodTask(ctx *Context, req *types.ConfigureStorageDrsForPod_Task) soap.HasFault {
 	task := CreateTask(m, "configureStorageDrsForPod", func(*Task) (types.AnyType, types.BaseMethodFault) {
-		cluster := Map.Get(req.Pod).(*StoragePod)
+		cluster := Map().Get(req.Pod).(*StoragePod)
 
 		if s := req.Spec.PodConfigSpec; s != nil {
 			config := &cluster.PodStorageDrsEntry.StorageDrsConfig.PodConfig
@@ -60,7 +60,7 @@ func (m *StorageResourceManager) pod(ref *types.ManagedObjectReference) *Storage
 	if ref == nil {
 		return nil
 	}
-	cluster := Map.Get(*ref).(*StoragePod)
+	cluster := Map().Get(*ref).(*StoragePod)
 	config := &cluster.PodStorageDrsEntry.StorageDrsConfig.PodConfig
 
 	if !config.Enabled {

--- a/simulator/task_manager.go
+++ b/simulator/task_manager.go
@@ -55,7 +55,7 @@ func (m *TaskManager) PutObject(obj mo.Reference) {
 		recent = recent[1:]
 	}
 
-	Map.Update(m, []types.PropertyChange{{Name: "recentTask", Val: recent}})
+	Map().Update(m, []types.PropertyChange{{Name: "recentTask", Val: recent}})
 	m.Unlock()
 }
 

--- a/simulator/task_manager_test.go
+++ b/simulator/task_manager_test.go
@@ -34,7 +34,7 @@ func TestTaskManagerRecent(t *testing.T) {
 
 	recentTaskMax = 5
 
-	tm := Map.Get(*esx.ServiceContent.TaskManager).(*TaskManager)
+	tm := Map().Get(*esx.ServiceContent.TaskManager).(*TaskManager)
 	tm.RecentTask = nil
 
 	for i := 0; i < recentTaskMax+2; i++ {

--- a/simulator/task_test.go
+++ b/simulator/task_test.go
@@ -35,7 +35,7 @@ func (a *addWaterTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 
 func TestNewTask(t *testing.T) {
 	f := &mo.Folder{}
-	Map.NewEntity(f)
+	Map().NewEntity(f)
 
 	add := &addWaterTask{f, nil}
 	task := NewTask(add)

--- a/simulator/view_manager.go
+++ b/simulator/view_manager.go
@@ -69,7 +69,7 @@ func destroyView(ref types.ManagedObjectReference) soap.HasFault {
 func (m *ViewManager) CreateContainerView(ctx *Context, req *types.CreateContainerView) soap.HasFault {
 	body := &methods.CreateContainerViewBody{}
 
-	root := Map.Get(req.Container)
+	root := Map().Get(req.Container)
 	if root == nil {
 		body.Fault_ = Fault("", &types.ManagedObjectNotFound{Obj: req.Container})
 		return body
@@ -185,7 +185,7 @@ func (v *ContainerView) add(root mo.Reference, seen map[types.ManagedObjectRefer
 		}
 
 		if v.Recursive {
-			v.add(Map.Get(child), seen)
+			v.add(Map().Get(child), seen)
 		}
 	})
 }
@@ -200,7 +200,7 @@ func (v *ContainerView) find(root mo.Reference, ref types.ManagedObjectReference
 			return
 		}
 		if v.Recursive {
-			*found = v.find(Map.Get(child), ref, found)
+			*found = v.find(Map().Get(child), ref, found)
 		}
 	})
 
@@ -211,12 +211,12 @@ func (v *ContainerView) PutObject(obj mo.Reference) {
 	ref := obj.Reference()
 
 	if v.include(ref) && v.find(v.root, ref, types.NewBool(false)) {
-		Map.Update(v, []types.PropertyChange{{Name: "view", Val: append(v.View, ref)}})
+		Map().Update(v, []types.PropertyChange{{Name: "view", Val: append(v.View, ref)}})
 	}
 }
 
 func (v *ContainerView) RemoveObject(ctx *Context, obj types.ManagedObjectReference) {
-	Map.RemoveReference(ctx, v, &v.View, obj)
+	Map().RemoveReference(ctx, v, &v.View, obj)
 }
 
 func (*ContainerView) UpdateObject(mo.Reference, []types.PropertyChange) {}
@@ -244,12 +244,12 @@ type ListView struct {
 }
 
 func (v *ListView) update() {
-	Map.Update(v, []types.PropertyChange{{Name: "view", Val: v.View}})
+	Map().Update(v, []types.PropertyChange{{Name: "view", Val: v.View}})
 }
 
 func (v *ListView) add(refs []types.ManagedObjectReference) *types.ManagedObjectNotFound {
 	for _, ref := range refs {
-		obj := Map.Get(ref)
+		obj := Map().Get(ref)
 		if obj == nil {
 			return &types.ManagedObjectNotFound{Obj: ref}
 		}

--- a/simulator/view_manager_test.go
+++ b/simulator/view_manager_test.go
@@ -77,7 +77,7 @@ func TestContainerViewVPX(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
-	vapp := object.NewVirtualApp(c.Client, Map.Any("VirtualApp").Reference())
+	vapp := object.NewVirtualApp(c.Client, Map().Any("VirtualApp").Reference())
 
 	count := m.Count()
 

--- a/simulator/virtual_disk_manager.go
+++ b/simulator/virtual_disk_manager.go
@@ -45,7 +45,7 @@ func vdmNames(name string) []string {
 }
 
 func vdmCreateVirtualDisk(op types.VirtualDeviceConfigSpecFileOperation, req *types.CreateVirtualDisk_Task) types.BaseMethodFault {
-	fm := Map.FileManager()
+	fm := Map().FileManager()
 
 	file, fault := fm.resolve(req.Datacenter, req.Name)
 	if fault != nil {
@@ -99,7 +99,7 @@ func (m *VirtualDiskManager) CreateVirtualDiskTask(ctx *Context, req *types.Crea
 
 func (m *VirtualDiskManager) DeleteVirtualDiskTask(ctx *Context, req *types.DeleteVirtualDisk_Task) soap.HasFault {
 	task := CreateTask(m, "deleteVirtualDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
-		fm := Map.FileManager()
+		fm := Map().FileManager()
 
 		for _, name := range vdmNames(req.Name) {
 			err := fm.deleteDatastoreFile(&types.DeleteDatastoreFile_Task{
@@ -124,7 +124,7 @@ func (m *VirtualDiskManager) DeleteVirtualDiskTask(ctx *Context, req *types.Dele
 
 func (m *VirtualDiskManager) MoveVirtualDiskTask(ctx *Context, req *types.MoveVirtualDisk_Task) soap.HasFault {
 	task := CreateTask(m, "moveVirtualDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
-		fm := Map.FileManager()
+		fm := Map().FileManager()
 
 		dest := vdmNames(req.DestName)
 
@@ -155,12 +155,12 @@ func (m *VirtualDiskManager) MoveVirtualDiskTask(ctx *Context, req *types.MoveVi
 func (m *VirtualDiskManager) CopyVirtualDiskTask(ctx *Context, req *types.CopyVirtualDisk_Task) soap.HasFault {
 	task := CreateTask(m, "copyVirtualDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		if req.DestSpec != nil {
-			if Map.IsVPX() {
+			if Map().IsVPX() {
 				return nil, new(types.NotImplemented)
 			}
 		}
 
-		fm := Map.FileManager()
+		fm := Map().FileManager()
 
 		dest := vdmNames(req.DestName)
 
@@ -198,7 +198,7 @@ func virtualDiskUUID(dc *types.ManagedObjectReference, file string) string {
 func (m *VirtualDiskManager) QueryVirtualDiskUuid(_ *Context, req *types.QueryVirtualDiskUuid) soap.HasFault {
 	body := new(methods.QueryVirtualDiskUuidBody)
 
-	fm := Map.FileManager()
+	fm := Map().FileManager()
 
 	file, fault := fm.resolve(req.Datacenter, req.Name)
 	if fault != nil {

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -57,11 +57,13 @@ func asVirtualMachineMO(obj mo.Reference) (*mo.VirtualMachine, bool) {
 }
 
 func NewVirtualMachine(ctx *Context, parent types.ManagedObjectReference, spec *types.VirtualMachineConfigSpec) (*VirtualMachine, types.BaseMethodFault) {
+	vimMap := Map()
+
 	vm := &VirtualMachine{}
 	vm.Parent = &parent
-	Map().reference(vm)
+	vimMap.reference(vm)
 
-	folder := Map().Get(parent)
+	folder := vimMap.Get(parent)
 
 	if spec.Name == "" {
 		return vm, &types.InvalidVmConfig{Property: "configSpec.name"}
@@ -102,8 +104,8 @@ func NewVirtualMachine(ctx *Context, parent types.ManagedObjectReference, spec *
 		vmx.Path = spec.Name
 	}
 
-	dc := Map().getEntityDatacenter(folder.(mo.Entity))
-	ds := Map().FindByName(vmx.Datastore, dc.Datastore).(*Datastore)
+	dc := vimMap.getEntityDatacenter(folder.(mo.Entity))
+	ds := vimMap.FindByName(vmx.Datastore, dc.Datastore).(*Datastore)
 	dir := path.Join(ds.Info.GetDatastoreInfo().Url, vmx.Path)
 
 	if path.Ext(vmx.Path) == ".vmx" {
@@ -811,9 +813,10 @@ func (vm *VirtualMachine) RefreshStorageInfo(ctx *Context, req *types.RefreshSto
 }
 
 func (vm *VirtualMachine) findDatastore(name string) *Datastore {
-	host := Map().Get(*vm.Runtime.Host).(*HostSystem)
+	vimMap := Map()
+	host := vimMap.Get(*vm.Runtime.Host).(*HostSystem)
 
-	return Map().FindByName(name, host.Datastore).(*Datastore)
+	return vimMap.FindByName(name, host.Datastore).(*Datastore)
 }
 
 func (vm *VirtualMachine) useDatastore(name string) *Datastore {
@@ -1009,26 +1012,28 @@ func getDiskSize(disk *types.VirtualDisk) int64 {
 }
 
 func (vm *VirtualMachine) validateSwitchMembers(id string) types.BaseMethodFault {
+	vimMap := Map()
+
 	var dswitch *DistributedVirtualSwitch
 
 	var find func(types.ManagedObjectReference)
 	find = func(child types.ManagedObjectReference) {
-		s, ok := Map().Get(child).(*DistributedVirtualSwitch)
+		s, ok := vimMap.Get(child).(*DistributedVirtualSwitch)
 		if ok && s.Uuid == id {
 			dswitch = s
 			return
 		}
-		walk(Map().Get(child), find)
+		walk(vimMap.Get(child), find)
 	}
-	f := Map().getEntityDatacenter(vm).NetworkFolder
-	walk(Map().Get(f), find) // search in NetworkFolder and any sub folders
+	f := vimMap.getEntityDatacenter(vm).NetworkFolder
+	walk(vimMap.Get(f), find) // search in NetworkFolder and any sub folders
 
 	if dswitch == nil {
 		log.Printf("DVS %s cannot be found", id)
 		return new(types.NotFound)
 	}
 
-	h := Map().Get(*vm.Runtime.Host).(*HostSystem)
+	h := vimMap.Get(*vm.Runtime.Host).(*HostSystem)
 	c := hostParent(&h.HostSystem)
 	isMember := func(val types.ManagedObjectReference) bool {
 		for _, mem := range dswitch.Summary.HostMember {
@@ -1070,7 +1075,8 @@ func (vm *VirtualMachine) configureDevice(ctx *Context, devices object.VirtualDe
 
 	label := devices.Name(device)
 	summary := label
-	dc := Map().getEntityDatacenter(Map().Get(*vm.Parent).(mo.Entity))
+	vimMap := Map()
+	dc := vimMap.getEntityDatacenter(vimMap.Get(*vm.Parent).(mo.Entity))
 
 	switch x := device.(type) {
 	case types.BaseVirtualEthernetCard:
@@ -1082,7 +1088,7 @@ func (vm *VirtualMachine) configureDevice(ctx *Context, devices object.VirtualDe
 		case *types.VirtualEthernetCardNetworkBackingInfo:
 			name = b.DeviceName
 			summary = name
-			net = Map().FindByName(b.DeviceName, dc.Network).Reference()
+			net = vimMap.FindByName(b.DeviceName, dc.Network).Reference()
 			b.Network = &net
 		case *types.VirtualEthernetCardDistributedVirtualPortBackingInfo:
 			summary = fmt.Sprintf("DVSwitch: %s", b.Port.SwitchUuid)
@@ -1093,7 +1099,7 @@ func (vm *VirtualMachine) configureDevice(ctx *Context, devices object.VirtualDe
 			}
 		}
 
-		Map().Update(vm, []types.PropertyChange{
+		vimMap.Update(vm, []types.PropertyChange{
 			{Name: "summary.config.numEthernetCards", Val: vm.Summary.Config.NumEthernetCards + 1},
 			{Name: "network", Val: append(vm.Network, net)},
 		})
@@ -1140,7 +1146,7 @@ func (vm *VirtualMachine) configureDevice(ctx *Context, devices object.VirtualDe
 				return err
 			}
 
-			Map().Update(vm, []types.PropertyChange{
+			vimMap.Update(vm, []types.PropertyChange{
 				{Name: "summary.config.numVirtualDisks", Val: vm.Summary.Config.NumVirtualDisks + 1},
 			})
 
@@ -1221,6 +1227,7 @@ func (vm *VirtualMachine) configureDevice(ctx *Context, devices object.VirtualDe
 
 func (vm *VirtualMachine) removeDevice(ctx *Context, devices object.VirtualDeviceList, spec *types.VirtualDeviceConfigSpec) object.VirtualDeviceList {
 	key := spec.Device.GetVirtualDevice().Key
+	vimMap := Map()
 
 	for i, d := range devices {
 		if d.GetVirtualDevice().Key != key {
@@ -1248,8 +1255,8 @@ func (vm *VirtualMachine) removeDevice(ctx *Context, devices object.VirtualDevic
 				}
 
 				if file != "" {
-					dc := Map().getEntityDatacenter(vm)
-					dm := Map().VirtualDiskManager()
+					dc := vimMap.getEntityDatacenter(vm)
+					dm := vimMap.VirtualDiskManager()
 					if dc == nil {
 						continue // parent was destroyed
 					}
@@ -1257,11 +1264,11 @@ func (vm *VirtualMachine) removeDevice(ctx *Context, devices object.VirtualDevic
 						Name:       file,
 						Datacenter: &dc.Self,
 					})
-					ctask := Map().Get(res.(*methods.DeleteVirtualDisk_TaskBody).Res.Returnval).(*Task)
+					ctask := vimMap.Get(res.(*methods.DeleteVirtualDisk_TaskBody).Res.Returnval).(*Task)
 					ctask.Wait()
 				}
 			}
-			Map().Update(vm, []types.PropertyChange{
+			vimMap.Update(vm, []types.PropertyChange{
 				{Name: "summary.config.numVirtualDisks", Val: vm.Summary.Config.NumVirtualDisks - 1},
 			})
 
@@ -1279,7 +1286,7 @@ func (vm *VirtualMachine) removeDevice(ctx *Context, devices object.VirtualDevic
 
 			networks := vm.Network
 			RemoveReference(&networks, net)
-			Map().Update(vm, []types.PropertyChange{
+			vimMap.Update(vm, []types.PropertyChange{
 				{Name: "summary.config.numEthernetCards", Val: vm.Summary.Config.NumEthernetCards - 1},
 				{Name: "network", Val: networks},
 			})
@@ -1522,15 +1529,16 @@ func (vm *VirtualMachine) SuspendVMTask(ctx *Context, req *types.SuspendVM_Task)
 
 func (vm *VirtualMachine) ResetVMTask(ctx *Context, req *types.ResetVM_Task) soap.HasFault {
 	task := CreateTask(vm, "reset", func(task *Task) (types.AnyType, types.BaseMethodFault) {
+		vimMap := Map()
 		res := vm.PowerOffVMTask(ctx, &types.PowerOffVM_Task{This: vm.Self})
-		ctask := Map().Get(res.(*methods.PowerOffVM_TaskBody).Res.Returnval).(*Task)
+		ctask := vimMap.Get(res.(*methods.PowerOffVM_TaskBody).Res.Returnval).(*Task)
 		ctask.Wait()
 		if ctask.Info.Error != nil {
 			return nil, ctask.Info.Error.Fault
 		}
 
 		res = vm.PowerOnVMTask(ctx, &types.PowerOnVM_Task{This: vm.Self})
-		ctask = Map().Get(res.(*methods.PowerOnVM_TaskBody).Res.Returnval).(*Task)
+		ctask = vimMap.Get(res.(*methods.PowerOnVM_TaskBody).Res.Returnval).(*Task)
 		ctask.Wait()
 
 		return nil, nil
@@ -1671,25 +1679,26 @@ func (vm *VirtualMachine) UnregisterVM(ctx *Context, c *types.UnregisterVM) soap
 		return r
 	}
 
-	host := Map().Get(*vm.Runtime.Host).(*HostSystem)
-	Map().RemoveReference(ctx, host, &host.Vm, vm.Self)
+	vimMap := Map()
+	host := vimMap.Get(*vm.Runtime.Host).(*HostSystem)
+	vimMap.RemoveReference(ctx, host, &host.Vm, vm.Self)
 
 	if vm.ResourcePool != nil {
-		switch pool := Map().Get(*vm.ResourcePool).(type) {
+		switch pool := vimMap.Get(*vm.ResourcePool).(type) {
 		case *ResourcePool:
-			Map().RemoveReference(ctx, pool, &pool.Vm, vm.Self)
+			vimMap.RemoveReference(ctx, pool, &pool.Vm, vm.Self)
 		case *VirtualApp:
-			Map().RemoveReference(ctx, pool, &pool.Vm, vm.Self)
+			vimMap.RemoveReference(ctx, pool, &pool.Vm, vm.Self)
 		}
 	}
 
 	for i := range vm.Datastore {
-		ds := Map().Get(vm.Datastore[i]).(*Datastore)
-		Map().RemoveReference(ctx, ds, &ds.Vm, vm.Self)
+		ds := vimMap.Get(vm.Datastore[i]).(*Datastore)
+		vimMap.RemoveReference(ctx, ds, &ds.Vm, vm.Self)
 	}
 
 	ctx.postEvent(&types.VmRemovedEvent{VmEvent: vm.event()})
-	if f, ok := asFolderMO(Map().getEntityParent(vm, "Folder")); ok {
+	if f, ok := asFolderMO(vimMap.getEntityParent(vm, "Folder")); ok {
 		folderRemoveChild(ctx, f, c.This)
 	}
 
@@ -1703,6 +1712,8 @@ type vmFolder interface {
 }
 
 func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soap.HasFault {
+	vimMap := Map()
+
 	pool := req.Spec.Location.Pool
 	if pool == nil {
 		if !vm.Config.Template {
@@ -1716,8 +1727,8 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 		destHost = req.Spec.Location.Host
 	}
 
-	folder, _ := asFolderMO(Map().Get(req.Folder))
-	host := Map().Get(*destHost).(*HostSystem)
+	folder, _ := asFolderMO(vimMap.Get(req.Folder))
+	host := vimMap.Get(*destHost).(*HostSystem)
 	event := vm.event()
 
 	ctx.postEvent(&types.VmBeingClonedEvent{
@@ -1732,7 +1743,7 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 	vmx := vm.vmx(nil)
 	vmx.Path = req.Name
 	if ref := req.Spec.Location.Datastore; ref != nil {
-		ds := Map().Get(*ref).(*Datastore).Name
+		ds := vimMap.Get(*ref).(*Datastore).Name
 		vmx.Datastore = ds
 	}
 
@@ -1786,21 +1797,21 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 			})
 		}
 
-		res := Map().Get(req.Folder).(vmFolder).CreateVMTask(ctx, &types.CreateVM_Task{
+		res := vimMap.Get(req.Folder).(vmFolder).CreateVMTask(ctx, &types.CreateVM_Task{
 			This:   folder.Self,
 			Config: config,
 			Pool:   *pool,
 			Host:   destHost,
 		})
 
-		ctask := Map().Get(res.(*methods.CreateVM_TaskBody).Res.Returnval).(*Task)
+		ctask := vimMap.Get(res.(*methods.CreateVM_TaskBody).Res.Returnval).(*Task)
 		ctask.Wait()
 		if ctask.Info.Error != nil {
 			return nil, ctask.Info.Error.Fault
 		}
 
 		ref := ctask.Info.Result.(types.ManagedObjectReference)
-		clone := Map().Get(ref).(*VirtualMachine)
+		clone := vimMap.Get(ref).(*VirtualMachine)
 		clone.configureDevices(ctx, &types.VirtualMachineConfigSpec{DeviceChange: req.Spec.Location.DeviceChange})
 		if req.Spec.Config != nil && req.Spec.Config.DeviceChange != nil {
 			clone.configureDevices(ctx, &types.VirtualMachineConfigSpec{DeviceChange: req.Spec.Config.DeviceChange})
@@ -1828,10 +1839,11 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 func (vm *VirtualMachine) RelocateVMTask(ctx *Context, req *types.RelocateVM_Task) soap.HasFault {
 	task := CreateTask(vm, "relocateVm", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		var changes []types.PropertyChange
+		vimMap := Map()
 
 		if ref := req.Spec.Datastore; ref != nil {
-			ds := Map().Get(*ref).(*Datastore)
-			Map().RemoveReference(ctx, ds, &ds.Vm, *ref)
+			ds := vimMap.Get(*ref).(*Datastore)
+			vimMap.RemoveReference(ctx, ds, &ds.Vm, *ref)
 
 			// TODO: migrate vm.Config.Files, vm.Summary.Config.VmPathName, vm.Layout and vm.LayoutEx
 
@@ -1839,15 +1851,15 @@ func (vm *VirtualMachine) RelocateVMTask(ctx *Context, req *types.RelocateVM_Tas
 		}
 
 		if ref := req.Spec.Pool; ref != nil {
-			pool := Map().Get(*ref).(*ResourcePool)
-			Map().RemoveReference(ctx, pool, &pool.Vm, *ref)
+			pool := vimMap.Get(*ref).(*ResourcePool)
+			vimMap.RemoveReference(ctx, pool, &pool.Vm, *ref)
 
 			changes = append(changes, types.PropertyChange{Name: "resourcePool", Val: ref})
 		}
 
 		if ref := req.Spec.Host; ref != nil {
-			host := Map().Get(*ref).(*HostSystem)
-			Map().RemoveReference(ctx, host, &host.Vm, *ref)
+			host := vimMap.Get(*ref).(*HostSystem)
+			vimMap.RemoveReference(ctx, host, &host.Vm, *ref)
 
 			changes = append(changes,
 				types.PropertyChange{Name: "runtime.host", Val: ref},
@@ -1856,13 +1868,13 @@ func (vm *VirtualMachine) RelocateVMTask(ctx *Context, req *types.RelocateVM_Tas
 		}
 
 		if ref := req.Spec.Folder; ref != nil {
-			folder := Map().Get(*ref).(*Folder)
+			folder := vimMap.Get(*ref).(*Folder)
 			folder.MoveIntoFolderTask(ctx, &types.MoveIntoFolder_Task{
 				List: []types.ManagedObjectReference{vm.Self},
 			})
 		}
 
-		Map().Update(vm, changes)
+		vimMap.Update(vm, changes)
 
 		return nil, nil
 	})
@@ -2002,7 +2014,8 @@ func (vm *VirtualMachine) CreateSnapshotTask(ctx *Context, req *types.CreateSnap
 		snapshot.Vm = vm.Reference()
 		snapshot.Config = *vm.Config
 
-		Map().Put(snapshot)
+		vimMap := Map()
+		vimMap.Put(snapshot)
 
 		treeItem := types.VirtualMachineSnapshotTree{
 			Snapshot:        snapshot.Self,
@@ -2019,7 +2032,7 @@ func (vm *VirtualMachine) CreateSnapshotTask(ctx *Context, req *types.CreateSnap
 
 		cur := vm.Snapshot.CurrentSnapshot
 		if cur != nil {
-			parent := Map().Get(*cur).(*VirtualMachineSnapshot)
+			parent := vimMap.Get(*cur).(*VirtualMachineSnapshot)
 			parent.ChildSnapshot = append(parent.ChildSnapshot, snapshot.Self)
 
 			ss := findSnapshotInTree(vm.Snapshot.RootSnapshotList, *cur)
@@ -2034,7 +2047,7 @@ func (vm *VirtualMachine) CreateSnapshotTask(ctx *Context, req *types.CreateSnap
 		snapshot.createSnapshotFiles()
 
 		changes = append(changes, types.PropertyChange{Name: "snapshot.currentSnapshot", Val: snapshot.Self})
-		Map().Update(vm, changes)
+		vimMap.Update(vm, changes)
 
 		return snapshot.Self, nil
 	})
@@ -2074,13 +2087,14 @@ func (vm *VirtualMachine) RemoveAllSnapshotsTask(ctx *Context, req *types.Remove
 
 		refs := allSnapshotsInTree(vm.Snapshot.RootSnapshotList)
 
-		Map().Update(vm, []types.PropertyChange{
+		vimMap := Map()
+		vimMap.Update(vm, []types.PropertyChange{
 			{Name: "snapshot", Val: nil},
 		})
 
 		for _, ref := range refs {
-			Map().Get(ref).(*VirtualMachineSnapshot).removeSnapshotFiles(ctx)
-			Map().Remove(ctx, ref)
+			vimMap.Get(ref).(*VirtualMachineSnapshot).removeSnapshotFiles(ctx)
+			vimMap.Remove(ctx, ref)
 		}
 
 		return nil, nil

--- a/simulator/virtual_machine_fault_test.go
+++ b/simulator/virtual_machine_fault_test.go
@@ -40,8 +40,8 @@ func TestSwitchMembers(t *testing.T) {
 		// The proper way to remove a host from is with dvs.Reconfigure + types.ConfigSpecOperationRemove,
 		// but that would fail here with ResourceInUse. And creating a new DVS + PG is cumbersome,
 		// so just force the removal of host from the DVS + PG, which has the same effect on vm.AddDevice().
-		dswitch := simulator.Map.Get(dvs.Reference()).(*simulator.DistributedVirtualSwitch)
-		portgrp := simulator.Map.Get(pg.Reference()).(*simulator.DistributedVirtualPortgroup)
+		dswitch := simulator.Map().Get(dvs.Reference()).(*simulator.DistributedVirtualSwitch)
+		portgrp := simulator.Map().Get(pg.Reference()).(*simulator.DistributedVirtualPortgroup)
 		simulator.RemoveReference(&dswitch.Summary.HostMember, host.Reference())
 		simulator.RemoveReference(&portgrp.Host, host.Reference())
 

--- a/simulator/virtual_machine_fault_test.go
+++ b/simulator/virtual_machine_fault_test.go
@@ -37,11 +37,12 @@ func TestSwitchMembers(t *testing.T) {
 		vm, _ := finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
 		host, _ := vm.HostSystem(ctx)
 
+		vimMap := simulator.Map()
 		// The proper way to remove a host from is with dvs.Reconfigure + types.ConfigSpecOperationRemove,
 		// but that would fail here with ResourceInUse. And creating a new DVS + PG is cumbersome,
 		// so just force the removal of host from the DVS + PG, which has the same effect on vm.AddDevice().
-		dswitch := simulator.Map().Get(dvs.Reference()).(*simulator.DistributedVirtualSwitch)
-		portgrp := simulator.Map().Get(pg.Reference()).(*simulator.DistributedVirtualPortgroup)
+		dswitch := vimMap.Get(dvs.Reference()).(*simulator.DistributedVirtualSwitch)
+		portgrp := vimMap.Get(pg.Reference()).(*simulator.DistributedVirtualPortgroup)
 		simulator.RemoveReference(&dswitch.Summary.HostMember, host.Reference())
 		simulator.RemoveReference(&portgrp.Host, host.Reference())
 

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -408,7 +408,7 @@ func TestReconfigVm(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vmm := Map().Any("VirtualMachine").(*VirtualMachine)
 	vm := object.NewVirtualMachine(c.Client, vmm.Reference())
 
 	tests := []struct {
@@ -655,7 +655,7 @@ func TestCreateVmWithDevices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vm := Map.Get(info.Result.(types.ManagedObjectReference)).(*VirtualMachine)
+	vm := Map().Get(info.Result.(types.ManagedObjectReference)).(*VirtualMachine)
 
 	expect := len(esx.VirtualDevice) + len(devices)
 	ndevice := len(vm.Config.Hardware.Device)
@@ -723,7 +723,7 @@ func TestShutdownGuest(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		vm := object.NewVirtualMachine(c.Client, Map.Any("VirtualMachine").Reference())
+		vm := object.NewVirtualMachine(c.Client, Map().Any("VirtualMachine").Reference())
 		// shutdown the vm
 		err = vm.ShutdownGuest(ctx)
 		if err != nil {
@@ -765,7 +765,7 @@ func TestVmSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	simVm := Map.Any("VirtualMachine")
+	simVm := Map().Any("VirtualMachine")
 	vm := object.NewVirtualMachine(c.Client, simVm.Reference())
 
 	_, err = fieldValue(reflect.ValueOf(simVm), "snapshot")
@@ -892,7 +892,7 @@ func TestVmMarkAsTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vm := object.NewVirtualMachine(c.Client, Map.Any("VirtualMachine").Reference())
+	vm := object.NewVirtualMachine(c.Client, Map().Any("VirtualMachine").Reference())
 
 	err = vm.MarkAsTemplate(ctx)
 	if err == nil {
@@ -935,7 +935,7 @@ func TestVmRefreshStorageInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vmm := Map().Any("VirtualMachine").(*VirtualMachine)
 	vm := object.NewVirtualMachine(c.Client, vmm.Reference())
 
 	// take snapshot
@@ -1018,8 +1018,8 @@ func TestVmRefreshStorageInfo(t *testing.T) {
 	}
 
 	findDsStorage := func(dsName string) *types.VirtualMachineUsageOnDatastore {
-		host := Map.Get(*vmm.Runtime.Host).(*HostSystem)
-		ds := Map.FindByName(dsName, host.Datastore).(*Datastore)
+		host := Map().Get(*vmm.Runtime.Host).(*HostSystem)
+		ds := Map().FindByName(dsName, host.Datastore).(*Datastore)
 
 		for _, dsUsage := range vmm.Storage.PerDatastoreUsage {
 			if dsUsage.Datastore == ds.Self {

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -935,7 +935,8 @@ func TestVmRefreshStorageInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vmm := Map().Any("VirtualMachine").(*VirtualMachine)
+	vimMap := Map()
+	vmm := vimMap.Any("VirtualMachine").(*VirtualMachine)
 	vm := object.NewVirtualMachine(c.Client, vmm.Reference())
 
 	// take snapshot
@@ -1018,8 +1019,8 @@ func TestVmRefreshStorageInfo(t *testing.T) {
 	}
 
 	findDsStorage := func(dsName string) *types.VirtualMachineUsageOnDatastore {
-		host := Map().Get(*vmm.Runtime.Host).(*HostSystem)
-		ds := Map().FindByName(dsName, host.Datastore).(*Datastore)
+		host := vimMap.Get(*vmm.Runtime.Host).(*HostSystem)
+		ds := vimMap.FindByName(dsName, host.Datastore).(*Datastore)
 
 		for _, dsUsage := range vmm.Storage.PerDatastoreUsage {
 			if dsUsage.Datastore == ds.Self {

--- a/simulator/vstorage_object_manager.go
+++ b/simulator/vstorage_object_manager.go
@@ -199,8 +199,8 @@ func (m *VcenterVStorageObjectManager) RegisterDisk(ctx *Context, req *types.Reg
 func (m *VcenterVStorageObjectManager) createObject(req *types.CreateDisk_Task, register bool) (*types.VStorageObject, types.BaseMethodFault) {
 	dir := "fcd"
 	ref := req.Spec.BackingSpec.GetVslmCreateSpecBackingSpec().Datastore
-	ds := Map.Get(ref).(*Datastore)
-	dc := Map.getEntityDatacenter(ds)
+	ds := Map().Get(ref).(*Datastore)
+	dc := Map().getEntityDatacenter(ds)
 
 	objects, ok := m.objects[ds.Self]
 	if !ok {
@@ -288,9 +288,9 @@ func (m *VcenterVStorageObjectManager) DeleteVStorageObjectTask(ctx *Context, re
 		}
 
 		backing := obj.Config.Backing.(*types.BaseConfigInfoDiskFileBackingInfo)
-		ds := Map.Get(req.Datastore).(*Datastore)
-		dc := Map.getEntityDatacenter(ds)
-		dm := Map.VirtualDiskManager()
+		ds := Map().Get(req.Datastore).(*Datastore)
+		dc := Map().getEntityDatacenter(ds)
+		dm := Map().VirtualDiskManager()
 		dm.DeleteVirtualDiskTask(ctx, &types.DeleteVirtualDisk_Task{
 			Name:       backing.FilePath,
 			Datacenter: &dc.Self,

--- a/simulator/vstorage_object_manager.go
+++ b/simulator/vstorage_object_manager.go
@@ -199,8 +199,9 @@ func (m *VcenterVStorageObjectManager) RegisterDisk(ctx *Context, req *types.Reg
 func (m *VcenterVStorageObjectManager) createObject(req *types.CreateDisk_Task, register bool) (*types.VStorageObject, types.BaseMethodFault) {
 	dir := "fcd"
 	ref := req.Spec.BackingSpec.GetVslmCreateSpecBackingSpec().Datastore
-	ds := Map().Get(ref).(*Datastore)
-	dc := Map().getEntityDatacenter(ds)
+	vimMap := Map()
+	ds := vimMap.Get(ref).(*Datastore)
+	dc := vimMap.getEntityDatacenter(ds)
 
 	objects, ok := m.objects[ds.Self]
 	if !ok {
@@ -288,9 +289,10 @@ func (m *VcenterVStorageObjectManager) DeleteVStorageObjectTask(ctx *Context, re
 		}
 
 		backing := obj.Config.Backing.(*types.BaseConfigInfoDiskFileBackingInfo)
-		ds := Map().Get(req.Datastore).(*Datastore)
-		dc := Map().getEntityDatacenter(ds)
-		dm := Map().VirtualDiskManager()
+		vimMap := Map()
+		ds := vimMap.Get(req.Datastore).(*Datastore)
+		dc := vimMap.getEntityDatacenter(ds)
+		dm := vimMap.VirtualDiskManager()
 		dm.DeleteVirtualDiskTask(ctx, &types.DeleteVirtualDisk_Task{
 			Name:       backing.FilePath,
 			Datacenter: &dc.Self,

--- a/vapi/cluster/cluster_test.go
+++ b/vapi/cluster/cluster_test.go
@@ -54,7 +54,7 @@ func TestClusterModules(t *testing.T) {
 			t.Errorf("expected 0 modules")
 		}
 
-		ccr := simulator.Map.Any("ClusterComputeResource")
+		ccr := simulator.Map().Any("ClusterComputeResource")
 
 		_, err = m.CreateModule(ctx, enoent)
 		if err == nil {
@@ -112,7 +112,7 @@ func TestClusterModuleMembers(t *testing.T) {
 			t.Error("expected error")
 		}
 
-		ccr := simulator.Map.Any("ClusterComputeResource")
+		ccr := simulator.Map().Any("ClusterComputeResource")
 
 		id, err := m.CreateModule(ctx, ccr)
 		if err != nil {

--- a/vapi/cluster/simulator/simulator.go
+++ b/vapi/cluster/simulator/simulator.go
@@ -80,7 +80,7 @@ func (h *Handler) modules(w http.ResponseWriter, r *http.Request) {
 		var m internal.CreateModule
 		if vapi.Decode(r, w, &m) {
 			ref := types.ManagedObjectReference{Type: "ClusterComputeResource", Value: m.Spec.ID}
-			if simulator.Map.Get(ref) == nil {
+			if simulator.Map().Get(ref) == nil {
 				vapi.BadRequest(w, "com.vmware.vapi.std.errors.invalid_argument")
 				return
 			}

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -204,7 +204,7 @@ func main() {
 			Registry *simulator.Registry
 			Model    *simulator.Model
 		}{
-			simulator.Map,
+			simulator.Map(),
 			&count,
 		}
 	}))


### PR DESCRIPTION
Close: #2750

## Description

There is data race when reinitialized the global `simulator.Map` during tests. This changes is to wrap access and re- initialization using singleton style functions with a corresponding mutex.

Closes: #2570

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] `make check`: 2 tests FAIL also fail on `master`
- [ ] Testing the simulator package directly with `-race -count 100`: 

```
GORACE=atexit_sleep_ms=10000 /usr/local/bin/go test -count 100 \
  -race \
  -timeout 10m \
  -v  \
  ./simulator/... | tee out.txt
```

**Test Configuration**:

* Toolchain: go 1.17
* SDK:
* (add more if needed)

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged