### PR TITLE
fix: Add IPv6 support for signing HTTP request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,4 @@ require (
 	github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728
 )
 
-require github.com/kr/text v0.1.0 // indirect
+require	github.com/kr/text v0.1.0 // indirect

--- a/sts/signer_test.go
+++ b/sts/signer_test.go
@@ -133,4 +133,10 @@ func TestSigner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	req, _ = http.NewRequest(http.MethodPost, "https://[0:0:0:0:0:0:0:1]", nil)
+	err = s.SignRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
Closes: #2696

## Description
Hostname that's an IPv6 address is expected to be surrounded by square brackets (like in URL), however govmomi uses url.Hostname() which strips those square brackets: https://github.com/vmware/govmomi/blob/master/sts/signer.go#L281

https://pkg.go.dev/net/url#URL.Hostname says:
Hostname returns u.Host, stripping any valid port number if present.
If the result is enclosed in square brackets, as literal IPv6 addresses are, the square brackets are removed from the result.

This may lead to authentication failure for services that use govmomi. This change added the check for IPv6 host and add the brackets.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?
Previously, vCenter deployed with pure IPv6 failed to authenticate dcli request; after this change, the dcli request can be successfully authenticated.

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] Test Description 1
- [ ] Test Description 2

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
NA
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
```
ok  	github.com/vmware/govmomi/sts	0.291s	coverage: 47.1% of statements
```

Note: This test is failing before & after this change was made
```
guest_operations_manager_test.go:48: exit status 1
--- FAIL: TestFileInfo (0.02s)
```
- [ ] Any dependent changes have been merged
NA