### PR TITLE
chore: Remove -i parameter in go install

### DIFF
--- a/program.mk
+++ b/program.mk
@@ -33,7 +33,7 @@ $(PROGRAM):
 	CGO_ENABLED=0 go build -a $(BUILD_ARGS) -o $@
 
 install:
-	CGO_ENABLED=0 go install -i -v $(BUILD_ARGS)
+	CGO_ENABLED=0 go install -v $(BUILD_ARGS)
 
 ifneq (,$(strip $(BUILD_OS)))
 ifneq (,$(strip $(BUILD_ARCH)))


### PR DESCRIPTION
## Description

Closes: #2608
Recent go versions throw go install: -i flag is deprecated

Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [x] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] `make install` does not throw warning anymore

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged