### PR TITLE
Added vm::ExportSnapshot and snapshot flag to export.ovf

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1837,8 +1837,8 @@ Options:
   -name=                 Specifies target name (defaults to source name)
   -prefix=true           Prepend target name to image filenames if missing
   -sha=0                 Generate manifest using SHA 1, 256, 512 or 0 to skip
-  -vm=                   Virtual machine [GOVC_VM]
   -snapshot=             Specifies a snapshot to export from (supports running VMs)
+  -vm=                   Virtual machine [GOVC_VM]
 ```
 
 ## extension.info

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1838,6 +1838,7 @@ Options:
   -prefix=true           Prepend target name to image filenames if missing
   -sha=0                 Generate manifest using SHA 1, 256, 512 or 0 to skip
   -vm=                   Virtual machine [GOVC_VM]
+  -snapshot=             Specifies a snapshot to export from (supports running VMs)
 ```
 
 ## extension.info

--- a/govc/export/ovf.go
+++ b/govc/export/ovf.go
@@ -24,12 +24,13 @@ import (
 	"crypto/sha512"
 	"flag"
 	"fmt"
-	"github.com/vmware/govmomi/object"
 	"hash"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/vmware/govmomi/object"
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -1063,3 +1063,16 @@ func (v VirtualMachine) QueryChangedDiskAreas(ctx context.Context, baseSnapshot,
 
 	return res.Returnval, nil
 }
+
+// ExportSnapshot exports all VMDK-files up to (but not including) a specified snapshot. This
+// is useful when exporting a running VM.
+func (v *VirtualMachine) ExportSnapshot(ctx context.Context, snapshot *types.ManagedObjectReference) (*nfc.Lease, error) {
+	req := types.ExportSnapshot{
+		This: *snapshot,
+	}
+	resp, err := methods.ExportSnapshot(ctx, v.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+	return nfc.NewLease(v.c, resp.Returnval), nil
+}


### PR DESCRIPTION
## Description

Added ExportSnapshot to object.VirtualMachine. Added a -snapshot flag to the govc export.ovf command. This allows users to export a running VM from a stable snapshot. Useful for backups etc.

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [x] Test harness against multiple live vCenters
- [x] Test using govc export.ovf and subsequent import.ovf

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works (simulator doesn't support this)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged