### PR TITLE
build: upgrade go directive in go.mod to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/vmware/govmomi
 
+go 1.17
+
 replace github.com/davecgh/go-xdr => github.com/rasky/go-xdr v0.0.0-20170217172119-4930550ba2e2
 
 replace github.com/kr/pretty v0.1.0 => github.com/dougm/pretty v0.0.0-20171025230240-2ee9d7453c02
@@ -9,8 +11,7 @@ require (
 	github.com/davecgh/go-xdr v0.0.0-20161123171359-e6a2ba005892
 	github.com/google/uuid v1.2.0
 	github.com/kr/pretty v0.1.0
-	github.com/kr/text v0.1.0 // indirect
 	github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728
 )
 
-go 1.14
+require github.com/kr/text v0.1.0 // indirect


### PR DESCRIPTION
## Description

This PR upgrades the `go` directive in `go.mod` file by running `go mod tidy -go=1.17` to enable [module graph pruning](https://golang.org/ref/mod#graph-pruning) and [lazy module loading](https://golang.org/ref/mod#lazy-loading) supported by Go 1.17 or higher.

**Note 1:** This does not prevent users with earlier Go versions from successfully building packages from this module.
**Note 2:** The additional `require` directive is used to record indirect dependencies by Go 1.17 or higher, see https://go.dev/ref/mod#go-mod-file-go.

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [x] Build related change

## How Has This Been Tested?

Manually tested by running `make test`.

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged