### PR TITLE
fix: rest.Client.LoginByToken invalid signature

### DIFF
--- a/sts/client_test.go
+++ b/sts/client_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/ssoadmin"
 	"github.com/vmware/govmomi/ssoadmin/types"
+	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -160,6 +161,12 @@ func TestIssueHOK(t *testing.T) {
 	}
 
 	log.Printf("current time=%s", now)
+
+	rc := rest.NewClient(c)
+	err = rc.LoginByToken(rc.WithSigner(ctx, s))
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestIssueTokenByToken(t *testing.T) {

--- a/sts/signer.go
+++ b/sts/signer.go
@@ -351,5 +351,5 @@ func isIPv6(s string) bool {
 	if ip == nil {
 		return false
 	}
-	return len(ip) == net.IPv6len
+	return ip.To4() == nil
 }

--- a/sts/signer_test.go
+++ b/sts/signer_test.go
@@ -140,3 +140,20 @@ func TestSigner(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestIsIPv6(t *testing.T) {
+	tests := []struct {
+		ip string
+		v6 bool
+	}{
+		{"0:0:0:0:0:0:0:1", true},
+		{"10.0.0.42", false},
+	}
+
+	for _, test := range tests {
+		v6 := isIPv6(test.ip)
+		if v6 != test.v6 {
+			t.Errorf("%s: expected %t, got %t", test.ip, test.v6, v6)
+		}
+	}
+}


### PR DESCRIPTION
## Description

PR #2701 (ebeaa71b) added IPv6 support for signing HTTP request,
but was treating all IPs as v6.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Added tests and ran against real vCenter using `govc session.login -r ...`

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged