### PR TITLE
docs: update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,33 @@
-[![Build](https://github.com/vmware/govmomi/actions/workflows/govmomi-build.yaml/badge.svg)](https://github.com/vmware/govmomi/actions/workflows/govmomi-build.yaml)
-[![Tests](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-tests.yaml/badge.svg)](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-tests.yaml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/vmware/govmomi)](https://goreportcard.com/report/github.com/vmware/govmomi)
-[![Latest Release](https://img.shields.io/github/release/vmware/govmomi.svg?logo=github&style=flat-square)](https://github.com/vmware/govmomi/releases/latest)
-[![Go Reference](https://pkg.go.dev/badge/github.com/vmware/govmomi.svg)](https://pkg.go.dev/github.com/vmware/govmomi)
-[![go.mod Go version](https://img.shields.io/github/go-mod/go-version/vmware/govmomi)](https://github.com/vmware/govmomi)
+<!-- markdownlint-disable first-line-h1 no-inline-html -->
+
+[![Build](https://github.com/vmware/govmomi/actions/workflows/govmomi-build.yaml/badge.svg)][ci-build]
+[![Tests](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-tests.yaml/badge.svg)][ci-tests]
+[![Go Report Card](https://goreportcard.com/badge/github.com/vmware/govmomi)][go-report-card]
+[![Latest Release](https://img.shields.io/github/release/vmware/govmomi.svg?logo=github&style=flat-square)][latest-release]
+[![Go Reference](https://pkg.go.dev/badge/github.com/vmware/govmomi.svg)][go-reference]
+[![go.mod Go version](https://img.shields.io/github/go-mod/go-version/vmware/govmomi)][go-version]
 
 # govmomi
 
-A Go library for interacting with VMware vSphere APIs (ESXi and/or vCenter).
+A Go library for interacting with VMware vSphere APIs (ESXi and/or vCenter Server).
 
 In addition to the vSphere API client, this repository includes:
 
-* [govc](./govc) - vSphere CLI
-
-* [vcsim](./vcsim) - vSphere API mock framework
-
-* [toolbox](./toolbox) - VM guest tools framework
+* [govc][govc] - vSphere CLI
+* [vcsim][vcsim] - vSphere API mock framework
+* [toolbox][toolbox] - VM guest tools framework
 
 ## Compatibility
 
-This library is built for and tested against ESXi and vCenter 6.5, 6.7 and 7.0.
+This library supports vCenter Server and ESXi versions following the [VMware Product Lifecycle Matrix][reference-lifecycle].
 
-It may work with versions 5.1, 5.5 and 6.0, but neither are officially supported.
+Product versions that are end of support may work, but are not officially supported.
 
 ## Documentation
 
-The APIs exposed by this library very closely follow the API described in the [VMware vSphere API Reference Documentation][apiref].
-Refer to this document to become familiar with the upstream API.
+The APIs exposed by this library closely follow the API described in the [VMware vSphere API Reference Documentation][reference-api]. Refer to the documentation to become familiar with the upstream API.
 
-The code in the `govmomi` package is a wrapper for the code that is generated from the vSphere API description.
-It primarily provides convenience functions for working with the vSphere API.
-See [godoc.org][godoc] for documentation.
-
-[apiref]:https://code.vmware.com/apis/968/vsphere
-[godoc]:http://godoc.org/github.com/vmware/govmomi
+The code in the `govmomi` package is a wrapper for the code that is generated from the vSphere API description. It primarily provides convenience functions for working with the vSphere API. See [godoc.org][reference-godoc] for documentation.
 
 ## Installation
 
@@ -45,79 +39,93 @@ go get -u github.com/vmware/govmomi
 
 ### Binaries and Docker Images for `govc` and `vcsim`
 
-Installation instructions, released binaries and Docker images are documented in
-the respective README files of [`govc`](govc/README.md) and
-[`vcsim`](vcsim/README.md).
+Installation instructions, released binaries, and Docker images are documented in the respective README files of [`govc`][govc] and [`vcsim`][vcsim].
 
 ## Discussion
 
-Contributors and users are encouraged to collaborate using GitHub issues and/or
-[Slack](https://vmwarecode.slack.com/messages/govmomi).
-Access to Slack requires a [VMware {code} membership](https://code.vmware.com/join/).
+The project encourages the community to collaborate using GitHub [issues][govmomi-github-issues], GitHub [discussions][govmomi-github-discussions], and [Slack][slack-channel].
+
+> **Note**
+> Access to Slack requires a free [VMware {code}][slack-join] developer program membership.
 
 ## Status
 
-Changes to the API are subject to [semantic versioning](http://semver.org).
+Changes to the API are subject to [semantic versioning][reference-semver].
 
-Refer to the [CHANGELOG](CHANGELOG.md) for version to version changes.
+Refer to the [CHANGELOG][govmomi-changelog] for version to version changes.
 
-## Projects using govmomi
-* [Elastic Agent VMware vSphere integration](https://github.com/elastic/integrations/tree/main/packages/vsphere)
+## Notable Projects Using govmomi
 
-* [collectd-vsphere](https://github.com/travis-ci/collectd-vsphere)
+* [collectd-vsphere][project-travisci-collectd-vsphere]
+* [Docker LinuxKit][project-docker-linuxKit]
+* [Elastic Agent VMware vSphere integration][project-elastic-agent]
+* [Gru][project-gru]
+* [Juju][project-juju]
+* [Jupiter Brain][project-travisci-jupiter-brain]
+* [Kubernetes vSphere Cloud Provider][project-k8s-cloud-provider]
+* [Kubernetes Cluster API][project-k8s-cluster-api]
+* [OPS][project-nanovms-ops]
+* [Packer Plugin for VMware vSphere][project-hashicorp-packer-plugin-vsphere]
+* [Rancher][project-rancher]
+* [Terraform Provider for VMware vSphere][project-hashicorp-terraform-provider-vsphere]
+* [Telegraf][project-influxdata-telegraf]
+* [VMware Event Broker Appliance][project-vmware-veba]
+* [VMware vSphere Integrated Containers Engine][project-vmware-vic]
+* [VMware vSphere 7.0][project-vmware-vsphere]
 
-* [Docker Machine](https://github.com/docker/machine/tree/master/drivers/vmwarevsphere)
+## Related Projects
 
-* [Docker InfraKit](https://github.com/docker/infrakit/tree/master/pkg/provider/vsphere)
-
-* [Docker LinuxKit](https://github.com/linuxkit/linuxkit/tree/master/src/cmd/linuxkit)
-
-* [Gru](https://github.com/dnaeon/gru)
-
-* [Juju](https://github.com/juju/juju)
-
-* [Kubernetes vSphere Cloud Provider](https://github.com/kubernetes/cloud-provider-vsphere)
-
-* [Kubernetes Cluster API](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere)
-
-* [Kubernetes kops](https://github.com/kubernetes/kops/tree/master/upup/pkg/fi/cloudup/vsphere)
-
-* [Libretto](https://github.com/apcera/libretto/tree/master/virtualmachine/vsphere)
-
-* [Open Storage](https://github.com/libopenstorage/openstorage/tree/master/pkg/storageops/vsphere)
-
-* [OPS](https://github.com/nanovms/ops)
-
-* [Packer](https://github.com/jetbrains-infra/packer-builder-vsphere)
-
-* [Rancher](https://github.com/rancher/rancher/blob/master/pkg/api/norman/customization/vsphere/listers.go)
-
-* [Terraform](https://github.com/terraform-providers/terraform-provider-vsphere)
-
-* [Travis CI](https://github.com/travis-ci/jupiter-brain)
-
-* [Telegraf](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/vsphere)
-
-* [VMware Event Broker Appliance](https://github.com/vmware-samples/vcenter-event-broker-appliance/tree/development/vmware-event-router)
-
-* [VMware VIC Engine](https://github.com/vmware/vic)
-  
-* [vSphere 7.0](https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-7-vsphere-with-kubernetes-release-notes.html)
-
-## Related projects
-
-* [rbvmomi](https://github.com/vmware/rbvmomi)
-
-* [pyvmomi](https://github.com/vmware/pyvmomi)
-
-* [go-vmware-nsxt](https://github.com/vmware/go-vmware-nsxt)
+* [go-vmware-nsxt][reference-go-vmware-nsxt]
+* [pyvmomi][reference-pyvmomi]
+* [rbvmomi][reference-rbvmomi]
 
 ## License
 
-govmomi is available under the [Apache 2 license](LICENSE.txt).
+govmomi is available under the [Apache 2 License][govmomi-license].
 
 ## Name
 
-Pronounced "go-v-mom-ie"
+Pronounced: _go·​v·​mom·​ie_
 
 Follows pyvmomi and rbvmomi: language prefix + the vSphere acronym "VM Object Management Infrastructure".
+
+[//]: Links
+
+[ci-build]: https://github.com/vmware/govmomi/actions/workflows/govmomi-build.yaml
+[ci-tests]: https://github.com/vmware/govmomi/actions/workflows/govmomi-go-tests.yaml
+[latest-release]: https://github.com/vmware/govmomi/releases/latest
+[govc]: govc/README.md
+[govmomi-github-issues]: https://github.com/vmware/govmomi/issues
+[govmomi-github-discussions]: https://github.com/vmware/govmomi/discussions
+[govmomi-changelog]: CHANGELOG.md
+[govmomi-license]: LICENSE.txt
+[go-reference]: https://pkg.go.dev/github.com/vmware/govmomi
+[go-report-card]: https://goreportcard.com/report/github.com/vmware/govmomi
+[go-version]: https://github.com/vmware/govmomi
+[project-docker-linuxKit]: https://github.com/linuxkit/linuxkit/tree/master/src/cmd/linuxkit
+[project-elastic-agent]: https://github.com/elastic/integrations/tree/main/packages/vsphere
+[project-gru]: https://github.com/dnaeon/gru
+[project-hashicorp-packer-plugin-vsphere]: https://github.com/hashicorp/packer-plugin-vsphere
+[project-hashicorp-terraform-provider-vsphere]: https://github.com/hashicorp/terraform-provider-vsphere
+[project-influxdata-telegraf]: https://github.com/influxdata/telegraf/tree/master/plugins/inputs/vsphere
+[project-juju]: https://github.com/juju/juju
+[project-k8s-cloud-provider]: https://github.com/kubernetes/cloud-provider-vsphere
+[project-k8s-cluster-api]: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere
+[project-nanovms-ops]: https://github.com/nanovms/ops
+[project-rancher]: https://github.com/rancher/rancher/blob/master/pkg/api/norman/customization/vsphere/listers.go
+[project-travisci-collectd-vsphere]: https://github.com/travis-ci/collectd-vsphere
+[project-travisci-jupiter-brain]: https://github.com/travis-ci/jupiter-brain
+[project-vmware-veba]: https://github.com/vmware-samples/vcenter-event-broker-appliance/tree/development/vmware-event-router
+[project-vmware-vic]: https://github.com/vmware/vic
+[project-vmware-vsphere]: https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-7-vsphere-with-kubernetes-release-notes.html
+[reference-api]: https://developer.vmware.com/apis/968/vsphere
+[reference-godoc]: http://godoc.org/github.com/vmware/govmomi
+[reference-go-vmware-nsxt]: https://github.com/vmware/go-vmware-nsxt
+[reference-lifecycle]: https://lifecycle.vmware.com
+[reference-pyvmomi]: https://github.com/vmware/pyvmomi
+[reference-rbvmomi]: https://github.com/vmware/rbvmomi
+[reference-semver]: http://semver.org
+[slack-join]: https://developer.vmware.com/join/
+[slack-channel]: https://vmwarecode.slack.com/messages/govmomi
+[toolbox]: toolbox/README.md
+[vcsim]: vcsim/README.md


### PR DESCRIPTION
## Description

Updates the `README.md` for accuracy, readability, and maintainability:

- Update the vSphere versions to refer to the VMware Product Lifecycle Matrix.
- Add comment to disable `markdownlint` check for an H1 on the first line.
- Moves all markdown links to the bottom of the file and use markdown references.
- Condenses unordered lists markdown.
- Removes links to notable projects that are not longer active.
- Updatds links to the Terraform Provider for vSphere and Packer Plugin for vSphere.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

## Type of change

Please mark options that are relevant:
 
- [x] Documentation

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged