### PR TITLE
Set custom HTTP headers for VAPI calls

### DIFF
--- a/vapi/internal/internal.go
+++ b/vapi/internal/internal.go
@@ -44,6 +44,7 @@ const (
 	VCenterVM                      = "/vcenter/vm"
 	SessionCookieName              = "vmware-api-session-id"
 	UseHeaderAuthn                 = "vmware-use-header-authn"
+	DebugEcho                      = "/vc-sim/debug/echo"
 )
 
 // AssociatedObject is the same structure as types.ManagedObjectReference,

--- a/vapi/rest/client.go
+++ b/vapi/rest/client.go
@@ -135,12 +135,30 @@ func (c *Client) WithSigner(ctx context.Context, s Signer) context.Context {
 	return context.WithValue(ctx, signerContext{}, s)
 }
 
+type headersContext struct{}
+
+// WithHeader returns a new Context populated with the provided headers map.
+// Calls to a VAPI REST client with this context will populate the HTTP headers
+// map using the provided headers.
+func (c *Client) WithHeader(
+	ctx context.Context,
+	headers http.Header) context.Context {
+
+	return context.WithValue(ctx, headersContext{}, headers)
+}
+
 type statusError struct {
 	res *http.Response
 }
 
 func (e *statusError) Error() string {
 	return fmt.Sprintf("%s %s: %s", e.res.Request.Method, e.res.Request.URL, e.res.Status)
+}
+
+// RawResponse may be used with the Do method as the resBody argument in order
+// to capture the raw response data.
+type RawResponse struct {
+	bytes.Buffer
 }
 
 // Do sends the http.Request, decoding resBody if provided.
@@ -159,6 +177,14 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 	if s, ok := ctx.Value(signerContext{}).(Signer); ok {
 		if err := s.SignRequest(req); err != nil {
 			return err
+		}
+	}
+
+	if headers, ok := ctx.Value(headersContext{}).(http.Header); ok {
+		for k, v := range headers {
+			for _, v := range v {
+				req.Header.Add(k, v)
+			}
 		}
 	}
 
@@ -183,6 +209,8 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 		}
 
 		switch b := resBody.(type) {
+		case *RawResponse:
+			return res.Write(b)
 		case io.Writer:
 			_, err := io.Copy(b, res.Body)
 			return err

--- a/vapi/rest/client_test.go
+++ b/vapi/rest/client_test.go
@@ -17,10 +17,15 @@ limitations under the License.
 package rest_test
 
 import (
+	"bytes"
 	"context"
+	"io/ioutil"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/internal"
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
 
@@ -52,6 +57,56 @@ func TestSession(t *testing.T) {
 
 		if session == nil {
 			t.Fatal("expected non-nil session")
+		}
+	})
+}
+
+func TestWithHeaders(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		c := rest.NewClient(vc)
+		if err := c.Login(ctx, simulator.DefaultLogin); err != nil {
+			t.Fatal(err)
+		}
+
+		// Assign the headers.
+		ctx = c.WithHeader(ctx, http.Header{
+			"client-token": []string{"unique-token"},
+			"pid":          []string{"2", "3", "4"},
+		})
+
+		req, err := http.NewRequest(
+			http.MethodPost,
+			c.Resource(internal.DebugEcho).String(),
+			strings.NewReader("Hello, world."))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Send a rest.RawResponse into the decoder to capture the raw
+		// response data.
+		var res rest.RawResponse
+		if err := c.Do(ctx, req, &res); err != nil {
+			t.Fatal(err)
+		}
+
+		// Read the raw response.
+		data, err := ioutil.ReadAll(&res.Buffer)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Assert all of the request headers were echoed back to the client.
+		if !bytes.Contains(data, []byte("Client-Token: unique-token")) {
+			t.Fatal("missing Client-Token: unique-token")
+		}
+		if !bytes.Contains(data, []byte("Pid: 2")) {
+			t.Fatal("missing Pid: 2")
+		}
+		if !bytes.Contains(data, []byte("Pid: 3")) {
+			t.Fatal("missing Pid: 3")
+		}
+		if !bytes.Contains(data, []byte("Pid: 4")) {
+			t.Fatal("missing Pid: 4")
 		}
 	})
 }

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -154,6 +154,7 @@ func New(u *url.URL, settings []vim.BaseOptionValue) (string, http.Handler) {
 		{internal.VCenterVMTXLibraryItem, s.libraryItemCreateTemplate},
 		{internal.VCenterVMTXLibraryItem + "/", s.libraryItemTemplateID},
 		{internal.VCenterVM + "/", s.vmID},
+		{internal.DebugEcho, s.debugEcho},
 	}
 
 	for i := range handlers {
@@ -2094,4 +2095,8 @@ func (s *handler) vmID(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.NotFound(w, r)
 	}
+}
+
+func (s *handler) debugEcho(w http.ResponseWriter, r *http.Request) {
+	r.Write(w)
 }


### PR DESCRIPTION
## Description

This patch adds support for setting custom HTTP headers when using the VAPI REST client. This is useful for setting header tokens in order to make specific calls idempotent, like the one for deploying a VM from an OVF in content library.

Closes: NA

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [x] Added a unit test to `vapi/rest/client_test.go` that validates the client headers are successfully passed to the server.

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged