### PR TITLE
govc: add 'device.clock.add' command

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -86,6 +86,7 @@ but appear via `govc $cmd -h`:
  - [device.cdrom.add](#devicecdromadd)
  - [device.cdrom.eject](#devicecdromeject)
  - [device.cdrom.insert](#devicecdrominsert)
+ - [device.clock.add](#deviceclockadd)
  - [device.connect](#deviceconnect)
  - [device.disconnect](#devicedisconnect)
  - [device.floppy.add](#devicefloppyadd)
@@ -1272,6 +1273,21 @@ Examples:
 Options:
   -device=               CD-ROM device name
   -ds=                   Datastore [GOVC_DATASTORE]
+  -vm=                   Virtual machine [GOVC_VM]
+```
+
+## device.clock.add
+
+```
+Usage: govc device.clock.add [OPTIONS]
+
+Add precision clock device to VM.
+
+Examples:
+  govc device.clock.add -vm $vm
+  govc device.info clock-*
+
+Options:
   -vm=                   Virtual machine [GOVC_VM]
 ```
 

--- a/govc/device/clock/add.go
+++ b/govc/device/clock/add.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package floppy
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("device.clock.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *add) Description() string {
+	return `Add precision clock device to VM.
+
+Examples:
+  govc device.clock.add -vm $vm
+  govc device.info clock-*`
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	d := &types.VirtualPrecisionClock{
+		VirtualDevice: types.VirtualDevice{
+			Backing: &types.VirtualPrecisionClockSystemClockBackingInfo{
+				Protocol: string(types.HostDateTimeInfoProtocolPtp), // TODO: ntp option
+			},
+		},
+	}
+
+	err = vm.AddDevice(ctx, d)
+	if err != nil {
+		return err
+	}
+
+	// output name of device we just created
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	devices = devices.SelectByType(d)
+
+	name := devices.Name(devices[len(devices)-1])
+
+	fmt.Println(name)
+
+	return nil
+}

--- a/govc/device/info.go
+++ b/govc/device/info.go
@@ -243,6 +243,14 @@ func (r *infoResult) Write(w io.Writer) error {
 				fmt.Fprintf(tw, "  Service URI:\t%s\n", b.ServiceURI)
 				fmt.Fprintf(tw, "  Proxy URI:\t%s\n", b.ProxyURI)
 			}
+		case *types.VirtualPrecisionClock:
+			if b, ok := md.Backing.(*types.VirtualPrecisionClockSystemClockBackingInfo); ok {
+				proto := b.Protocol
+				if proto == "" {
+					proto = string(types.HostDateTimeInfoProtocolPtp)
+				}
+				fmt.Fprintf(tw, "  Protocol:\t%s\n", proto)
+			}
 		}
 	}
 

--- a/govc/main.go
+++ b/govc/main.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/datastore/vsan"
 	_ "github.com/vmware/govmomi/govc/device"
 	_ "github.com/vmware/govmomi/govc/device/cdrom"
+	_ "github.com/vmware/govmomi/govc/device/clock"
 	_ "github.com/vmware/govmomi/govc/device/floppy"
 	_ "github.com/vmware/govmomi/govc/device/pci"
 	_ "github.com/vmware/govmomi/govc/device/scsi"

--- a/govc/test/device.bats
+++ b/govc/test/device.bats
@@ -279,6 +279,22 @@ load test_helper
   [ $result -eq 1 ]
 }
 
+@test "device.clock" {
+  vcsim_env
+
+  vm=$(new_empty_vm)
+
+  result=$(govc device.ls -vm "$vm" | grep clock | wc -l)
+  [ "$result" -eq 0 ]
+
+  run govc device.clock.add -vm "$vm"
+  assert_success
+  id=$output
+
+  result=$(govc device.ls -vm "$vm" | grep "$id" | wc -l)
+  [ "$result" -eq 1 ]
+}
+
 @test "device.scsi slots" {
   vcsim_env
 

--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -894,6 +894,8 @@ func (l VirtualDeviceList) Type(device types.BaseVirtualDevice) string {
 		return "lsilogic-sas"
 	case *types.VirtualNVMEController:
 		return "nvme"
+	case *types.VirtualPrecisionClock:
+		return "clock"
 	default:
 		return l.deviceName(device)
 	}


### PR DESCRIPTION
## Description

add 'device.clock.add' command - Add precision clock device to VM

Closes: #2834

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Tested against real vCenter + vcsim

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged