### PR TITLE
govc: add event key for json and plain text output

### DIFF
--- a/govc/events/command.go
+++ b/govc/events/command.go
@@ -113,6 +113,10 @@ func (cmd *events) printEvents(ctx context.Context, obj *types.ManagedObjectRefe
 			r.Type = reflect.TypeOf(e).Elem().Name()
 		}
 
+		if cmd.Long {
+			r.Key = event.Key
+		}
+
 		// if this is a TaskEvent gather a little more information
 		if t, ok := e.(*types.TaskEvent); ok {
 			// some tasks won't have this information, so just use the event message
@@ -134,6 +138,7 @@ type record struct {
 	CreatedTime time.Time
 	Category    string
 	Message     string
+	Key         int32 `json:",omitempty"`
 
 	event types.BaseEvent
 }
@@ -145,11 +150,14 @@ func (r *record) Dump() interface{} {
 
 func (r *record) Write(w io.Writer) error {
 	when := r.CreatedTime.Local().Format(time.ANSIC)
-	var kind string
+	var kind, key string
 	if r.Type != "" {
 		kind = fmt.Sprintf(" [%s]", r.Type)
 	}
-	_, err := fmt.Fprintf(w, "[%s] [%s]%s %s\n", when, r.Category, kind, r.Message)
+	if r.Key != 0 {
+		key = fmt.Sprintf(" [%d]", r.Key)
+	}
+	_, err := fmt.Fprintf(w, "[%s] [%s]%s%s %s\n", when, r.Category, key, kind, r.Message)
 	return err
 }
 

--- a/govc/test/events.bats
+++ b/govc/test/events.bats
@@ -15,6 +15,13 @@ load test_helper
   run govc events -n $((nevents - 1))
   assert_success
   [ ${#lines[@]} -le $nevents ]
+
+  # test keys in json
+  [ "$(govc events -l -n 1 -json | jq -r 'has("CreatedTime")')" = "true" ]
+  [ "$(govc events -l -n 1 -json | jq -r 'has("Category")')" = "true" ]
+  [ "$(govc events -l -n 1 -json | jq -r 'has("Message")')" = "true" ]
+  [ "$(govc events -l -n 1 -json | jq -r 'has("Type")')" = "true" ]
+  [ "$(govc events -l -n 1 -json | jq -r 'has("Key")')" = "true" ]
 }
 
 @test "events host" {


### PR DESCRIPTION
## Description

Since key is an important and fundamental value for
identifying events, this patch changes it to be
included in the json or plain text output of
"govc events" command.

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] add unit tests

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged