### PR TITLE
Update query selection parameter name

### DIFF
--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -717,7 +717,7 @@ func TestClient(t *testing.T) {
 			string(cnstypes.CnsQuerySelectionName_VOLUME_NAME),
 			string(cnstypes.CnsQuerySelectionName_VOLUME_TYPE),
 			string(cnstypes.CnsQuerySelectionName_DATASTORE_URL),
-			string(cnstypes.CnsQuerySelectionName_STORAGE_POLICY_ID),
+			string(cnstypes.CnsQuerySelectionName_POLICY_ID),
 			string(cnstypes.CnsQuerySelectionName_HEALTH_STATUS),
 			string(cnstypes.CnsQuerySelectionName_BACKING_OBJECT_DETAILS),
 			string(cnstypes.CnsQuerySelectionName_COMPLIANCE_STATUS),

--- a/cns/types/enum.go
+++ b/cns/types/enum.go
@@ -56,7 +56,7 @@ const (
 	QuerySelectionNameTypeDataStoreAccessibility = QuerySelectionNameType("DATASTORE_ACCESSIBILITY_STATUS")
 	QuerySelectionNameTypeHealthStatus           = QuerySelectionNameType("HEALTH_STATUS")
 	QuerySelectionNameTypeDataStoreUrl           = QuerySelectionNameType("DATASTORE_URL")
-	QuerySelectionNameTypeStoragePolicyId        = QuerySelectionNameType("POLICY_ID")
+	QuerySelectionNameTypePolicyId               = QuerySelectionNameType("POLICY_ID")
 )
 
 func init() {
@@ -91,7 +91,7 @@ const (
 	CnsQuerySelectionName_DATASTORE_ACCESSIBILITY_STATUS = CnsQuerySelectionNameType("DATASTORE_ACCESSIBILITY_STATUS")
 	CnsQuerySelectionName_HEALTH_STATUS                  = CnsQuerySelectionNameType("HEALTH_STATUS")
 	CnsQuerySelectionName_DATASTORE_URL                  = CnsQuerySelectionNameType("DATASTORE_URL")
-	CnsQuerySelectionName_STORAGE_POLICY_ID              = CnsQuerySelectionNameType("POLICY_ID")
+	CnsQuerySelectionName_POLICY_ID                      = CnsQuerySelectionNameType("POLICY_ID")
 )
 
 func init() {


### PR DESCRIPTION
This PR addresses review comments for https://github.com/vmware/govmomi/pull/2951 from @chethanv28 

How Has This Been Tested?

Tested QueryAllVolume API with new parameter from cns/client_test.go

=== RUN   TestClient
...
    client_test.go:732: Successfully Queried all Volumes. queryResult: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "6e5ab646-c23c-4ee5-90cd-95ff4e34d365",
                    },
                    DatastoreUrl:         "ds:///vmfs/volumes/vsan:5200264f8423829b-138888a14230b49d/",
                    Name:                 "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:           "BLOCK",
                    StoragePolicyId:      "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:             types.CnsVolumeMetadata{},
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 10240,
                        },
                        BackingDiskId:       "6e5ab646-c23c-4ee5-90cd-95ff4e34d365",
                        BackingDiskUrlPath:  "",
                        BackingDiskObjectId: "d6162463-aa23-c7b2-3ca7-0200ab5fee16",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "green",
                },
            },
            Cursor: types.CnsCursor{
                Offset:       1,
                Limit:        0,
                TotalRecords: 1,
            },
        }
...
--- PASS: TestClient (155.25s)
PASS
ok      github.com/vmware/govmomi/cns   186.649s

