### PR TITLE
fix: Interface conversion panic in pkg simulator

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -839,7 +839,7 @@ func (vm *VirtualMachine) RefreshStorageInfo(ctx *Context, req *types.RefreshSto
 
 		files, err := ioutil.ReadDir(directory)
 		if err != nil {
-			body.Fault_ = soap.ToSoapFault(err)
+			body.Fault_ = Fault("", ctx.Map.FileManager().fault(directory, err, new(types.CannotAccessFile)))
 			return body
 		}
 


### PR DESCRIPTION
## Description

Mitigates a panic situation in the `simulator` panic, where an unguarded interface conversion to SoapFault can potentially cause a panic in dependents if they call on a number of simulator methods without waiting for inflight tasks to complete.

Reference: https://github.com/vmware/govmomi/issues/2393#issuecomment-828116732

Closes: `nil`

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged