### PR TITLE
Add BackingDiskObjectId go bindings to CNS API

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -394,6 +394,7 @@ type CnsBlockBackingDetails struct {
 
 	BackingDiskId      string `xml:"backingDiskId,omitempty"`
 	BackingDiskUrlPath string `xml:"backingDiskUrlPath,omitempty"`
+	BackingDiskObjectId string `xml:"backingDiskObjectId,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
## Description
Add BackingDiskObjectId go bindings in CnsBlockBackingDetails to CNS API.
This field is only for vsan and vvol.

issues: #2744 

**Testing:**
Executed govmomi/cns/client_test.go 
1. **For vsan datastore** 
export CNS_VC_URL='https://Administrator@vsphere.local:Admin!23@10.78.116.147/sdk'
export CNS_DATACENTER='vcqaDC'
export CNS_DATASTORE='vsanDatastore'
```
client_test.go:278: Successfully Queried Volumes. queryResultBackingDiskObjectIdTest: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "1d65a09c-1fb7-4e7a-bf8a-4501d8971a46",
                    },
                    DatastoreUrl:    "ds:///vmfs/volumes/vsan:52ba6157403606a4-6332b4a97562ad04/",
                    Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:      "BLOCK",
                    StoragePolicyId: "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:        types.CnsVolumeMetadata{
                        ContainerCluster: types.CnsContainerCluster{
                            ClusterType:         "KUBERNETES",
                            ClusterId:           "demo-cluster-id",
                            VSphereUser:         "Administrator@vsphere.local",
                            ClusterFlavor:       "VANILLA",
                            ClusterDistribution: "OpenShift",
                        },
                        EntityMetadata:        nil,
                        ContainerClusterArray: []types.CnsContainerCluster{
                            {
                                ClusterType:         "KUBERNETES",
                                ClusterId:           "demo-cluster-id",
                                VSphereUser:         "Administrator@vsphere.local",
                                ClusterFlavor:       "VANILLA",
                                ClusterDistribution: "OpenShift",
                            },
                        },
                    },
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 5120,
                        },
                        BackingDiskId:       "1d65a09c-1fb7-4e7a-bf8a-4501d8971a46",
                        BackingDiskUrlPath:  "",
                        BackingDiskObjectId: "a2af0362-f274-f5ec-06ee-020078f07c87",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "green",
                },
            },
            Cursor: types.CnsCursor{
                Offset:       1,
                Limit:        100,
                TotalRecords: 1,
            },
        }
    client_test.go:279: Checking backingDiskObjectId retieved
...
--- PASS: TestClient (24.98s)
PASS
ok  	github.com/vmware/govmomi/cns	25.009s

```
2. **For nfs datastore, BackingDiskObjectId is empty, test should not fail**
export CNS_VC_URL='https://Administrator@vsphere.local:Admin!23@10.78.116.147/sdk'
export CNS_DATACENTER='vcqaDC'
export CNS_DATASTORE='nfs-01'
```
client_test.go:278: Successfully Queried Volumes. queryResultBackingDiskObjectIdTest: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "45feb98e-8192-4fc9-8926-d1cf4efdba29",
                    },
                    DatastoreUrl:    "ds:///vmfs/volumes/d5bd3359-59ff9b64/",
                    Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:      "BLOCK",
                    StoragePolicyId: "",
                    Metadata:        types.CnsVolumeMetadata{
                        ContainerCluster: types.CnsContainerCluster{
                            ClusterType:         "KUBERNETES",
                            ClusterId:           "demo-cluster-id",
                            VSphereUser:         "Administrator@vsphere.local",
                            ClusterFlavor:       "VANILLA",
                            ClusterDistribution: "OpenShift",
                        },
                        EntityMetadata:        nil,
                        ContainerClusterArray: []types.CnsContainerCluster{
                            {
                                ClusterType:         "KUBERNETES",
                                ClusterId:           "demo-cluster-id",
                                VSphereUser:         "Administrator@vsphere.local",
                                ClusterFlavor:       "VANILLA",
                                ClusterDistribution: "OpenShift",
                            },
                        },
                    },
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 5120,
                        },
                        BackingDiskId:       "45feb98e-8192-4fc9-8926-d1cf4efdba29",
                        BackingDiskUrlPath:  "",
                        BackingDiskObjectId: "",
                    },
                    ComplianceStatus:             "",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "green",
                },
            },
            Cursor: types.CnsCursor{
                Offset:       1,
                Limit:        100,
                TotalRecords: 1,
            },
        }
    client_test.go:279: Checking backingDiskObjectId retieved
    client_test.go:343: Creating snapshot using the spec: []types.CnsSnapshotCreateSpec{
            {
...
--- PASS: TestClient (27.32s)
PASS
ok  	github.com/vmware/govmomi/cns	27.336s
```