### PR TITLE
vcsim: Use new action type in simulator PlaceVmsXCluster response

### DIFF
--- a/vim25/types/unreleased.go
+++ b/vim25/types/unreleased.go
@@ -116,6 +116,8 @@ func init() {
 	t["PlaceVmsXClusterSpecVmPlacementSpec"] = reflect.TypeOf((*PlaceVmsXClusterSpecVmPlacementSpec)(nil)).Elem()
 }
 
+const RecommendationReasonCodeXClusterPlacement = RecommendationReasonCode("xClusterPlacement")
+
 type ClusterClusterInitialPlacementAction struct {
 	ClusterInitialPlacementAction
 


### PR DESCRIPTION
The ClusterClusterInitialPlacementAction type is the expected action
type in the PlaceVmsXCluster response. While here, also define and use
the xClusterPlacement reason code.

## Description

Instead of returning the PlacementAction action type (via calling PlaceVm under the covers) return the expected ClusterClusterInitialPlacementAction type, along with the new, expected reason code.

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Client code against simulator works as expected. Verification of this E2E against actual in-flight.

```
--- PASS: TestPlaceVmsXCluster (1.38s)
```

## Checklist:

- [] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged