### PR TITLE
fix: Typos in vim25/soap/client CA tests

### DIFF
--- a/vim25/soap/client_test.go
+++ b/vim25/soap/client_test.go
@@ -111,7 +111,7 @@ func TestMultipleCAPaths(t *testing.T) {
 
 	certErr, ok := err.(errInvalidCACertificate)
 	if !ok {
-		t.Fatalf("Expected errInvalidCertificate to occur")
+		t.Fatalf("Expected errInvalidCACertificate to occur")
 	}
 	if certErr.File != "fixtures/invalid-cert.pem" {
 		t.Fatalf("Expected Err to show invalid file")
@@ -138,7 +138,7 @@ func TestInvalidRootCAs(t *testing.T) {
 
 	certErr, ok := err.(errInvalidCACertificate)
 	if !ok {
-		t.Fatalf("Expected errInvalidCertificate to occur")
+		t.Fatalf("Expected errInvalidCACertificate to occur")
 	}
 	if certErr.File != "fixtures/invalid-cert.pem" {
 		t.Fatalf("Expected Err to show invalid file")


### PR DESCRIPTION
## Description

Replace incomplete sentinel error name in these tests:

- TestMultipleCAPaths
- TestInvalidRootCAs

Closes: #2883

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.*

- [x] Ran `make check`
  - passed
- [x] Ran `make test`
  - unrelated test failure (see output below)

<details>
<summary>test failure output</summary>

```
--- FAIL: ExampleClient_Run (0.50s)
panic: ServerFaultCode: GuestOperationsUnavailable [recovered]
        panic: ServerFaultCode: GuestOperationsUnavailable

goroutine 1 [running]:
testing.(*InternalExample).processRunResult(0xc000019ca8, {0x0, 0x0}, 0x4, 0x0, {0xdb7e80, 0xc000152050})
        /usr/local/go/src/testing/example.go:91 +0x505
testing.runExample.func2()
        /usr/local/go/src/testing/run_example.go:60 +0x11c
panic({0xdb7e80, 0xc000152050})
        /usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/vmware/govmomi/simulator.Run(0x2d84bf20, {0x0, 0xc00012fbb0, 0x48aad7})
        /mnt/t/github/govmomi/simulator/model.go:907 +0x1e5
github.com/vmware/govmomi/guest/toolbox_test.ExampleClient_Run()
        /mnt/t/github/govmomi/guest/toolbox/example_test.go:32 +0x27
testing.runExample({{0xeb154c, 0x11}, 0xf274d0, {0xea54a6, 0x6}, 0x0})
        /usr/local/go/src/testing/run_example.go:64 +0x28d
testing.runExamples(0xc000019e70, {0x178d5e0, 0x1, 0x0})
        /usr/local/go/src/testing/example.go:44 +0x18e
testing.(*M).Run(0xc0001d8180)
        /usr/local/go/src/testing/testing.go:1505 +0x587
main.main()
        _testmain.go:45 +0x14b
FAIL    github.com/vmware/govmomi/guest/toolbox 0.531s
```

```console
$ git log -n 2
commit d6dd8fb32270e6c9bf0e932e504293939b09b6d8 (HEAD -> issue-2876-fix-typo-in-test-fatalf-messages, origin/issue-2876-fix-typo-in-test-fatalf-messages)
Author: Adam Chalkley <atc0005@users.noreply.github.com>
Date:   Tue Jun 21 08:06:20 2022 -0500

    fix: Typos in vim25/soap/client CA tests

    Replace incomplete sentinel error name in these tests with the
    intended name:

    - TestMultipleCAPaths
    - TestInvalidRootCAs

    Closes: #2876

commit 7556da8754304dcaa2eed82f7b83adeedd0f29f7 (upstream/master, origin/master, origin/HEAD, master)
Merge: 63aa05d3 361c90ca
Author: Michael Gasch <mgasch@vmware.com>
Date:   Fri Jun 17 08:22:52 2022 +0200

    Merge pull request #2878 from bryanv/bryanv/vcsim-remove-nic-guest-net
```

</details>

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](./../CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged