### PR TITLE
fix: switch url encoding for namespace.cluster.enable edge cluster lookup

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -3721,6 +3721,7 @@ Examples:
     -cluster "Workload-Cluster" \
     -service-cidr 10.96.0.0/23 \
     -pod-cidrs 10.244.0.0/20 \
+    -control-plane-dns 10.10.10.10 \
     -control-plane-dns-names wcp.example.com \
     -workload-network.egress-cidrs 10.0.0.128/26 \
     -workload-network.ingress-cidrs "10.0.0.64/26" \

--- a/govc/namespace/cluster/enable.go
+++ b/govc/namespace/cluster/enable.go
@@ -154,6 +154,7 @@ Examples:
     -cluster "Workload-Cluster" \
     -service-cidr 10.96.0.0/23 \
     -pod-cidrs 10.244.0.0/20 \
+    -control-plane-dns 10.10.10.10 \
     -control-plane-dns-names wcp.example.com \
     -workload-network.egress-cidrs 10.0.0.128/26 \
     -workload-network.ingress-cidrs "10.0.0.64/26" \
@@ -243,7 +244,7 @@ func (cmd *enableCluster) Run(ctx context.Context, f *flag.FlagSet) error {
 	edgeClusterDisplayName := cmd.NcpClusterNetworkSpec.NsxEdgeCluster
 	edgeClusters, err := m.ListCompatibleEdgeClusters(ctx, clusterId, switchId)
 	if err != nil {
-		return fmt.Errorf("error in compatible switch lookup: %s", err)
+		return fmt.Errorf("error in compatible edge cluster lookup: %s", err)
 	}
 
 	matchingEdgeClusters := make([]string, 0)

--- a/vapi/namespace/namespace.go
+++ b/vapi/namespace/namespace.go
@@ -188,7 +188,7 @@ type EdgeClusterCompatibilitySummary struct {
 func (c *Manager) ListCompatibleEdgeClusters(ctx context.Context, clusterId string, switchId string) (result []EdgeClusterCompatibilitySummary, err error) {
 	listUrl := c.Resource(internal.NamespaceEdgeClusterCompatibility).
 		WithParam("cluster", clusterId).
-		WithParam("distributed_switch", switchId).
-		WithParam("compatible", "true")
+		WithParam("compatible", "true").
+		WithPathEncodedParam("distributed_switch", switchId)
 	return result, c.Do(ctx, listUrl.Request(http.MethodGet), &result)
 }

--- a/vapi/rest/resource.go
+++ b/vapi/rest/resource.go
@@ -51,9 +51,33 @@ func (r *Resource) WithAction(action string) *Resource {
 // WithParam adds one parameter on the URL.RawQuery
 func (r *Resource) WithParam(name string, value string) *Resource {
 	// ParseQuery handles empty case, and we control access to query string so shouldn't encounter an error case
-	params, _ := url.ParseQuery(r.u.RawQuery)
+	params, err := url.ParseQuery(r.u.RawQuery)
+	if err != nil {
+		panic(err)
+	}
 	params[name] = append(params[name], value)
 	r.u.RawQuery = params.Encode()
+	return r
+}
+
+// WithPathEncodedParam appends a parameter on the URL.RawQuery,
+// For special cases where URL Path-style encoding is needed
+func (r *Resource) WithPathEncodedParam(name string, value string) *Resource {
+	t := &url.URL{Path: value}
+	encodedValue := t.String()
+	t = &url.URL{Path: name}
+	encodedName := t.String()
+	// ParseQuery handles empty case, and we control access to query string so shouldn't encounter an error case
+	params, err := url.ParseQuery(r.u.RawQuery)
+	if err != nil {
+		panic(err)
+	}
+	// Values.Encode() doesn't escape exactly how we want, so we need to build the query string ourselves
+	if len(params) >= 1 {
+		r.u.RawQuery = r.u.RawQuery + "&" + encodedName + "=" + encodedValue
+	} else {
+		r.u.RawQuery = r.u.RawQuery + encodedName + "=" + encodedValue
+	}
 	return r
 }
 

--- a/vapi/rest/resource_test.go
+++ b/vapi/rest/resource_test.go
@@ -51,3 +51,34 @@ func TestResource_WithParam(t *testing.T) {
 		}
 	})
 }
+
+func TestResource_WithPathEncodedParam(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		c := rest.NewClient(vc)
+
+		// path is correctly formatted when Path-Encoded param is first
+		url := c.Resource("api/some/resource").
+			WithPathEncodedParam("key1", "value 1")
+		expectedPath := "api/some/resource?key1=value%201"
+		if !strings.Contains(url.String(), expectedPath) {
+			t.Errorf("First path-encoded param incorrectly added to resource, URL %q, expected path %q", url.String(), expectedPath)
+		}
+
+		// path is correctly formatted when Path-Encoded param is last
+		url = c.Resource("api/some/resource").
+			WithParam("key1", "value 1").
+			WithPathEncodedParam("key2", "value 2")
+		expectedPath = "api/some/resource?key1=value+1&key2=value%202"
+		if !strings.Contains(url.String(), expectedPath) {
+			t.Errorf("Last path-encoded param incorrectly added to resource, URL %q, expected path %q", url.String(), expectedPath)
+		}
+
+		// if WithParam is used again, it will re-encode the Path-Encoded value
+		url = url.WithParam("key3", "value 3")
+		expectedPath = "api/some/resource?key1=value+1&key2=value+2&key3=value+3"
+		if !strings.Contains(url.String(), expectedPath) {
+			t.Errorf("Middle path-encoded param not endcoded as expected, URL %q, expected path %q", url.String(), expectedPath)
+		}
+
+	})
+}


### PR DESCRIPTION
## Description

Was receiving an error when running namespace.cluster.enable (with Vcenter 7U2):

```
govc: error in compatible switch lookup: GET https://VCENTER-HOST/api/vcenter/namespace-management/edge-cluster-compatibility?cluster=domain-c8&compatible=true&distributed_switch=50+32+27+0c+a8+8e+db+57-33+db+9e+e7+6e+49+58+ca: 500 Internal Server Error
```

It seems like vCenter is no longer accepting the parameter strings query-encoded (" " -> "+") and instead wants them to be URL-encoded (" " -> "%20"). Both ways should be valid, but only the second is now accepted. This isn't how go encodes strings, so it requires a bit of working-around.

Also noticed that the example given in the help no longer works, an additional mandatory parameter is needed

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Added unit tests around expected built URLs. Tested the command E2E manually against my VCenter 7 U2

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
  -> Seems like I have issues running the example client, apparently unrelated to this change. Same error both on master branch and my branch:
```
    317-ok          github.com/vmware/govmomi/guest 1.054s
318-=== RUN   ExampleClient_Run
319:2022/02/02 12:33:44 DC0_H0_VM0 [/bin/sh -c docker run -d --name vcsim-DC0_H0_VM0-265104de-1472-547c-b873-6dc7883fb6cb -v vcsim-DC0_H0_VM0-265104de-1472-547c-b873-6dc7883fb6cb:/sys/class/dmi/id:ro nginx]: exit status 125 docker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: rootfs_linux.go:76: mounting "/var/lib/docker/volumes/vcsim-DC0_H0_VM0-265104de-1472-547c-b873-6dc7883fb6cb/_data" to rootfs at "/sys/class/dmi/id" caused: mkdir /var/lib/docker/overlay2/9b0e1a6f265917d62b00f9c03d9acdbed8901c6e9693186299b6b12554f89c24/merged/sys/class/dmi: read-only file system: unknown.
320:--- FAIL: ExampleClient_Run (4.08s)
321-panic: ServerFaultCode: GuestOperationsUnavailable [recovered]
322-    panic: ServerFaultCode: GuestOperationsUnavailable
323-
--
340-    /home/linuxbrew/.linuxbrew/Cellar/go/1.17.6/libexec/src/testing/testing.go:1505 +0xa5d
341-main.main()
342-    _testmain.go:45 +0x22c
343:FAIL        github.com/vmware/govmomi/guest/toolbox 4.110s
344-?           github.com/vmware/govmomi/history       [no test files]
345-=== RUN   TestHostSystemManagementIPs
346---- PASS: TestHostSystemManagementIPs (0.00s)
--
539-=== RUN   TestRefreshDatastore
540---- PASS: TestRefreshDatastore (0.00s)
541-=== RUN   TestDatastoreHTTP
542:2022/02/02 12:33:45 failed to PUT '/tmp/govcsim-ha-datacenter-LocalDS_0-3576033707': open /tmp/govcsim-ha-datacenter-LocalDS_0-3576033707: is a directory
543:2022/02/02 12:33:46 failed to locate datastore with query params: dsName=nope
544:2022/02/02 12:33:47 failed to PUT '/tmp/govcsim-DC0-LocalDS_0-3304178270': open /tmp/govcsim-DC0-LocalDS_0-3304178270: is a directory
545:2022/02/02 12:33:47 failed to locate datastore with query params: dsName=nope
546---- PASS: TestDatastoreHTTP (2.67s)
547-=== RUN   TestDVS
548---- PASS: TestDVS (0.77s)
--
3413-2022/02/02 12:34:50 [VmInstanceUuidAssignedEvent] Assign a new instance UUID (a9a58383-ffb4-5c09-b5e0-cd19153b9e91) to nginx
3414-2022/02/02 12:34:50 [VmUuidAssignedEvent] Assigned new BIOS UUID (9d949740-e0e2-5783-903b-a7024c36273d) to nginx on DC0_H0 in DC0
3415-2022/02/02 12:34:50 [VmCreatedEvent] Created virtual machine nginx on DC0_H0 in DC0
3416:2022/02/02 12:34:54 nginx [/bin/sh -c docker run -d --name vcsim-nginx-9d949740-e0e2-5783-903b-a7024c36273d -v vcsim-nginx-9d949740-e0e2-5783-903b-a7024c36273d:/sys/class/dmi/id:ro -v '/tmp/example2457113515:/usr/share/nginx/html:ro' nginx]: exit status 125 docker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: rootfs_linux.go:76: mounting "/var/lib/docker/volumes/vcsim-nginx-9d949740-e0e2-5783-903b-a7024c36273d/_data" to rootfs at "/sys/class/dmi/id" caused: mkdir /var/lib/docker/overlay2/eb24e4235b988df13cbe2e148b2a28b2e50a0bea786087e08e60e34448c976d4/merged/sys/class/dmi: read-only file system: unknown.
3417-2022/02/02 12:34:54 [VmStartingEvent] nginx on host DC0_H0 in DC0 is starting
3418-2022/02/02 12:34:54 [VmPoweredOnEvent] nginx on DC0_H0 in DC0 is powered on
3419-panic: test timed out after 5m0s
```
- [x] Any dependent changes have been merged