### PR TITLE
Update CnsQueryAsync API request parameters to handle empty values for QuerySelection

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -190,11 +190,11 @@ func (c *Client) QueryAllVolume(ctx context.Context, queryFilter cnstypes.CnsQue
 }
 
 // QueryVolumeAsync calls the CNS QueryAsync API and return a task, from which we can extract CnsQueryResult
-func (c *Client) QueryVolumeAsync(ctx context.Context, queryFilter cnstypes.CnsQueryFilter, querySelection cnstypes.CnsQuerySelection) (*object.Task, error) {
+func (c *Client) QueryVolumeAsync(ctx context.Context, queryFilter cnstypes.CnsQueryFilter, querySelection *cnstypes.CnsQuerySelection) (*object.Task, error) {
 	req := cnstypes.CnsQueryAsync{
 		This:      CnsVolumeManagerInstance,
 		Filter:    queryFilter,
-		Selection: &querySelection,
+		Selection: querySelection,
 	}
 	res, err := methods.CnsQueryAsync(ctx, c, &req)
 	if err != nil {

--- a/cns/simulator/simulator_test.go
+++ b/cns/simulator/simulator_test.go
@@ -290,7 +290,7 @@ func TestSimulator(t *testing.T) {
 	// QueryAsync
 	queryFilter = cnstypes.CnsQueryFilter{}
 	querySelection := cnstypes.CnsQuerySelection{}
-	queryVolumeAsyncTask, err := cnsClient.QueryVolumeAsync(ctx, queryFilter, querySelection)
+	queryVolumeAsyncTask, err := cnsClient.QueryVolumeAsync(ctx, queryFilter, &querySelection)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description

This PR is updating the CnsQueryAsync API request parameters to handle empty values for QuerySelection. Without this change the API will return "VolumeId" field only when empty QuerySelection is passed. Instead, the API is expected to return entire Volume{} struct with all the fields(not just volumeId) when empty QuerySelection is passed. The fix is essentially changing the API request to consume pointer to QuerySelection which can be set to nil when clients choose to pass empty QuerySelection in order to fetch all fields from QueryAsync API.



## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Ran the existing unit test:

**Before:**
```
client_test.go:881: Successfully queried Volume using queryAsync API. queryVolumeAsyncTaskResult: &types.CnsAsyncQueryResult{
            CnsVolumeOperationResult: types.CnsVolumeOperationResult{},
            QueryResult:              types.CnsQueryResult{
                Volumes: []types.CnsVolume{
                    {
                        VolumeId: types.CnsVolumeId{
                            Id: "5235f91b-fece-4c71-b948-9397d87fd8c5",
                        },
                        DatastoreUrl:                 "",
                        Name:                         "",
                        VolumeType:                   "",
                        StoragePolicyId:              "",
                        Metadata:                     types.CnsVolumeMetadata{},
                        BackingObjectDetails:         nil,
                        ComplianceStatus:             "",
                        DatastoreAccessibilityStatus: "",
                        HealthStatus:                 "",
                    },
                },
                Cursor: types.CnsCursor{
                    Offset:       1,
                    Limit:        100,
                    TotalRecords: 1,
                },
            },
        }
```
**After:**
```
    client_test.go:881: Successfully queried Volume using queryAsync API. queryVolumeAsyncTaskResult: &types.CnsAsyncQueryResult{
            CnsVolumeOperationResult: types.CnsVolumeOperationResult{},
            QueryResult:              types.CnsQueryResult{
                Volumes: []types.CnsVolume{
                    {
                        VolumeId: types.CnsVolumeId{
                            Id: "463f30aa-b698-4cab-8577-205f2a06bee0",
                        },
                        DatastoreUrl:    "ds:///vmfs/volumes/vsan:520e5afe58336876-6d9b508e67d14272/",
                        Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                        VolumeType:      "BLOCK",
                        StoragePolicyId: "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                        Metadata:        types.CnsVolumeMetadata{
                            ContainerCluster: types.CnsContainerCluster{
                                ClusterType:         "KUBERNETES",
                                ClusterId:           "demo-cluster-id",
                                VSphereUser:         "Administrator@vsphere.local",
                                ClusterFlavor:       "VANILLA",
                                ClusterDistribution: "OpenShift",
                            },
                            EntityMetadata: []types.BaseCnsEntityMetadata{
                                &types.CnsKubernetesEntityMetadata{
                                    CnsEntityMetadata: types.CnsEntityMetadata{
                                        EntityName: "example-pod",
                                        Labels:     nil,
                                        Delete:     false,
                                        ClusterID:  "demo-cluster-id",
                                    },
                                    EntityType:     "POD",
                                    Namespace:      "default",
                                    ReferredEntity: []types.CnsKubernetesEntityReference{
                                        {EntityType:"PERSISTENT_VOLUME_CLAIM", EntityName:"example-vanilla-block-pvc", Namespace:"default", ClusterID:"demo-cluster-id"},
                                    },
                                },
                                &types.CnsKubernetesEntityMetadata{
                                    CnsEntityMetadata: types.CnsEntityMetadata{
                                        EntityName: "example-vanilla-block-pvc",
                                        Labels:     []types.KeyValue{
                                            {
                                                Key:   "testLabel",
                                                Value: "testValue",
                                            },
                                        },
                                        Delete:    false,
                                        ClusterID: "demo-cluster-id",
                                    },
                                    EntityType:     "PERSISTENT_VOLUME_CLAIM",
                                    Namespace:      "default",
                                    ReferredEntity: []types.CnsKubernetesEntityReference{
                                        {EntityType:"PERSISTENT_VOLUME", EntityName:"pvc-53465372-5c12-4818-96f8-0ace4f4fd116", Namespace:"", ClusterID:"demo-cluster-id"},
                                    },
                                },
                                &types.CnsKubernetesEntityMetadata{
                                    CnsEntityMetadata: types.CnsEntityMetadata{
                                        EntityName: "pvc-53465372-5c12-4818-96f8-0ace4f4fd116",
                                        Labels:     []types.KeyValue{
                                            {
                                                Key:   "testLabel",
                                                Value: "testValue",
                                            },
                                        },
                                        Delete:    false,
                                        ClusterID: "demo-cluster-id",
                                    },
                                    EntityType:     "PERSISTENT_VOLUME",
                                    Namespace:      "",
                                    ReferredEntity: nil,
                                },
                            },
                            ContainerClusterArray: []types.CnsContainerCluster{
                                {
                                    ClusterType:         "KUBERNETES",
                                    ClusterId:           "demo-cluster-id",
                                    VSphereUser:         "Administrator@vsphere.local",
                                    ClusterFlavor:       "VANILLA",
                                    ClusterDistribution: "OpenShift",
                                },
                            },
                        },
                        BackingObjectDetails: &types.CnsBlockBackingDetails{
                            CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                                CapacityInMb: 10240,
                            },
                            BackingDiskId:      "463f30aa-b698-4cab-8577-205f2a06bee0",
                            BackingDiskUrlPath: "",
                        },
                        ComplianceStatus:             "compliant",
                        DatastoreAccessibilityStatus: "accessible",
                        HealthStatus:                 "green",
                    },
                },
                Cursor: types.CnsCursor{
                    Offset:       1,
                    Limit:        100,
                    TotalRecords: 1,
                },
            },
        }
    client_test.go:885: Deleting volume: [{DynamicData:{} Id:463f30aa-b698-4cab-8577-205f2a06bee0}]
    client_test.go:909: Volume: "463f30aa-b698-4cab-8577-205f2a06bee0" deleted sucessfully
--- PASS: TestClient (79.09s)
PASS
ok      github.com/vmware/govmomi/cns   79.353s

```

**Test Configuration**:
* Toolchain:
* SDK:
* (add more if needed)

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged