### PR TITLE
Add content library VmConfigSpec support

### DIFF
--- a/govc/cli/register.go
+++ b/govc/cli/register.go
@@ -27,6 +27,10 @@ var aliases = map[string]string{}
 // Setting the env var GOVC_SHOW_UNRELEASED=true enables any commands registered as unreleased.
 var hideUnreleased = os.Getenv("GOVC_SHOW_UNRELEASED") != "true"
 
+func ShowUnreleased() bool {
+	return !hideUnreleased
+}
+
 func Register(name string, c Command, unreleased ...bool) {
 	if len(unreleased) != 0 && unreleased[0] && hideUnreleased {
 		return

--- a/govc/library/deploy.go
+++ b/govc/library/deploy.go
@@ -38,6 +38,7 @@ type deploy struct {
 	*importx.OptionsFlag
 
 	profile string
+	config  string
 }
 
 func init() {
@@ -61,6 +62,10 @@ func (cmd *deploy) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.OptionsFlag.Register(ctx, f)
 
 	f.StringVar(&cmd.profile, "profile", "", "Storage profile")
+
+	if cli.ShowUnreleased() {
+		f.StringVar(&cmd.config, "config", "", "VM config spec")
+	}
 }
 
 func (cmd *deploy) Process(ctx context.Context) error {
@@ -220,6 +225,14 @@ func (cmd *deploy) Run(ctx context.Context, f *flag.FlagSet) error {
 				FolderID:       folder.Reference().Value,
 			},
 		}
+
+		if cmd.config != "" {
+			deploy.VmConfigSpec = &vcenter.VmConfigSpec{
+				Provider: "XML",
+				XML:      cmd.config,
+			}
+		}
+
 		ref, err = m.DeployLibraryItem(ctx, item.ID, deploy)
 		if err != nil {
 			return err

--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -231,12 +231,28 @@ EOF
   run govc vm.info -r ttylinux2
   assert_success
   assert_matches DC0_DVPG0
+  assert_matches 32MB
+  assert_matches "1 vCPU"
 
   run env GOVC_DATASTORE="" govc library.deploy "my-content/$TTYLINUX_NAME" ttylinux3 # datastore is not required
   assert_success
 
   run govc vm.destroy ttylinux ttylinux2 ttylinux3
   assert_success
+
+  config=$(base64 <<<'
+<obj xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="vim25:VirtualMachineConfigSpec" xmlns:vim25="urn:vim25">
+ <numCPUs>4</numCPUs>
+ <memoryMB>2048</memoryMB>
+</obj>')
+
+  run env GOVC_SHOW_UNRELEASED=true govc library.deploy -config "$config" "my-content/$TTYLINUX_NAME" ttylinux
+  assert_success
+
+  run govc vm.info -r ttylinux
+  assert_success
+  assert_matches 2048MB
+  assert_matches "4 vCPU"
 
   item_id=$(govc library.info -json "/my-content/$TTYLINUX_NAME" | jq -r .[].id)
 

--- a/vapi/vcenter/vcenter_ovf.go
+++ b/vapi/vcenter/vcenter_ovf.go
@@ -123,6 +123,12 @@ type StorageMapping struct {
 	Value StorageGroupMapping `json:"value"`
 }
 
+// VmConfigSpec defines the optional virtual machine configuration settings used when deploying an OVF template
+type VmConfigSpec struct {
+	Provider string `json:"provider"`
+	XML      string `json:"xml"`
+}
+
 // DeploymentSpec is the deployment specification for the deployment
 type DeploymentSpec struct {
 	Name                string             `json:"name,omitempty"`
@@ -136,6 +142,7 @@ type DeploymentSpec struct {
 	Flags               []string           `json:"flags,omitempty"`
 	AdditionalParams    []AdditionalParams `json:"additional_parameters,omitempty"`
 	DefaultDatastoreID  string             `json:"default_datastore_id,omitempty"`
+	VmConfigSpec        *VmConfigSpec      `json:"vmConfigSpec,omitempty"`
 }
 
 // Target is the target for the deployment


### PR DESCRIPTION
## Description

- govc: add library.deploy '-config' flag

- vcsim: add content library VmConfigSpec support

- api: add VmConfigSpec field to content library DeploymentSpec

Closes: #2843

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged