### PR TITLE
Use powerclicore on `ghcr.io`

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -20,7 +20,8 @@ load test_helper
   server=$(govc env -x GOVC_URL_HOST)
   port=$(govc env -x GOVC_URL_PORT)
 
-  docker run --rm projects.registry.vmware.com/pez/powerclicore@sha256:09b29f69c0653f871f6d569f7c4c03c952909f68a27e9792ef2f7c8653235668 /usr/bin/pwsh -f - <<EOF
+  # docker run --rm projects.registry.vmware.com/pez/powerclicore@sha256:09b29f69c0653f871f6d569f7c4c03c952909f68a27e9792ef2f7c8653235668 /usr/bin/pwsh -f - <<EOF
+  docker run --rm ghcr.io/embano1/powerclicore@sha256:09b29f69c0653f871f6d569f7c4c03c952909f68a27e9792ef2f7c8653235668 /usr/bin/pwsh -f - <<EOF
 Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -confirm:\$false | Out-Null
 Connect-VIServer -Server $server -Port $port -User user -Password pass
 


### PR DESCRIPTION
## Description

The `powerclicore` image used in the `govc-test` target is now available (pushed) on Github's own package registry (`ghcr.io/embano1/powerclicore`). The image is exactly the same (`sha256:09b29f69c0653f871f6d569f7c4c03c952909f68a27e9792ef2f7c8653235668`) as the originally used image `projects.registry.vmware.com/pez/powerclicore`.

This provides some efficiency, availability and performance gains.

Closes: #2794
Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [x] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Existing CI checks pass

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged