### PR TITLE
govc: Edit disk storage IO

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -5658,6 +5658,7 @@ Examples:
 
 Options:
   -disk.filePath=        Disk file name
+  -disk.io.limit=<nil>   Disk storage IO per seconds limit (-1 for unlimited)
   -disk.key=0            Disk unique key
   -disk.label=           Disk label
   -disk.name=            Disk name

--- a/govc/vm/disk/change.go
+++ b/govc/vm/disk/change.go
@@ -41,6 +41,9 @@ type change struct {
 
 	bytes units.ByteSize
 	mode  string
+
+	// 	SIOC
+	limit *int64
 }
 
 func init() {
@@ -73,6 +76,7 @@ func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
 	f.IntVar(&cmd.key, "disk.key", 0, "Disk unique key")
 	f.StringVar(&cmd.mode, "mode", "", fmt.Sprintf("Disk mode (%s)", strings.Join(vdmTypes, "|")))
 	f.StringVar(&cmd.sharing, "sharing", "", fmt.Sprintf("Sharing (%s)", strings.Join(sharing, "|")))
+	f.Var(flags.NewOptionalInt64(&cmd.limit), "disk.io.limit", "Disk storage IO per seconds limit (-1 for unlimited)")
 }
 
 func (cmd *change) Process(ctx context.Context) error {
@@ -151,6 +155,8 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
 	if int64(cmd.bytes) != 0 {
 		editdisk.CapacityInKB = int64(cmd.bytes) / 1024
 	}
+
+	editdisk.StorageIOAllocation.Limit = cmd.limit
 
 	switch backing := editdisk.Backing.(type) {
 	case *types.VirtualDiskFlatVer2BackingInfo:


### PR DESCRIPTION
## Description

Allow setting disk IO limits (or `-1` for unlimited). vCenter validates values and returns error message when a limit is invalid, e.g. `-disk.io.limit 0`.

Closes: #2806
Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Various `govc` runs against vCenter 6.7U3 setting/removing (invalid) disk IO limits

```console
./govc vm.disk.change -vm /vcqaDC/vm/vm-with-disk -disk.key 2000 -disk.io.limit -1
./govc object.collect -json /vcqaDC/vm/vm-with-disk config.hardware.device | jq '.[0].Val.VirtualDevice[]|select(.Key==2000)|.StorageIOAllocation'
{
  "Limit": -1,
  "Shares": {
    "Shares": 1000,
    "Level": "normal"
  },
  "Reservation": 0
}
```

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged