### PR TITLE
vcsim: Remove VM Guest.Net entry when removing Ethernet card

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1163,15 +1163,15 @@ func (vm *VirtualMachine) configureDevice(ctx *Context, devices object.VirtualDe
 			c.MacAddress = vm.generateMAC(*c.UnitNumber - 7) // Note 7 == PCI offset
 		}
 
-		if spec.Operation == types.VirtualDeviceConfigSpecOperationAdd {
-			vm.Guest.Net = append(vm.Guest.Net, types.GuestNicInfo{
-				Network:        name,
-				IpAddress:      nil,
-				MacAddress:     c.MacAddress,
-				Connected:      true,
-				DeviceConfigId: c.Key,
-			})
+		vm.Guest.Net = append(vm.Guest.Net, types.GuestNicInfo{
+			Network:        name,
+			IpAddress:      nil,
+			MacAddress:     c.MacAddress,
+			Connected:      true,
+			DeviceConfigId: c.Key,
+		})
 
+		if spec.Operation == types.VirtualDeviceConfigSpecOperationAdd {
 			if c.ResourceAllocation == nil {
 				c.ResourceAllocation = &types.VirtualEthernetCardResourceAllocation{
 					Reservation: types.NewInt64(0),
@@ -1350,6 +1350,13 @@ func (vm *VirtualMachine) removeDevice(ctx *Context, devices object.VirtualDevic
 			case *types.VirtualEthernetCardDistributedVirtualPortBackingInfo:
 				net.Type = "DistributedVirtualPortgroup"
 				net.Value = b.Port.PortgroupKey
+			}
+
+			for j, nicInfo := range vm.Guest.Net {
+				if nicInfo.DeviceConfigId == key {
+					vm.Guest.Net = append(vm.Guest.Net[:j], vm.Guest.Net[j+1:]...)
+					break
+				}
 			}
 
 			networks := vm.Network


### PR DESCRIPTION
When an Ethernet card is added, an entry for the card is appended to
the VMs Guest.Net. If the Ethernet card is later removed, this entry
was not removed. If Customize() is later called, it will fail with a
NicSettingMismatch error because the Guest.Net still contains an entry
for the removed card.

In configureDevice() always append to the VM's Guest.Net so it is kept
consistent because vcsim Edit operation is done by removing and then
adding the device.

## Description

If a VM originally has one card that is then removed and a new card added, vcsim Customize will fail with:

              LocalizedMethodFault: {
                  DynamicData: {},
                  Fault: <*types.NicSettingMismatch | 0xc00097f7d0>{
                      CustomizationFault: {
                          VimFault: {
                              MethodFault: {FaultCause: nil, FaultMessage: nil},
                          },
                      },
                      NumberOfNicsInSpec: 1,
                      NumberOfNicsInVM: 2,
                  },
                  LocalizedMessage: "*types.NicSettingMismatch",
              },
              Description: nil,
          }

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?




- [ ] Test Description 1
- [ ] Test Description 2

## Checklist:

- [ ] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged