### PR TITLE
vcsim: Allow updating custom fields

### DIFF
--- a/simulator/object_test.go
+++ b/simulator/object_test.go
@@ -54,6 +54,7 @@ func TestObjectCustomFields(t *testing.T) {
 
 	fieldName := "testField"
 	fieldValue := "12345"
+	updatedFieldValue := "67890"
 
 	// Test that field is not created
 	err = vmm.SetCustomValue(ctx, fieldName, fieldValue)
@@ -113,37 +114,47 @@ func TestObjectCustomFields(t *testing.T) {
 		t.Fatalf("len(vm.AvailableField) expected 2, got %d", len(vm.AvailableField))
 	}
 
+	testFieldValues := func(want string) {
+		if len(vm.CustomValue) != 1 {
+			t.Fatalf("len(vm.CustomValue) expected 1, got %d", len(vm.CustomValue))
+		}
+
+		if len(vm.Value) != 1 {
+			t.Fatalf("len(vm.Value) expected 1, got %d", len(vm.Value))
+		}
+
+		if vm.CustomValue[0].(*types.CustomFieldStringValue).Key != field.Key {
+			t.Fatalf("vm.CustomValue[0].Key expected %d, got %d",
+				field.Key, vm.CustomValue[0].(*types.CustomFieldStringValue).Key)
+		}
+		if vm.CustomValue[0].(*types.CustomFieldStringValue).Value != want {
+			t.Fatalf("vm.CustomValue[0].Value expected %s, got %s",
+				want, vm.CustomValue[0].(*types.CustomFieldStringValue).Value)
+		}
+
+		if vm.Value[0].(*types.CustomFieldStringValue).Key != field.Key {
+			t.Fatalf("vm.Value[0].Key expected %d, got %d",
+				field.Key, vm.Value[0].(*types.CustomFieldStringValue).Key)
+		}
+		if vm.Value[0].(*types.CustomFieldStringValue).Value != want {
+			t.Fatalf("vm.Value[0].Value expected %s, got %s",
+				want, vm.Value[0].(*types.CustomFieldStringValue).Value)
+		}
+	}
+
 	// Set field
 	err = vmm.SetCustomValue(ctx, fieldName, fieldValue)
 	if err != nil {
 		t.Fatal(err)
 	}
+	testFieldValues(fieldValue)
 
-	if len(vm.CustomValue) != 1 {
-		t.Fatalf("len(vm.CustomValue) expected 1, got %d", len(vm.CustomValue))
+	// Update field
+	err = vmm.SetCustomValue(ctx, fieldName, updatedFieldValue)
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	if len(vm.Value) != 1 {
-		t.Fatalf("len(vm.Value) expected 1, got %d", len(vm.Value))
-	}
-
-	if vm.CustomValue[0].(*types.CustomFieldStringValue).Key != field.Key {
-		t.Fatalf("vm.CustomValue[0].Key expected %d, got %d",
-			field.Key, vm.CustomValue[0].(*types.CustomFieldStringValue).Key)
-	}
-	if vm.CustomValue[0].(*types.CustomFieldStringValue).Value != fieldValue {
-		t.Fatalf("vm.CustomValue[0].Value expected %s, got %s",
-			fieldValue, vm.CustomValue[0].(*types.CustomFieldStringValue).Value)
-	}
-
-	if vm.Value[0].(*types.CustomFieldStringValue).Key != field.Key {
-		t.Fatalf("vm.Value[0].Key expected %d, got %d",
-			field.Key, vm.Value[0].(*types.CustomFieldStringValue).Key)
-	}
-	if vm.Value[0].(*types.CustomFieldStringValue).Value != fieldValue {
-		t.Fatalf("vm.Value[0].Value expected %s, got %s",
-			fieldValue, vm.Value[0].(*types.CustomFieldStringValue).Value)
-	}
+	testFieldValues(updatedFieldValue)
 
 	// Rename field
 	newName := field.Name + "_renamed"


### PR DESCRIPTION
## Description

The govmomi simulator currently has unexpected behavior when trying to update the custom fields of a VM. Instead of replacing the old value with the new one, it creates a duplicate key with the new value. More details in https://github.com/vmware/govmomi/issues/2687

Closes: https://github.com/vmware/govmomi/issues/2687

I suggest ignoring whitespace when reviewing.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Updated relevant unit test to account for updating custom values.

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not needed)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged