### PR TITLE
Move to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,7 @@ details for your test configuration.
 ## Checklist:
 
 - [ ] My code follows the `CONTRIBUTION`
-  [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of
+  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
   this project
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation

--- a/.github/comment-template.md
+++ b/.github/comment-template.md
@@ -1,3 +1,3 @@
 Howdy 🖐 &nbsp; {{ .author }} ! Thank you for your interest in this project. We value your feedback and will respond soon.
 
-If you want to contribute to this project, please make yourself familiar with the `CONTRIBUTION` [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md).
+If you want to contribute to this project, please make yourself familiar with the `CONTRIBUTION` [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '30 23 * * 6'
 

--- a/.github/workflows/govmomi-build.yaml
+++ b/.github/workflows/govmomi-build.yaml
@@ -16,10 +16,10 @@ name: Build
 
 on:
   push:
-    branches: ["main", "master"]
+    branches: ["main"]
 
   pull_request:
-    branches: ["main", "master"]
+    branches: ["main"]
 
   # also run every night
   schedule:

--- a/.github/workflows/govmomi-go-lint.yaml
+++ b/.github/workflows/govmomi-go-lint.yaml
@@ -16,10 +16,10 @@ name: Code Style
 
 on:
   push:
-    branches: [ 'main', 'master' ]
+    branches: [ 'main' ]
 
   pull_request:
-    branches: [ 'main', 'master' ]
+    branches: [ 'main' ]
 
 jobs:
   lint:

--- a/.github/workflows/govmomi-go-tests.yaml
+++ b/.github/workflows/govmomi-go-tests.yaml
@@ -16,10 +16,10 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ 'main', 'master' ]
+    branches: [ 'main' ]
 
   pull_request:
-    branches: [ 'main', 'master' ]
+    branches: [ 'main' ]
 
 jobs:
   go-tests:

--- a/.github/workflows/govmomi-govc-tests.yaml
+++ b/.github/workflows/govmomi-govc-tests.yaml
@@ -16,10 +16,10 @@ name: govc Tests
 
 on:
   push:
-    branches: ["main", "master"]
+    branches: ["main"]
 
   pull_request:
-    branches: ["main", "master"]
+    branches: ["main"]
 
 concurrency:
   group: govmomi-govc-tests-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/govmomi-release.yaml
+++ b/.github/workflows/govmomi-release.yaml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Validate branch and tag
         run: |
-          # do not allow release on master branch
-          if [[ ${{ github.ref }} == refs/heads/master ]]; then
+          # do not allow release on main branch
+          if [[ ${{ github.ref }} == refs/heads/main ]]; then
             echo "::error:: release must be done on a release branch"
             exit 1
           fi
@@ -163,7 +163,7 @@ jobs:
         with:
           # for changelog
           fetch-depth: 0
-          ref: "master"
+          ref: "main"
 
       - name: Create CHANGELOG.md commit
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -88,7 +88,7 @@ brews:
       name: Alfred the Narwhal
       email: cna-alfred@vmware.com
     folder: Formula
-    homepage: "https://github.com/vmware/govmomi/blob/master/govc/README.md"
+    homepage: "https://github.com/vmware/govmomi/blob/main/govc/README.md"
     description: "govc is a vSphere CLI built on top of govmomi."
     test: |
       system "#{bin}/govc version"
@@ -108,7 +108,7 @@ brews:
       name: Alfred the Narwhal
       email: cna-alfred@vmware.com
     folder: Formula
-    homepage: "https://github.com/vmware/govmomi/blob/master/vcsim/README.md"
+    homepage: "https://github.com/vmware/govmomi/blob/main/vcsim/README.md"
     description: "vcsim is a vSphere API simulator built on top of govmomi."
     test: |
       system "#{bin}/vcsim -h"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ and **supported prefixes**, e.g. `govc: <message>`.
 ### Example 1 - Fix a Bug in `govmomi`
 
 ```bash
-git checkout -b issue-<number> vmware/master
+git checkout -b issue-<number> main
 git add <files>
 git commit -m "fix: ..." -m "Closes: #<issue-number>"
 git push $USER issue-<number>
@@ -50,7 +50,7 @@ git push $USER issue-<number>
 ### Example 2 - Add a new (non-breaking) API to `govmomi`
 
 ```bash
-git checkout -b issue-<number> vmware/master
+git checkout -b issue-<number> main
 git add <files>
 git commit -m "Add API ..." -m "Closes: #<issue-number>"
 git push $USER issue-<number>
@@ -59,7 +59,7 @@ git push $USER issue-<number>
 ### Example 3 - Add a Feature to `govc`
 
 ```bash
-git checkout -b issue-<number> vmware/master
+git checkout -b issue-<number> main
 git add <files>
 git commit -m "govc: Add feature ..." -m "Closes: #<issue-number>"
 git push $USER issue-<number>
@@ -70,7 +70,7 @@ To register the new `govc` command package, add a blank `_` import to `govmomi/g
 ### Example 4 - Fix a Bug in `vcsim`
 
 ```bash
-git checkout -b issue-<number> vmware/master
+git checkout -b issue-<number> main
 git add <files>
 git commit -m "vcsim: Fix ..." -m "Closes: #<issue-number>"
 git push $USER issue-<number>
@@ -87,7 +87,7 @@ Thus these details should be stated at the body of the commit message.
 Multi-line strings are supported.
 
 ```bash
-git checkout -b issue-<number> vmware/master
+git checkout -b issue-<number> main
 git add <files>
 cat << EOF | git commit -F -
 Add ctx to funcXYZ
@@ -103,13 +103,13 @@ git push $USER issue-<number>
 
 ### Stay in sync with Upstream
 
-When your branch gets out of sync with the vmware/master branch, use the
+When your branch gets out of sync with the main branch, use the
 following to update (rebase):
 
 ```bash
 git checkout issue-<number>
 git fetch -a
-git rebase vmware/master
+git rebase main
 git push --force-with-lease $USER issue-<number>
 ```
 
@@ -139,7 +139,7 @@ Once the review is complete, squash and push your final commit(s):
 ```bash
 # squash all commits into one
 # --autosquash will automatically detect and merge fixup commits
-git rebase -i --autosquash vmware/master
+git rebase -i --autosquash main
 git push --force-with-lease $USER issue-<number>
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@ uses [`goreleaser`](http://goreleaser.com/) and automatically creates/pushes:
 - Docker images for `vmware/govc` and `vmware/vcsim` to Docker Hub
 - Source code
 
-Starting with release tag `v0.29.0`, releases are not tagged on the `master`
+Starting with release tag `v0.29.0`, releases are not tagged on the `main`
 branch anymore but a dedicated release branch, for example `release-0.29`. This
 process has already been followed for patch releases and back-ports.
 
@@ -37,15 +37,15 @@ which can be done through the Github UI or `git` CLI.
 
 This guide describes the CLI process.
 
-### Verify `master` branch is up to date with the remote
+### Verify `main` branch is up to date with the remote
 
 ```console
-git checkout master
+git checkout main
 git fetch -avp
-git diff master origin/master
+git diff main origin/main
 
 # if your local and remote branches diverge run
-git pull origin/master
+git pull origin/main
 ```
 
 > **Warning** 
@@ -57,7 +57,7 @@ git pull origin/master
 ### Create a release branch
 
 For new releases, create a release branch from the most recent commit in
-`master`, e.g. `release-0.30`.
+`main`, e.g. `release-0.30`.
 
 ```console
 export RELEASE_BRANCH=release-0.30
@@ -106,7 +106,7 @@ navigate to `Actions -> Workflows -> Release`.
 
 Click `Run Workflow` which opens a dropdown list.
 
-Select the new/updated branch, e.g. `release-0.30`, i.e. **not** the `master`
+Select the new/updated branch, e.g. `release-0.30`, i.e. **not** the `main`
 branch.
 
 Specify a semantic `tag` to associate with the release, e.g. `v0.30.0`. 
@@ -124,7 +124,7 @@ Click `Run Workflow` to kick off the workflow.
 
 After successful completion and if the newly created `tag` is the **latest**
 (semantic version sorted) tag in the repository, a PR is automatically opened
-against the `master` branch to update the `CHANGELOG`. Please review and merge
+against the `main` branch to update the `CHANGELOG`. Please review and merge
 accordingly.
 
 ## Creating a release before Version `v0.29.0`
@@ -133,15 +133,15 @@ The release process before `v0.29.0` differs since it's based on manually
 creating and pushing tags. Here, on every new tag matching `v*` pushed to the
 repository a Github Action Release Workflow is executed. 
 
-### Verify `master` branch is up to date with the remote
+### Verify `main` branch is up to date with the remote
 
 ```console
-git checkout master
+git checkout main
 git fetch -avp
-git diff master origin/master
+git diff main origin/main
 
 # if your local and remote branches diverge run
-git pull origin/master
+git pull origin/main
 ```
 
 > **Warning** 

--- a/find/doc.go
+++ b/find/doc.go
@@ -32,6 +32,6 @@ otherwise "find" mode is used.
 The exception is to use a "..." wildcard with a path to find all objects recursively underneath any root object.
 For example: VirtualMachineList("/DC1/...")
 
-See also: https://github.com/vmware/govmomi/blob/master/govc/README.md#usage
+See also: https://github.com/vmware/govmomi/blob/main/govc/README.md#usage
 */
 package find

--- a/govc/README.md
+++ b/govc/README.md
@@ -269,7 +269,7 @@ Several examples are embedded in the govc command [help](USAGE.md)
 
 * [Upload ssh public key to a VM](examples/lib/ssh.sh)
 
-* [Create a CoreOS VM](https://github.com/vmware/govmomi/blob/master/toolbox/toolbox-test.sh)
+* [Create a CoreOS VM](https://github.com/vmware/govmomi/blob/main/toolbox/toolbox-test.sh)
 
 * [Create a Debian VM](https://github.com/kubernetes/kubernetes/tree/master/cluster/vsphere)
 

--- a/govc/build.sh
+++ b/govc/build.sh
@@ -6,7 +6,7 @@ git_version=$(git describe --dirty)
  if [[ $git_version == *-dirty ]] ; then
   echo 'Working tree is dirty.'
   echo 'NOTE: This script is meant for building govc releases via release.sh'
-  echo 'To build govc from source see: https://github.com/vmware/govmomi/blob/master/govc/README.md#source'
+  echo 'To build govc from source see: https://github.com/vmware/govmomi/blob/main/govc/README.md#source'
   exit 1
 fi
 

--- a/govc/emacs/govc.el
+++ b/govc/emacs/govc.el
@@ -1,7 +1,7 @@
 ;;; govc.el --- Interface to govc for managing VMware ESXi and vCenter
 
 ;; Author: The govc developers
-;; URL: https://github.com/vmware/govmomi/tree/master/govc/emacs
+;; URL: https://github.com/vmware/govmomi/tree/main/govc/emacs
 ;; Keywords: convenience
 ;; Version: 0.18.0
 ;; Package-Requires: ((emacs "24.3") (dash "1.5.0") (s "1.9.0") (magit-popup "2.0.50") (json-mode "1.6.0"))

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,5 +21,5 @@ const (
 	ClientName = "govmomi"
 
 	// ClientVersion is the version of this SDK
-	ClientVersion = "master"
+	ClientVersion = "main"
 )

--- a/scripts/devbox/README.md
+++ b/scripts/devbox/README.md
@@ -9,7 +9,7 @@ This script makes it simple to run your laptop/desktop local binaries on such a 
 This script is a fork of the [VIC devbox](https://github.com/vmware/vic/tree/master/infra/machines/devbox),
 without a Vagrant file or provisioning beyond the bento box itself.
 
-[toolbox]:https://github.com/vmware/govmomi/blob/master/toolbox/README.md
+[toolbox]:https://github.com/vmware/govmomi/blob/main/toolbox/README.md
 [vic]:https://github.com/vmware/vic
 [vcp]:https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/vsphere
 

--- a/scripts/vcsa/create-esxi-vm.sh
+++ b/scripts/vcsa/create-esxi-vm.sh
@@ -22,7 +22,7 @@ usage() {
   cat <<'EOF'
 Usage: $0 [-d DISK_GB] [-m MEM_GB] [-i ESX_ISO] [-s] ESX_URL VM_NAME
 
-GOVC_* environment variables also apply, see https://github.com/vmware/govmomi/tree/master/govc#usage
+GOVC_* environment variables also apply, see https://github.com/vmware/govmomi/tree/main/govc#usage
 If GOVC_USERNAME is set, it is used to create an account on the ESX vm.  Default is to use the existing root account.
 If GOVC_PASSWORD is set, the account password will be set to this value.  Default is to use the given ESX_URL password.
 EOF

--- a/simulator/doc.go
+++ b/simulator/doc.go
@@ -17,6 +17,6 @@ limitations under the License.
 /*
 Package simulator is a mock framework for the vSphere API.
 
-See also: https://github.com/vmware/govmomi/blob/master/vcsim/README.md
+See also: https://github.com/vmware/govmomi/blob/main/vcsim/README.md
 */
 package simulator

--- a/toolbox/README.md
+++ b/toolbox/README.md
@@ -53,19 +53,19 @@ See [vim.vm.guest.AuthManager](http://pubs.vmware.com/vsphere-60/index.jsp?topic
 
 | Method                          | Supported | Client Examples                                                                     |
 |---------------------------------|-----------|-------------------------------------------------------------------------------------|
-| ChangeFileAttributesInGuest     | Yes       | [chmod](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/chmod.go)       |
-|                                 |           | [chown](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/chown.go)       |
-|                                 |           | [touch](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/touch.go)       |
-| CreateTemporaryDirectoryInGuest | Yes       | [mktemp](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/mktemp.go)     |
-| CreateTemporaryFileInGuest      | Yes       | [mktemp](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/mktemp.go)     |
-| DeleteDirectoryInGuest          | Yes       | [rmdir](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/rmdir.go)       |
-| DeleteFileInGuest               | Yes       | [rm](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/rm.go)             |
-| InitiateFileTransferFromGuest   | Yes       | [download](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/download.go) |
-| InitiateFileTransferToGuest     | Yes       | [upload](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/upload.go)     |
-| ListFilesInGuest                | Yes       | [ls](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/ls.go)             |
-| MakeDirectoryInGuest            | Yes       | [mkdir](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/mkdir.go)       |
-| MoveDirectoryInGuest            | Yes       | [mv](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/mv.go)             |
-| MoveFileInGuest                 | Yes       | [mv](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/mv.go)             |
+| ChangeFileAttributesInGuest     | Yes       | [chmod](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/chmod.go)       |
+|                                 |           | [chown](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/chown.go)       |
+|                                 |           | [touch](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/touch.go)       |
+| CreateTemporaryDirectoryInGuest | Yes       | [mktemp](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/mktemp.go)     |
+| CreateTemporaryFileInGuest      | Yes       | [mktemp](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/mktemp.go)     |
+| DeleteDirectoryInGuest          | Yes       | [rmdir](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/rmdir.go)       |
+| DeleteFileInGuest               | Yes       | [rm](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/rm.go)             |
+| InitiateFileTransferFromGuest   | Yes       | [download](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/download.go) |
+| InitiateFileTransferToGuest     | Yes       | [upload](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/upload.go)     |
+| ListFilesInGuest                | Yes       | [ls](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/ls.go)             |
+| MakeDirectoryInGuest            | Yes       | [mkdir](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/mkdir.go)       |
+| MoveDirectoryInGuest            | Yes       | [mv](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/mv.go)             |
+| MoveFileInGuest                 | Yes       | [mv](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/mv.go)             |
 
 See [vim.vm.guest.FileManager](http://pubs.vmware.com/vsphere-60/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.vm.guest.FileManager.html)
 
@@ -76,10 +76,10 @@ started by `StartProgramInGuest`.
 
 | Method                         | Supported | Client Examples                                                                     |
 |--------------------------------|-----------|-------------------------------------------------------------------------------------|
-| ListProcessesInGuest           | Yes       | [ps](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/ps.go)             |
-| ReadEnvironmentVariableInGuest | Yes       | [getenv](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/getenv.go)     |
-| StartProgramInGuest            | Yes       | [start](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/start.go)       |
-| TerminateProcessInGuest        | Yes       | [kill](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/kill.go)         |
+| ListProcessesInGuest           | Yes       | [ps](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/ps.go)             |
+| ReadEnvironmentVariableInGuest | Yes       | [getenv](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/getenv.go)     |
+| StartProgramInGuest            | Yes       | [start](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/start.go)       |
+| TerminateProcessInGuest        | Yes       | [kill](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/kill.go)         |
 
 See [vim.vm.guest.ProcessManager](http://pubs.vmware.com/vsphere-60/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.vm.guest.ProcessManager.html)
 
@@ -102,8 +102,8 @@ The `hgfs.FileHandler` interface can be used to customize file transfer.
 The toolbox provides support for I/O redirection without the use of disk files within the guest.
 Access to *stdin*, *stdout* and *stderr* streams is implemented as an `hgfs.FileHandler` within the `ProcessManager`.
 
-See [toolbox.Client](https://github.com/vmware/govmomi/blob/master/guest/toolbox/client.go) and
-[govc guest.run](https://github.com/vmware/govmomi/blob/master/govc/vm/guest/run.go)
+See [toolbox.Client](https://github.com/vmware/govmomi/blob/main/guest/toolbox/client.go) and
+[govc guest.run](https://github.com/vmware/govmomi/blob/main/govc/vm/guest/run.go)
 
 ### http.RoundTripper
 
@@ -117,7 +117,7 @@ example.
 
 The toolbox provides support for transferring directories to and from guests as gzip'd tar streams, without writing the
 tar file itself to the guest file system.  Archive supports is implemented as an `hgfs.FileHandler` within the `hgfs`
-package.  See [hgfs.NewArchiveHandler](https://github.com/vmware/govmomi/blob/master/toolbox/hgfs/archive.go)
+package.  See [hgfs.NewArchiveHandler](https://github.com/vmware/govmomi/blob/main/toolbox/hgfs/archive.go)
 
 ### Linux /proc file access
 
@@ -140,7 +140,7 @@ without running the test suite.
 
 ## Consumers of the toolbox library
 
-* [Toolbox example main](https://github.com/vmware/govmomi/blob/master/toolbox/toolbox/main.go)
+* [Toolbox example main](https://github.com/vmware/govmomi/blob/main/toolbox/toolbox/main.go)
 
 * [VIC tether toolbox extension](https://github.com/vmware/vic/blob/master/lib/tether/toolbox.go)
 

--- a/vapi/library/finder/README.md
+++ b/vapi/library/finder/README.md
@@ -1,5 +1,5 @@
 # The content library finder
-The govmomi package now includes a finder for the content library, [`github.com/vmware/govmomi/vapi/library.Finder`](https://github.com/akutz/govmomi/blob/feature/content-library/vapi/library/finder/finder.go). This finder supports searching for objects in the content library using an inventory path design similar to the [standard govmomi finder](https://github.com/vmware/govmomi/blob/master/find/finder.go) and includes support for wildcard matching courtesy of golang's [`path.Match`](https://golang.org/pkg/path/#Match). For example:
+The govmomi package now includes a finder for the content library, [`github.com/vmware/govmomi/vapi/library.Finder`](https://github.com/akutz/govmomi/blob/feature/content-library/vapi/library/finder/finder.go). This finder supports searching for objects in the content library using an inventory path design similar to the [standard govmomi finder](https://github.com/vmware/govmomi/blob/main/find/finder.go) and includes support for wildcard matching courtesy of golang's [`path.Match`](https://golang.org/pkg/path/#Match). For example:
 
 | Pattern | Result |
 |---------|--------|


### PR DESCRIPTION
## Description

This patch prepares the repository for moving to the `main` branch. The following steps were taken to identify and change valid occurrences of `master` to `main`:

1. Replace obvious patterns:

    ```shell
    grep -rIl 'govmomi/[^/]\{1,\}/master' * | xargs -n1 -I% \
      sed -i.m2m -e 's~govmomi/\(.*\)/master~govmomi/\1/main~g' % && \
      find . -name '*.m2m' -type f -delete
    ```

1. Replace instances in `RELEASE.md`:

    ```shell
    sed -i.m2m -e 's~master~main~g' RELEASE.md && rm -f RELEASE.md.m2m
    ```

1. Replace instances in `CONTRIBUTING.md`:

    ```shell
    sed -i.m2m -e 's~vmware/master~main~g' CONTRIBUTING.md && \
      rm -f CONTRIBUTING.md.m2m
    ```

1. Replace instances in `.goreleaser.yml`:

    ```shell
    sed -i.m2m -e 's~govmomi/\(.*\)/master~govmomi/\1/main~g' \
      .goreleaser.yml && rm -f .goreleaser.yml.m2m
    ```

1. Replace instances in GitHub workflows:

    ```shell
    grep -rIl "'main', 'master'" .github/* | xargs -n1 -I% \
      sed -i.m2m -e "s~'main', 'master'~'main'~g" % && \
      find .github -name '*.m2m' -type f -delete
    ```

    ```shell
    grep -rIl '"main", "master"' .github/* | xargs -n1 -I% \
      sed -i.m2m -e 's~"main", "master"~"main"~g' % && \
      find .github -name '*.m2m' -type f -delete
    ```

    ```shell
    sed -i.m2m -e 's~master~main~g' \
      .github/workflows/codeql-analysis.yml && \
      rm -f .github/workflows/codeql-analysis.yml.m2m
    ```

    ```shell
    sed -i.m2m -e 's~master branch~main branch~g' \
      -e 's~refs/heads/master~refs/heads/main~g' \
      -e 's~ref: "master"~ref: "main"~g' \
      .github/workflows/govmomi-release.yaml && \
      rm -f .github/workflows/govmomi-release.yaml.m2m
    ```

    ```shell
    grep -rIl 'govmomi/[^/]\{1,\}/master' .github/* | xargs -n1 -I% \
      sed -i.m2m -e 's~govmomi/\(.*\)/master~govmomi/\1/main~g' % && \
      find .github -name '*.m2m' -type f -delete
    ```

1. Replace the project's default version:

    ```shell
    sed -i.m2m 's~master~main~g' ./internal/version/version.go && \
      rm -f ./internal/version/version.go.m2m
    ```

1. Searched for all other instances of the word `master` and manually verified they do not refer to this repository:

    ```shell
    find . -type f -not -path './.git/*' -exec grep -IH master \{\} \;
    ```

   For example:

    ```shell
    ./CHANGELOG.md:- [0422a070]	Merge branch 'master' into pc/HardwareInfoNotReplicatingInCloning
    ./CHANGELOG.md:- [a5c9e1f0]	Merge branch 'master' into master
    ./CHANGELOG.md:- [86375ceb]	Merge branch 'master' into fields-info
    ./CHANGELOG.md:- [26ba22de]	Merge branch 'gavrie-master'
    ./CHANGELOG.md:- [8dbb438b]	Merge remote-tracking branch 'upstream/master' into event_manager
    ./govc/flags/int64.go:// https://github.com/golang/go/blob/master/src/cmd/internal/obj/flag.go
    ./govc/flags/int32.go:// https://github.com/golang/go/blob/master/src/cmd/internal/obj/flag.go
    ./govc/test/images/update.sh:wget -qN https://github.com/icebreaker/floppybird/raw/master/build/floppybird.img
    ./govc/test/README.md:        curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
    ./govc/test/vendor/manifest:			"branch": "master",
    ./govc/USAGE.md:  -mgmt-network.floating-IP=               Optional. The Floating IP used by the HA master cluster in the when network Mode is DHCP.
    ./govc/namespace/cluster/enable.go:	ControlPlaneManagementNetwork          masterManagementNetwork
    ./govc/namespace/cluster/enable.go:type masterManagementNetwork struct {
    ./govc/namespace/cluster/enable.go:		ControlPlaneManagementNetwork: masterManagementNetwork{
    ./govc/namespace/cluster/enable.go:		"Optional. The Floating IP used by the HA master cluster in the when network Mode is DHCP.")
    ./govc/namespace/cluster/enable.go:	var masterManagementNetwork *namespace.MasterManagementNetwork
    ./govc/namespace/cluster/enable.go:		masterManagementNetwork = &namespace.MasterManagementNetwork{}
    ./govc/namespace/cluster/enable.go:		masterManagementNetwork.AddressRange = cmd.ControlPlaneManagementNetwork.AddressRange
    ./govc/namespace/cluster/enable.go:		masterManagementNetwork.FloatingIP = cmd.ControlPlaneManagementNetwork.FloatingIP
    ./govc/namespace/cluster/enable.go:		masterManagementNetwork.Mode = &ipam
    ./govc/namespace/cluster/enable.go:		masterManagementNetwork.Network = cmd.ControlPlaneManagementNetwork.Network
    ./govc/namespace/cluster/enable.go:	if masterManagementNetwork != nil {
    ./govc/namespace/cluster/enable.go:		if (masterManagementNetwork.AddressRange.SubnetMask == "") &&
    ./govc/namespace/cluster/enable.go:			(masterManagementNetwork.AddressRange.StartingAddress == "") &&
    ./govc/namespace/cluster/enable.go:			(masterManagementNetwork.AddressRange.Gateway == "") &&
    ./govc/namespace/cluster/enable.go:			(masterManagementNetwork.AddressRange.AddressCount == 0) {
    ./govc/namespace/cluster/enable.go:			masterManagementNetwork.AddressRange = nil
    ./govc/namespace/cluster/enable.go:		masterManagementNetwork.Network = refs.Network
    ./govc/namespace/cluster/enable.go:		MasterManagementNetwork:                masterManagementNetwork,
    ./govc/README.md:* [Create a Debian VM](https://github.com/kubernetes/kubernetes/tree/master/cluster/vsphere)
    ./govc/README.md:* [Create a Windows VM](https://github.com/dougm/govc-windows-box/blob/master/provision-esx.sh)
    ./govc/vm/rdm/attach.go://This file in particular https://github.com/codedellemc/govmax/blob/master/api/v1/vmomi.go
    ./vim25/types/enum.go:	ClusterDasFdmAvailabilityStateMaster                       = ClusterDasFdmAvailabilityState("master")
    ./vim25/types/enum.go:	VsanHostNodeStateMaster                  = VsanHostNodeState("master")
    ./vim25/mo/retrieve_test.go:	if vm.Config.Name != "kubernetes-master" {
    ./vim25/mo/fixtures/nested_property.xml:      <val xsi:type="xsd:string">kubernetes-master</val>
    ./gen/sdk/vim-types.xsd:         <enumeration value="master" />
    ./gen/sdk/vim-types.xsd:         <enumeration value="master" />
    ./gen/sdk/internalvim-types.xsd:         <enumeration value="master" />
    ./gen/sdk/internalvim-types.xsd:         <enumeration value="master" />
    ./README.md:[project-docker-linuxKit]: https://github.com/linuxkit/linuxkit/tree/master/src/cmd/linuxkit
    ./README.md:[project-influxdata-telegraf]: https://github.com/influxdata/telegraf/tree/master/plugins/inputs/vsphere
    ./README.md:[project-rancher]: https://github.com/rancher/rancher/blob/master/pkg/api/norman/customization/vsphere/listers.go
    ./vcsim/README.md:* [Kubernetes](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/vsphere)
    ./vcsim/README.md:* [Telegraf](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/vsphere)
    ./vcsim/README.md:* [LocalStack](https://github.com/localstack/localstack/blob/master/README.md#why-localstack)
    ./toolbox/README.md:* [VIC tether toolbox extension](https://github.com/vmware/vic/blob/master/lib/tether/toolbox.go)
    ./toolbox/README.md:* [VIC container host tether](https://github.com/vmware/vic/blob/master/cmd/vic-init/main_linux.go)
    ./toolbox/hgfs/server.go:// See: https://github.com/vmware/open-vm-tools/blob/master/open-vm-tools/lib/hgfsServer/hgfsServer.c
    ./toolbox/hgfs/protocol.go:// See: https://github.com/vmware/open-vm-tools/blob/master/open-vm-tools/lib/include/hgfsProto.h
    ./scripts/devbox/README.md:This script is a fork of the [VIC devbox](https://github.com/vmware/vic/tree/master/infra/machines/devbox),
    ./scripts/devbox/README.md:[vcp]:https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/vsphere
    ./scripts/devbox/README.md:As an alternative to the [VIC devbox](https://github.com/vmware/vic/tree/master/infra/machines/devbox).
    ./.github/workflows/govmomi-go-lint.yaml:          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" 2>&1
    ./.github/workflows/govmomi-release.yaml:            > Due to a [limitation](https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#triggering-further-workflow-runs) in Github Actions please **close and immediately reopen** this PR to trigger the required workflow checks before merging.
    ./vapi/namespace/namespace.go:	MasterDNSSearchDomains []string               `json:"master_DNS_search_domains,omitempty"`
    ./vapi/namespace/namespace.go:	MasterManagementNetwork *MasterManagementNetwork    `json:"master_management_network"`
    ./vapi/namespace/namespace.go:	MasterNTPServers        []string                    `json:"master_NTP_servers,omitempty"`
    ./vapi/namespace/namespace.go:	MasterDNS            []string              `json:"master_DNS,omitempty"`
    ./vapi/namespace/namespace.go:	MasterStoragePolicy                    string                  `json:"master_storage_policy,omitempty"`
    ./vsan/types/types.go:	Master  string   `xml:"master"`
    ./vsan/types/types.go:	MasterInfo     *VsanPerfMasterInformation `xml:"masterInfo,omitempty"`
    ```

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

There is not much that *can* be done to validate this other than let the GH actions run.

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/master/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged