### PR TITLE
fix: Allow go 1.17 to go install

### DIFF
--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kr/pretty"
+	"github.com/dougm/pretty"
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -21,7 +21,7 @@ import (
 	"flag"
 	"time"
 
-	"github.com/kr/pretty"
+	"github.com/dougm/pretty"
 
 	"github.com/vmware/govmomi/task"
 

--- a/go.mod
+++ b/go.mod
@@ -2,15 +2,11 @@ module github.com/vmware/govmomi
 
 go 1.17
 
-replace github.com/davecgh/go-xdr => github.com/rasky/go-xdr v0.0.0-20170217172119-4930550ba2e2
-
-replace github.com/kr/pretty v0.1.0 => github.com/dougm/pretty v0.0.0-20171025230240-2ee9d7453c02
-
 require (
 	github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d
-	github.com/davecgh/go-xdr v0.0.0-20161123171359-e6a2ba005892
+	github.com/rasky/go-xdr v0.0.0-20170217172119-4930550ba2e2
 	github.com/google/uuid v1.2.0
-	github.com/kr/pretty v0.1.0
+	github.com/dougm/pretty v0.0.0-20171025230240-2ee9d7453c02
 	github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728
 )
 

--- a/govc/flags/debug.go
+++ b/govc/flags/debug.go
@@ -31,7 +31,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/kr/pretty"
+	"github.com/dougm/pretty"
 
 	"github.com/vmware/govmomi/vim25/debug"
 	"github.com/vmware/govmomi/vim25/soap"

--- a/govc/flags/output.go
+++ b/govc/flags/output.go
@@ -29,7 +29,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kr/pretty"
+	"github.com/dougm/pretty"
 
 	"github.com/vmware/govmomi/task"
 	"github.com/vmware/govmomi/vim25/progress"

--- a/toolbox/guest_info.go
+++ b/toolbox/guest_info.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net"
 
-	xdr "github.com/davecgh/go-xdr/xdr2"
+	xdr "github.com/rasky/go-xdr/xdr2"
 )
 
 // Defs from: open-vm-tools/lib/guestRpc/nicinfo.x

--- a/vsan/client_test.go
+++ b/vsan/client_test.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kr/pretty"
+	"github.com/dougm/pretty"
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"

--- a/vslm/client_test.go
+++ b/vslm/client_test.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kr/pretty"
+	"github.com/dougm/pretty"
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/cns"


### PR DESCRIPTION
## Description

Go.mod contains two replace directives. This commit moves the replaced packages directly in the required.
It allows to `go install github.com/vmare/govmomi/govc@latest` with go 1.17.

Otherwise we get:

```
go install github.com/vmware/govmomi/govc@latest
go install: github.com/vmware/govmomi/govc@latest (in github.com/vmware/govmomi@v0.27.3):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [x] Build related change

<!-- template
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] Test Description 1
- [ ] Test Description 2

## Checklist:

- [ ] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

-->