### PR TITLE
Fix: Deep compare errors in simulator VM tests

### DIFF
--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -491,7 +491,7 @@ func TestVAppConfigAdd(t *testing.T) {
 			}
 
 			err := vmm.updateVAppProperty(testCase.spec.VAppConfig.GetVmConfigSpec())
-			if err != testCase.expectedErr {
+			if !reflect.DeepEqual(err, testCase.expectedErr) {
 				t.Errorf("unexpected error in updating VApp property of VM. expectedErr: %v, actualErr: %v", testCase.expectedErr, err)
 			}
 
@@ -607,7 +607,7 @@ func TestVAppConfigEdit(t *testing.T) {
 			}
 
 			err := vmm.updateVAppProperty(testCase.spec.VAppConfig.GetVmConfigSpec())
-			if err != testCase.expectedErr {
+			if !reflect.DeepEqual(err, testCase.expectedErr) {
 				t.Errorf("unexpected error in updating VApp property of VM. expectedErr: %v, actualErr: %v", testCase.expectedErr, err)
 			}
 
@@ -680,6 +680,7 @@ func TestVAppConfigRemove(t *testing.T) {
 					},
 				},
 			},
+			expectedProps: []types.VAppPropertyInfo{},
 		},
 		{
 			description: "return error when a property that doesn't exist is removed",
@@ -711,7 +712,7 @@ func TestVAppConfigRemove(t *testing.T) {
 			}
 
 			err := vmm.updateVAppProperty(testCase.spec.VAppConfig.GetVmConfigSpec())
-			if err != testCase.expectedErr {
+			if !reflect.DeepEqual(err, testCase.expectedErr) {
 				t.Errorf("unexpected error in updating VApp property of VM. expectedErr: %v, actualErr: %v", testCase.expectedErr, err)
 			}
 


### PR DESCRIPTION
Modify the simulator VM VApp tests to deep compare expected and actual
errors.

## Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Existing tests.

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged