### PR TITLE
Clarify squash in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,29 +109,33 @@ $ git push --force-with-lease $USER issue-<number>
 
 ### Updating Pull Requests
 
-If your PR fails to pass CI or needs changes based on code review, you'll most
-likely want to squash these changes into existing commits.
+If your PR fails to pass CI or needs changes based on code review, it's ok to
+add more commits stating the changes made, e.g. "Address review comments". This
+is to assist the reviewer(s) to easily detect and review the recent changes.
 
-If your pull request contains a single commit or your changes are related to the
-most recent commit, you can simply amend the commit.
-
-```console
-$ git add .
-$ git commit --amend
-$ git push --force-with-lease $USER issue-<number>
-```
-
-If you need to squash changes into an earlier commit, you can use:
+In case of small PRs, it's ok to squash and force-push (see further below)
+directly instead.
 
 ```console
+# incorporate review feedback
 $ git add .
+
+# create a fixup commit which will be merged into your (original) <commit>
 $ git commit --fixup <commit>
-$ git rebase -i --autosquash vmware/master
-$ git push --force-with-lease $USER issue-<number>
+$ git push $USER issue-<number>
 ```
 
 Be sure to add a comment to the PR indicating your new changes are ready to
 review, as Github does not generate a notification when you git push.
+
+Once the review is complete, squash and push your final commit(s):
+
+```console
+# squash all commits into one
+# --autosquash will automatically detect and merge fixup commits
+$ git rebase -i --autosquash vmware/master
+$ git push --force-with-lease $USER issue-<number>
+```
 
 ### Code Style
 


### PR DESCRIPTION
## Description

Ask contributors to not use `force` pushes during review.

Closes: #2736
Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

n/a

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged