### PR TITLE
Add vSAN 7.0U2 release constant to CNS client

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -37,6 +37,7 @@ const (
 	ReleaseVSAN67u3 = "vSAN 6.7U3"
 	ReleaseVSAN70   = "7.0"
 	ReleaseVSAN70u1 = "vSAN 7.0U1"
+	ReleaseVSAN70u2 = "vSAN 7.0U2"
 )
 
 var (


### PR DESCRIPTION
## Description

This PR adds a constant for vSAN 7.0U2 release. This version will be used by CSI in unit tests and other places. Having this as a constant here seems better than using local strings. Please refer to a similar previous PR for adding the 7.0U1 release constant #2272 

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] Test Description 1
- [ ] Test Description 2

## Checklist:

- [ ] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged