### PR TITLE
fix: Distribute vcsim VMs across resource pools

### DIFF
--- a/simulator/finder_test.go
+++ b/simulator/finder_test.go
@@ -74,9 +74,9 @@ func TestFinderVPX(t *testing.T) {
 		{"DatacenterList", "/F0/*", 1},
 		{"DatacenterList", "/DC0", 1},
 		{"VirtualMachineList", "/DC0/vm/*", (m.Host + m.Cluster) * m.Machine},
-		{"VirtualMachineList", "F0/DC1_C0_RP0_VM0", 1},
-		{"VirtualMachineList", "./DC1_C0_RP0_VM0", 0},
-		{"VirtualMachineList", "DC1_C0_RP0_VM0", 1}, // find . -type VirtualMachine -name DC1_C0_RP0_VM0
+		{"VirtualMachineList", "F0/DC1_C0_RP1_VM0", 1},
+		{"VirtualMachineList", "./DC1_C0_RP1_VM0", 0},
+		{"VirtualMachineList", "DC1_C0_RP1_VM0", 1}, // find . -type VirtualMachine -name DC1_C0_RP0_VM0
 		{"VirtualAppList", "/DC0/vm/*", 0},
 		{"DatastoreList", "/DC0/datastore/*", m.Datastore},
 		{"DatastoreList", "./*", 0},
@@ -123,7 +123,7 @@ func TestFinderVPX(t *testing.T) {
 		{"DatacenterList", "/*", m.Datacenter - m.Folder},
 		{"DatacenterList", "/*/*", m.Folder},
 		{"DatastoreList", "/F1/DC2/datastore/F1/LocalDS_0", 1},
-		{"VirtualMachineList", "DC1_C0_RP0_VM0", 0}, // TODO: recurse all Datacenters?
+		{"VirtualMachineList", "DC1_C0_RP1_VM0", 0}, // TODO: recurse all Datacenters?
 	}
 
 	f := reflect.ValueOf(finder)

--- a/simulator/model_test.go
+++ b/simulator/model_test.go
@@ -26,7 +26,7 @@ func compareModel(t *testing.T, m *Model) {
 	count := m.Count()
 
 	hosts := (m.Host + (m.ClusterHost * m.Cluster)) * m.Datacenter
-	vms := ((m.Host + m.Cluster) * m.Datacenter) * m.Machine
+	vms := ((m.Host + m.Cluster + m.Pool) * m.Datacenter) * m.Machine
 	// child pools + root pools
 	pools := (m.Pool * m.Cluster * m.Datacenter) + (m.Host+m.Cluster)*m.Datacenter
 	// root folder + Datacenter folders {host,vm,datastore,network} + top-level folders

--- a/simulator/search_index_test.go
+++ b/simulator/search_index_test.go
@@ -160,9 +160,9 @@ func TestSearchIndexFindChild(t *testing.T) {
 		// Datacenter -> host Folder -> Cluster -> ResourcePool -> ResourcePool
 		{"DC0", "host", "DC0_C0", "Resources", "DC0_C0_RP1"},
 		// Datacenter -> host Folder -> Cluster -> ResourcePool -> VirtualMachine
-		{"DC0", "host", "DC0_C0", "Resources", "DC0_C0_RP0_VM0"},
+		{"DC0", "host", "DC0_C0", "Resources", "DC0_C0_RP1", "DC0_C0_RP1_VM0"},
 		// Datacenter -> vm Folder -> VirtualMachine
-		{"DC0", "vm", "DC0_C0_RP0_VM0"},
+		{"DC0", "vm", "DC0_C0_RP1_VM0"},
 	}
 
 	root := c.ServiceContent.RootFolder


### PR DESCRIPTION
This fix aligns the behavior of vcsim with the documentation for the
`pool` and `machine` model flags.

When no child pools are created, i.e. `pool` is not specified, VMs will
be deployed in the root resource pool of a cluster, i.e. `RP0`. The VMs
will also be prefixed with the corresponding resource pool. In order to
not break standalone host behavior, VMs deployed on a standalone host
will not carry a resource pool identifier in their name. See the linked
issue for deployment examples and naming.

The total number of VMs deployed in a VPX model is the result of the
number of datacenters, clusters and resource pools.

BREAKING:

The name of virtual machines deployed in `vcsim` in a cluster (and
optionally child resource pools) has changed to include the
corresponding resource pool name. VM names deployed to standalone hosts
in `vcsim` are not changed.

Closes: #2047
Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] make test passes
- [x] make govc-test passes

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged