### PR TITLE
Add optional recommRequired PlaceVmsXCluster req arguments

### DIFF
--- a/vim25/types/unreleased.go
+++ b/vim25/types/unreleased.go
@@ -98,8 +98,10 @@ func init() {
 type PlaceVmsXClusterSpec struct {
 	DynamicData
 
-	ResourcePools    []ManagedObjectReference              `xml:"resourcePools,omitempty"`
-	VmPlacementSpecs []PlaceVmsXClusterSpecVmPlacementSpec `xml:"vmPlacementSpecs,omitempty"`
+	ResourcePools           []ManagedObjectReference              `xml:"resourcePools,omitempty"`
+	VmPlacementSpecs        []PlaceVmsXClusterSpecVmPlacementSpec `xml:"vmPlacementSpecs,omitempty"`
+	HostRecommRequired      *bool                                 `xml:"hostRecommRequired"`
+	DatastoreRecommRequired *bool                                 `xml:"datastoreRecommRequired"`
 }
 
 func init() {


### PR DESCRIPTION
PlaceVmsXCluster request has two optional bool fields as to whether host and/or datastore selection is required as a part of the placement response.

Update simulator PlaceVmsXCluster response to include the ConfigSpec only when the datastore selection is required to match real VC behavior.

## Description

Note that the simulator handling of DatastoreRecommRequired is just an initial pass, and something we'll likely need to improve on later. My immediate need is just for HostRecommRequired.

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Verified client behavior against both VC and vcsim

## Checklist:

- [ ] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged