### PR TITLE
govc: Use unique searchFlagKey when calling NewSearchFlag

### DIFF
--- a/govc/flags/search.go
+++ b/govc/flags/search.go
@@ -54,9 +54,9 @@ type SearchFlag struct {
 	isset bool
 }
 
-var searchFlagKey = flagKey("search")
-
 func NewSearchFlag(ctx context.Context, t int) (*SearchFlag, context.Context) {
+	searchFlagKey := flagKey(fmt.Sprintf("search%d", t))
+
 	if v := ctx.Value(searchFlagKey); v != nil {
 		return v.(*SearchFlag), ctx
 	}


### PR DESCRIPTION
## Description

When cloning a VM if you specify the `-host.dns` flag it throws the error `expected VirtualMachine entity, got HostSystem`, this is because the SearchFlag instance is saved in the context with a static `searchFlagKey`

Closes: #2849 

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

I successfully cloned a VM by using this command:
`./govc vm.clone -vm "TestDHCP" -host.dns "esxi-eu-dev-01.example.com" testvm`

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged