### PR TITLE
Issue 2995

### DIFF
--- a/govc/flags/output.go
+++ b/govc/flags/output.go
@@ -106,8 +106,14 @@ func (flag *OutputFlag) Write(b []byte) (int, error) {
 		return 0, nil
 	}
 
-	n, err := os.Stdout.Write(b)
-	os.Stdout.Sync()
+	w := flag.Out
+	if w == nil {
+		w = os.Stdout
+	}
+	n, err := w.Write(b)
+	if w == os.Stdout {
+		os.Stdout.Sync()
+	}
 	return n, err
 }
 

--- a/govc/host/info.go
+++ b/govc/host/info.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"os"
 	"text/tabwriter"
 
 	"github.com/vmware/govmomi/govc/cli"
@@ -132,7 +131,7 @@ func (r *infoResult) Write(w io.Writer) error {
 		objects[o.Reference()] = o
 	}
 
-	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
 
 	for _, o := range r.objects {
 		host := objects[o.Reference()]


### PR DESCRIPTION
## Description

**govc**

* host.info writes always write to os.Stdout instead of the provided writer
* OutputFlag.Write always write to os.Stdout instead of the provided writer

Closes: #2995

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

To reproduce the issue see the code in issue #2995.
This code is also used to test the fix.
Besides the test code, govc was also tested against a live environment.

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged