### PR TITLE
toolbox: add hgfs OpenBSD stub

### DIFF
--- a/toolbox/hgfs/hgfs_openbsd.go
+++ b/toolbox/hgfs/hgfs_openbsd.go
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hgfs
+
+import (
+	"os"
+)
+
+func (a *AttrV2) sysStat(info os.FileInfo) {
+}

--- a/toolbox/hgfs/hgfs_openbsd.go
+++ b/toolbox/hgfs/hgfs_openbsd.go
@@ -2,7 +2,7 @@
 // +build openbsd
 
 /*
-Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+Copyright (c) 2022-2022 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/toolbox/hgfs/hgfs_openbsd.go
+++ b/toolbox/hgfs/hgfs_openbsd.go
@@ -1,3 +1,6 @@
+//go:build openbsd
+// +build openbsd
+
 /*
 Copyright (c) 2022 VMware, Inc. All Rights Reserved.
 


### PR DESCRIPTION
Fix build on OpenBSD, add hgfs stub.

Basically I need this for telegraf, so this is untested with VMware vSphere APIs.