### PR TITLE
vcsim: Fix StorageIOAllocationInfo of VirtualDisk

### DIFF
--- a/simulator/model.go
+++ b/simulator/model.go
@@ -556,6 +556,7 @@ func (m *Model) Create() error {
 				disk := devices.CreateDisk(scsi.(types.BaseVirtualController), ds,
 					config.Files.VmPathName+" "+path.Join(name, "disk1.vmdk"))
 				disk.CapacityInKB = int64(units.GB*10) / units.KB
+				disk.StorageIOAllocation = &types.StorageIOAllocationInfo{Limit: types.NewInt64(-1)}
 
 				devices = append(devices, scsi, cdrom, disk, &nic)
 


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

Set initial value to virtualDisk.StorageIOAllocationInfo in the simulator model so that `govc vm.disk.change` to `vcsim` does not panic.

Closes: #2904

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Request `govc vm.disk.change` to vcsim does not panic.

```bash
$ govc device.info -vm DC0_H0_VM0 "disk-*"
Name:           disk-202-0
  Type:         VirtualDisk
  Label:        disk-202-0
  Summary:      10,485,760 KB
  Key:          204
  Controller:   pvscsi-202
  Unit number:  0
  File:         [LocalDS_0] DC0_H0_VM0/disk1.vmdk
$ govc vm.disk.change -vm DC0_H0_VM0 -disk.name disk-202-0 -size 10G
```

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged