### PR TITLE
fix:fail to add ssd disk into allflash disk group

### DIFF
--- a/vsan/types/enum.go
+++ b/vsan/types/enum.go
@@ -828,7 +828,7 @@ func init() {
 type VimClusterVsanDiskGroupCreationType string
 
 const (
-	VimClusterVsanDiskGroupCreationTypeallflash                          = VimClusterVsanDiskGroupCreationType("allflash")
+	VimClusterVsanDiskGroupCreationTypeallflash                          = VimClusterVsanDiskGroupCreationType("allFlash")
 	VimClusterVsanDiskGroupCreationTypepmem                              = VimClusterVsanDiskGroupCreationType("pmem")
 	VimClusterVsanDiskGroupCreationTypehybrid                            = VimClusterVsanDiskGroupCreationType("hybrid")
 	VimClusterVsanDiskGroupCreationTypeVsanDiskGroupCreationType_Unknown = VimClusterVsanDiskGroupCreationType("VsanDiskGroupCreationType_Unknown")


### PR DESCRIPTION
## Description

The string value 'allflash' can not be used to add disk to all flash disk group, So here changes it to 'allFlash'. 

Closes: #2846 

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

I have reproduced the issue #2846 in my lab cluster. And succeeded to add ssd disk to existing disk group of type of all flash.

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged