### PR TITLE
fix: avoid use of vNIC IP in guest.TransferURL if there are multiple

### DIFF
--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -17,9 +17,11 @@ limitations under the License.
 package internal
 
 import (
+	"net"
 	"path"
 
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 // InventoryPath composed of entities by Name
@@ -35,4 +37,27 @@ func InventoryPath(entities []mo.ManagedEntity) string {
 	}
 
 	return val
+}
+
+func HostSystemManagementIPs(config []types.VirtualNicManagerNetConfig) []net.IP {
+	var ips []net.IP
+
+	for _, nc := range config {
+		if nc.NicType != string(types.HostVirtualNicManagerNicTypeManagement) {
+			continue
+		}
+		for ix := range nc.CandidateVnic {
+			for _, selectedVnicKey := range nc.SelectedVnic {
+				if nc.CandidateVnic[ix].Key != selectedVnicKey {
+					continue
+				}
+				ip := net.ParseIP(nc.CandidateVnic[ix].Spec.Ip.IpAddress)
+				if ip != nil {
+					ips = append(ips, ip)
+				}
+			}
+		}
+	}
+
+	return ips
 }

--- a/internal/helpers_test.go
+++ b/internal/helpers_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/vmware/govmomi/internal"
+	"github.com/vmware/govmomi/simulator/esx"
+)
+
+func TestHostSystemManagementIPs(t *testing.T) {
+	ips := internal.HostSystemManagementIPs(esx.HostSystem.Config.VirtualNicManagerInfo.NetConfig)
+
+	if len(ips) != 1 {
+		t.Fatalf("no mgmt ip found")
+	}
+	if ips[0].String() != "127.0.0.1" {
+		t.Fatalf("Expected management ip %s, got %s", "127.0.0.1", ips[0].String())
+	}
+}

--- a/object/host_system.go
+++ b/object/host_system.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/vmware/govmomi/internal"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -81,24 +82,7 @@ func (h HostSystem) ManagementIPs(ctx context.Context) ([]net.IP, error) {
 		return nil, err
 	}
 
-	var ips []net.IP
-	for _, nc := range mh.Config.VirtualNicManagerInfo.NetConfig {
-		if nc.NicType != string(types.HostVirtualNicManagerNicTypeManagement) {
-			continue
-		}
-		for ix := range nc.CandidateVnic {
-			for _, selectedVnicKey := range nc.SelectedVnic {
-				if nc.CandidateVnic[ix].Key != selectedVnicKey {
-					continue
-				}
-				ip := net.ParseIP(nc.CandidateVnic[ix].Spec.Ip.IpAddress)
-				if ip != nil {
-					ips = append(ips, ip)
-				}
-			}
-		}
-	}
-	return ips, nil
+	return internal.HostSystemManagementIPs(mh.Config.VirtualNicManagerInfo.NetConfig), nil
 }
 
 func (h HostSystem) Disconnect(ctx context.Context) (*Task, error) {


### PR DESCRIPTION
## Description

InitiateFileTransfer{To,From}Guest methods return an ESX host's inventory name (HostSystem.Name).
This name was used to add the host to vCenter and cannot be changed
(unless the host is removed from inventory and added back with another name).
The name used when adding to VC may not resolvable by this client's DNS, so we prefer an ESX management IP.
However, if there is more than one management vNIC, we don't know which IP(s) the client has a route to.
Leave the hostname as-is in that case or if the env var has disabled the preference.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added new tests to file_manager_test.go

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged