### PR TITLE
govc: Require full or absolute paths

### DIFF
--- a/govc/flags/datacenter.go
+++ b/govc/flags/datacenter.go
@@ -203,6 +203,10 @@ func (flag *DatacenterFlag) ManagedObjects(ctx context.Context, args []string) (
 			continue
 		}
 
+		if !strings.Contains(arg, "/") {
+			return nil, fmt.Errorf("%q must be qualified with a path", arg)
+		}
+
 		elements, err := finder.ManagedObjectList(ctx, arg)
 		if err != nil {
 			return nil, err

--- a/govc/test/fields.bats
+++ b/govc/test/fields.bats
@@ -25,6 +25,10 @@ load test_helper
   key=$(govc fields.ls | grep $field | awk '{print $1}')
 
   val="foo"
+
+  run govc fields.set $field $val $vm_id
+  assert_failure
+
   run govc fields.set $field $val vm/$vm_id
   assert_success
 


### PR DESCRIPTION
## Description

When using the object name instead of absolute/relative paths, e.g. in `govc field.set`, the finder could return duplicate objects. This change errors out if the specified (object) path is not absolute/relative.

Closes: 2561
Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Added `govc fields.set` test

## Checklist:

- [ ] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged