### PR TITLE
Refactor EAM code to use BaseAgencyConfigInfo interface instead of impl

### DIFF
--- a/eam/mo/agency.go
+++ b/eam/mo/agency.go
@@ -27,7 +27,7 @@ type Agency struct {
 	EamObject `yaml:",inline"`
 
 	Agent      []vim.ManagedObjectReference `json:"agent,omitempty"`
-	Config     types.AgencyConfigInfo       `json:"config"`
+	Config     types.BaseAgencyConfigInfo   `json:"config"`
 	Runtime    types.EamObjectRuntimeInfo   `json:"runtime"`
 	SolutionId string                       `json:"solutionId,omitempty"`
 }

--- a/eam/mo/agent.go
+++ b/eam/mo/agent.go
@@ -20,8 +20,8 @@ import (
 	"github.com/vmware/govmomi/eam/types"
 )
 
-// Agenct is the vSphere ESX Agent Manager managed object responsible
-// fordeploying an Agency on a single host. The Agent maintains the state
+// Agent is the vSphere ESX Agent Manager managed object responsible
+// for deploying an Agency on a single host. The Agent maintains the state
 // of the current deployment in its runtime information
 type Agent struct {
 	EamObject `yaml:",inline"`

--- a/eam/object/agency.go
+++ b/eam/object/agency.go
@@ -54,14 +54,14 @@ func (m Agency) Agents(ctx context.Context) ([]Agent, error) {
 	return objs, nil
 }
 
-func (m Agency) Config(ctx context.Context) (*types.AgencyConfigInfo, error) {
+func (m Agency) Config(ctx context.Context) (types.BaseAgencyConfigInfo, error) {
 	resp, err := methods.QueryConfig(ctx, m.c, &types.QueryConfig{
 		This: m.r,
 	})
 	if err != nil {
 		return nil, err
 	}
-	return resp.Returnval.GetAgencyConfigInfo(), nil
+	return resp.Returnval, nil
 }
 
 func (m Agency) Runtime(ctx context.Context) (*types.EamObjectRuntimeInfo, error) {
@@ -154,10 +154,11 @@ func (m Agency) UnregisterAgentVm(
 
 func (m Agency) Update(
 	ctx context.Context,
-	config types.AgencyConfigInfo) error {
+	config types.BaseAgencyConfigInfo) error {
 
 	_, err := methods.Update(ctx, m.c, &types.Update{
-		This: m.r,
+		This:   m.r,
+		Config: config,
 	})
 	if err != nil {
 		return err

--- a/eam/object/agency_test.go
+++ b/eam/object/agency_test.go
@@ -76,7 +76,7 @@ func TestAgency(t *testing.T) {
 	)
 	var (
 		agency       object.Agency
-		agencyConfig = types.AgencyConfigInfo{
+		agencyConfig = &types.AgencyConfigInfo{
 			AgencyName: t.Name(),
 			AgentName:  t.Name(),
 			AgentConfig: []types.AgentConfigInfo{
@@ -135,10 +135,11 @@ func TestAgency(t *testing.T) {
 	testConfig := func(t *testing.T) {
 		t.Parallel()
 
-		config, err := agency.Config(client.ctx)
+		baseConfig, err := agency.Config(client.ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
+		config := baseConfig.GetAgencyConfigInfo()
 		if config.AgencyName != agencyConfig.AgencyName {
 			t.Fatalf(
 				"unexpected agency name: exp=%v, act=%v",

--- a/eam/object/esx_agent_manager.go
+++ b/eam/object/esx_agent_manager.go
@@ -41,13 +41,13 @@ func NewEsxAgentManager(c *eam.Client, ref vim.ManagedObjectReference) EsxAgentM
 
 func (m EsxAgentManager) CreateAgency(
 	ctx context.Context,
-	config types.AgencyConfigInfo,
+	config types.BaseAgencyConfigInfo,
 	initialGoalState string) (Agency, error) {
 
 	var agency Agency
 	resp, err := methods.CreateAgency(ctx, m.c, &types.CreateAgency{
 		This:             m.r,
-		AgencyConfigInfo: config.GetAgencyConfigInfo(),
+		AgencyConfigInfo: config,
 		InitialGoalState: initialGoalState,
 	})
 	if err != nil {

--- a/eam/simulator/agency.go
+++ b/eam/simulator/agency.go
@@ -43,9 +43,10 @@ type Agency struct {
 // EsxAgentManager object.
 func NewAgency(
 	ctx *simulator.Context,
-	agencyConfig types.AgencyConfigInfo,
+	baseAgencyConfig types.BaseAgencyConfigInfo,
 	initialGoalState string) (*Agency, vim.BaseMethodFault) {
 
+	agencyConfig := baseAgencyConfig.GetAgencyConfigInfo()
 	if agencyConfig.AgentName == "" {
 		agencyConfig.AgentName = agencyConfig.AgencyName
 	}
@@ -197,7 +198,7 @@ func (m *Agency) QueryConfig(
 
 	return &methods.QueryConfigBody{
 		Res: &types.QueryConfigResponse{
-			Returnval: &m.Config,
+			Returnval: m.Config,
 		},
 	}
 }
@@ -237,7 +238,7 @@ func (m *Agency) Update(
 	ctx *simulator.Context,
 	req *types.Update) soap.HasFault {
 
-	m.Config = *req.Config.GetAgencyConfigInfo()
+	m.Config = req.Config
 
 	return &methods.UpdateBody{
 		Res: &types.UpdateResponse{},

--- a/eam/simulator/esx_agent_manager.go
+++ b/eam/simulator/esx_agent_manager.go
@@ -39,7 +39,7 @@ func (m *EsxAgentManager) CreateAgency(
 
 	if agency, err := NewAgency(
 		ctx,
-		*req.AgencyConfigInfo.GetAgencyConfigInfo(),
+		req.AgencyConfigInfo,
 		req.InitialGoalState); err != nil {
 
 		res.Fault_ = simulator.Fault("", err)

--- a/eam/simulator/simulator_test.go
+++ b/eam/simulator/simulator_test.go
@@ -161,7 +161,7 @@ func TestSimulator(t *testing.T) {
 		t.Log("creating a new agency")
 		agency, err := mgr.CreateAgency(
 			ctx,
-			types.AgencyConfigInfo{
+			&types.AgencyConfigInfo{
 				AgencyName: "nginx",
 				AgentVmDatastore: []vim.ManagedObjectReference{
 					datastore.Reference(),

--- a/eam/simulator/utils.go
+++ b/eam/simulator/utils.go
@@ -47,10 +47,10 @@ func getAgentVMPlacementOptions(
 	ctx *simulator.Context,
 	reg *simulator.Registry,
 	r *rand.Rand, i int,
-	agencyConfig types.AgencyConfigInfo) (AgentVMPlacementOptions, error) {
+	baseAgencyConfig types.BaseAgencyConfigInfo) (AgentVMPlacementOptions, error) {
 
 	var opts AgentVMPlacementOptions
-
+	agencyConfig := baseAgencyConfig.GetAgencyConfigInfo()
 	if l := len(agencyConfig.AgentVmDatastore); l == 0 {
 		return opts, agentVmDatastoreEmptyErr
 	} else if l == len(agencyConfig.AgentConfig) {


### PR DESCRIPTION
## Description

With this change we are updating some EAM API wrappers and simulator code to use the newly introduced `BaseAgencyConfigInfo` instead of its implementation - `AgencyConfigInfo`.

Closes: #2622

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

```
╭─ ~/Documents/VMware/fork/govmomi/eam  on issue-2622 
╰─ go test ./...                                                                                                                                                                                       ─╯
?       github.com/vmware/govmomi/eam   [no test files]
?       github.com/vmware/govmomi/eam/internal  [no test files]
?       github.com/vmware/govmomi/eam/methods   [no test files]
?       github.com/vmware/govmomi/eam/mo        [no test files]
ok      github.com/vmware/govmomi/eam/object    0.433s
ok      github.com/vmware/govmomi/eam/simulator 0.828s
?       github.com/vmware/govmomi/eam/types     [no test files]

```
```
make lint
make install
make test (some tests in simulator/ fail on MacOS with Go 1.16.3)
```

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged