### PR TITLE
Fix: use correct controlflag for vslm SetControlFlags API test

### DIFF
--- a/vslm/client_test.go
+++ b/vslm/client_test.go
@@ -119,7 +119,8 @@ func TestClient(t *testing.T) {
 	t.Logf("volumeCreateResult %+v", volumeCreateResult)
 	t.Logf("Volume created sucessfully. volumeId: %s", volumeId)
 
-	err = globalObjectManager.SetControlFlags(ctx, types.ID{Id: volumeId}, []string{"FCD_KEEP_AFTER_DELETE_VM"})
+	err = globalObjectManager.SetControlFlags(ctx, types.ID{Id: volumeId}, []string{
+		string(types.VslmVStorageObjectControlFlagKeepAfterDeleteVm)})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description

`FCD_KEEP_AFTER_DELETE_VM` is not correct control flag.
correcting test to use correct control flag VslmVStorageObjectControlFlagKeepAfterDeleteVm with value `keepAfterDeleteVm` 

## Type of change

Please mark options that are relevant:
Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Validated control flag in this PR - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1762 


cc: @chethanv28 @bandyopadhyays-vmware