### PR TITLE
vcsim: add support for cloning HostSystems

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -477,6 +477,16 @@ EOF
   objs=$(govc find / | wc -l)
   assert_equal 23 "$objs"
 
+  run govc cluster.add -cluster DC0_C0 -hostname DC0_C0_H0-clone -username DC0_C0_H0 -password pass -noverify
+  assert_success
+  objs=$(govc find / | wc -l)
+  assert_equal 24 "$objs"
+
+  run govc host.add -hostname DC0_H0-clone -username DC0_H0 -password pass -noverify
+  assert_success
+  objs=$(govc find / | wc -l)
+  assert_equal 27 "$objs" # ComputeResource + ResourcePool + HostSystem
+
   run govc host.portgroup.add -host DC0_H0 -vswitch vSwitch0 bridge
   assert_success # issue #2016
 }


### PR DESCRIPTION
## Description

The simulator.ClusterComputeResource.AddHost method uses the compiled in esx.HostSystem template by default,
as does simulator.AddStandaloneHost.
With this change, if the HostConnectSpec.UserName is that of a HostSystem.Name in the given Cluster or
of a standalone host, use that HostSystem as the template.

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged