### PR TITLE
Fix: use latestPages in task HistoryCollector

### DIFF
--- a/task/history_collector.go
+++ b/task/history_collector.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2022 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -38,12 +38,15 @@ func newHistoryCollector(c *vim25.Client, ref types.ManagedObjectReference) *His
 	}
 }
 
-// RecentTasks returns a list of task managed objects that completed recently,
-// that are currently running, or that are queued to run.
-func (h HistoryCollector) RecentTasks(ctx context.Context) ([]types.TaskInfo, error) {
+// LatestPage returns items in the 'viewable latest page' of the task history collector.
+// As new tasks that match the collector's TaskFilterSpec are created,
+// they are added to this page, and the oldest tasks are removed from the collector to keep
+// the size of the page to that allowed by SetCollectorPageSize.
+// The "oldest task" is the one with the oldest creation time. The tasks in the returned page are unordered.
+func (h HistoryCollector) LatestPage(ctx context.Context) ([]types.TaskInfo, error) {
 	var o mo.TaskHistoryCollector
 
-	err := h.Properties(ctx, h.Reference(), []string{"recentTask"}, &o)
+	err := h.Properties(ctx, h.Reference(), []string{"latestPage"}, &o)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This change fixes the recentTasks errors in the task historyCollector. TaskHistoryCollector does not have a recentTask property, so this method always fails.
Update recentTasks to latestPage to fix this bug.

## Type of change

Please mark options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [X] Verified in a real environment.
Test code:
```
taskManager := task.NewManager(vcClient.VimClient())
	filterSpec := types.TaskFilterSpec{
		ActivationId: []string{actID},
	}

	collector, err := taskManager.CreateCollectorForTasks(ctx, filterSpec)
	if err != nil {
		return nil, errors.Wrapf(err, "failed to create collector for tasks")
	}
	defer func() {
		retErr = collector.Destroy(ctx)
	}()

	tasks, err := collector.LatestPage(ctx)
	log.Info("TaskHistoryCollector", "latestPage", tasks)
```
Output:
```
I1017 22:11:47.900807       1 logr.go:249] vsphere "msg"="TaskHistoryCollector"  "latestPage"=[{"Key":"task-3825","Task":{"Type":"Task","Value":"task-3825"},"Description":null,"Name":"","DescriptionId":"com.vmware.ovfs.LibraryItem.capture","Entity":{"Type":"ContentLibrary","Value":"clib-3093"},"EntityName":"cl-1","Locked":null,"State":"queued","Cancelled":false,"Cancelable":false,"Error":null,"Result":null,"Progress":0,"Reason":{"UserName":"vsphere.local\\wcp-vmop-user-8c8149a0-761b-4b0c-95f5-adca76a5d480-39bc1f75-9e57-49d6-bc25-0b6d295f6207"},"QueueTime":"2022-10-17T22:11:47.857999Z","StartTime":null,"CompleteTime":null,"EventChainId":39193,"ChangeTag":"","ParentTaskKey":"","RootTaskKey":"","ActivationId":"3203fa56-a395-4392-971c-71c8af4a8355-1"}]
```

## Checklist:

- [X] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of
  this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged