### PR TITLE
vcsim: Fix keys in DistributedVirtualPorts

### DIFF
--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -277,18 +277,12 @@ func (s *DistributedVirtualSwitch) dvPortgroups(_ *types.DistributedVirtualSwitc
 
 	for _, ref := range s.Portgroup {
 		pg := Map.Get(ref).(*DistributedVirtualPortgroup)
-		res = append(res, types.DistributedVirtualPort{
-			DvsUuid: s.Uuid,
-			Key:     pg.Key,
-			Config: types.DVPortConfigInfo{
-				Setting: pg.Config.DefaultPortConfig,
-			},
-		})
 
 		for _, key := range pg.PortKeys {
 			res = append(res, types.DistributedVirtualPort{
-				DvsUuid: s.Uuid,
-				Key:     key,
+				DvsUuid:      s.Uuid,
+				Key:          key,
+				PortgroupKey: pg.Key,
 				Config: types.DVPortConfigInfo{
 					Setting: pg.Config.DefaultPortConfig,
 				},

--- a/simulator/dvs_test.go
+++ b/simulator/dvs_test.go
@@ -124,7 +124,9 @@ func TestDVS(t *testing.T) {
 		} else {
 			switch test.op {
 			case types.ConfigSpecOperationAdd:
-				dtask, err = dswitch.AddPortgroup(ctx, []types.DVPortgroupConfigSpec{{Name: test.pg}})
+				dtask, err = dswitch.AddPortgroup(ctx, []types.DVPortgroupConfigSpec{
+					{Name: test.pg, NumPorts: 1},
+				})
 			}
 		}
 

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -640,8 +640,9 @@ func (f *Folder) CreateDVSTask(ctx *Context, req *types.CreateDVS_Task) soap.Has
 
 		dvs.AddDVPortgroupTask(ctx, &types.AddDVPortgroup_Task{
 			Spec: []types.DVPortgroupConfigSpec{{
-				Name: dvs.Name + "-DVUplinks" + strings.TrimPrefix(dvs.Self.Value, "dvs"),
-				Type: string(types.DistributedVirtualPortgroupPortgroupTypeEarlyBinding),
+				Name:     dvs.Name + "-DVUplinks" + strings.TrimPrefix(dvs.Self.Value, "dvs"),
+				Type:     string(types.DistributedVirtualPortgroupPortgroupTypeEarlyBinding),
+				NumPorts: 1,
 				DefaultPortConfig: &types.VMwareDVSPortSetting{
 					Vlan: &types.VmwareDistributedVirtualSwitchTrunkVlanSpec{
 						VlanId: []types.NumericRange{{Start: 0, End: 4094}},

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -654,8 +654,9 @@ func (m *Model) Create() error {
 		for npg := 0; npg < m.Portgroup; npg++ {
 			name := m.fmtName(dcName+"_DVPG", npg)
 			spec := types.DVPortgroupConfigSpec{
-				Name: name,
-				Type: string(types.DistributedVirtualPortgroupPortgroupTypeEarlyBinding),
+				Name:     name,
+				Type:     string(types.DistributedVirtualPortgroupPortgroupTypeEarlyBinding),
+				NumPorts: 1,
 			}
 
 			task, err := dvs.AddPortgroup(ctx, []types.DVPortgroupConfigSpec{spec})


### PR DESCRIPTION
## Description

Fix vcsim `FetchDVPorts` to set `portgroupKey` field to the portgroup moid and `port` field to the port number respectively

Closes: #2726

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [x] request to vcsim using govc

```bash
$ vcsim &
$ export GOVC_URL=https://user:pass@127.0.0.1:8989/sdk GOVC_INSECURE=true
$ govc dvs.portgroup.info DVS0
PortgroupKey: dvportgroup-11
DvsUuid:      fea97929-4b2d-5972-b146-930c6d0b4014
VlanId:       0
PortKey:      0

PortgroupKey: dvportgroup-13
DvsUuid:      fea97929-4b2d-5972-b146-930c6d0b4014
VlanId:       0
PortKey:      0
```

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged