### PR TITLE
Helpers for enc/dec VIM objects to/from XML

### DIFF
--- a/vim25/xml/extras.go
+++ b/vim25/xml/extras.go
@@ -21,7 +21,10 @@ import (
 	"time"
 )
 
-var xmlSchemaInstance = Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"}
+// SchemaInstanceURI is the XML namespace URI for the schema instance.
+const SchemaInstanceURI = "http://www.w3.org/2001/XMLSchema-instance"
+
+var xmlSchemaInstance = Name{Space: SchemaInstanceURI, Local: "type"}
 
 var xsiType = Name{Space: "xsi", Local: "type"}
 

--- a/vim25/xml/util/README.md
+++ b/vim25/xml/util/README.md
@@ -1,0 +1,15 @@
+# XML Utilities
+
+This package provides helper functions for marshaling/unmarshaling vim objects to and from XML across the various languages that have vSphere API clients, such as Golang and Python.
+
+## Notes
+
+* Does not need to know about the type of object being decoded ahead of time!
+* Can decode _multiple_ VIM objects from one XML string and return them into a channel.
+* Produces output compatible with the Python and Java SDKs for vSphere.
+
+## Examples
+
+* The directory [`./examples`](./examples) illustrates how to share VIM objects between Go and Python using XML!
+* The file [`util_examples_test.go`](util_examples_test.go) includes examples for how to decode/encode objects from/to XML using these new helper functions.
+* The file [`util_test.go`](util_test.go) includes even more examples of the new helper functions.

--- a/vim25/xml/util/examples/README.md
+++ b/vim25/xml/util/examples/README.md
@@ -1,0 +1,75 @@
+# Sharing VIM objects between Golang and Python using XML
+
+This directory includes several examples of how to share VIM objects between multiple languages, such as Golang and Python, by marshaling and unmarshaling those objects to and from XML.
+
+# Requirements
+
+* Golang 1.16+
+* Python 3.9+
+* PyVmomi (use `pip3 install --user pyvmomi` to make sure you have the latest version)
+
+# Marshal a ConfigSpec to XML
+
+The following examples demonstrate how to marshal a simple `ConfigSpec` object to XML to stdout in Golang and Python:
+
+## Golang
+
+```bash
+$ go run main.go
+<obj xmlns:vim25="urn:vim25" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="vim25:VirtualMachineConfigSpec">
+  <name>go-vm</name>
+  <numCPUs>2</numCPUs>
+  <memoryMB>2048</memoryMB>
+</obj>
+```
+
+## Python
+
+```bash
+$ python3 main.py
+<?xml version="1.0" ?>
+<object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="urn:vim25" xsi:type="VirtualMachineConfigSpec">
+  <name>python-vm</name>
+  <numCPUs>2</numCPUs>
+  <memoryMB>2048</memoryMB>
+</object>
+```
+
+# Unmarshal XML to a ConfigSpec
+
+The following examples demonstrate how to unmarshal XML to a `ConfigSpec` and back to stdout in Golang and Python:
+
+## Golang
+
+Please note the output will reflect the name from the object created in Python, `python-vm`, which indicates the resource was:
+
+1. Marshaled to XML in Python
+1. Unmarshaled to XML in Go
+1. Marshaled _back_ to XML in Go
+
+```bash
+$ python3 main.py | go run main.go -
+<obj xmlns:vim25="urn:vim25" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="vim25:VirtualMachineConfigSpec">
+  <name>python-vm</name>
+  <numCPUs>2</numCPUs>
+  <memoryMB>2048</memoryMB>
+</obj>
+```
+
+## Python
+
+Please note the output will reflect the name from the object created in Go, `go-vm`, which indicates the resource was:
+
+1. Marshaled to XML in Go
+1. Unmarshaled to XML in Python
+1. Marshaled _back_ to XML in Python
+
+```bash
+$ go run main.go | python3 main.py -
+<?xml version="1.0" ?>
+<object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="urn:vim25" xsi:type="VirtualMachineConfigSpec">
+  <name>go-vm</name>
+  <numCPUs>2</numCPUs>
+  <memoryMB>2048</memoryMB>
+</object>
+```

--- a/vim25/xml/util/examples/main.go
+++ b/vim25/xml/util/examples/main.go
@@ -1,0 +1,55 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
+	"github.com/vmware/govmomi/vim25/xml/util"
+)
+
+func main() {
+	var objToXml interface{}
+
+	if len(os.Args) > 1 && os.Args[1] == "-" {
+		chanObj, chanErr := util.VimObjectsFromReader(os.Stdin)
+		select {
+		case obj := <-chanObj:
+			objToXml = obj
+		case err := <-chanErr:
+			log.Fatal(err)
+		}
+	} else {
+		objToXml = &types.VirtualMachineConfigSpec{
+			Name:     "go-vm",
+			NumCPUs:  2,
+			MemoryMB: 2048,
+		}
+	}
+
+	// Create an XML encoder so we can use pretty-printing for the XML.
+	enc := xml.NewEncoder(os.Stdout)
+	enc.Indent("", "  ")
+
+	if err := util.VimObjectsToEncoder(enc, objToXml); err != nil {
+		log.Fatal(err)
+	}
+	os.Stdout.Write([]byte{10})
+}

--- a/vim25/xml/util/examples/main.py
+++ b/vim25/xml/util/examples/main.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+"""
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from os import linesep;
+from sys import argv, stdin;
+from xml.dom import minidom;
+
+from pyVmomi import SoapAdapter;
+from pyVmomi import vim;
+
+objToXml = None
+
+# If the program is invoked with a "-" command line argument then decode stdin.
+# Otherwise create a new vim.vm.ConfigSpec.
+if len(argv) > 1 and argv[1] == "-":
+    objToXml = SoapAdapter.Deserialize(stdin.buffer)
+else:
+    objToXml = vim.vm.ConfigSpec()
+    objToXml.name = "python-vm"
+    objToXml.numCPUs = 2
+    objToXml.memoryMB = 2048
+
+# Serialize the object to an XML string.
+xmlStr = SoapAdapter.SerializeToUnicode(objToXml)
+
+# Prettify the XML string.
+xmlDom = minidom.parseString(xmlStr)
+xmlStr = xmlDom.toprettyxml(indent="  ")
+xmlStr = linesep.join([s for s in xmlStr.splitlines() if s.strip()])
+
+# Print the XML string.
+print(xmlStr)

--- a/vim25/xml/util/util.go
+++ b/vim25/xml/util/util.go
@@ -1,0 +1,243 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package util implements some helper functions for marshaling/unmarshaling
+// vim objects to/from XML.
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
+)
+
+// VimObjectsFromBytes returns all vim objects decoded from the provided bytes.
+//
+// This is a helper function that wraps VimObjectsFromDecoder. Please see
+// the documentation on VimObjectsFromDecoder for additional information.
+func VimObjectsFromBytes(v []byte) (<-chan interface{}, <-chan error) {
+	return VimObjectsFromReader(bytes.NewReader(v))
+}
+
+// VimObjectsFromString returns all vim objects decoded from the provided
+// string.
+//
+// This is a helper function that wraps VimObjectsFromDecoder. Please see
+// the documentation on VimObjectsFromDecoder for additional information.
+func VimObjectsFromString(v string) (<-chan interface{}, <-chan error) {
+	return VimObjectsFromReader(strings.NewReader(v))
+}
+
+// VimObjectsFromReader returns all vim objects decoded from the provided input
+// stream.
+//
+// This is a helper function that wraps VimObjectsFromDecoder. Please see
+// the documentation on VimObjectsFromDecoder for additional information.
+func VimObjectsFromReader(r io.Reader) (<-chan interface{}, <-chan error) {
+	return VimObjectsFromDecoder(xml.NewDecoder(r))
+}
+
+// VimObjectsFromDecoder returns all vim objects from the provided decoder.
+//
+// Any decode errors are sent on the error channel.
+//
+// Both channels are closed when io.EOF is reached.
+//
+// The decoder's TypeFunc is used to construct types from their XML data.
+// If the decoder's TypeFunc is nil then vim25.TypeFunc is used.
+func VimObjectsFromDecoder(d *xml.Decoder) (<-chan interface{}, <-chan error) {
+
+	var (
+		chanObj = make(chan interface{})
+		chanErr = make(chan error)
+	)
+
+	// If the decoder did not provide a TypeFunc then use the one from the
+	// vim25.types package.
+	if d.TypeFunc == nil {
+		d.TypeFunc = types.TypeFunc()
+	}
+
+	// Returns the value of the "xsi:type" attribute if it exists, otherwise
+	// the value of the "type" attribute, otherwise an empty string.
+	getVimTypeName := func(attrs []xml.Attr) string {
+		var vimTypeName string
+		for _, a := range attrs {
+			if a.Name.Local == "type" {
+				if a.Name.Space == xml.SchemaInstanceURI {
+					vimTypeName = a.Value
+				} else if vimTypeName == "" {
+					vimTypeName = a.Value
+				}
+			}
+		}
+		return vimTypeName
+	}
+
+	// Decode the input stream in the background, returning tokens/errors on
+	// the chanObj and chanErr channels.
+	go func() {
+
+		defer func() {
+			// Once there are no more tokens and/or an error occurred, the loop
+			// will exit. At this point we should notify readers by closing the
+			// channels to indicate the operation has completed.
+			close(chanObj)
+			close(chanErr)
+		}()
+
+		// Keep iterating until there are no more tokens.
+		for {
+
+			// Get the next token.
+			tok, err := d.Token()
+
+			// If there are no more tokens then break out othe loop.
+			if tok == nil && err == io.EOF {
+				return
+			}
+
+			// If there was an error then send that over the channel and jump to
+			// the next iteration of the loop.
+			if err != nil {
+				chanErr <- err
+				continue
+			}
+
+			// If the token is not a start element then we can jump to the next
+			// iteration of the loop.
+			startElement, ok := tok.(xml.StartElement)
+			if !ok {
+				continue
+			}
+
+			// If there is no vim type name then jump to the next iteration of
+			// the loop.
+			vimTypeName := getVimTypeName(startElement.Attr)
+			if vimTypeName == "" {
+				continue
+			}
+
+			// At this point we have what looks like an XML element with a vim
+			// type name, so let's try and get that from the registered lookup
+			// function.
+			//
+			// If we cannot find a registered type with that name then we send
+			// an error over the channel and jump to the next iteration of the
+			// loop.
+			vimType, ok := d.TypeFunc(vimTypeName)
+			if !ok {
+				chanErr <- fmt.Errorf("vim type not found: %s", vimTypeName)
+				continue
+			}
+
+			// Create a new object from the vim type.
+			vimObj := reflect.New(vimType).Interface()
+
+			// Try to decode the element into the new vim object. If this
+			// operation fails then the entire decode function must cease here
+			// because the position of the underlying stream is not advanced
+			// until the object can be decoded successfully.
+			if err := d.DecodeElement(vimObj, &startElement); err != nil {
+				chanErr <- err
+				return
+			}
+
+			// Send the decoded object into the channel.
+			chanObj <- vimObj
+		}
+	}()
+
+	return chanObj, chanErr
+}
+
+// VimObjectsToBytes marshals the provided vim objects to XML and returns the
+// result as a byte slice.
+//
+// This is a helper function that wraps VimObjectsToEncoder. Please see
+// the documentation on VimObjectsToEncoder for additional information.
+func VimObjectsToBytes(objs ...interface{}) ([]byte, error) {
+	w := &bytes.Buffer{}
+	if err := VimObjectsToWriter(w, objs...); err != nil {
+		return nil, err
+	}
+	return w.Bytes(), nil
+}
+
+// VimObjectsToString marshals the provided vim objects to XML and returns the
+// result as a string.
+//
+// This is a helper function that wraps VimObjectsToEncoder. Please see
+// the documentation on VimObjectsToEncoder for additional information.
+func VimObjectsToString(objs ...interface{}) (string, error) {
+	w := &bytes.Buffer{}
+	if err := VimObjectsToWriter(w, objs...); err != nil {
+		return "", err
+	}
+	return w.String(), nil
+}
+
+// VimObjectsToWriter marshals the provided vim objects to XML using the
+// provided io.Writer.
+//
+// This is a helper function that wraps VimObjectsToEncoder. Please see
+// the documentation on VimObjectsToEncoder for additional information.
+func VimObjectsToWriter(w io.Writer, objs ...interface{}) error {
+	return VimObjectsToEncoder(xml.NewEncoder(w), objs...)
+}
+
+// VimObjectsToEncoder marshals vim objects using an xml.Encoder so the result
+// can be unmarshaled by other vSphere SDKs, such as Java, Python, Ruby, etc.
+func VimObjectsToEncoder(e *xml.Encoder, objs ...interface{}) error {
+
+	for i := range objs {
+		vimTypeName := fmt.Sprintf(
+			"%s:%s",
+			vim25.Namespace,
+			reflect.TypeOf(objs[i]).Elem().Name())
+
+		startElement := xml.StartElement{
+			Name: xml.Name{
+				Local: "obj",
+			},
+			Attr: []xml.Attr{
+				{
+					Name:  xml.Name{Local: "xmlns:" + vim25.Namespace},
+					Value: "urn:" + vim25.Namespace,
+				},
+				{
+					Name:  xml.Name{Local: "xmlns:xsi"},
+					Value: xml.SchemaInstanceURI,
+				},
+				{
+					Name:  xml.Name{Local: "xsi:type"},
+					Value: vimTypeName,
+				},
+			},
+		}
+		if err := e.EncodeElement(objs[i], startElement); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vim25/xml/util/util_examples_test.go
+++ b/vim25/xml/util/util_examples_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package util implements some helper functions for marshaling/unmarshaling
+// vim objects to/from XML.
+package util_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
+	"github.com/vmware/govmomi/vim25/xml/util"
+)
+
+func ExampleVimObjectsFromString() {
+	const vimObjects = `
+<obj xmlns:vim25="urn:vim25"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="vim25:VirtualMachineConfigSpec">
+    <name>go-vm</name>
+    <numCPUs>2</numCPUs>
+    <memoryMB>2048</memoryMB>
+</obj>
+<obj xmlns:vim25="urn:vim25"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="vim25:VirtualMachineConfigInfo">
+    <name>go-vm</name>
+    <version>vmx-07</version>
+    <guestId>dosGuest</guestId>
+    <hardware>
+        <numCPU>2</numCPU>
+        <memoryMB>2048</memoryMB>
+    </hardware>
+</obj>
+`
+
+	// Decode all of the objects from the XML string.
+	chanObj, chanErr := util.VimObjectsFromString(vimObjects)
+
+	// For each object we see, print its type and information about it, along
+	// with any errors that occur along the way.
+	for {
+		select {
+		case obj, ok := <-chanObj:
+			if !ok {
+				return
+			}
+			fmt.Printf("%T\n", obj)
+			switch t := obj.(type) {
+			case *types.VirtualMachineConfigInfo:
+				fmt.Printf("  name:    %s\n", t.Name)
+				fmt.Printf("  numCPU:  %d\n", t.Hardware.NumCPU)
+				fmt.Printf("  memMiB:  %d\n", t.Hardware.MemoryMB)
+				fmt.Printf("  version: %s\n", t.Version)
+				fmt.Printf("  guestID: %s\n", t.GuestId)
+			case *types.VirtualMachineConfigSpec:
+				fmt.Printf("  name:   %s\n", t.Name)
+				fmt.Printf("  numCPU: %d\n", t.NumCPUs)
+				fmt.Printf("  memMiB: %d\n", t.MemoryMB)
+			}
+		case err, ok := <-chanErr:
+			if !ok {
+				return
+			}
+			fmt.Println(err)
+		}
+	}
+
+	// Output:
+	// *types.VirtualMachineConfigSpec
+	//   name:   go-vm
+	//   numCPU: 2
+	//   memMiB: 2048
+	// *types.VirtualMachineConfigInfo
+	//   name:    go-vm
+	//   numCPU:  2
+	//   memMiB:  2048
+	//   version: vmx-07
+	//   guestID: dosGuest
+}
+
+func ExampleVimObjectsToEncoder() {
+	vimObjs := []interface{}{
+		&types.VirtualMachineConfigInfo{
+			Name:    "MyFirstVM",
+			GuestId: "dosGuest",
+			Version: "vmx-07",
+			Hardware: types.VirtualHardware{
+				NumCPU:   2,
+				MemoryMB: 2048,
+			},
+		},
+		&types.VirtualMachineConfigSpec{
+			Name:     "MyFirstVM",
+			NumCPUs:  2,
+			MemoryMB: 2048,
+		},
+	}
+
+	// Create an XML encoder so we can use pretty-printing for the XML.
+	enc := xml.NewEncoder(os.Stdout)
+	enc.Indent("", "  ")
+
+	// Encode the objects to stdout.
+	util.VimObjectsToEncoder(enc, vimObjs...)
+
+	// Print a trailing \n character.
+	os.Stdout.Write([]byte{10})
+
+	// Output:
+	// <obj xmlns:vim25="urn:vim25" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="vim25:VirtualMachineConfigInfo">
+	//   <changeVersion></changeVersion>
+	//   <modified>0001-01-01T00:00:00Z</modified>
+	//   <name>MyFirstVM</name>
+	//   <guestFullName></guestFullName>
+	//   <version>vmx-07</version>
+	//   <uuid></uuid>
+	//   <template>false</template>
+	//   <guestId>dosGuest</guestId>
+	//   <alternateGuestName></alternateGuestName>
+	//   <files></files>
+	//   <flags></flags>
+	//   <defaultPowerOps></defaultPowerOps>
+	//   <hardware>
+	//     <numCPU>2</numCPU>
+	//     <memoryMB>2048</memoryMB>
+	//   </hardware>
+	// </obj>
+	// <obj xmlns:vim25="urn:vim25" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="vim25:VirtualMachineConfigSpec">
+	//   <name>MyFirstVM</name>
+	//   <numCPUs>2</numCPUs>
+	//   <memoryMB>2048</memoryMB>
+	// </obj>
+}

--- a/vim25/xml/util/util_test.go
+++ b/vim25/xml/util/util_test.go
@@ -1,0 +1,435 @@
+/*
+Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package util implements some helper functions for marshaling/unmarshaling
+// vim objects to/from XML.
+package util_test
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
+	"github.com/vmware/govmomi/vim25/xml/util"
+)
+
+type testCaseKind uint8
+
+const (
+	testCaseFrom testCaseKind = 1 << iota
+	testCaseTo
+)
+
+var (
+	testCases = []struct {
+		name string
+		data string
+		objs []interface{}
+		errs []error
+		kind testCaseKind
+	}{
+		{
+			name: "Single valid vim.vm.ConfigSpec",
+			kind: testCaseFrom | testCaseTo,
+			data: vimVmConfigSpecSmall,
+			objs: []interface{}{
+				&types.VirtualMachineConfigSpec{
+					NumCPUs:  2,
+					MemoryMB: 2048,
+				},
+			},
+		},
+		{
+			name: "Multiple valid vim.vm.ConfigSpec",
+			kind: testCaseFrom | testCaseTo,
+			data: vimVmConfigSpecSmallAndMed,
+			objs: []interface{}{
+				&types.VirtualMachineConfigSpec{
+					NumCPUs:  2,
+					MemoryMB: 2048,
+				},
+				&types.VirtualMachineConfigSpec{
+					NumCPUs:  4,
+					MemoryMB: 4096,
+				},
+			},
+		},
+		{
+			name: "Single invalid vim.vm.ConfigSpec",
+			kind: testCaseFrom,
+			data: vimVmConfigSpecInvalidEndElement,
+			errs: []error{
+				&xml.SyntaxError{
+					Line: 6,
+					Msg:  "element <obj> closed by </obj1>",
+				},
+			},
+		},
+		{
+			name: "Single valid vim.vm.ConfigInfo",
+			kind: testCaseFrom | testCaseTo,
+			data: vimVmConfigInfoSmall,
+			objs: []interface{}{
+				&types.VirtualMachineConfigInfo{
+					Name:    "MyFirstVM",
+					GuestId: "dosGuest",
+					Version: "vmx-07",
+					Hardware: types.VirtualHardware{
+						NumCPU:   2,
+						MemoryMB: 2048,
+						Device: []types.BaseVirtualDevice{
+							&types.VirtualSCSIController{
+								VirtualController: types.VirtualController{
+									BusNumber: 1,
+									VirtualDevice: types.VirtualDevice{
+										Key: -1,
+									},
+								},
+								ScsiCtlrUnitNumber: 1,
+								SharedBus:          types.VirtualSCSISharingNoSharing,
+							},
+							&types.VirtualDisk{
+								VirtualDevice: types.VirtualDevice{
+									Key:           -2,
+									ControllerKey: -1,
+									Backing:       &types.VirtualDiskFlatVer2BackingInfo{},
+								},
+								CapacityInKB: 51200,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestVimObjectsFrom(t *testing.T) {
+
+	// Please note only the FromBytes and FromString variants are directly
+	// tested. This is because they both in turn invoke FromReader which in
+	// turn invokes FromDecoder. This means both FromBytes and FromString
+	// provide coverage for FromReader and FromDecoder.
+	methods := []struct {
+		name string
+	}{
+		{name: "Bytes"},
+		{name: "String"},
+	}
+
+	for i := range methods {
+		m := methods[i]
+
+		t.Run(m.name, func(t *testing.T) {
+
+			for j := range testCases {
+				c := testCases[j]
+
+				// Only run supported test cases.
+				if c.kind&testCaseFrom == 0 {
+					continue
+				}
+
+				t.Run(c.name, func(t *testing.T) {
+					var (
+						chanObj <-chan interface{}
+						chanErr <-chan error
+					)
+					switch m.name {
+					case "Bytes":
+						chanObj, chanErr = util.VimObjectsFromBytes([]byte(c.data))
+					case "String":
+						chanObj, chanErr = util.VimObjectsFromString(c.data)
+
+					}
+
+					// Get the decoded objects and any errors that occurred.
+					objs, errs := getVimObjectsAndErrors(chanObj, chanErr)
+
+					// Validate the expected errors.
+					if e, a := len(c.errs), len(errs); e != a {
+						t.Errorf("invalid error count: exp=%d, act=%d", e, a)
+					}
+					for i := range c.errs {
+						if e, a := c.errs[i].Error(), errs[i].Error(); e != a {
+							t.Errorf("unxpected error: exp=%s, act=%s", e, a)
+						}
+					}
+
+					// Validate the expected objects.
+					if e, a := len(c.objs), len(objs); e != a {
+						t.Errorf("invalid object count: exp=%d, act=%d", e, a)
+					}
+					for i := range c.objs {
+						e, a := c.objs[i], objs[i]
+						if err := compareVimObjects(e, a); err != nil {
+							t.Error(err)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestVimObjectsTo(t *testing.T) {
+
+	// Please note only the ToBytes and ToString variants are directly
+	// tested. This is because they both in turn invoke ToWriter which in
+	// turn invokes ToEncoder. This means both ToBytes and ToString
+	// provide coverage for ToWriter and ToEncoder.
+	methods := []struct {
+		name string
+	}{
+		{name: "String"},
+		{name: "Bytes"},
+	}
+
+	for i := range methods {
+		m := methods[i]
+
+		t.Run(m.name, func(t *testing.T) {
+
+			for j := range testCases {
+				c := testCases[j]
+
+				// Only run supported test cases.
+				if c.kind&testCaseTo == 0 {
+					continue
+				}
+
+				t.Run(c.name, func(t *testing.T) {
+
+					var (
+						aval string
+						aerr error
+					)
+
+					switch m.name {
+					case "Bytes":
+						var b []byte
+						b, aerr = util.VimObjectsToBytes(c.objs...)
+						if len(b) > 0 {
+							aval = string(b)
+						}
+					case "String":
+						aval, aerr = util.VimObjectsToString(c.objs...)
+					}
+
+					if len(c.errs) > 0 {
+						if aerr == nil {
+							t.Errorf("invalid error count: exp=1, act=0")
+						} else if e, a := c.errs[0].Error(), aerr.Error(); e != a {
+							t.Errorf("unxpected error: exp=%s, act=%s", e, a)
+						}
+					}
+
+					if len(c.data) > 0 {
+						if e, a := trimXMLWhiteSpace(c.data), aval; e != a {
+							t.Errorf("invalid xml string: exp=%s, act=%s", e, a)
+						}
+					} else {
+						t.Log(aval)
+					}
+				})
+			}
+		})
+	}
+}
+
+func getVimObjectsAndErrors(
+	chanObj <-chan interface{},
+	chanErr <-chan error) (objs []interface{}, errs []error) {
+
+	for {
+		select {
+		case v, ok := <-chanObj:
+			if !ok {
+				return
+			}
+			objs = append(objs, v)
+		case v, ok := <-chanErr:
+			if !ok {
+				return
+			}
+			errs = append(errs, v)
+		}
+	}
+}
+
+func compareVimObjects(e, a interface{}) error {
+
+	// eqFn is used to determine if e and a are equal and is dependent upon the
+	// type of vim object.
+	var eqFn func() error
+
+	switch tA := a.(type) {
+	case *types.VirtualMachineConfigInfo:
+		eqFn = func() error {
+			return compareVimVmConfigInfos(
+				e.(*types.VirtualMachineConfigInfo),
+				tA,
+			)
+		}
+	case *types.VirtualMachineConfigSpec:
+		eqFn = func() error {
+			return compareVimVmConfigSpecs(
+				e.(*types.VirtualMachineConfigSpec),
+				tA,
+			)
+		}
+	default:
+		return fmt.Errorf("unexpected type: %T", a)
+	}
+
+	typeE, typeA := reflect.TypeOf(e), reflect.TypeOf(a)
+	if typeE != typeA {
+		return fmt.Errorf("invalid type: exp=%s, act=%s", typeE, typeA)
+	}
+
+	return eqFn()
+}
+
+func compareVimVmConfigSpecs(e, a *types.VirtualMachineConfigSpec) error {
+	if e, a := e.NumCPUs, a.NumCPUs; e != a {
+		return fmt.Errorf("invalid num cpu: exp: %d, act: %d", e, a)
+	}
+	if e, a := e.MemoryMB, a.MemoryMB; e != a {
+		return fmt.Errorf("invalid mem mib: exp: %d, act: %d", e, a)
+	}
+
+	return nil
+}
+
+func compareVimVmConfigInfos(e, a *types.VirtualMachineConfigInfo) error {
+	if e, a := e.Name, a.Name; e != a {
+		return fmt.Errorf("invalid name: exp: %s, act: %s", e, a)
+	}
+	if e, a := e.GuestId, a.GuestId; e != a {
+		return fmt.Errorf("invalid guestID: exp: %s, act: %s", e, a)
+	}
+
+	he, ha := e.Hardware, a.Hardware
+	if e, a := he.NumCPU, ha.NumCPU; e != a {
+		return fmt.Errorf("invalid hardware.numCPU: exp: %d, act: %d", e, a)
+	}
+	if e, a := he.MemoryMB, ha.MemoryMB; e != a {
+		return fmt.Errorf("invalid hardware.memoryMB: exp: %d, act: %d", e, a)
+	}
+
+	if e, a := len(he.Device), len(ha.Device); e != a {
+		return fmt.Errorf("invalid device count: exp=%d, act=%d", e, a)
+	}
+	for i := range he.Device {
+		hed, had := he.Device[i], ha.Device[i]
+		hev, hav := hed.GetVirtualDevice(), had.GetVirtualDevice()
+		if hev == nil {
+			return fmt.Errorf("exp virtual device is nil")
+		}
+		if hav == nil {
+			return fmt.Errorf("act virtual device is nil")
+		}
+		if e, a := hev.Key, hav.Key; e != a {
+			return fmt.Errorf("invalid deviceKey: exp: %d, act: %d", e, a)
+		}
+	}
+
+	return nil
+}
+
+var (
+	wsInBetweenLTGTRx   = regexp.MustCompile(`>\s+?<`)
+	wsAtBeginningOfLine = regexp.MustCompile(`(?m)^\s{2,}`)
+)
+
+func trimXMLWhiteSpace(s string) string {
+	s = wsAtBeginningOfLine.ReplaceAllString(s, " ")
+	s = strings.ReplaceAll(s, "\n", "")
+	s = wsInBetweenLTGTRx.ReplaceAllString(s, "><")
+	return s
+}
+
+func ptrToInt64(i int64) *int64 {
+	return &i
+}
+
+const (
+	vimVmConfigSpecSmall = `
+<obj xmlns:vim25="urn:vim25"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="vim25:VirtualMachineConfigSpec">
+    <numCPUs>2</numCPUs>
+    <memoryMB>2048</memoryMB>
+</obj>
+`
+	vimVmConfigSpecMed = `
+<obj xmlns:vim25="urn:vim25"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="vim25:VirtualMachineConfigSpec">
+    <numCPUs>4</numCPUs>
+    <memoryMB>4096</memoryMB>
+</obj>
+`
+
+	vimVmConfigSpecSmallAndMed = vimVmConfigSpecSmall + vimVmConfigSpecMed
+
+	vimVmConfigSpecInvalidEndElement = `
+<obj xmlns:vim25="urn:vim25"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="vim25:VirtualMachineConfigSpec">
+    <numCPUs>4</numCPUs>
+    <memoryMB>4096</memoryMB>
+</obj1>
+`
+
+	vimVmConfigInfoSmall = `
+<obj xmlns:vim25="urn:vim25"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="vim25:VirtualMachineConfigInfo">
+    <changeVersion></changeVersion>
+    <modified>0001-01-01T00:00:00Z</modified>
+    <name>MyFirstVM</name>
+    <guestFullName></guestFullName>
+    <version>vmx-07</version>
+    <uuid></uuid>
+    <template>false</template>
+    <guestId>dosGuest</guestId>
+    <alternateGuestName></alternateGuestName>
+    <files></files>
+    <flags></flags>
+    <defaultPowerOps></defaultPowerOps>
+    <hardware>
+        <numCPU>2</numCPU>
+        <memoryMB>2048</memoryMB>
+        <device xmlns:XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" XMLSchema-instance:type="VirtualSCSIController">
+            <key>-1</key>
+            <busNumber>1</busNumber>
+            <sharedBus>noSharing</sharedBus>
+            <scsiCtlrUnitNumber>1</scsiCtlrUnitNumber>
+        </device>
+        <device xmlns:XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" XMLSchema-instance:type="VirtualDisk">
+            <key>-2</key>
+            <backing XMLSchema-instance:type="VirtualDiskFlatVer2BackingInfo">
+                <fileName></fileName>
+                <diskMode></diskMode>
+            </backing>
+            <controllerKey>-1</controllerKey>
+            <capacityInKB>51200</capacityInKB>
+        </device>
+    </hardware>
+</obj>
+`
+)


### PR DESCRIPTION
## Description

This patch provides several new helper functions for encoding/decoding VIM objects to/from XML:

* The decoder functions can return multiple VIM objects from a `string`, `byte` slice, `io.Reader`, or `xml.Decoder`, all without needing to know the type of the objects in advance!
* The encoder functions produce output that is consumable by other vSphere SDKs for Java and Python.
* The file [`util_examples_test.go`](https://github.com/akutz/govmomi/blob/feature/xml-helpers/vim25/xml/util/util_examples_test.go) includes two examples for using the encoder and decoder functions.
* The file [`util_test.go`](https://github.com/akutz/govmomi/blob/feature/xml-helpers/vim25/xml/util/util_test.go) provides 100% code coverage!
* The directory [`vim25/xml/util/examples`](https://github.com/akutz/govmomi/blob/feature/xml-helpers/vim25/xml/util/examples) includes code and documentation that illustrates how to use the new helper functions to share VIM objects between Go and Python.

Closes: `na`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [x] Unit tests
- [x] Example tests
- [x] Documented (with code) use cases with Go and Python

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged