### PR TITLE
Add notes to PR RELEASE workflow

### DIFF
--- a/.github/workflows/govmomi-release.yaml
+++ b/.github/workflows/govmomi-release.yaml
@@ -18,7 +18,6 @@ on:
   push:
     tags:
       - "v*" # Push events to matching v*, i.e. v0.25.0, v1.15.1
-  workflow_dispatch:
 
 jobs:
   release:
@@ -44,6 +43,15 @@ jobs:
           # generate CHANGELOG for this Github release tag only
           docker run --rm -v $PWD:/workdir ${IMAGE}@sha256:${IMAGE_SHA} -o RELEASE_CHANGELOG.md $(basename "${{ github.ref }}" )
 
+      - name: Archive CHANGELOG
+        uses: actions/upload-artifact@v2
+        continue-on-error: true
+        with:
+          name: CHANGELOG
+          path: |
+            ./RELEASE_CHANGELOG.md
+          retention-days: 14
+
       - name: Create Release and build/push Artifacts
         uses: goreleaser/goreleaser-action@v2
         env:
@@ -56,7 +64,7 @@ jobs:
     needs: release
     name: Create CHANGELOG.md PR
     runs-on: ubuntu-latest
-    continue-on-error: true # errors caused by this job won't stop workflow
+    continue-on-error: true
 
     steps:
       - name: Checkout
@@ -74,15 +82,23 @@ jobs:
         run: |
           # generate CHANGELOG for this Github release tag only
           docker run --rm -v $PWD:/workdir ${IMAGE}@sha256:${IMAGE_SHA} -o CHANGELOG.md -t .chglog/CHANGELOG.tpl.md v0.1.0..$(basename "${{ github.ref }}" )
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git config user.name "${{ github.actor }}"
-          git add CHANGELOG.md
-          git commit -m "Update CHANGELOG for $(basename ${{ github.ref }})"
 
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
+          commit-message: "Update CHANGELOG for ${{ github.ref }}"
           delete-branch: true
-          title: "Update CHANGELOG"
+          title: "Update CHANGELOG for ${{ github.ref }}"
+          signoff: true
+          reviewers: embano1,dougm
+          draft: false
           body: |
-            Update CHANGELOG.md for new release
+            Update CHANGELOG.md for new release.
+
+            **Note:** Due to a [limitation](https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#triggering-further-workflow-runs) in Github Actions please **close and immediately reopen** this PR to trigger the required workflow checks before merging.
+
+      - name: Pull Request Information
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
## Description

The `CHANGELOG` PR created by the bot during a release workflow run would not trigger repository workflows due to a limitation in GHA:

> When you use the repository's GITHUB_TOKEN to perform tasks on behalf of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not create a new workflow run.

In my opinion, out of the many workarounds, the simplest (and perhaps safest) solution for now is close/reopen the PR to trigger the workflows.

Changes:

- Add note how to resolve the above issue, i.e. by closing and reopening the CHANGELOG PR
- Add PR notes to workflow output
- Upload `RELEASE_CHANGELOG.md` artifact during run for later inspection (retention 14d)

Closes: #2629
Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [x] Build related change

## How Has This Been Tested?

Workflow tested in forked repo.

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged