### PR TITLE
vcsim: Update Dockerfile

### DIFF
--- a/Dockerfile.vcsim
+++ b/Dockerfile.vcsim
@@ -43,4 +43,5 @@ EXPOSE 8989
 COPY vcsim /vcsim
 
 # Set entrypoint to application with container defaults
-CMD ["/vcsim", "-l", "0.0.0.0:8989"]
+ENTRYPOINT [ "/vcsim" ]
+CMD ["-l", "0.0.0.0:8989"]


### PR DESCRIPTION
## Description

The `vcsim` Dockerfile now uses `ENTRYPOINT` for the `vcsim` binary and
`CMD` for default listener address `0.0.0.0:8989`. A user can now easily
overwrite the default behavior without having to specify `/vcsim`
explicitly since it is the defined `ENTRYPOINT`.

Signed-off-by: Michael Gasch <mgasch@vmware.com>

Closes: #2841 

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [x] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] `docker run vmware/vcsim` (run with defaults)
- [x] `docker run vmware/vcsim -l :9090` (overwrite bind address 

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (Docker Hub)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged