### PR TITLE
fix: support govc import.spec for remote ova

### DIFF
--- a/govc/importx/spec.go
+++ b/govc/importx/spec.go
@@ -107,7 +107,7 @@ func (cmd *spec) Run(ctx context.Context, f *flag.FlagSet) error {
 			return fmt.Errorf("invalid file extension %s", path.Ext(fpath))
 		}
 
-		if isRemotePath(fpath) {
+		if isRemotePath(f.Arg(0)) {
 			client, err := cmd.Client()
 			if err != nil {
 				return err

--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -22,6 +22,9 @@ load test_helper
   run govc import.spec "https://$(govc env GOVC_URL)/folder/$TTYLINUX_NAME.ovf"
   assert_success
 
+  run govc import.spec "https://$(govc env GOVC_URL)/folder/$TTYLINUX_NAME.ova"
+  assert_success
+
   proto=$(jq -r .IPProtocol <<<"$output")
   assert_equal IPv4 "$proto"
 


### PR DESCRIPTION
## Description

PR #1885 added support for remote ovf files, but not ova.

Closes: #1836

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged