### PR TITLE
govc: Fix arguments validation in datastore.disk.inflate/shrink

### DIFF
--- a/govc/datastore/disk/inflate.go
+++ b/govc/datastore/disk/inflate.go
@@ -55,6 +55,10 @@ Examples:
 }
 
 func (cmd *inflate) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
 	dc, err := cmd.Datacenter()
 	if err != nil {
 		return err

--- a/govc/datastore/disk/shrink.go
+++ b/govc/datastore/disk/shrink.go
@@ -59,6 +59,10 @@ Examples:
 }
 
 func (cmd *shrink) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
 	dc, err := cmd.Datacenter()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Fix arguments validation in `datastore.disk.inflate` and `datastore.disk.shrink` to ensure vmdk is specified.

Closes: #2791 

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] run `govc.disk.inflate` without any parameters
- [x] run `govc.disk.shrink` without any parameters

Since command line arguments are invalid, govc shows usage help.

```bash
$ ./govc datastore.disk.inflate
Usage: ./govc datastore.disk.inflate [OPTIONS] VMDK

Inflate VMDK on DS.

Examples:
  govc datastore.disk.inflate disks/disk1.vmdk

Options:
  -cert=                              Certificate [GOVC_CERTIFICATE]
  -dc=                                Datacenter [GOVC_DATACENTER]
  -debug=false                        Store debug logs [GOVC_DEBUG]
  -ds=                                Datastore [GOVC_DATASTORE]
  -dump=false                         Enable Go output
  -json=false                         Enable JSON output
  -k=true                             Skip verification of server certificate [GOVC_INSECURE]
  -key=                               Private key [GOVC_PRIVATE_KEY]
  -persist-session=true               Persist session to disk [GOVC_PERSIST_SESSION]
  -tls-ca-certs=                      TLS CA certificates file [GOVC_TLS_CA_CERTS]
  -tls-known-hosts=                   TLS known hosts file [GOVC_TLS_KNOWN_HOSTS]
  -trace=false                        Write SOAP/REST traffic to stderr
  -u=https://user@127.0.0.1:8989/sdk  ESX or vCenter URL [GOVC_URL]
  -verbose=false                      Write request/response data to stderr
  -vim-namespace=vim25                Vim namespace [GOVC_VIM_NAMESPACE]
  -vim-version=7.0                    Vim version [GOVC_VIM_VERSION]
  -xml=false                          Enable XML output

$ ./govc datastore.disk.shrink
Usage: ./govc datastore.disk.shrink [OPTIONS] VMDK

Shrink VMDK on DS.

Examples:
  govc datastore.disk.shrink disks/disk1.vmdk

Options:
  -cert=                              Certificate [GOVC_CERTIFICATE]
  -copy=<nil>                         Perform shrink in-place mode if false, copy-shrink mode otherwise
  -dc=                                Datacenter [GOVC_DATACENTER]
  -debug=false                        Store debug logs [GOVC_DEBUG]
  -ds=                                Datastore [GOVC_DATASTORE]
  -dump=false                         Enable Go output
  -json=false                         Enable JSON output
  -k=true                             Skip verification of server certificate [GOVC_INSECURE]
  -key=                               Private key [GOVC_PRIVATE_KEY]
  -persist-session=true               Persist session to disk [GOVC_PERSIST_SESSION]
  -tls-ca-certs=                      TLS CA certificates file [GOVC_TLS_CA_CERTS]
  -tls-known-hosts=                   TLS known hosts file [GOVC_TLS_KNOWN_HOSTS]
  -trace=false                        Write SOAP/REST traffic to stderr
  -u=https://user@127.0.0.1:8989/sdk  ESX or vCenter URL [GOVC_URL]
  -verbose=false                      Write request/response data to stderr
  -vim-namespace=vim25                Vim namespace [GOVC_VIM_NAMESPACE]
  -vim-version=7.0                    Vim version [GOVC_VIM_VERSION]
  -xml=false                          Enable XML output
```

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged