### PR TITLE
Add versioned user-agent header

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2014-2022 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+const (
+	// ClientName is the name of this SDK
+	ClientName = "govmomi"
+
+	// ClientVersion is the version of this SDK
+	ClientVersion = "master"
+)


### PR DESCRIPTION
## Description

If a user does not provide a custom `user-agent` via `client.UserAgent` a default request header `user-agent` will be constructed using `ClientName/ClientVersion (GOVERSION;GOOS;GOARCH)` syntax, e.g. `govmomi/0.28.0 (go1.18.3;linux;amd64)` and added to each outgoing HTTP request (SOAP/VAPI).

Adds a new `version.go` file in `internal/package`. The version number gets bumped on every release (see TODO below).

I decided to put this change in `client.Do` because there's multiple ways to construct a `Client`. `Do` is the place where we have full control over the new behavior without touching existing constructors, etc.

See comments in the PR review section for further details on the proposed implementation.

Not considering this a breaking change:

- currently we don't set a `user-agent` header in the library (`govc` does), i.e. the Go `net/http` standard header is used which I don't think users rely on as it is generic
- a custom `user-agent` can be supplied via `client.UserAgent`, retaining the current behavior and what some users are doing (see issue)

Closes: #2693
Signed-off-by: Michael Gasch <mgasch@vmware.com>

TODO:

- [ ] Update release automation to sync `SDKVersion` (separate PR)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Added unit tests

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged