### PR TITLE
vcsim: Fix NFS datastore moid collision

### DIFF
--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -1523,10 +1523,13 @@ func (s *handler) updateFileInfo(id string) *update {
 
 // libraryPath returns the local Datastore fs path for a Library or Item if id is specified.
 func libraryPath(l *library.Library, id string) string {
-	// DatastoreID (moref) format is "$local-path@$ds-folder-id",
-	// see simulator.HostDatastoreSystem.CreateLocalDatastore
-	ds := strings.SplitN(l.Storage[0].DatastoreID, "@", 2)[0]
-	return path.Join(append([]string{ds, "contentlib-" + l.ID}, id)...)
+	dsref := types.ManagedObjectReference{
+		Type:  "Datastore",
+		Value: l.Storage[0].DatastoreID,
+	}
+	ds := simulator.Map.Get(dsref).(*simulator.Datastore)
+
+	return path.Join(append([]string{ds.Info.GetDatastoreInfo().Url, "contentlib-" + l.ID}, id)...)
 }
 
 func (s *handler) libraryItemFileCreate(up *update, name string, body io.ReadCloser) error {


### PR DESCRIPTION
## Description

Fix NFS datastore moids in vcsim so that they are unique to each datastore.
This fixes the issue that multiple `CreateNfsDatastore` requests except the first one does not work.

Closes: #2767

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

1. Start vcsim
1. create NFS Datastore `ds1` on `DC0_C0_H0` by govc
1. create NFS Datastore `ds2` on `DC0_C0_H0` by govc

```bash
$ govc datastore.create -name /ds1 -type nfs DC0_C0_H0
$ govc datastore.create -name /ds2 -type nfs DC0_C0_H0
$ govc datastore.info
Name:        LocalDS_0
  Path:      /DC0/datastore/LocalDS_0
  Type:      OTHER
  URL:       /tmp/govcsim-DC0-LocalDS_0-2611405272
  Capacity:  10240.0 GB
  Free:      10200.0 GB
Name:        ds1
  Path:      /DC0/datastore/ds1
  Type:      NFS
  URL:       /ds1
  Capacity:  10240.0 GB
  Free:      10240.0 GB
  Remote:    :
Name:        ds2
  Path:      /DC0/datastore/ds2
  Type:      NFS
  URL:       /ds2
  Capacity:  10240.0 GB
  Free:      10240.0 GB
  Remote:    :
# every datastore has unique moid
govc datastore.info -json | jq .Datastores[].Self
{
  "Type": "Datastore",
  "Value": "datastore-52"
}
{
  "Type": "Datastore",
  "Value": "datastore-66"
}
{
  "Type": "Datastore",
  "Value": "datastore-68"
}
```

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged
