### PR TITLE
fix: DiskFileOperation must consider both capacity fields

### DIFF
--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -939,25 +939,9 @@ func (l VirtualDeviceList) ConfigSpec(op types.VirtualDeviceConfigSpecOperation)
 	var res []types.BaseVirtualDeviceConfigSpec
 	for _, device := range l {
 		config := &types.VirtualDeviceConfigSpec{
-			Device:    device,
-			Operation: op,
-		}
-
-		if disk, ok := device.(*types.VirtualDisk); ok {
-			config.FileOperation = fop
-
-			// Special case to attach an existing disk
-			if op == types.VirtualDeviceConfigSpecOperationAdd && disk.CapacityInKB == 0 {
-				childDisk := false
-				if b, ok := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
-					childDisk = b.Parent != nil
-				}
-
-				if !childDisk {
-					// Existing disk, clear file operation
-					config.FileOperation = ""
-				}
-			}
+			Device:        device,
+			Operation:     op,
+			FileOperation: diskFileOperation(op, fop, device),
 		}
 
 		res = append(res, config)

--- a/object/virtual_machine_test.go
+++ b/object/virtual_machine_test.go
@@ -204,3 +204,52 @@ func TestVirtualMachineSnapshotMap(t *testing.T) {
 		}
 	}
 }
+
+func TestDiskFileOperation(t *testing.T) {
+	backing := &types.VirtualDiskFlatVer2BackingInfo{
+		VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
+			FileName: "[datastore1] data/disk1.vmdk",
+		},
+		Parent: nil,
+	}
+
+	parent := &types.VirtualDiskFlatVer2BackingInfo{
+		VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
+			FileName: "[datastore1] data/parent.vmdk",
+		},
+	}
+
+	disk := &types.VirtualDisk{
+		VirtualDevice: types.VirtualDevice{
+			Backing: backing,
+		},
+	}
+
+	op := types.VirtualDeviceConfigSpecOperationAdd
+	fop := types.VirtualDeviceConfigSpecFileOperationCreate
+
+	res := diskFileOperation(op, fop, disk)
+	if res != "" {
+		t.Errorf("res=%s", res)
+	}
+
+	disk.CapacityInKB = 1
+	res = diskFileOperation(op, fop, disk)
+	if res != types.VirtualDeviceConfigSpecFileOperationCreate {
+		t.Errorf("res=%s", res)
+	}
+
+	disk.CapacityInKB = 0
+	disk.CapacityInBytes = 1
+	res = diskFileOperation(op, fop, disk)
+	if res != types.VirtualDeviceConfigSpecFileOperationCreate {
+		t.Errorf("res=%s", res)
+	}
+
+	disk.CapacityInBytes = 0
+	backing.Parent = parent
+	res = diskFileOperation(op, fop, disk)
+	if res != types.VirtualDeviceConfigSpecFileOperationCreate {
+		t.Errorf("res=%s", res)
+	}
+}


### PR DESCRIPTION
## Description

Config spec helpers have logic to clear the DiskFileOperation for existing disks,
when 'CapacityInKB' is '0'. But we also need to check 'Capacity'.

Refactor some duplicate code into a separate function.

Closes #2805

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Added `TestDiskFileOperation`

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged