### PR TITLE
Implement mo.Reference interface in task+event managers

### DIFF
--- a/event/example_test.go
+++ b/event/example_test.go
@@ -24,8 +24,12 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
+
+// ensure event.Manager implements the mo.Reference interface
+var _ mo.Reference = new(event.Manager)
 
 func ExampleManager_Events() {
 	simulator.Run(func(ctx context.Context, c *vim25.Client) error {

--- a/event/manager.go
+++ b/event/manager.go
@@ -50,6 +50,11 @@ func NewManager(c *vim25.Client) *Manager {
 	return &m
 }
 
+// Reference returns the event.Manager MOID
+func (m Manager) Reference() types.ManagedObjectReference {
+	return m.r
+}
+
 func (m Manager) Client() *vim25.Client {
 	return m.c
 }

--- a/task/manager.go
+++ b/task/manager.go
@@ -23,6 +23,11 @@ func NewManager(c *vim25.Client) *Manager {
 	return &m
 }
 
+// Reference returns the task.Manager MOID
+func (m Manager) Reference() types.ManagedObjectReference {
+	return m.r
+}
+
 // CreateCollectorForTasks returns a task history collector, a specialized
 // history collector that gathers TaskInfo data objects.
 func (m Manager) CreateCollectorForTasks(ctx context.Context, filter types.TaskFilterSpec) (*HistoryCollector, error) {

--- a/task/wait_test.go
+++ b/task/wait_test.go
@@ -19,8 +19,12 @@ package task
 import (
 	"testing"
 
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
+
+// ensure task.Manager implements the mo.Reference interface
+var _ mo.Reference = new(Manager)
 
 func TestCallbackFn(t *testing.T) {
 	cb := &taskCallback{}


### PR DESCRIPTION
## Description

Prior to #2535 both managers implemented mo.Reference via the embedded 'object.Common' field,
but that field was removed.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged