### PR TITLE
Adding support for LLDP and CDP details for GOVC and VCSIM

### DIFF
--- a/govc/host/vnic/hint.go
+++ b/govc/host/vnic/hint.go
@@ -1,0 +1,72 @@
+/*
+Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vnic
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type hint struct {
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("host.vnic.hint", &hint{})
+}
+
+func (cmd *hint) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *hint) Usage() string {
+	return "[DEVICE]..."
+}
+
+func (cmd *hint) Description() string {
+	return `Query virtual nic DEVICE hints.
+Examples:
+  govc host.vnic.hint -host hostname
+  govc host.vnic.hint -host hostname vmnic1`
+}
+
+type hintResult struct {
+	Hint []types.PhysicalNicHintInfo
+}
+
+func (i *hintResult) Write(w io.Writer) error {
+	// TODO: human friendly output
+	return errors.New("-xml, -json or -dump flag required")
+}
+
+func (cmd *hint) Run(ctx context.Context, f *flag.FlagSet) error {
+	ns, err := cmd.HostNetworkSystem()
+	if err != nil {
+		return err
+	}
+
+	hints, err := ns.QueryNetworkHint(ctx, f.Args())
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(&hintResult{Hint: hints})
+}

--- a/govc/object/save.go
+++ b/govc/object/save.go
@@ -120,10 +120,19 @@ func saveEnvironmentBrowser(ctx context.Context, c *vim25.Client, ref types.Mana
 	return []saveMethod{{"QueryConfigOption", res}}, nil
 }
 
+func saveHostNetworkSystem(ctx context.Context, c *vim25.Client, ref types.ManagedObjectReference) ([]saveMethod, error) {
+	res, err := methods.QueryNetworkHint(ctx, c, &types.QueryNetworkHint{This: ref})
+	if err != nil {
+		return nil, err
+	}
+	return []saveMethod{{"QueryNetworkHint", res}}, nil
+}
+
 // saveObjects maps object types to functions that can save data that isn't available via the PropertyCollector
 var saveObjects = map[string]func(context.Context, *vim25.Client, types.ManagedObjectReference) ([]saveMethod, error){
 	"VmwareDistributedVirtualSwitch": saveDVS,
 	"EnvironmentBrowser":             saveEnvironmentBrowser,
+	"HostNetworkSystem":              saveHostNetworkSystem,
 }
 
 func (cmd *save) save(content []types.ObjectContent) error {

--- a/simulator/host_network_system.go
+++ b/simulator/host_network_system.go
@@ -27,6 +27,8 @@ type HostNetworkSystem struct {
 	mo.HostNetworkSystem
 
 	Host *mo.HostSystem
+
+	types.QueryNetworkHintResponse
 }
 
 func NewHostNetworkSystem(host *mo.HostSystem) *HostNetworkSystem {
@@ -198,9 +200,13 @@ func (s *HostNetworkSystem) UpdateNetworkConfig(req *types.UpdateNetworkConfig) 
 func (s *HostNetworkSystem) QueryNetworkHint(req *types.QueryNetworkHint) soap.HasFault {
 	var info []types.PhysicalNicHintInfo
 
-	for _, nic := range s.Host.Config.Network.Pnic {
+	for _, nic := range s.QueryNetworkHintResponse.Returnval {
 		info = append(info, types.PhysicalNicHintInfo{
-			Device: nic.Device,
+			Device:              nic.Device,
+			Subnet:              nic.Subnet,
+			Network:             nic.Network,
+			ConnectedSwitchPort: nic.ConnectedSwitchPort,
+			LldpInfo:            nic.LldpInfo,
 		})
 	}
 


### PR DESCRIPTION
## Description
Generally VC is connected to Switches like Cisco, Dell etc. these are called as neighbouring routers. VC UI show their details under : ESX host -> Configure -> Networking -> Physical Adapters -> vmnic0 -> CDP + LLDP
But VC simulator does not return these details

Closes: #2940

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

This has been tested in our environments, we have lab where VC is connected to cisco devices nexus 7000.

- [x] Test Description 1 : we dumped topology with VC + cisco nexus, and brought but simulators.
- [ ] Test Description 2

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged