### PR TITLE
vcsim: allow VM PowerOff when Host is in maintenance mode

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -1130,12 +1130,15 @@ load test_helper
   run govc object.collect -s vm/DC0_H0_VM0 guest.ipAddress
   assert_success 10.0.0.45
 
-  run govc vm.power -off DC0_H0_VM0
-  assert_success
-
   host=$(govc ls -L "$(govc object.collect -s vm/DC0_H0_VM0 runtime.host)")
   run govc host.maintenance.enter "$host"
   assert_success
+
+  run govc vm.power -off DC0_H0_VM0
+  assert_success
+
+  run govc vm.power -on DC0_H0_VM0
+  assert_failure # InvalidState
 
   run govc vm.customize -vm DC0_H0_VM0 -ip 10.0.0.45 -netmask 255.255.0.0 -type Linux
   assert_failure # InvalidState

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1445,10 +1445,6 @@ func (c *powerVMTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 		}
 	}
 
-	if c.VirtualMachine.hostInMM(c.ctx) {
-		return nil, new(types.InvalidState)
-	}
-
 	var boot types.AnyType
 	if c.state == types.VirtualMachinePowerStatePoweredOn {
 		boot = time.Now()
@@ -1457,6 +1453,10 @@ func (c *powerVMTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	event := c.event()
 	switch c.state {
 	case types.VirtualMachinePowerStatePoweredOn:
+		if c.VirtualMachine.hostInMM(c.ctx) {
+			return nil, new(types.InvalidState)
+		}
+
 		c.run.start(c.ctx, c.VirtualMachine)
 		c.ctx.postEvent(
 			&types.VmStartingEvent{VmEvent: event},


### PR DESCRIPTION
## Description

e67b1b1 prevented all VM power ops when host is in MM, we should only prevent PowerOn.

Issue #2633

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged