### PR TITLE
govc: Add support for VM hardware upgrade scheduling

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -5098,6 +5098,7 @@ Examples:
   govc vm.change -vm $vm -latency high
   govc vm.change -vm $vm -latency normal
   govc vm.change -vm $vm -uuid 4139c345-7186-4924-a842-36b69a24159b
+  govc vm.change -vm $vm -scheduled-hw-upgrade-policy always
 
 Options:
   -annotation=                   VM description
@@ -5118,6 +5119,7 @@ Options:
   -memory-pin=<nil>              Reserve all guest memory
   -name=                         Display name
   -nested-hv-enabled=<nil>       Enable nested hardware-assisted virtualization
+  -scheduled-hw-upgrade-policy=  Schedule hardware upgrade policy (onSoftPowerOff|never|always)
   -sync-time-with-host=<nil>     Enable SyncTimeWithHost
   -uuid=                         BIOS UUID
   -vm=                           Virtual machine [GOVC_VM]


### PR DESCRIPTION
## Description

This PR adds support for scheduling a hardware upgrade for a VM.

Closes: #2647

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?
I tested this on vcenter 6.7. Listed below are the results from upgrading vmx-13 to latest (vmx-15).

Query current version:
```
./govc vm.info -u <vcenter> -dc <datacenter> -json <vm> | jq '.[]? | .[]? | .Config.Version'
"vmx-13"
```

Query current policy:
```
./govc vm.info -u <vcenter> -dc <dc> -json <vm> | jq '.[]? | .[]? | .Config.ScheduledHardwareUpgradeInfo'
{
  "UpgradePolicy": "never",
  "VersionKey": "",
  "ScheduledHardwareUpgradeStatus": "none",
  "Fault": null
}
```

Schedule upgrade:
```
./govc vm.change -u <vcenter> -dc <dc> -vm <vm> -scheduled-hw-upgrade-policy=always
```

Verify scheduled upgrade:
```
./govc vm.info -u <vcenter> -dc <dc> -json <vm> | jq '.[]? | .[]? | .Config.ScheduledHardwareUpgradeInfo'
{
  "UpgradePolicy": "always",
  "VersionKey": "vmx-15",
  "ScheduledHardwareUpgradeStatus": "pending",
  "Fault": null
}
```
Reboot and verify upgrade occurred:
```
./govc vm.info -u <vcenter> -dc <dc> -json <vm> | jq '.[]? | .[]? | .Config.ScheduledHardwareUpgradeInfo'
{
  "UpgradePolicy": "never",
  "VersionKey": "",
  "ScheduledHardwareUpgradeStatus": "success",
  "Fault": null
}

./govc vm.info -u <vcenter> -dc <dc> -json <vm> | jq '.[]? | .[]? | .Config.Version'
"vmx-15"
```

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged