### PR TITLE
fix: govc vcsa.net.proxy.info doesnt give output in json format

### DIFF
--- a/govc/vcsa/proxy/proxy.go
+++ b/govc/vcsa/proxy/proxy.go
@@ -64,8 +64,8 @@ Examples:
 }
 
 type proxyResult struct {
-	proxy   *vnetworking.ProxyList
-	noProxy []string
+	Proxy   *vnetworking.ProxyList
+	NoProxy []string
 }
 
 func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -93,10 +93,10 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 
 func (res proxyResult) Write(w io.Writer) error {
 	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
-	printProxyConfig("HTTP", res.proxy.Http, tw)
-	printProxyConfig("HTTPS", res.proxy.Https, tw)
-	printProxyConfig("FTP", res.proxy.Ftp, tw)
-	fmt.Fprintf(tw, "No Proxy addresses:\t%s\n", strings.Join(res.noProxy, ", "))
+	printProxyConfig("HTTP", res.Proxy.Http, tw)
+	printProxyConfig("HTTPS", res.Proxy.Https, tw)
+	printProxyConfig("FTP", res.Proxy.Ftp, tw)
+	fmt.Fprintf(tw, "No Proxy addresses:\t%s\n", strings.Join(res.NoProxy, ", "))
 
 	return tw.Flush()
 }


### PR DESCRIPTION
Closes: #2664

## Description

fix: govc vcsa.net.proxy.info doesnt give output in json format

Closes: #2664

Exposes components in `proxyResult` so that json encoder can output the information.

## Type of change

Please mark options that are relevant:

- Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Ran the unit tests in the package

```
zhusa@zhusa-a02 govmomi % go test
PASS
ok      github.com/vmware/govmomi       0.279s
zhusa@zhusa-a02 govmomi % cd govc
zhusa@zhusa-a02 govc % go test
PASS
ok      github.com/vmware/govmomi/govc  0.280s
```

Run govc vcsa.net.proxy.info to confirm the change works
```
zhusa@zhusa-a02 govc % ./govc vcsa.net.proxy.info --json=true -u administrator@vsphere.local@10.161.166.146
{
  "Proxy": {
    "ftp": {
      "port": -1
    },
    "http": {
      "server": "http://proxy.vmware.com",
      "port": 3128,
      "enabled": true
    },
    "https": {
      "port": -1
    }
  },
  "NoProxy": [
    "localhost",
    "127.0.0.1"
  ]
}
```

## Checklist:

- My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged