### PR TITLE
Support finding Portgroups by ID in Finder.Network

### DIFF
--- a/find/finder.go
+++ b/find/finder.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware/govmomi/list"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -789,9 +790,26 @@ func (f *Finder) NetworkList(ctx context.Context, path string) ([]object.Network
 	return ns, nil
 }
 
+// Network finds a NetworkReference using a Name, Inventory Path, ManagedObject ID, Logical Switch UUID or Segment ID.
+// With standard vSphere networking, Portgroups cannot have the same name within the same network folder.
+// With NSX, Portgroups can have the same name, even within the same Switch. In this case, using an inventory path
+// results in a MultipleFoundError. A MOID, switch UUID or segment ID can be used instead, as both are unique.
+// See also: https://kb.vmware.com/s/article/79872#Duplicate_names
+// Examples:
+// - Name:                "dvpg-1"
+// - Inventory Path:      "vds-1/dvpg-1"
+// - ManagedObject ID:    "DistributedVirtualPortgroup:dvportgroup-53"
+// - Logical Switch UUID: "da2a59b8-2450-4cb2-b5cc-79c4c1d2144c"
+// - Segment ID:          "/infra/segments/vnet_ce50e69b-1784-4a14-9206-ffd7f1f146f7"
 func (f *Finder) Network(ctx context.Context, path string) (object.NetworkReference, error) {
 	networks, err := f.NetworkList(ctx, path)
 	if err != nil {
+		if _, ok := err.(*NotFoundError); ok {
+			net, nerr := f.networkByID(ctx, path)
+			if nerr == nil {
+				return net, nil
+			}
+		}
 		return nil, err
 	}
 
@@ -800,6 +818,41 @@ func (f *Finder) Network(ctx context.Context, path string) (object.NetworkRefere
 	}
 
 	return networks[0], nil
+}
+
+func (f *Finder) networkByID(ctx context.Context, path string) (object.NetworkReference, error) {
+	if ref := object.ReferenceFromString(path); ref != nil {
+		// This is a MOID
+		return object.NewReference(f.client, *ref).(object.NetworkReference), nil
+	}
+
+	kind := []string{"DistributedVirtualPortgroup"}
+
+	m := view.NewManager(f.client)
+	v, err := m.CreateContainerView(ctx, f.client.ServiceContent.RootFolder, kind, true)
+	if err != nil {
+		return nil, err
+	}
+	defer v.Destroy(ctx)
+
+	filter := property.Filter{
+		"config.logicalSwitchUuid": path,
+		"config.segmentId":         path,
+	}
+
+	refs, err := v.FindAny(ctx, kind, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(refs) == 0 {
+		return nil, &NotFoundError{"network", path}
+	}
+	if len(refs) > 1 {
+		return nil, &MultipleFoundError{"network", path}
+	}
+
+	return object.NewReference(f.client, refs[0]).(object.NetworkReference), nil
 }
 
 func (f *Finder) DefaultNetwork(ctx context.Context) (object.NetworkReference, error) {

--- a/property/filter.go
+++ b/property/filter.go
@@ -130,12 +130,36 @@ func (f Filter) MatchPropertyList(props []types.DynamicProperty) bool {
 	return len(f) == len(props) // false if a property such as VM "guest" is unset
 }
 
-// MatchObjectContent returns a list of ObjectContent.Obj where the ObjectContent.PropSet matches the Filter.
+// MatchObjectContent returns a list of ObjectContent.Obj where the ObjectContent.PropSet matches all properties the Filter.
 func (f Filter) MatchObjectContent(objects []types.ObjectContent) []types.ManagedObjectReference {
 	var refs []types.ManagedObjectReference
 
 	for _, o := range objects {
 		if f.MatchPropertyList(o.PropSet) {
+			refs = append(refs, o.Obj)
+		}
+	}
+
+	return refs
+}
+
+// MatchAnyPropertyList returns true if any given props match the Filter.
+func (f Filter) MatchAnyPropertyList(props []types.DynamicProperty) bool {
+	for _, p := range props {
+		if f.MatchProperty(p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// MatchAnyObjectContent returns a list of ObjectContent.Obj where the ObjectContent.PropSet matches any property in the Filter.
+func (f Filter) MatchAnyObjectContent(objects []types.ObjectContent) []types.ManagedObjectReference {
+	var refs []types.ManagedObjectReference
+
+	for _, o := range objects {
+		if f.MatchAnyPropertyList(o.PropSet) {
 			refs = append(refs, o.Obj)
 		}
 	}

--- a/simulator/entity.go
+++ b/simulator/entity.go
@@ -23,11 +23,12 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-func RenameTask(ctx *Context, e mo.Entity, r *types.Rename_Task) soap.HasFault {
+func RenameTask(ctx *Context, e mo.Entity, r *types.Rename_Task, dup ...bool) soap.HasFault {
 	task := CreateTask(e, "rename", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		obj := Map.Get(r.This).(mo.Entity).Entity()
 
-		if parent, ok := asFolderMO(Map.Get(*obj.Parent)); ok {
+		canDup := len(dup) == 1 && dup[0]
+		if parent, ok := asFolderMO(Map.Get(*obj.Parent)); ok && !canDup {
 			if Map.FindByName(r.NewName, parent.ChildEntity) != nil {
 				return nil, &types.InvalidArgument{InvalidProperty: "name"}
 			}

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -669,9 +669,9 @@ func (m *Model) Create() error {
 		for npg := 0; npg < m.PortgroupNSX; npg++ {
 			name := m.fmtName(dcName+"_NSXPG", npg)
 			spec := types.DVPortgroupConfigSpec{
-				Name:              name,
-				LogicalSwitchUuid: uuid.New().String(),
-				Type:              string(types.DistributedVirtualPortgroupPortgroupTypeEarlyBinding),
+				Name:        name,
+				Type:        string(types.DistributedVirtualPortgroupPortgroupTypeEarlyBinding),
+				BackingType: string(types.DistributedVirtualPortgroupBackingTypeNsx),
 			}
 
 			task, err := dvs.AddPortgroup(ctx, []types.DVPortgroupConfigSpec{spec})

--- a/simulator/portgroup.go
+++ b/simulator/portgroup.go
@@ -27,6 +27,12 @@ type DistributedVirtualPortgroup struct {
 	mo.DistributedVirtualPortgroup
 }
 
+func (s *DistributedVirtualPortgroup) RenameTask(ctx *Context, req *types.Rename_Task) soap.HasFault {
+	canDup := s.DistributedVirtualPortgroup.Config.BackingType == string(types.DistributedVirtualPortgroupBackingTypeNsx)
+
+	return RenameTask(ctx, s, req, canDup)
+}
+
 func (s *DistributedVirtualPortgroup) ReconfigureDVPortgroupTask(ctx *Context, req *types.ReconfigureDVPortgroup_Task) soap.HasFault {
 	task := CreateTask(s, "reconfigureDvPortgroup", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		s.Config.DefaultPortConfig = req.Spec.DefaultPortConfig

--- a/view/container_view.go
+++ b/view/container_view.go
@@ -126,3 +126,20 @@ func (v ContainerView) Find(ctx context.Context, kind []string, filter property.
 
 	return filter.MatchObjectContent(content), nil
 }
+
+// FindAny returns object references for entities of type kind, matching any property the given filter.
+func (v ContainerView) FindAny(ctx context.Context, kind []string, filter property.Filter) ([]types.ManagedObjectReference, error) {
+	if len(filter) == 0 {
+		// Ensure we have at least 1 filter to avoid retrieving all properties.
+		filter = property.Filter{"name": "*"}
+	}
+
+	var content []types.ObjectContent
+
+	err := v.Retrieve(ctx, kind, filter.Keys(), &content)
+	if err != nil {
+		return nil, err
+	}
+
+	return filter.MatchAnyObjectContent(content), nil
+}


### PR DESCRIPTION
## Description

With standard vSphere networking, Portgroups cannot have the same name within the same network folder.
With NSX, Portgroups can have the same name, even within the same Switch. In this case, using an inventory path
results in a MultipleFoundError. A MOID, switch UUID or segment ID can be used instead, as both are unique.

- Add ContainerView.FindAny method
- Add nsx backing and SegmentId defaults to the simulator for testing
- Add simulator support for renaming a Portgroup, only allowing nsx to have duplicate names

Note that applications using `Finder.Network` do not require any code changes to use this functionality. Only the go module dependency needs to be bumped to include this change.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- Added TestFindNetwork that uses Finder.Network with MOID, Switch UUID and Segment ID
- Added govc tests using the `-net` flags with MOID, Switch UUID and Segment ID

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged