### PR TITLE
vcsim: copy device list when cloning a VM

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -818,6 +818,16 @@ load test_helper
   backing=$(govc device.info -json -vm "$clone" disk-* | jq .Devices[].Backing)
   assert_equal true "$(jq .EagerlyScrub <<<"$backing")"
   assert_equal false "$(jq .ThinProvisioned <<<"$backing")"
+
+  # test that each vm has a unique vmdk path
+  for item in FileName Uuid;  do
+    items=$(govc object.collect -json -type m / config.hardware.device | \
+              jq ".ChangeSet[].Val.VirtualDevice[].Backing.$item | select(. != null)")
+
+    nitems=$(wc -l <<<"$items")
+    uitems=$(sort -u <<<"$items" | wc -l)
+    assert_equal "$nitems" "$uitems"
+  done
 }
 
 @test "vm.clone change resources" {

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1769,6 +1769,15 @@ type vmFolder interface {
 	CreateVMTask(ctx *Context, c *types.CreateVM_Task) soap.HasFault
 }
 
+func (vm *VirtualMachine) cloneDevice() []types.BaseVirtualDevice {
+	src := types.ArrayOfVirtualDevice{
+		VirtualDevice: vm.Config.Hardware.Device,
+	}
+	dst := types.ArrayOfVirtualDevice{}
+	deepCopy(src, &dst)
+	return dst.VirtualDevice
+}
+
 func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soap.HasFault {
 	pool := req.Spec.Location.Pool
 	if pool == nil {
@@ -1827,7 +1836,8 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 		config.VirtualSMCPresent = vm.Config.Hardware.VirtualSMCPresent
 
 		defaultDevices := object.VirtualDeviceList(esx.VirtualDevice)
-		devices := vm.Config.Hardware.Device
+		devices := vm.cloneDevice()
+
 		for _, device := range devices {
 			var fop types.VirtualDeviceConfigSpecFileOperation
 


### PR DESCRIPTION
Closes #2706

## Description

The vcsim CloneVM_Task method was sharing the config.hardware.device property
between the source and target VMs. The target VM now has a copy of the device
list so changes to it won't change the source VM's device list.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged