### PR TITLE
Fixes data race in simulator.EventManager.PostEvent

### DIFF
--- a/simulator/event_manager.go
+++ b/simulator/event_manager.go
@@ -39,9 +39,11 @@ var (
 type EventManager struct {
 	mo.EventManager
 
-	root       types.ManagedObjectReference
-	history    *list.List
-	key        int32
+	root types.ManagedObjectReference
+
+	history *list.List
+	key     int32
+
 	collectors map[types.ManagedObjectReference]*EventHistoryCollector
 	templates  map[string]*template.Template
 }


### PR DESCRIPTION
## Description

This PR introduces independent `simulator.Context` for the multiple tasks spawned by `PowerOnMultiVM`.

Closes: #2650

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] `make test`
- [ ] `TEST_COUNT=10 make test`

## Checklist:

- [ ] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged