### PR TITLE
Fixed docs for govc library.info w/-json

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -3285,7 +3285,7 @@ Examples:
   govc library.info */
   govc device.cdrom.insert -vm $vm -device cdrom-3000 $(govc library.info -L /lib1/item1/file1)
   govc library.info -json | jq .
-  govc library.info /lib1/item1 -json | jq .
+  govc library.info -json /lib1/item1 | jq .
 
 Options:
   -L=false               List Datastore path only

--- a/govc/library/info.go
+++ b/govc/library/info.go
@@ -89,7 +89,7 @@ Examples:
   govc library.info */
   govc device.cdrom.insert -vm $vm -device cdrom-3000 $(govc library.info -L /lib1/item1/file1)
   govc library.info -json | jq .
-  govc library.info /lib1/item1 -json | jq .`
+  govc library.info -json /lib1/item1 | jq .`
 }
 
 type infoResultsWriter struct {


### PR DESCRIPTION
Fixed docs for govc library.info w/-json

When -json comes after the "library/item" then it does not trigger JSON output.