### PR TITLE
chore: Cancel in-progress workflows on newer changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,12 +13,19 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: ["main", "master"]
+    
+  # The branches below must be a subset of the branches above
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: ["main", "master"]
+    
   schedule:
     - cron: '30 23 * * 6'
+
+# cancel any in-progress job or run on changes
+concurrency: 
+  group: join(github.head_ref,github.workflow,'-'')
+  cancel-in-progress: true
 
 jobs:
   analyze:

--- a/.github/workflows/govmomi-build.yaml
+++ b/.github/workflows/govmomi-build.yaml
@@ -27,6 +27,11 @@ on:
   
   workflow_dispatch:
 
+# cancel any in-progress job or run on changes
+concurrency: 
+  group: join(github.head_ref,github.workflow,'-'')
+  cancel-in-progress: true
+
 jobs:
   artifacts:
     name: Build Snapshot Release (no upload)

--- a/.github/workflows/govmomi-check-wip.yaml
+++ b/.github/workflows/govmomi-check-wip.yaml
@@ -19,6 +19,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+# cancel any in-progress job or run on changes
+concurrency: 
+  group: join(github.head_ref,github.workflow,'-'')
+  cancel-in-progress: true
+
 jobs:
   wip:
     runs-on: ubuntu-latest

--- a/.github/workflows/govmomi-go-lint.yaml
+++ b/.github/workflows/govmomi-go-lint.yaml
@@ -21,6 +21,11 @@ on:
   pull_request:
     branches: [ 'main', 'master' ]
 
+# cancel any in-progress job or run on changes
+concurrency: 
+  group: join(github.head_ref,github.workflow,'-'')
+  cancel-in-progress: true
+
 jobs:
 
   lint:

--- a/.github/workflows/govmomi-go-tests.yaml
+++ b/.github/workflows/govmomi-go-tests.yaml
@@ -21,6 +21,11 @@ on:
   pull_request:
     branches: [ 'main', 'master' ]
 
+# cancel any in-progress job or run on changes
+concurrency: 
+  group: join(github.head_ref,github.workflow,'-'')
+  cancel-in-progress: true
+
 jobs:
   go-tests:
     name: Run Unit Tests

--- a/.github/workflows/govmomi-govc-tests.yaml
+++ b/.github/workflows/govmomi-govc-tests.yaml
@@ -21,6 +21,11 @@ on:
   pull_request:
     branches: ["main", "master"]
 
+# cancel any in-progress job or run on changes
+concurrency: 
+  group: join(github.head_ref,github.workflow,'-'')
+  cancel-in-progress: true
+
 jobs:
   govc-tests:
     name: Run govc Tests


### PR DESCRIPTION
## Description

Closes: #2601
Signed-off-by: Michael Gasch <mgasch@vmware.com>

> When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled. To also cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.

https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] Test Description 1
- [ ] Test Description 2

**Test Configuration**:
* Toolchain:
* SDK:
* (add more if needed)

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged