### PR TITLE
[resubmission] adding govc: add dvs.create '-num-uplinks' flag to control number of uplinks for a new distributed switch

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1726,6 +1726,7 @@ Options:
   -discovery-protocol=   Link Discovery Protocol
   -folder=               Inventory folder [GOVC_FOLDER]
   -mtu=0                 DVS Max MTU
+  -num-uplinks=0         Number of Uplinks
   -product-version=      DVS product version
 ```
 

--- a/govc/dvs/create.go
+++ b/govc/dvs/create.go
@@ -34,6 +34,8 @@ type create struct {
 	configSpec *types.VMwareDVSConfigSpec
 
 	dProtocol string
+
+	numUplinkPorts uint
 }
 
 func init() {
@@ -52,6 +54,7 @@ func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 	f.StringVar(&cmd.ProductInfo.Version, "product-version", "", "DVS product version")
 	f.Var(flags.NewInt32(&cmd.configSpec.MaxMtu), "mtu", "DVS Max MTU")
 	f.StringVar(&cmd.dProtocol, "discovery-protocol", "", "Link Discovery Protocol")
+	f.UintVar(&cmd.numUplinkPorts, "num-uplinks", 0, "Number of Uplinks")
 }
 
 func (cmd *create) Usage() string {
@@ -93,6 +96,14 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 			Operation: "listen",
 		}
 	}
+
+	numUplinkPorts := int(cmd.numUplinkPorts)
+
+	var policy types.DVSNameArrayUplinkPortPolicy
+	for i := 0; i < numUplinkPorts; i++ {
+		policy.UplinkPortName = append(policy.UplinkPortName, fmt.Sprintf("Uplink %d", i+1))
+	}
+	cmd.configSpec.UplinkPortPolicy = &policy
 
 	folder, err := cmd.FolderOrDefault("network")
 	if err != nil {

--- a/govc/dvs/create.go
+++ b/govc/dvs/create.go
@@ -99,11 +99,13 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	numUplinkPorts := int(cmd.numUplinkPorts)
 
-	var policy types.DVSNameArrayUplinkPortPolicy
-	for i := 0; i < numUplinkPorts; i++ {
-		policy.UplinkPortName = append(policy.UplinkPortName, fmt.Sprintf("Uplink %d", i+1))
+	if numUplinkPorts > 0 {
+		var policy types.DVSNameArrayUplinkPortPolicy
+		for i := 0; i < numUplinkPorts; i++ {
+			policy.UplinkPortName = append(policy.UplinkPortName, fmt.Sprintf("Uplink %d", i+1))
+		}
+		cmd.configSpec.UplinkPortPolicy = &policy
 	}
-	cmd.configSpec.UplinkPortPolicy = &policy
 
 	folder, err := cmd.FolderOrDefault("network")
 	if err != nil {


### PR DESCRIPTION
## Description

When creating distributed and nested switches, you will often want to provide only a single uplink port, or in the case of a 4 port nic, utilize 4 ports.  This feature was missing from dvs.create.

I also added a local check to ensure that you don't try and create a DVS with 0 or invalid ports, as vSphere won't let you do that.

No dependencies

Resubmission of PR: https://github.com/vmware/govmomi/pull/2499

Closes: #2314

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- I used the code that  @dougm provided in the issue, and put modified the code. I compared what I received in the simulator with the output Doug provided by running the Powershell command.

- I then powered up my homelab and tested this against VSphere 7.0 u2 and created a DVS with 1 uplink port, 3, 1030. 
Added a default of 2 ports, and added the CLI flags to override.  Tested again with no flag, 1,3,1030.

**Test Configuration**:
* Toolchain: go version go1.14.2 linux/amd64

## Checklist:

- [ ] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works  - I can't find where to add tests to this?
- [ ] New and existing unit tests pass locally with my changes - I can't find where to add tests to this? ran go test but didnt' see any tests (other than main) run.
- [x] Any dependent changes have been merged