### PR TITLE
govc: fix host.esxcli runtime error occurred when no arguments specified

### DIFF
--- a/govc/host/esxcli/esxcli.go
+++ b/govc/host/esxcli/esxcli.go
@@ -71,6 +71,10 @@ func (cmd *esxcli) Process(ctx context.Context) error {
 }
 
 func (cmd *esxcli) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
 	c, err := cmd.Client()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

This PR fixes `govc host.esxcli` runtime error occurred when no arguments specified.

Closes: #2960

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] run commands below

```bash
$ ./govc host.esxcli
./govc: no argument
```

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged