### PR TITLE
govc: Add feature to get and set default idp

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -282,6 +282,8 @@ but appear via `govc $cmd -h`:
  - [sso.group.ls](#ssogroupls)
  - [sso.group.rm](#ssogrouprm)
  - [sso.group.update](#ssogroupupdate)
+ - [sso.idp.default.ls](#ssoidpdefaultls)
+ - [sso.idp.default.update](#ssoidpdefaultupdate)
  - [sso.idp.ls](#ssoidpls)
  - [sso.lpp.info](#ssolppinfo)
  - [sso.lpp.update](#ssolppupdate)
@@ -4769,6 +4771,33 @@ Options:
   -d=                    Group description
   -g=false               Add/Remove group from group
   -r=                    Remove user/group from group
+```
+
+## sso.idp.default.ls
+
+```
+Usage: govc sso.idp.default.ls [OPTIONS]
+
+List SSO default identity provider sources.
+
+Examples:
+  govc sso.idp.default.ls
+  govc sso.idp.default.ls -json
+
+Options:
+```
+
+## sso.idp.default.update
+
+```
+Usage: govc sso.idp.default.update [OPTIONS] NAME
+
+Set SSO default identity provider source.
+
+Examples:
+  govc sso.idp.default.update NAME
+
+Options:
 ```
 
 ## sso.idp.ls

--- a/govc/sso/idp/default.ls.go
+++ b/govc/sso/idp/default.ls.go
@@ -1,0 +1,84 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package idp
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/sso"
+	"github.com/vmware/govmomi/ssoadmin"
+)
+
+type didp struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("sso.idp.default.ls", &didp{})
+}
+
+func (cmd *didp) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *didp) Description() string {
+	return `List SSO default identity provider sources.
+
+Examples:
+  govc sso.idp.default.ls
+  govc sso.idp.default.ls -json`
+}
+
+func (cmd *didp) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+type didpInfo struct {
+	DefaultIdentitySource []string
+}
+
+func (r *didpInfo) Write(w io.Writer) error {
+	fmt.Fprintf(w, "Default identity provider source(s): %s\n", strings.Join(r.DefaultIdentitySource, ","))
+	return nil
+}
+
+func (cmd *didp) Run(ctx context.Context, f *flag.FlagSet) error {
+	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {
+		var errids error
+		var defaultids didpInfo
+
+		defaultids.DefaultIdentitySource, errids = c.GetDefaultDomains(ctx)
+		if errids != nil {
+			return errids
+		}
+		return cmd.WriteResult(&defaultids)
+	})
+}

--- a/govc/sso/idp/default.update.go
+++ b/govc/sso/idp/default.update.go
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package idp
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/sso"
+	"github.com/vmware/govmomi/ssoadmin"
+)
+
+type didpupd struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("sso.idp.default.update", &didpupd{})
+}
+
+func (cmd *didpupd) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *didpupd) Usage() string {
+	return "NAME"
+}
+
+func (cmd *didpupd) Description() string {
+	return `Set SSO default identity provider source.
+
+Examples:
+  govc sso.idp.default.update NAME`
+}
+
+func (cmd *didpupd) Run(ctx context.Context, f *flag.FlagSet) error {
+	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {
+		return c.SetDefaultDomains(ctx, f.Arg(0))
+	})
+}

--- a/ssoadmin/client.go
+++ b/ssoadmin/client.go
@@ -510,3 +510,26 @@ func (c *Client) IdentitySources(ctx context.Context) (*types.IdentitySources, e
 
 	return &res.Returnval, nil
 }
+
+func (c *Client) GetDefaultDomains(ctx context.Context) ([]string, error) {
+	req := types.GetDefaultDomains{
+		This: c.ServiceContent.IdentitySourceManagementService,
+	}
+
+	res, err := methods.GetDefaultDomains(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (c *Client) SetDefaultDomains(ctx context.Context, domain string) error {
+	req := types.SetDefaultDomains{
+		This:        c.ServiceContent.IdentitySourceManagementService,
+		DomainNames: domain,
+	}
+
+	_, err := methods.SetDefaultDomains(ctx, c, &req)
+	return err
+}

--- a/ssoadmin/methods/methods.go
+++ b/ssoadmin/methods/methods.go
@@ -763,6 +763,26 @@ func Get(ctx context.Context, r soap.RoundTripper, req *types.Get) (*types.GetRe
 	return resBody.Res, nil
 }
 
+type GetDefaultDomainsBody struct {
+	Req    *types.GetDefaultDomains         `xml:"urn:sso IdS_getDefaultDomains,omitempty"`
+	Res    *types.GetDefaultDomainsResponse `xml:"urn:sso IdS_getDefaultDomainsResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetDefaultDomainsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetDefaultDomains(ctx context.Context, r soap.RoundTripper, req *types.GetDefaultDomains) (*types.GetDefaultDomainsResponse, error) {
+	var reqBody, resBody GetDefaultDomainsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type GetAllCertificatesBody struct {
 	Req    *types.GetAllCertificates         `xml:"urn:sso GetAllCertificates,omitempty"`
 	Res    *types.GetAllCertificatesResponse `xml:"urn:sso GetAllCertificatesResponse,omitempty"`
@@ -1333,6 +1353,26 @@ func (b *SetClockToleranceBody) Fault() *soap.Fault { return b.Fault_ }
 
 func SetClockTolerance(ctx context.Context, r soap.RoundTripper, req *types.SetClockTolerance) (*types.SetClockToleranceResponse, error) {
 	var reqBody, resBody SetClockToleranceBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SetDefaultDomainsBody struct {
+	Req    *types.SetDefaultDomains         `xml:"urn:sso IdS_setDefaultDomains,omitempty"`
+	Res    *types.SetDefaultDomainsResponse `xml:"urn:sso IdS_setDefaultDomainsResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetDefaultDomainsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SetDefaultDomains(ctx context.Context, r soap.RoundTripper, req *types.SetDefaultDomains) (*types.SetDefaultDomainsResponse, error) {
+	var reqBody, resBody SetDefaultDomainsBody
 
 	reqBody.Req = req
 

--- a/ssoadmin/types/types.go
+++ b/ssoadmin/types/types.go
@@ -1094,6 +1094,24 @@ type GetResponse struct {
 	Returnval IdentitySources `xml:"returnval,omitempty"`
 }
 
+type GetDefaultDomains GetDefaultDomainsRequestType
+
+func init() {
+	types.Add("sso:GetDefaultDomains", reflect.TypeOf((*GetDefaultDomains)(nil)).Elem())
+}
+
+type GetDefaultDomainsRequestType struct {
+	This types.ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	types.Add("sso:GetDefaultDomainsRequestType", reflect.TypeOf((*GetDefaultDomainsRequestType)(nil)).Elem())
+}
+
+type GetDefaultDomainsResponse struct {
+	Returnval []string `xml:"returnval,omitempty"`
+}
+
 type GetAllCertificates GetAllCertificatesRequestType
 
 func init() {
@@ -1647,6 +1665,24 @@ func init() {
 }
 
 type SetClockToleranceResponse struct {
+}
+
+type SetDefaultDomains SetDefaultDomainsRequestType
+
+func init() {
+	types.Add("sso:SetDefaultDomains", reflect.TypeOf((*SetDefaultDomains)(nil)).Elem())
+}
+
+type SetDefaultDomainsRequestType struct {
+	This        types.ManagedObjectReference `xml:"_this"`
+	DomainNames string                       `xml:"domainNames"`
+}
+
+func init() {
+	types.Add("sso:SetDefaultDomainsRequestType", reflect.TypeOf((*SetDefaultDomainsRequestType)(nil)).Elem())
+}
+
+type SetDefaultDomainsResponse struct {
 }
 
 type SetDelegationCount SetDelegationCountRequestType


### PR DESCRIPTION
## Description
It extends the govc functionality with GetDefaultDomains and SetDefaultDomains methods (sso idp)
It adds a command sso.idp.default.ls to get and sso.idp.default.update to set the default sso idp

Closes: #3023 

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [X] sso.idp.default.ls
```
$ govc sso.idp.default.ls -json
{
  "DefaultIdentitySource": [
    "corp.local"
  ]
}
$ govc sso.idp.default.ls
Default identity provider source(s): corp.local
```

- [X] sso.idp.default.update
```
$ govc sso.idp.default.update corp.localzz
$ govc sso.idp.default.update corp.localzz
$ govc sso.idp.default.update corp.localzzz
govc: ServerFaultCode: Domain 'Identity Provider 'corp.localzzz' does not exist.' does not exist.
$ govc sso.idp.default.ls
Default identity provider source(s): corp.localzz
```


## Checklist:

- [X] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged