### PR TITLE
vcsim: support disconnect/reconnect host

### DIFF
--- a/govc/test/host.bats
+++ b/govc/test/host.bats
@@ -246,3 +246,28 @@ load test_helper
   run govc host.date.info -json
   assert_success
 }
+
+@test "host.disconnect and host.reconnect" {
+  vcsim_env
+
+  run govc host.info
+  assert_success
+  status=$(govc host.info| grep -i "State"| awk '{print $2}')
+  assert_equal 'connected' $status
+
+  run govc host.disconnect "$GOVC_HOST"
+  assert_success
+
+  run govc host.info
+  assert_success
+  status=$(govc host.info| grep -i "State"| awk '{print $2}')
+  assert_equal 'disconnected' $status
+
+  run govc host.reconnect "$GOVC_HOST"
+  assert_success
+
+  run govc host.info
+  assert_success
+  status=$(govc host.info| grep -i "State"| awk '{print $2}')
+  assert_equal 'connected' $status
+}

--- a/simulator/host_system.go
+++ b/simulator/host_system.go
@@ -283,3 +283,29 @@ func (h *HostSystem) ExitMaintenanceModeTask(ctx *Context, spec *types.ExitMaint
 		},
 	}
 }
+
+func (h *HostSystem) DisconnectHostTask(ctx *Context, spec *types.DisconnectHost_Task) soap.HasFault {
+	task := CreateTask(h, "disconnectHost", func(t *Task) (types.AnyType, types.BaseMethodFault) {
+		h.Runtime.ConnectionState = types.HostSystemConnectionStateDisconnected
+		return nil, nil
+	})
+
+	return &methods.DisconnectHost_TaskBody{
+		Res: &types.DisconnectHost_TaskResponse{
+			Returnval: task.Run(ctx),
+		},
+	}
+}
+
+func (h *HostSystem) ReconnectHostTask(ctx *Context, spec *types.ReconnectHost_Task) soap.HasFault {
+	task := CreateTask(h, "reconnectHost", func(t *Task) (types.AnyType, types.BaseMethodFault) {
+		h.Runtime.ConnectionState = types.HostSystemConnectionStateConnected
+		return nil, nil
+	})
+
+	return &methods.ReconnectHost_TaskBody{
+		Res: &types.ReconnectHost_TaskResponse{
+			Returnval: task.Run(ctx),
+		},
+	}
+}


### PR DESCRIPTION
## Description

This PR introduces support for host disconnect/reconnect to vcsim, with associated `bats` tests.

As both operations are so closely related to each other, I've tested them together through disconnecting then reconnecting a host in the simulator. Happy to update to follow a different approach if the project prefers things done a different way.

Closes: #2899

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Ran `go test` against `simulator/host_system_test.go`
- [x] Ran the BATS tests `govc/test/host.bats`
- [x] Ran `make check` 

I've not been able to run the full test suite on my machine (first time contributing and think I have some missing dependencies which cause some tests to time out) but tests relating to the functionality I've added all pass.

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ 
In line with similar functions/tests, I've not added any specific comments
- [ ] ~~I have made corresponding changes to the documentation~~ 
no doc updates required
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged