### PR TITLE
fix: govc vm.destroy only destroys the 1st argument

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -319,6 +319,12 @@ load test_helper
   # destroy powers off vm before destruction
   run govc vm.destroy $vm
   assert_success
+
+  run govc vm.destroy '*'
+  assert_success
+
+  run govc find / -type m
+  assert_success "" # expect all VMs are gone
 }
 
 @test "vm.create pvscsi" {

--- a/govc/vm/destroy.go
+++ b/govc/vm/destroy.go
@@ -101,7 +101,9 @@ func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
 			return err
 		}
 
-		return task.Wait(ctx)
+		if err = task.Wait(ctx); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Description

With PR #2532 , vm.destroy was returning after the 1st VM was destroyed.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged