### PR TITLE
Add a new type of cluster action

### DIFF
--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -9146,7 +9146,7 @@ func init() {
 type ClusterClusterInitialPlacementAction struct {
 	ClusterInitialPlacementAction
 
-	ConfigSpec *VirtualMachineConfigSpec   `xml:"configSpec,omitempty"`
+	ConfigSpec *VirtualMachineConfigSpec `xml:"configSpec,omitempty"`
 }
 
 func init() {

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -9143,16 +9143,6 @@ func init() {
 	t["ClusterInitialPlacementAction"] = reflect.TypeOf((*ClusterInitialPlacementAction)(nil)).Elem()
 }
 
-type ClusterClusterInitialPlacementAction struct {
-	ClusterInitialPlacementAction
-
-	ConfigSpec *VirtualMachineConfigSpec `xml:"configSpec,omitempty"`
-}
-
-func init() {
-	t["ClusterClusterInitialPlacementAction"] = reflect.TypeOf((*ClusterClusterInitialPlacementAction)(nil)).Elem()
-}
-
 type ClusterIoFilterInfo struct {
 	IoFilterInfo
 

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -9143,6 +9143,16 @@ func init() {
 	t["ClusterInitialPlacementAction"] = reflect.TypeOf((*ClusterInitialPlacementAction)(nil)).Elem()
 }
 
+type ClusterClusterInitialPlacementAction struct {
+	ClusterInitialPlacementAction
+
+	ConfigSpec *VirtualMachineConfigSpec   `xml:"configSpec,omitempty"`
+}
+
+func init() {
+	t["ClusterClusterInitialPlacementAction"] = reflect.TypeOf((*ClusterClusterInitialPlacementAction)(nil)).Elem()
+}
+
 type ClusterIoFilterInfo struct {
 	IoFilterInfo
 

--- a/vim25/types/unreleased.go
+++ b/vim25/types/unreleased.go
@@ -115,3 +115,13 @@ type PlaceVmsXClusterSpecVmPlacementSpec struct {
 func init() {
 	t["PlaceVmsXClusterSpecVmPlacementSpec"] = reflect.TypeOf((*PlaceVmsXClusterSpecVmPlacementSpec)(nil)).Elem()
 }
+
+type ClusterClusterInitialPlacementAction struct {
+	ClusterInitialPlacementAction
+
+	ConfigSpec *VirtualMachineConfigSpec `xml:"configSpec,omitempty"`
+}
+
+func init() {
+	t["ClusterClusterInitialPlacementAction"] = reflect.TypeOf((*ClusterClusterInitialPlacementAction)(nil)).Elem()
+}


### PR DESCRIPTION
Add a new type of cluster action.

## Description

Add a new type of cluster action used for placing a VM. This action inherits from InitialPlacement action because it conveys the resource pool and host for placing the VM. In addition, it also has the VM's ConfigSpecwhich is used for indicating the recommended datastore for each virtual disk in VM's ConfigSpec.

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged