### PR TITLE
ConfigInfo2ConfigSpec

### DIFF
--- a/vim25/types/helpers.go
+++ b/vim25/types/helpers.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2022 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -92,6 +92,149 @@ func DefaultResourceConfigSpec() ResourceConfigSpec {
 		CpuAllocation:    defaultResourceAllocationInfo(),
 		MemoryAllocation: defaultResourceAllocationInfo(),
 	}
+}
+
+// ToConfigSpec returns a VirtualMachineConfigSpec based on the
+// VirtualMachineConfigInfo.
+func (ci VirtualMachineConfigInfo) ToConfigSpec() VirtualMachineConfigSpec {
+	cs := VirtualMachineConfigSpec{
+		ChangeVersion:                ci.ChangeVersion,
+		Name:                         ci.Name,
+		Version:                      ci.Version,
+		CreateDate:                   ci.CreateDate,
+		Uuid:                         ci.Uuid,
+		InstanceUuid:                 ci.InstanceUuid,
+		NpivNodeWorldWideName:        ci.NpivNodeWorldWideName,
+		NpivPortWorldWideName:        ci.NpivPortWorldWideName,
+		NpivWorldWideNameType:        ci.NpivWorldWideNameType,
+		NpivDesiredNodeWwns:          ci.NpivDesiredNodeWwns,
+		NpivDesiredPortWwns:          ci.NpivDesiredPortWwns,
+		NpivTemporaryDisabled:        ci.NpivTemporaryDisabled,
+		NpivOnNonRdmDisks:            ci.NpivOnNonRdmDisks,
+		LocationId:                   ci.LocationId,
+		GuestId:                      ci.GuestId,
+		AlternateGuestName:           ci.AlternateGuestName,
+		Annotation:                   ci.Annotation,
+		Files:                        &ci.Files,
+		Tools:                        ci.Tools,
+		Flags:                        &ci.Flags,
+		ConsolePreferences:           ci.ConsolePreferences,
+		PowerOpInfo:                  &ci.DefaultPowerOps,
+		NumCPUs:                      ci.Hardware.NumCPU,
+		VcpuConfig:                   ci.VcpuConfig,
+		NumCoresPerSocket:            ci.Hardware.NumCoresPerSocket,
+		MemoryMB:                     int64(ci.Hardware.MemoryMB),
+		MemoryHotAddEnabled:          ci.MemoryHotAddEnabled,
+		CpuHotAddEnabled:             ci.CpuHotAddEnabled,
+		CpuHotRemoveEnabled:          ci.CpuHotRemoveEnabled,
+		VirtualICH7MPresent:          ci.Hardware.VirtualICH7MPresent,
+		VirtualSMCPresent:            ci.Hardware.VirtualSMCPresent,
+		DeviceChange:                 make([]BaseVirtualDeviceConfigSpec, len(ci.Hardware.Device)),
+		CpuAllocation:                ci.CpuAllocation,
+		MemoryAllocation:             ci.MemoryAllocation,
+		LatencySensitivity:           ci.LatencySensitivity,
+		CpuAffinity:                  ci.CpuAffinity,
+		MemoryAffinity:               ci.MemoryAffinity,
+		NetworkShaper:                ci.NetworkShaper,
+		CpuFeatureMask:               make([]VirtualMachineCpuIdInfoSpec, len(ci.CpuFeatureMask)),
+		ExtraConfig:                  ci.ExtraConfig,
+		SwapPlacement:                ci.SwapPlacement,
+		BootOptions:                  ci.BootOptions,
+		FtInfo:                       ci.FtInfo,
+		RepConfig:                    ci.RepConfig,
+		VAssertsEnabled:              ci.VAssertsEnabled,
+		ChangeTrackingEnabled:        ci.ChangeTrackingEnabled,
+		Firmware:                     ci.Firmware,
+		MaxMksConnections:            ci.MaxMksConnections,
+		GuestAutoLockEnabled:         ci.GuestAutoLockEnabled,
+		ManagedBy:                    ci.ManagedBy,
+		MemoryReservationLockedToMax: ci.MemoryReservationLockedToMax,
+		NestedHVEnabled:              ci.NestedHVEnabled,
+		VPMCEnabled:                  ci.VPMCEnabled,
+		MessageBusTunnelEnabled:      ci.MessageBusTunnelEnabled,
+		MigrateEncryption:            ci.MigrateEncryption,
+		FtEncryptionMode:             ci.FtEncryptionMode,
+		SevEnabled:                   ci.SevEnabled,
+		PmemFailoverEnabled:          ci.PmemFailoverEnabled,
+		Pmem:                         ci.Pmem,
+	}
+
+	// Unassign the Files field if all of its fields are empty.
+	if ci.Files.FtMetadataDirectory == "" && ci.Files.LogDirectory == "" &&
+		ci.Files.SnapshotDirectory == "" && ci.Files.SuspendDirectory == "" &&
+		ci.Files.VmPathName == "" {
+		cs.Files = nil
+	}
+
+	// Unassign the Flags field if all of its fields are empty.
+	if ci.Flags.CbrcCacheEnabled == nil &&
+		ci.Flags.DisableAcceleration == nil &&
+		ci.Flags.DiskUuidEnabled == nil &&
+		ci.Flags.EnableLogging == nil &&
+		ci.Flags.FaultToleranceType == "" &&
+		ci.Flags.HtSharing == "" &&
+		ci.Flags.MonitorType == "" &&
+		ci.Flags.RecordReplayEnabled == nil &&
+		ci.Flags.RunWithDebugInfo == nil &&
+		ci.Flags.SnapshotDisabled == nil &&
+		ci.Flags.SnapshotLocked == nil &&
+		ci.Flags.SnapshotPowerOffBehavior == "" &&
+		ci.Flags.UseToe == nil &&
+		ci.Flags.VbsEnabled == nil &&
+		ci.Flags.VirtualExecUsage == "" &&
+		ci.Flags.VirtualMmuUsage == "" &&
+		ci.Flags.VvtdEnabled == nil {
+		cs.Flags = nil
+	}
+
+	// Unassign the PowerOps field if all of its fields are empty.
+	if ci.DefaultPowerOps.DefaultPowerOffType == "" &&
+		ci.DefaultPowerOps.DefaultResetType == "" &&
+		ci.DefaultPowerOps.DefaultSuspendType == "" &&
+		ci.DefaultPowerOps.PowerOffType == "" &&
+		ci.DefaultPowerOps.ResetType == "" &&
+		ci.DefaultPowerOps.StandbyAction == "" &&
+		ci.DefaultPowerOps.SuspendType == "" {
+		cs.PowerOpInfo = nil
+	}
+
+	for i := 0; i < len(cs.CpuFeatureMask); i++ {
+		cs.CpuFeatureMask[i] = VirtualMachineCpuIdInfoSpec{
+			ArrayUpdateSpec: ArrayUpdateSpec{
+				Operation: ArrayUpdateOperationAdd,
+			},
+			Info: &HostCpuIdInfo{
+				// TODO: Does DynamicData need to be copied?
+				//       It is an empty struct...
+				Level:  ci.CpuFeatureMask[i].Level,
+				Vendor: ci.CpuFeatureMask[i].Vendor,
+				Eax:    ci.CpuFeatureMask[i].Eax,
+				Ebx:    ci.CpuFeatureMask[i].Ebx,
+				Ecx:    ci.CpuFeatureMask[i].Ecx,
+				Edx:    ci.CpuFeatureMask[i].Edx,
+			},
+		}
+	}
+
+	for i := 0; i < len(cs.DeviceChange); i++ {
+		cs.DeviceChange[i] = &VirtualDeviceConfigSpec{
+			// TODO: Does DynamicData need to be copied?
+			//       It is an empty struct...
+			Operation:     VirtualDeviceConfigSpecOperationAdd,
+			FileOperation: VirtualDeviceConfigSpecFileOperationCreate,
+			Device:        ci.Hardware.Device[i],
+			// TODO: It is unclear how the profiles associated with the VM or
+			//       its hardware can be reintroduced/persisted in the
+			//       ConfigSpec.
+			Profile: nil,
+			// The backing will come from the device.
+			Backing: nil,
+			// TODO: Investigate futher.
+			FilterSpec: nil,
+		}
+	}
+
+	return cs
 }
 
 func init() {

--- a/vim25/types/helpers_test.go
+++ b/vim25/types/helpers_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/xml"
+)
+
+func TestVirtualMachineConfigInfoToConfigSpec(t *testing.T) {
+	testCases := []struct {
+		name string
+		conf VirtualMachineConfigInfo
+		spec VirtualMachineConfigSpec
+		fail bool
+	}{
+		{
+			name: "default value",
+			conf: VirtualMachineConfigInfo{},
+			spec: VirtualMachineConfigSpec{},
+		},
+		{
+			name: "matching names",
+			conf: VirtualMachineConfigInfo{
+				Name: "Hello, world.",
+			},
+			spec: VirtualMachineConfigSpec{
+				Name: "Hello, world.",
+			},
+		},
+		{
+			name: "matching nics",
+			conf: VirtualMachineConfigInfo{
+				Name: "Hello, world.",
+				Hardware: VirtualHardware{
+					Device: []BaseVirtualDevice{
+						&VirtualVmxnet3{
+							VirtualVmxnet: VirtualVmxnet{
+								VirtualEthernetCard: VirtualEthernetCard{
+									VirtualDevice: VirtualDevice{
+										Key: 3,
+									},
+									MacAddress: "00:11:22:33:44:55:66:77",
+								},
+							},
+						},
+					},
+				},
+			},
+			spec: VirtualMachineConfigSpec{
+				Name: "Hello, world.",
+				DeviceChange: []BaseVirtualDeviceConfigSpec{
+					&VirtualDeviceConfigSpec{
+						Operation:     VirtualDeviceConfigSpecOperationAdd,
+						FileOperation: VirtualDeviceConfigSpecFileOperationCreate,
+						Device: &VirtualVmxnet3{
+							VirtualVmxnet: VirtualVmxnet{
+								VirtualEthernetCard: VirtualEthernetCard{
+									VirtualDevice: VirtualDevice{
+										Key: 3,
+									},
+									MacAddress: "00:11:22:33:44:55:66:77",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nics with different mac addresses",
+			fail: true,
+			conf: VirtualMachineConfigInfo{
+				Name: "Hello, world.",
+				Hardware: VirtualHardware{
+					Device: []BaseVirtualDevice{
+						&VirtualVmxnet3{
+							VirtualVmxnet: VirtualVmxnet{
+								VirtualEthernetCard: VirtualEthernetCard{
+									VirtualDevice: VirtualDevice{
+										Key: 3,
+									},
+									MacAddress: "00:11:22:33:44:55:66:77",
+								},
+							},
+						},
+					},
+				},
+			},
+			spec: VirtualMachineConfigSpec{
+				Name: "Hello, world.",
+				DeviceChange: []BaseVirtualDeviceConfigSpec{
+					&VirtualDeviceConfigSpec{
+						Operation:     VirtualDeviceConfigSpecOperationAdd,
+						FileOperation: VirtualDeviceConfigSpecFileOperationCreate,
+						Device: &VirtualVmxnet3{
+							VirtualVmxnet: VirtualVmxnet{
+								VirtualEthernetCard: VirtualEthernetCard{
+									VirtualDevice: VirtualDevice{
+										Key: 3,
+									},
+									MacAddress: "00:11:22:33:44:55:66:88",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "really big config",
+			conf: VirtualMachineConfigInfo{
+				Name:    "vm-001",
+				GuestId: "otherGuest",
+				Files:   VirtualMachineFileInfo{VmPathName: "[datastore1]"},
+				Hardware: VirtualHardware{
+					NumCPU:   1,
+					MemoryMB: 128,
+					Device: []BaseVirtualDevice{
+						&VirtualLsiLogicController{
+							VirtualSCSIController: VirtualSCSIController{
+								SharedBus: VirtualSCSISharingNoSharing,
+								VirtualController: VirtualController{
+									BusNumber: 0,
+									VirtualDevice: VirtualDevice{
+										Key: 1000,
+									},
+								},
+							},
+						},
+						&VirtualDisk{
+							VirtualDevice: VirtualDevice{
+								Key:           0,
+								ControllerKey: 1000,
+								UnitNumber:    new(int32), // zero default value
+								Backing: &VirtualDiskFlatVer2BackingInfo{
+									DiskMode:        string(VirtualDiskModePersistent),
+									ThinProvisioned: NewBool(true),
+									VirtualDeviceFileBackingInfo: VirtualDeviceFileBackingInfo{
+										FileName: "[datastore1]",
+									},
+								},
+							},
+							CapacityInKB: 4000000,
+						},
+						&VirtualE1000{
+							VirtualEthernetCard: VirtualEthernetCard{
+								VirtualDevice: VirtualDevice{
+									Key: 0,
+									DeviceInfo: &Description{
+										Label:   "Network Adapter 1",
+										Summary: "VM Network",
+									},
+									Backing: &VirtualEthernetCardNetworkBackingInfo{
+										VirtualDeviceDeviceBackingInfo: VirtualDeviceDeviceBackingInfo{
+											DeviceName: "VM Network",
+										},
+									},
+								},
+								AddressType: string(VirtualEthernetCardMacTypeGenerated),
+							},
+						},
+					},
+				},
+				ExtraConfig: []BaseOptionValue{
+					&OptionValue{Key: "bios.bootOrder", Value: "ethernet0"},
+				},
+			},
+			spec: VirtualMachineConfigSpec{
+				Name:     "vm-001",
+				GuestId:  "otherGuest",
+				Files:    &VirtualMachineFileInfo{VmPathName: "[datastore1]"},
+				NumCPUs:  1,
+				MemoryMB: 128,
+				DeviceChange: []BaseVirtualDeviceConfigSpec{
+					&VirtualDeviceConfigSpec{
+						Operation:     VirtualDeviceConfigSpecOperationAdd,
+						FileOperation: VirtualDeviceConfigSpecFileOperationCreate,
+						Device: &VirtualLsiLogicController{VirtualSCSIController{
+							SharedBus: VirtualSCSISharingNoSharing,
+							VirtualController: VirtualController{
+								BusNumber: 0,
+								VirtualDevice: VirtualDevice{
+									Key: 1000,
+								},
+							},
+						}},
+					},
+					&VirtualDeviceConfigSpec{
+						Operation:     VirtualDeviceConfigSpecOperationAdd,
+						FileOperation: VirtualDeviceConfigSpecFileOperationCreate,
+						Device: &VirtualDisk{
+							VirtualDevice: VirtualDevice{
+								Key:           0,
+								ControllerKey: 1000,
+								UnitNumber:    new(int32), // zero default value
+								Backing: &VirtualDiskFlatVer2BackingInfo{
+									DiskMode:        string(VirtualDiskModePersistent),
+									ThinProvisioned: NewBool(true),
+									VirtualDeviceFileBackingInfo: VirtualDeviceFileBackingInfo{
+										FileName: "[datastore1]",
+									},
+								},
+							},
+							CapacityInKB: 4000000,
+						},
+					},
+					&VirtualDeviceConfigSpec{
+						Operation:     VirtualDeviceConfigSpecOperationAdd,
+						FileOperation: VirtualDeviceConfigSpecFileOperationCreate,
+						Device: &VirtualE1000{VirtualEthernetCard{
+							VirtualDevice: VirtualDevice{
+								Key: 0,
+								DeviceInfo: &Description{
+									Label:   "Network Adapter 1",
+									Summary: "VM Network",
+								},
+								Backing: &VirtualEthernetCardNetworkBackingInfo{
+									VirtualDeviceDeviceBackingInfo: VirtualDeviceDeviceBackingInfo{
+										DeviceName: "VM Network",
+									},
+								},
+							},
+							AddressType: string(VirtualEthernetCardMacTypeGenerated),
+						}},
+					},
+				},
+				ExtraConfig: []BaseOptionValue{
+					&OptionValue{Key: "bios.bootOrder", Value: "ethernet0"},
+				},
+			},
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			e, a := tc.spec, tc.conf.ToConfigSpec()
+			ed, err := xml.MarshalIndent(e, "", "  ")
+			if err != nil {
+				t.Fatalf("failed to marshal expected ConfigSpec: %v", err)
+			}
+			ad, err := xml.MarshalIndent(a, "", "  ")
+			if err != nil {
+				t.Fatalf("failed to marshal actual   ConfigSpec: %v", err)
+			}
+			eds, ads := string(ed), string(ad)
+			if eds != ads && !tc.fail {
+				t.Errorf("unexpected error: \n\n"+
+					"exp=%+v\n\nact=%+v\n\n"+
+					"exp.s=%s\n\nact.s=%s\n\n", e, a, eds, ads)
+			} else if eds == ads && tc.fail {
+				t.Errorf("expected error did not occur: \n\n"+
+					"exp=%+v\n\nact=%+v\n\n"+
+					"exp.s=%s\n\nact.s=%s\n\n", e, a, eds, ads)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This patch introduces a helper so that a `VirtualMachineConfigInfo` can be converted to an equivalent representation as a `VirtualMachineConfigSpec`.

Closes: NA

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [x] [`TestVirtualMachineConfigInfoToConfigSpec`](https://github.com/akutz/govmomi/blob/feature/vmconfig2spec/vim25/types/helpers_test.go)

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged