### PR TITLE
Reconfigure LACP API for DVS

### DIFF
--- a/object/distributed_virtual_switch.go
+++ b/object/distributed_virtual_switch.go
@@ -102,3 +102,17 @@ func (s DistributedVirtualSwitch) ReconfigureDVPort(ctx context.Context, spec []
 
 	return NewTask(s.Client(), res.Returnval), nil
 }
+
+func (s DistributedVirtualSwitch) ReconfigureLACP(ctx context.Context, spec []types.VMwareDvsLacpGroupSpec) (*Task, error) {
+	req := types.UpdateDVSLacpGroupConfig_Task{
+		This:          s.Reference(),
+		LacpGroupSpec: spec,
+	}
+
+	res, err := methods.UpdateDVSLacpGroupConfig_Task(ctx, s.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(s.Client(), res.Returnval), nil
+}


### PR DESCRIPTION
## Description

LACP reconfiguration on DVS is not exposed. This PR adds API to configure.

Closes: #([2774](https://github.com/vmware/govmomi/issues/2774))

## Type of change

Please mark options that are relevant:
 New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually tested.
