### PR TITLE
fix: govc-tests in Go v1.18

### DIFF
--- a/.github/workflows/govmomi-govc-tests.yaml
+++ b/.github/workflows/govmomi-govc-tests.yaml
@@ -74,8 +74,6 @@ jobs:
 
       - name: Run ${{ matrix.cmd }}
         run: |
-          # hack: https://github.com/actions/setup-go/issues/107#issuecomment-956161446
-          cp -fv `which go` /usr/bin/go || true
           make ${{ matrix.cmd }}
 
   govc-docs:


### PR DESCRIPTION
## Description

The previous workaround to support Go `v1.18` is not needed anymore and in fact now breaks the CI during the `govc vcsim examples` tests. Removing it.

Closes: #2865
Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [x] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] CI passes for `govc-tests` for `vcsim examples` with `Go 1.18`

Note that certain jobs still fail bc they're the usual flakes. This is not addressed with this PR.

## Checklist:

- [ ] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged