### PR TITLE
Fix host lookup in sim/vm/hostInMM

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -197,7 +197,9 @@ func (vm *VirtualMachine) event() types.VmEvent {
 }
 
 func (vm *VirtualMachine) hostInMM(ctx *Context) bool {
-	return ctx.Map.Get(*vm.Runtime.Host).(*HostSystem).Runtime.InMaintenanceMode
+	// TODO Change back to ctx.Map once it is determined why this
+	//      causes the expected behavior of CustomizeVM to fail.
+	return Map.Get(*vm.Runtime.Host).(*HostSystem).Runtime.InMaintenanceMode
 }
 
 func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {


### PR DESCRIPTION
## Description

This patch addresses an issue with the way the host is looked up for a VM in the simulator when CustomizeVM_Task is called.
The previous logic used "ctx.Map", which should work, but for some reason this is resulting in unexpected behavior. Switching to the "Map" singleton fixes the issue, but it is something we will want to reexamine later as there is an effort to move away from this singleton.

Related to https://github.com/vmware/govmomi/pull/2557

Closes: NA

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```go
simulator.Test(func(ctx goctx.Context, client *vim25.Client) {
	remoteVM := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
	localVM := object.NewVirtualMachine(client, remoteVM.Reference())
	
	localHost, err := localVM.HostSystem(ctx)
	Expect(err).ToNot(HaveOccurred())
	Expect(localHost).ToNot(BeNil())
	task, err := localHost.EnterMaintenanceMode(ctx, 0, false, nil)
	Expect(err).ToNot(HaveOccurred())
	Expect(task.Wait(ctx)).To(Succeed())

	remoteHost := simulator.Map.Get(localHost.Reference()).(*simulator.HostSystem)
	Expect(remoteHost.Runtime.InMaintenanceMode).To(BeTrue())

	// call CustomizeVM using localVM, and expect the returned task
	// to complete with an error of InvalidState. Instead the task
	// succeeds unless the provided patch is used
})
```

**Test Configuration**:
* Toolchain: Go 1.16
* SDK: NA

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged