### PR TITLE
fix: govc: disambiguate vm/host search flags in vm.migrate

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -5905,6 +5905,7 @@ Options:
   -host=                     Host system [GOVC_HOST]
   -pool=                     Resource pool [GOVC_RESOURCE_POOL]
   -priority=defaultPriority  The task priority
+  -vm=                       Virtual machine [GOVC_VM]
 ```
 
 ## vm.network.add

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -770,7 +770,7 @@ load test_helper
   vm="DC0_H0_VM0"
   clone=$(new_id)
 
-  run govc vm.clone -vm "$vm" -annotation $$ "$clone"
+  run govc vm.clone -vm "$vm" -host.ipath /DC0/host/DC0_C0/DC0_C0_H0 -annotation $$ "$clone"
   assert_success
 
   backing=$(govc device.info -json -vm "$clone" disk-* | jq .Devices[].Backing)

--- a/govc/vm/migrate.go
+++ b/govc/vm/migrate.go
@@ -32,7 +32,7 @@ type migrate struct {
 	*flags.ResourcePoolFlag
 	*flags.HostSystemFlag
 	*flags.DatastoreFlag
-	*flags.SearchFlag
+	*flags.VirtualMachineFlag
 
 	priority types.VirtualMachineMovePriority
 	spec     types.VirtualMachineRelocateSpec
@@ -46,8 +46,8 @@ func (cmd *migrate) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
 	cmd.FolderFlag.Register(ctx, f)
 
-	cmd.SearchFlag, ctx = flags.NewSearchFlag(ctx, flags.SearchVirtualMachines)
-	cmd.SearchFlag.Register(ctx, f)
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
 
 	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
 	cmd.ResourcePoolFlag.Register(ctx, f)
@@ -63,6 +63,9 @@ func (cmd *migrate) Register(ctx context.Context, f *flag.FlagSet) {
 
 func (cmd *migrate) Process(ctx context.Context) error {
 	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
 		return err
 	}
 	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
@@ -109,7 +112,7 @@ func (cmd *migrate) relocate(ctx context.Context, vm *object.VirtualMachine) err
 }
 
 func (cmd *migrate) Run(ctx context.Context, f *flag.FlagSet) error {
-	vms, err := cmd.VirtualMachines(f.Args())
+	vms, err := cmd.VirtualMachineFlag.VirtualMachines(f.Args())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

PR #2850 fix a search flag issue with the vm.clone command, but caused an issue with the vm.migrate command.
Rather than embed the SearchFlag directly, vm.migrate needs to embed the VirtualMachineFlag

Issue #2849

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged