### PR TITLE
govc: Add feature to read file contents for ExtraConfig

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -4962,6 +4962,8 @@ Examples:
   # Enable both cpu and memory hotplug on a guest:
   govc vm.change -vm $vm -cpu-hot-add-enabled -memory-hot-add-enabled
   govc vm.change -vm $vm -e guestinfo.vmname $vm
+  # Read the contents of a file and use them as ExtraConfig value
+  govc vm.change -vm $vm -f guestinfo.data="$(realpath .)/vmdata.config"
   # Read the variable set above inside the guest:
   vmware-rpctool "info-get guestinfo.vmname"
   govc vm.change -vm $vm -latency high
@@ -4976,6 +4978,7 @@ Options:
   -cpu.reservation=<nil>         CPU reservation in MHz
   -cpu.shares=                   CPU shares level or number
   -e=[]                          ExtraConfig. <key>=<value>
+  -f=[]                          ExtraConfig. <key>=<absolute file path>
   -g=                            Guest OS
   -latency=                      Latency sensitivity (low|normal|high)
   -m=0                           Size in MB of memory

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -142,6 +142,7 @@ load test_helper
   assert_line "Memory: 1024MB"
   assert_line "CPU: 2 vCPU(s)"
 
+  # test extraConfig
   run govc vm.change -e "guestinfo.a=1" -e "guestinfo.b=2" -vm $id
   assert_success
 
@@ -149,6 +150,18 @@ load test_helper
   assert_success
   assert_line "guestinfo.a: 1"
   assert_line "guestinfo.b: 2"
+
+  # test extraConfigFile
+  run govc vm.change -f "guestinfo.c=this_is_not_an_existing.file" -vm $id
+  assert_failure
+
+  echo -n "3" > "$BATS_TMPDIR/extraConfigFile.conf"
+  run govc vm.change -f "guestinfo.d=$BATS_TMPDIR/extraConfigFile.conf" -vm $id
+  assert_success
+
+  run govc vm.info -e $id
+  assert_success
+  assert_line "guestinfo.d: 3"
 
   run govc vm.change -sync-time-with-host=false -vm $id
   assert_success
@@ -418,6 +431,19 @@ load test_helper
   run govc vm.change -e "guestinfo.a=" -vm $id
   assert_success
   refute_line "guestinfo.a: 2"
+
+  # test extraConfigFile
+  run govc vm.change -f "guestinfo.b=this_is_not_an_existing.file" -vm $id
+  assert_failure
+  echo -n "3" > "$BATS_TMPDIR/extraConfigFile.conf"
+  run govc vm.change -f "guestinfo.b=$BATS_TMPDIR/extraConfigFile.conf" -vm $id
+  assert_success
+  run govc vm.info -e $id
+  assert_success
+  assert_line "guestinfo.b: 3"
+  run govc vm.change -f "guestinfo.b=" -vm $id
+  assert_success
+  refute_line "guestinfo.b: 3"
 
   # test optional bool Config
   run govc vm.change -nested-hv-enabled=true -vm "$id"


### PR DESCRIPTION
## Description

The `vm.change` command allows setting extra values via `-e`, however, they have to be inline and are, hence, subject to the `getconf ARG_MAX` value of the local shell. To allow larger contents, e.g. for Fedora CoreOS Ignition configs, providing a file path and processing it internally is required.

Closes: #2488

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

I added some bats tests in `govc/test/vm.bats` similar to the existing extraConfig tests. Don't have a (local) ESX instance I can use to run the tests, though 🤷‍♂️ . Also I am not sure whether I can simply turn on the the GitHub Actions and have them run the tests for me. Would it be possible for you guys to add a pull request workflow that does run all tests?

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged