### PR TITLE
Add `IsAlreadyExists` error helper

### DIFF
--- a/vim25/types/fault.go
+++ b/vim25/types/fault.go
@@ -30,3 +30,14 @@ func IsFileNotFound(err error) bool {
 
 	return false
 }
+
+func IsAlreadyExists(err error) bool {
+	if f, ok := err.(HasFault); ok {
+		switch f.Fault().(type) {
+		case *AlreadyExists:
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## Description

Adds `types.IsAlreadyExists` helper to easily identify whether an error was thrown due to an object already existing.

Closes: #2675
Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] Test Description 1
- [ ] Test Description 2

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged