### PR TITLE
correct SetControlFlags and ClearControlFlags APIs

### DIFF
--- a/vslm/client_test.go
+++ b/vslm/client_test.go
@@ -24,8 +24,10 @@ import (
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/cns"
-	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
 )
 
 func TestClient(t *testing.T) {
@@ -116,4 +118,15 @@ func TestClient(t *testing.T) {
 	volumeCreateResult := (createTaskResult).(*cnstypes.CnsVolumeCreateResult)
 	t.Logf("volumeCreateResult %+v", volumeCreateResult)
 	t.Logf("Volume created sucessfully. volumeId: %s", volumeId)
+
+	err = globalObjectManager.SetControlFlags(ctx, types.ID{Id: volumeId}, []string{"FCD_KEEP_AFTER_DELETE_VM"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Control flag: FCD_KEEP_AFTER_DELETE_VM set for the volumeId: %s", volumeId)
+	err = globalObjectManager.ClearControlFlags(ctx, types.ID{Id: volumeId})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Control flags removed the volumeId: %s", volumeId)
 }

--- a/vslm/global_object_manager.go
+++ b/vslm/global_object_manager.go
@@ -345,9 +345,10 @@ func (this *GlobalObjectManager) Relocate(ct context.Context, id vim.ID, spec vi
 	return NewTask(this.c, res.Returnval), nil
 }
 
-func (this *GlobalObjectManager) SetControlFlags(ct context.Context, controlFlags []string) error {
+func (this *GlobalObjectManager) SetControlFlags(ct context.Context, id vim.ID, controlFlags []string) error {
 	req := types.VslmSetVStorageObjectControlFlags{
 		This:         this.Reference(),
+		Id:           id,
 		ControlFlags: controlFlags,
 	}
 
@@ -359,9 +360,10 @@ func (this *GlobalObjectManager) SetControlFlags(ct context.Context, controlFlag
 	return nil
 }
 
-func (this *GlobalObjectManager) ClearControlFlags(ct context.Context) error {
+func (this *GlobalObjectManager) ClearControlFlags(ct context.Context, id vim.ID) error {
 	req := types.VslmClearVStorageObjectControlFlags{
 		This: this.Reference(),
+		Id:   id,
 	}
 
 	_, err := methods.VslmClearVStorageObjectControlFlags(ct, this.c, &req)


### PR DESCRIPTION
## Description

This PR is correcting `SetControlFlags` and `ClearControlFlags` APIs to supply Volume ID.
When we call these APIs without Volume ID, APIs fail with `ServerFaultCode: VolumeId is empty.`


Please mark options that are relevant:
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Created VMDK and executed tests

```
% go test -v
=== RUN   TestClient
    client_test.go:60: Successfully registered disk with path https://10.187.116.17/folder/29be9662-ce3c-0818-fd35-0200ad8e5983/test-disk.vmdk?dcPath=VSAN-DC&dsName=vsanDatastore as FCD with storage object id e60716d1-6447-4041-9b2a-ca45bebbdd35
    client_test.go:91: Creating volume using the spec: types.CnsVolumeCreateSpec{
            Name:       "pvc-abc123",
            VolumeType: "BLOCK",
            Datastores: nil,
            Metadata:   types.CnsVolumeMetadata{
                ContainerCluster: types.CnsContainerCluster{
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "KUBERNETES",
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    CapacityInMb: 5120,
                },
                BackingDiskId:       "e60716d1-6447-4041-9b2a-ca45bebbdd35",
                BackingDiskUrlPath:  "",
                BackingDiskObjectId: "",
            },
            Profile:      nil,
            CreateSpec:   nil,
            VolumeSource: nil,
        }
    client_test.go:117: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:e60716d1-6447-4041-9b2a-ca45bebbdd35} Fault:<nil>} Name:pvc-abc123 PlacementResults:[]}
    client_test.go:118: Volume created sucessfully. volumeId: e60716d1-6447-4041-9b2a-ca45bebbdd35
    client_test.go:124: Control flag: FCD_KEEP_AFTER_DELETE_VM set for the volumeId: e60716d1-6447-4041-9b2a-ca45bebbdd35
    client_test.go:129: Control flags removed the volumeId: e60716d1-6447-4041-9b2a-ca45bebbdd35
--- PASS: TestClient (10.64s)
PASS
ok      github.com/vmware/govmomi/vslm  10.830s
```
![snap](https://user-images.githubusercontent.com/22985595/171309773-3048288b-109b-46b5-b31a-1e2a45d6b41c.jpg)

This PR is required for https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1762 

cc: @chethanv28  @bandyopadhyays-vmware