### PR TITLE
Adding support extending virtual disk for virtual disk manager

### DIFF
--- a/object/virtual_disk_manager.go
+++ b/object/virtual_disk_manager.go
@@ -145,6 +145,27 @@ func (m VirtualDiskManager) DeleteVirtualDisk(ctx context.Context, name string, 
 	return NewTask(m.c, res.Returnval), nil
 }
 
+// ExtendVirtualDisk extends a virtual disk
+func (m VirtualDiskManager) ExtendVirtualDisk(ctx context.Context, name string, dc *Datacenter, newSize int64) (*Task, error) {
+	req := types.ExtendVirtualDisk_Task{
+		This:          m.Reference(),
+		Name:          name,
+		NewCapacityKb: newSize,
+	}
+
+	if dc != nil {
+		ref := dc.Reference()
+		req.Datacenter = &ref
+	}
+
+	res, err := methods.ExtendVirtualDisk_Task(ctx, m.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(m.c, res.Returnval), nil
+}
+
 // InflateVirtualDisk inflates a virtual disk.
 func (m VirtualDiskManager) InflateVirtualDisk(ctx context.Context, name string, dc *Datacenter) (*Task, error) {
 	req := types.InflateVirtualDisk_Task{


### PR DESCRIPTION
## Description

Adding support extending virtual disk for virtual disk manager. 
There is a need to extends the vmdk virtual disk not connected to the virtual machine. It seems to be easy to do this with the help of a virtual disk manager. The necessary types already existed, but there was just no method.
I checked the work on the real vsphere ver 7.0.2, it works correctly.

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Using the new method, the size of the virtual disk was changed on the real vsphere version 7.0.2

## Checklist:

- [x] My code follows the CONTRIBUTION [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged