### PR TITLE
fix: multi-value query params for vAPI methods

### DIFF
--- a/vapi/rest/resource.go
+++ b/vapi/rest/resource.go
@@ -52,7 +52,7 @@ func (r *Resource) WithAction(action string) *Resource {
 func (r *Resource) WithParam(name string, value string) *Resource {
 	// ParseQuery handles empty case, and we control access to query string so shouldn't encounter an error case
 	params, _ := url.ParseQuery(r.u.RawQuery)
-	params[name] = []string{value}
+	params[name] = append(params[name], value)
 	r.u.RawQuery = params.Encode()
 	return r
 }

--- a/vapi/rest/resource_test.go
+++ b/vapi/rest/resource_test.go
@@ -42,5 +42,12 @@ func TestResource_WithParam(t *testing.T) {
 		if !strings.Contains(url.String(), expectedPath) {
 			t.Errorf("Param incorrectly updated on resource, URL %q, expected path %q", url.String(), expectedPath)
 		}
+
+		url = c.Resource("api/some/resource")
+		url = url.WithParam("names", "foo").WithParam("names", "bar")
+		expectedPath = "api/some/resource?names=foo&names=bar"
+		if !strings.Contains(url.String(), expectedPath) {
+			t.Errorf("Param incorrectly updated on resource, URL %q, expected path %q", url.String(), expectedPath)
+		}
 	})
 }


### PR DESCRIPTION
## Description

vAPI methods can have multi-value query params, but the vapi/rest.Resource helper was setting to a single value.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged