### PR TITLE
govc: Support creating content libraries with security policies

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -204,6 +204,7 @@ but appear via `govc $cmd -h`:
  - [library.import](#libraryimport)
  - [library.info](#libraryinfo)
  - [library.ls](#libraryls)
+ - [library.policy.ls](#librarypolicyls)
  - [library.publish](#librarypublish)
  - [library.rm](#libraryrm)
  - [library.session.ls](#librarysessionls)
@@ -3204,6 +3205,7 @@ Examples:
 Options:
   -d=                    Description of library
   -ds=                   Datastore [GOVC_DATASTORE]
+  -policy=               Security Policy ID
   -pub=<nil>             Publish library
   -pub-password=         Publication password
   -pub-username=         Publication username
@@ -3324,6 +3326,20 @@ Examples:
   govc library.ls */
   govc library.ls -json | jq .
   govc library.ls /lib1/item1 -json | jq .
+
+Options:
+```
+
+## library.policy.ls
+
+```
+Usage: govc library.policy.ls [OPTIONS]
+
+List security policies for content libraries.
+
+Examples:
+  govc library.policy.ls
+
 
 Options:
 ```
@@ -3848,9 +3864,9 @@ Options:
   -control-plane-dns-names=                Comma-separated list of DNS names to associate with the Kubernetes API server. These DNS names are embedded in the TLS certificate presented by the API server.
   -control-plane-dns-search-domains=       Comma-separated list of domains to be searched when trying to lookup a host name on Kubernetes API server, specified in order of preference.
   -control-plane-ntp-servers=              Optional. Comma-separated list of NTP server DNS names or IP addresses to use on Kubernetes API server, specified in order of preference. If unset, VMware Tools based time synchronization is enabled.
-  -control-plane-storage-policy=           Storage policy associated with Kubernetes API server.
-  -ephemeral-storage-policy=               Storage policy associated with ephemeral disks of all the Kubernetes Pods in the cluster.
-  -image-storage-policy=                   Storage policy to be used for container images.
+  -control-plane-storage-policy=           Storage Policy associated with Kubernetes API server.
+  -ephemeral-storage-policy=               Storage Policy associated with ephemeral disks of all the Kubernetes Pods in the cluster.
+  -image-storage-policy=                   Storage Policy to be used for container images.
   -login-banner=                           Optional. Disclaimer to be displayed prior to login via the Kubectl plugin.
   -mgmt-network.address-count=5            The number of IP addresses in the management range. Optional, but required with network mode STATICRANGE.
   -mgmt-network.floating-IP=               Optional. The Floating IP used by the HA master cluster in the when network Mode is DHCP.

--- a/govc/flags/library.go
+++ b/govc/flags/library.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+Copyright (c) 2020-2022 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/govc/library/create.go
+++ b/govc/library/create.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2022 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io"
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
@@ -55,6 +54,7 @@ func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 	f.Var(flags.NewOptionalBool(&cmd.pub.Published), "pub", "Publish library")
 	f.StringVar(&cmd.pub.UserName, "pub-username", "", "Publication username")
 	f.StringVar(&cmd.pub.Password, "pub-password", "", "Publication password")
+	f.StringVar(&cmd.library.SecurityPolicyID, "policy", "", "Security Policy ID")
 }
 
 func (cmd *create) Usage() string {
@@ -68,15 +68,6 @@ Examples:
   govc library.create library_name
   govc library.create -sub http://server/path/lib.json library_name
   govc library.create -pub library_name`
-}
-
-type createResult []library.Library
-
-func (r createResult) Write(w io.Writer) error {
-	for i := range r {
-		fmt.Fprintln(w, r[i].Name)
-	}
-	return nil
 }
 
 func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {

--- a/govc/library/info.go
+++ b/govc/library/info.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2022 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -171,6 +171,7 @@ func (r infoResultsWriter) writeLibrary(
 	fmt.Fprintf(w, "  Description:\t%s\n", v.Description)
 	fmt.Fprintf(w, "  Version:\t%s\n", v.Version)
 	fmt.Fprintf(w, "  Created:\t%s\n", v.CreationTime.Format(time.ANSIC))
+	fmt.Fprintf(w, "  Security Policy ID\t%s\n", v.SecurityPolicyID)
 	fmt.Fprintf(w, "  StorageBackings:\t\n")
 	for _, d := range v.Storage {
 		fmt.Fprintf(w, "    DatastoreID:\t%s\n", d.DatastoreID)

--- a/govc/library/policy/ls.go
+++ b/govc/library/policy/ls.go
@@ -1,0 +1,121 @@
+/*
+Copyright (c) 2022-2022 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("library.policy.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Description() string {
+	return `List security policies for content libraries.
+
+Examples:
+  govc library.policy.ls
+`
+}
+
+type lsResultsWriter struct {
+	Policies []library.ContentSecurityPoliciesInfo `json:"policies,omitempty"`
+}
+
+func (r lsResultsWriter) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	if len(r.Policies) == 0 {
+		_, _ = fmt.Fprintln(tw, "No Policies found")
+		return tw.Flush()
+	}
+
+	for _, p := range r.Policies {
+		if _, err := fmt.Fprintf(tw, "Name:\t%s\n", p.Name); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(tw, "Policy ID:\t%s\n", p.Policy); err != nil {
+			return err
+		}
+		if err := writeItemRules(tw, p); err != nil {
+			return err
+		}
+	}
+
+	return tw.Flush()
+}
+
+func (r lsResultsWriter) Dump() interface{} {
+	return r.Policies
+}
+
+func writeItemRules(w io.Writer, policy library.ContentSecurityPoliciesInfo) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 4, ' ', 0)
+	if _, err := fmt.Fprintln(w, "Rules:"); err != nil {
+		return err
+	}
+	for k, v := range policy.ItemTypeRules {
+		if _, err := fmt.Fprintf(tw, "\tItem: %s\n", k); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(tw, "\tRule: %s\n", v); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func (cmd *ls) Run(ctx context.Context, _ *flag.FlagSet) error {
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
+
+	m := library.NewManager(c)
+	policies, err := m.ListSecurityPolicies(ctx)
+	if err != nil {
+		return err
+	}
+	return cmd.WriteResult(&lsResultsWriter{policies})
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2022 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/host/vswitch"
 	_ "github.com/vmware/govmomi/govc/importx"
 	_ "github.com/vmware/govmomi/govc/library"
+	_ "github.com/vmware/govmomi/govc/library/policy"
 	_ "github.com/vmware/govmomi/govc/library/session"
 	_ "github.com/vmware/govmomi/govc/library/subscriber"
 	_ "github.com/vmware/govmomi/govc/license"

--- a/govc/namespace/cluster/enable.go
+++ b/govc/namespace/cluster/enable.go
@@ -128,11 +128,11 @@ func (cmd *enableCluster) Register(ctx context.Context, f *flag.FlagSet) {
 	f.StringVar(&cmd.WorkerDNS, "worker-dns", "",
 		"Comma-separated list of DNS server IP addresses to use on the worker nodes, specified in order of preference.")
 	f.StringVar(&cmd.ControlPlaneStoragePolicy, "control-plane-storage-policy", "",
-		"Storage policy associated with Kubernetes API server.")
+		"Storage Policy associated with Kubernetes API server.")
 	f.StringVar(&cmd.EphemeralStoragePolicy, "ephemeral-storage-policy", "",
-		"Storage policy associated with ephemeral disks of all the Kubernetes Pods in the cluster.")
+		"Storage Policy associated with ephemeral disks of all the Kubernetes Pods in the cluster.")
 	f.StringVar(&cmd.ImageStoragePolicy, "image-storage-policy", "",
-		"Storage policy to be used for container images.")
+		"Storage Policy to be used for container images.")
 	f.StringVar(&cmd.LoginBanner, "login-banner", "",
 		"Optional. Disclaimer to be displayed prior to login via the Kubectl plugin.")
 	// documented API is currently ambiguous with these duplicated fields, need to wait for this to be resolved

--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -454,6 +454,25 @@ EOF
   done
 }
 
+@test "library.create.withpolicy" {
+  vcsim_env
+
+  policy_id=$(govc library.policy.ls -json | jq '.[][0].policy' -r)
+  echo "$policy_id"
+
+  run govc library.create -policy=foo secure-content
+  assert_failure
+
+  run govc library.create -policy "$policy_id" secure-content
+  assert_success
+
+  library_secpol=$(govc library.info -json secure-content | jq '.[].security_policy_id' -r)
+  assert_equal "$library_secpol" "$policy_id"
+
+  run govc library.rm secure-content
+  assert_success
+}
+
 @test "library.findbyid" {
   vcsim_env
 

--- a/vapi/internal/internal.go
+++ b/vapi/internal/internal.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2022 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ const (
 	LibraryItemDownloadSessionFile = "/com/vmware/content/library/item/downloadsession/file"
 	LocalLibraryPath               = "/com/vmware/content/local-library"
 	SubscribedLibraryPath          = "/com/vmware/content/subscribed-library"
+	SecurityPoliciesPath           = "/api/content/security-policies"
 	SubscribedLibraryItem          = "/com/vmware/content/library/subscribed-item"
 	Subscriptions                  = "/com/vmware/content/library/subscriptions"
 	VCenterOVFLibraryItem          = "/com/vmware/vcenter/ovf/library-item"

--- a/vapi/library/library.go
+++ b/vapi/library/library.go
@@ -36,17 +36,19 @@ type StorageBackings struct {
 
 // Library  provides methods to create, read, update, delete, and enumerate libraries.
 type Library struct {
-	CreationTime     *time.Time        `json:"creation_time,omitempty"`
-	Description      string            `json:"description,omitempty"`
-	ID               string            `json:"id,omitempty"`
-	LastModifiedTime *time.Time        `json:"last_modified_time,omitempty"`
-	LastSyncTime     *time.Time        `json:"last_sync_time,omitempty"`
-	Name             string            `json:"name,omitempty"`
-	Storage          []StorageBackings `json:"storage_backings,omitempty"`
-	Type             string            `json:"type,omitempty"`
-	Version          string            `json:"version,omitempty"`
-	Subscription     *Subscription     `json:"subscription_info,omitempty"`
-	Publication      *Publication      `json:"publish_info,omitempty"`
+	CreationTime          *time.Time        `json:"creation_time,omitempty"`
+	Description           string            `json:"description,omitempty"`
+	ID                    string            `json:"id,omitempty"`
+	LastModifiedTime      *time.Time        `json:"last_modified_time,omitempty"`
+	LastSyncTime          *time.Time        `json:"last_sync_time,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Storage               []StorageBackings `json:"storage_backings,omitempty"`
+	Type                  string            `json:"type,omitempty"`
+	Version               string            `json:"version,omitempty"`
+	Subscription          *Subscription     `json:"subscription_info,omitempty"`
+	Publication           *Publication      `json:"publish_info,omitempty"`
+	SecurityPolicyID      string            `json:"security_policy_id,omitempty"`
+	UnsetSecurityPolicyID bool              `json:"unset_security_policy_id,omitempty"`
 }
 
 // Subscription info

--- a/vapi/library/security_policy.go
+++ b/vapi/library/security_policy.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2022-2022 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/internal"
+)
+
+const (
+	OvfDefaultSecurityPolicy = "OVF default policy"
+)
+
+// ContentSecurityPoliciesInfo contains information on security policies that can
+// be used to describe security for content library items.
+type ContentSecurityPoliciesInfo struct {
+	// ItemTypeRules are rules governing the policy.
+	ItemTypeRules map[string]string `json:"item_type_rules"`
+	// Name is a human-readable identifier identifying the policy.
+	Name string `json:"name"`
+	// Policy is the unique identifier for a policy.
+	Policy string `json:"policy"`
+}
+
+// ListSecurityPolicies lists security policies
+func (c *Manager) ListSecurityPolicies(ctx context.Context) ([]ContentSecurityPoliciesInfo, error) {
+	url := c.Resource(internal.SecurityPoliciesPath)
+	var res []ContentSecurityPoliciesInfo
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+func (c *Manager) DefaultOvfSecurityPolicy(ctx context.Context) (string, error) {
+	res, err := c.ListSecurityPolicies(ctx)
+
+	if err != nil {
+		return "", err
+	}
+
+	for _, policy := range res {
+		if policy.Name == OvfDefaultSecurityPolicy {
+			return policy.Policy, nil
+		}
+	}
+
+	return "", errors.New("failed to find default ovf security policy")
+}

--- a/vapi/resource.go
+++ b/vapi/resource.go
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2022-2022 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vapi
+
+const (
+	// Path is the new-style endpoint for API resources. It supersedes /rest.
+	Path = "/api"
+)


### PR DESCRIPTION
## Description

Security policies are important as they allow vCenter to secure content
at rest instead of requiring on thumbprints or TLS, which only verifies
you are talking to the correct server, but does nothing if the contents
themselves are compromised.

This changes adds a new cli command to support querying existing
library security policies. Support was added for creating new libraries
with a security policy and querying libraries that may have a security
policy attached.

Support was added to the vcsim mux to handle the /api endpoint for the
library module, since this endpoint is not served on /rest endpoints.
I thought this approach made more sense than a new mux since the
changes to add support for this were fairly minor. Having one module for
all library functions made sense organizationally, since ventually they
all could be migrated together to /api when the time comes.

New bats tests for the library module were introduced.

Closes: #2641

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] New bats test to find security policies, create a library with a new security policy, list and confirm the library was created with the appropriate policy, and delete a library with a security policy.
- [x] Negative test to fail creating a library with a bad security policy


Real VC testing:

```
[brak govc (cl-security-policy)]$ ./govc library.policy.ls # Default policy
Name:       OVF default policy
Policy ID:  356f6976-3123-9f7a-d67c-15f7e764ad15
Rules:
    Item: ovf
    Rule: OVF_STRICT_VERIFICATION

[brak govc (cl-security-policy)]$ ./govc library.create -ds=/cluster-1/datastore/nfsDatastore1 -policy=356f6976-3123-9f7a-d67c-15f7e764ad15 -sub=https://wp-content.vmware.com/v2/latest/lib.json -thumbprint=b2:52:9e:4d:57:9f:ea:53:4d:a0:0b:7f:d4:7e:55:91:56:c0:64:bb -dc=/datacenter-1 govc
fc1417d7-b557-4128-bb31-8654961d9fa0

[brak govc (cl-security-policy)]$ ./govc library.info fc1417d7-b557-4128-bb31-8654961d9fa0
Name:                 govc
  ID:                 fc1417d7-b557-4128-bb31-8654961d9fa0
  Path:               /govc
  Description:
  Version:            2
  Created:            Wed Jul 20 15:56:11 2022
  Security Policy ID  356f6976-3123-9f7a-d67c-15f7e764ad15
  StorageBackings:
    DatastoreID:      nfsDatastore1
    Type:             DATASTORE
  Subscription:
    AutoSync:         true
    URL:              https://wp-content.vmware.com/v2/latest/lib.json
    Auth:             NONE
    Download:         All

[brak govc (cl-security-policy)]$ ./govc library.ls -json | jq '.[] | {"name": .name, "policy":.security_policy_id}'
{
  "name": "Kubernetes Service Content Library",
  "policy": null
}
{
  "name": "k8s",
  "policy": "356f6976-3123-9f7a-d67c-15f7e764ad15"
}
{
  "name": "govc",
  "policy": "356f6976-3123-9f7a-d67c-15f7e764ad15"
}
```

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged