### PR TITLE
Add api: commit prefix

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -15,8 +15,10 @@ options:
         - docs
         - examples
         - fix
+        - api
   commit_groups:
     title_maps:
+      api: 💫 API Changes
       govc: 💫 `govc` (CLI)
       vcsim: 💫 `vcsim` (Simulator)
       chore: 🧹 Chore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,12 +167,16 @@ $ git commit -s -m "govc: Add CLI command X" -m "Closes: #1234"
 
 Currently the following prefixes are used:
 
+- `api:` - Use for API-related changes
 - `govc:` - Use for changes to `govc` CLI
 - `vcsim:` - Use for changes to vCenter Simulator
 - `chore:` - Use for repository related activities
 - `fix:` - Use for bug fixes
 - `docs:` - Use for changes to the documentation
 - `examples:` - Use for changes to examples
+
+If your contribution falls into multiple categories, e.g. `api` and `vcsim` it
+is recommended to break up your commits using distinct prefixes.
 
 ### Running CI Checks and Tests
 You can run both `make check` and `make test` from the top level of the


### PR DESCRIPTION
## Description

Add new `api: ` commit prefix and guideline for `govmomi` API-related changes, e.g. new/changed bindings, etc.

Example output:

<a name="v0.28.0"></a>
## [Release v0.28.0](https://github.com/vmware/govmomi/compare/v0.27.4...v0.28.0)

> Release Date: 2022-02-17

### 🐞 Fix

- [a587742b]	avoid debug trace if http.Request.Body is nil
- [7e2ce135]	Ignore concurrent deletes in GetCategories
- [a7c6f15b]	Allow go 1.17 to go install

### 💫 API Changes

- [d1f0fd97]	Add XYZ bindings

### 💫 `govc` (CLI)

- [40e6cbc8]	Add Appliance access API
- [949ef572]	Add Appliance shutdown API's

Closes: #2763
Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Generated `CHANGELOG` (see example above).

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged