### PR TITLE
sts: support issuing HoK token using HoK token

### DIFF
--- a/govc/session/login.go
+++ b/govc/session/login.go
@@ -215,6 +215,13 @@ func (cmd *login) loginByToken(ctx context.Context, c *vim25.Client) error {
 		},
 	}
 
+	// something behind the LoginByToken scene requires a version from /sdk/vimServiceVersions.xml
+	// in the SOAPAction header. For example, if vim25.Version is "7.0" but the service version is "6.3",
+	// LoginByToken fails with: 'VersionMismatchFaultCode: Unsupported version URI "urn:vim25/7.0"'
+	if c.Version == vim25.Version {
+		_ = c.UseServiceVersion()
+	}
+
 	return session.NewManager(c).LoginByToken(c.WithHeader(ctx, header))
 }
 

--- a/sts/client.go
+++ b/sts/client.go
@@ -71,6 +71,9 @@ func (c *Client) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
 
 // TokenRequest parameters for issuing a SAML token.
 // At least one of Userinfo or Certificate must be specified.
+// When `TokenRequest.Certificate` is set, the `tls.Certificate.PrivateKey` field must be set as it is required to sign the request.
+// When the `tls.Certificate.Certificate` field is not set, the request Assertion header is set to that of the TokenRequest.Token.
+// Otherwise `tls.Certificate.Certificate` is used as the BinarySecurityToken in the request.
 type TokenRequest struct {
 	Userinfo    *url.Userinfo    // Userinfo when set issues a Bearer token
 	Certificate *tls.Certificate // Certificate when set issues a HoK token


### PR DESCRIPTION
## Description

govmomi had support for public key auth to issue a HoK token, this change adds support for using a HoK token to issue a HoK token.

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Added sts/client_test.go:TestIssueTokenByToken, which runs against a real vCenter/STS

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged