### PR TITLE
api: Add SRIOV device names

### DIFF
--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -919,7 +919,7 @@ func (l VirtualDeviceList) Name(device types.BaseVirtualDevice) string {
 	dtype := l.Type(device)
 	switch dtype {
 	case DeviceTypeEthernet:
-		// Ethernet devices of UnitNumber 7-19 are non-SRIOV. Ethernet devices of 
+		// Ethernet devices of UnitNumber 7-19 are non-SRIOV. Ethernet devices of
 		// UnitNumber 45-36 descending are SRIOV
 		if UnitNumber <= 45 && UnitNumber >= 36 {
 			key = fmt.Sprintf("sriov-%d", 45-UnitNumber)

--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -919,7 +919,13 @@ func (l VirtualDeviceList) Name(device types.BaseVirtualDevice) string {
 	dtype := l.Type(device)
 	switch dtype {
 	case DeviceTypeEthernet:
-		key = fmt.Sprintf("%d", UnitNumber-7)
+		// Ethernet devices of UnitNumber 7-19 are non-SRIOV. Ethernet devices of 
+		// UnitNumber 45-36 descending are SRIOV
+		if UnitNumber <= 45 && UnitNumber >= 36 {
+			key = fmt.Sprintf("(sriov)-%d", 45-UnitNumber)
+		} else {
+			key = fmt.Sprintf("%d", UnitNumber-7)
+		}
 	case DeviceTypeDisk:
 		key = fmt.Sprintf("%d-%d", d.ControllerKey, UnitNumber)
 	default:

--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -922,7 +922,7 @@ func (l VirtualDeviceList) Name(device types.BaseVirtualDevice) string {
 		// Ethernet devices of UnitNumber 7-19 are non-SRIOV. Ethernet devices of 
 		// UnitNumber 45-36 descending are SRIOV
 		if UnitNumber <= 45 && UnitNumber >= 36 {
-			key = fmt.Sprintf("(sriov)-%d", 45-UnitNumber)
+			key = fmt.Sprintf("sriov-%d", 45-UnitNumber)
 		} else {
 			key = fmt.Sprintf("%d", UnitNumber-7)
 		}


### PR DESCRIPTION
Closes #2956

Signed-off-by: Sunny Carter <sunny.carter@metaswitch.com>

## Description
https://github.com/vmware/govmomi/issues/2956 
Is your feature request related to a problem? Please describe.
SR-IOV, Single Root I/O Virtualization, allows a single NIC (termed the Physical Function - PF) to be shared between a bounded number of VMs, providing a Virtual Function (VF) network interface to each VM. It is used for high-performance throughput on the network interface.

In VMWare, Ethernet devices of UnitNumber 7-19 are non-SRIOV. Ethernet devices of UnitNumber 45-36 descending are SRIOV.
Current code uses the UnitNumber to determine the device name, but it only takes into account non-SRIOV devices.
It is necessary to have a different stable name for SRIOV devices that takes this into account, otherwise non-SRIOV devices and SRIOV devices can be confused.

Without this, I cannot support SRIOV in the terraform vsphere provider: https://github.com/hashicorp/terraform-provider-vsphere/pull/1417 as it cannot differentiate between devices using the name.
A clear and concise description of what the problem is. Ex. I cannot do X because [...]

Describe the solution you'd like
I'd like the Name function in virtual_device_list.go for DeviceTypeEthernet to return:
[devicetype]-0 for unit Number 7
[devicetype]-1 for unit Number 8
etc
[devicetype]-sriov-0 for unit number 45
[devicetype]-sriov-1 for unit number 44
etc.
## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?
I made this change over a year ago in the copy of the govmomi code which was pulled into terraform-vsphere-provider, and have been running with a locally built copy of that ever since. 
https://github.com/hashicorp/terraform-provider-vsphere/pull/1417 

I tested these changes along with that code:
Manual testing
`make tests` which gave the output in [govmomi_maketest_output.txt](https://github.com/vmware/govmomi/files/9648185/govmomi_maketest_output.txt)
The following manual tests have been done:
Error cases:

- Missing host
- Invalid Physical function
- Memory not reserved
- SRIOV not enabled on physical function
- Simple - change adapter type to sriov from vmxnet
- Simple - change adapter type to vmxnet to sriov
- Missing physical function on sriov nic


- Physical function on vmxnet nic
- Wrong host

Apply new:

- 2x VMXnet then 2xSRIOV
- Vmxnet, SRIOV, vmxnet, SRIOV
- 10 VMXnet, 10 SRIOV
- 10 VMXnet, 11 SRIOV
- 2 SRIOV
- 2xVM pair with 2VMxnet 2SRIOV
- Bandwidth limit on vmxnet
- e1000 network
- 3 non-SRIOV

Update (new interfaces):

- Additional SRIOV new resource indexes
- Additional VMXnet new resource indexes no SRIOV
- 2VMXnet, 2 SRIOV add new VMXnet before SRIOV
- Switch physical adapter on two SRIOV NICs
- Vmxnet bandwidth limit

Delete interfaces:

- Delete SRIOV NICs from end of list
- Delete SRIOV NICs within list
- Delete Vmxnet NIC at end of VMxnet list with no SRIOV
- Delete Vmxnet within list containing SRIOV after
- Delete vmxnet within list containing only Vmxnet

Import:

- 2x VMXnet then 2xSRIOV
- 6 VMXnet, 6 SRIOV
- e1000
- Bandwidth limit non default

Bandwidth stuff:

- One vmxnet without, one with non-defaults, one sriov, apply
- same as above but import then plan
- Add new SRIOV NIC - Update
- Update vmxnet bandwidth setting
- Import after the above
- Bandwidth setting on SRIOV nic

Non-interface tests:

- Update some other non NIC function
- Import without SRIOV

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged