### PR TITLE
emacs: fix json mode

### DIFF
--- a/govc/emacs/govc.el
+++ b/govc/emacs/govc.el
@@ -743,8 +743,7 @@ returned, assuming that's what the user wanted."
                     (copy-to-buffer buffer (point-min) (point-max))
                     (with-current-buffer buffer
                       (json-mode)
-                      ;; We use `json-mode-beautify' as `json-pretty-print-buffer' does not work for `govc-host-json-info'
-                      (json-mode-beautify))
+                      (json-pretty-print-buffer))
                     (display-buffer buffer))))
   (if current-prefix-arg
       (govc-json-diff)))


### PR DESCRIPTION
## Description

Switching back to json-pretty-print-buffer, which works again, and json-mode-beautify does not. :shrug:

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Emacs 27.2 

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged