### PR TITLE
fix: avoid possible panic in HostSystem.ManagementIPs

### DIFF
--- a/object/host_system.go
+++ b/object/host_system.go
@@ -82,7 +82,17 @@ func (h HostSystem) ManagementIPs(ctx context.Context) ([]net.IP, error) {
 		return nil, err
 	}
 
-	return internal.HostSystemManagementIPs(mh.Config.VirtualNicManagerInfo.NetConfig), nil
+	config := mh.Config
+	if config == nil {
+		return nil, nil
+	}
+
+	info := config.VirtualNicManagerInfo
+	if info == nil {
+		return nil, nil
+	}
+
+	return internal.HostSystemManagementIPs(info.NetConfig), nil
 }
 
 func (h HostSystem) Disconnect(ctx context.Context) (*Task, error) {


### PR DESCRIPTION
## Description

If the HostSystem.Config or HostSystem.Config.VirtualNicManagerInfo fields are nil, the ManagementIPs method would panic.
I was not able to reproduce this situation in a real VC, even with disconnecting a host from VC.
Assuming this state is possible while an ESX host is being upgraded. Updated the test to nil both fields to ensure we don't panic.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged