### PR TITLE
vcsim: Fix snapshot tasks to update rootSnapshot

### DIFF
--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -123,9 +123,16 @@ func (v *VirtualMachineSnapshot) RemoveSnapshotTask(ctx *Context, req *types.Rem
 			rootSnapshots := removeSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This, req.RemoveChildren)
 			changes = append(changes, types.PropertyChange{Name: "snapshot.rootSnapshotList", Val: rootSnapshots})
 
+			rootSnapshotRefs := make([]types.ManagedObjectReference, len(rootSnapshots))
+			for i, rs := range rootSnapshots {
+				rootSnapshotRefs[i] = rs.Snapshot
+			}
+			changes = append(changes, types.PropertyChange{Name: "rootSnapshot", Val: rootSnapshotRefs})
+
 			if len(rootSnapshots) == 0 {
 				changes = []types.PropertyChange{
 					{Name: "snapshot", Val: nil},
+					{Name: "rootSnapshot", Val: nil},
 				}
 			}
 

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -2168,6 +2168,10 @@ func (vm *VirtualMachine) CreateSnapshotTask(ctx *Context, req *types.CreateSnap
 				Name: "snapshot.rootSnapshotList",
 				Val:  append(vm.Snapshot.RootSnapshotList, treeItem),
 			})
+			changes = append(changes, types.PropertyChange{
+				Name: "rootSnapshot",
+				Val:  append(vm.RootSnapshot, treeItem.Snapshot),
+			})
 		}
 
 		snapshot.createSnapshotFiles()
@@ -2215,6 +2219,7 @@ func (vm *VirtualMachine) RemoveAllSnapshotsTask(ctx *Context, req *types.Remove
 
 		ctx.Map.Update(vm, []types.PropertyChange{
 			{Name: "snapshot", Val: nil},
+			{Name: "rootSnapshot", Val: nil},
 		})
 
 		for _, ref := range refs {

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -1503,6 +1503,10 @@ func TestVmSnapshot(t *testing.T) {
 	if err == errEmptyField {
 		t.Fatal("snapshot property should not be 'nil' if there are snapshots")
 	}
+	// NOTE: fieldValue cannot be used for nil check
+	if len(simVm.(*VirtualMachine).RootSnapshot) == 0 {
+		t.Fatal("rootSnapshot property should have elements if there are snapshots")
+	}
 
 	task, err = vm.CreateSnapshot(ctx, "child", "description", true, true)
 	if err != nil {
@@ -1553,6 +1557,10 @@ func TestVmSnapshot(t *testing.T) {
 	if err == errEmptyField {
 		t.Fatal("snapshot property should not be 'nil' if there are snapshots")
 	}
+	// NOTE: fieldValue cannot be used for nil check
+	if len(simVm.(*VirtualMachine).RootSnapshot) == 0 {
+		t.Fatal("rootSnapshot property should have elements if there are snapshots")
+	}
 
 	_, err = vm.FindSnapshot(ctx, "child")
 	if err == nil {
@@ -1572,6 +1580,10 @@ func TestVmSnapshot(t *testing.T) {
 	_, err = fieldValue(reflect.ValueOf(simVm), "snapshot")
 	if err != errEmptyField {
 		t.Fatal("snapshot property should be 'nil' if there are no snapshots")
+	}
+	// NOTE: fieldValue cannot be used for nil check
+	if len(simVm.(*VirtualMachine).RootSnapshot) != 0 {
+		t.Fatal("rootSnapshot property should not have elements if there are no snapshots")
 	}
 
 	_, err = vm.FindSnapshot(ctx, "root")


### PR DESCRIPTION
## Description

This PR fixes snapshot tasks in vcsim to update virtual machine's `rootSnapshot` properly.

Closes: #2912

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] add unit tests
- [x] run command below to vcsim to ensure rootSnapshot is set

```bash
# create a new snapshot
$ govc snapshot.create -vm DC0_H0_VM0 snapshot1
$ govc snapshot.tree -vm DC0_H0_VM0 -i
[snapshot-67]  snapshot1
[snapshot-67]  .
$ govc vm.info -json DC0_H0_VM0 | jq .VirtualMachines[].RootSnapshot
[
  {
    "Type": "VirtualMachineSnapshot",
    "Value": "snapshot-67"
  }
]

# create another snapshot
$ govc snapshot.create -vm DC0_H0_VM0 snapshot2
$ govc snapshot.tree -vm DC0_H0_VM0 -i
[snapshot-67]  snapshot1
  [snapshot-69]  snapshot2
  [snapshot-69]  .
$ govc vm.info -json DC0_H0_VM0 | jq .VirtualMachines[].Snapshot.RootSnapshotList[].Snapshot
{
  "Type": "VirtualMachineSnapshot",
  "Value": "snapshot-67"
}

# make snapshot tree forked
$ govc snapshot.revert -vm DC0_H0_VM0 snapshot1
$ govc snapshot.create -vm DC0_H0_VM0 snapshot3
$ govc snapshot.tree -vm DC0_H0_VM0 -i
[snapshot-67]  snapshot1
  [snapshot-69]  snapshot2
  [snapshot-72]  snapshot3
  [snapshot-72]  .
$ govc vm.info -json DC0_H0_VM0 | jq .VirtualMachines[].RootSnapshot
[
  {
    "Type": "VirtualMachineSnapshot",
    "Value": "snapshot-67"
  }
]

# remove root snapshot
$ govc snapshot.remove -vm DC0_H0_VM0 snapshot1
$ govc snapshot.tree -vm DC0_H0_VM0 -i
[snapshot-69]  snapshot2
[snapshot-72]  snapshot3
[snapshot-72]  .
$ govc vm.info -json DC0_H0_VM0 | jq .VirtualMachines[].RootSnapshot
[
  {
    "Type": "VirtualMachineSnapshot",
    "Value": "snapshot-69"
  },
  {
    "Type": "VirtualMachineSnapshot",
    "Value": "snapshot-72"
  }
]

# remove all snapshots
$ govc snapshot.remove -vm DC0_H0_VM0 '*'
$ govc vm.info -json DC0_H0_VM0 | jq .VirtualMachines[].RootSnapshot
null
```

## Checklist:

- [x] My code follows the `CONTRIBUTION`  [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged