### PR TITLE
fix: generate negative device key in AssignController

### DIFF
--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -69,13 +69,7 @@ func EthernetCardTypes() VirtualDeviceList {
 		&types.VirtualSriovEthernetCard{},
 	}).Select(func(device types.BaseVirtualDevice) bool {
 		c := device.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-
-		key := rand.Int31() * -1
-		if key == 0 {
-			key = -1
-		}
-
-		c.GetVirtualDevice().Key = key
+		c.GetVirtualDevice().Key = VirtualDeviceList{}.newRandomKey()
 		return true
 	})
 }
@@ -463,8 +457,20 @@ func (l VirtualDeviceList) AssignController(device types.BaseVirtualDevice, c ty
 	d.UnitNumber = new(int32)
 	*d.UnitNumber = l.newUnitNumber(c)
 	if d.Key == 0 {
-		d.Key = int32(rand.Uint32()) * -1
+		d.Key = l.newRandomKey()
 	}
+}
+
+// newRandomKey returns a random negative device key.
+// The generated key can be used for devices you want to add so that it does not collide with existing ones.
+func (l VirtualDeviceList) newRandomKey() int32 {
+	// NOTE: rand.Uint32 cannot be used here because conversion from uint32 to int32 may change the sign
+	key := rand.Int31() * -1
+	if key == 0 {
+		return -1
+	}
+
+	return key
 }
 
 // CreateDisk creates a new VirtualDisk device which can be added to a VM.


### PR DESCRIPTION
## Description

Fix `VirtualDeviceList#AssignController` to always generate negative device keys so that they will not collide with existing keys.

Closes: #2881

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [x] Add unit tests

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged