### PR TITLE
govc: Add checksum validation to govc import.ova

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -3097,6 +3097,7 @@ Options:
   -ds=                   Datastore [GOVC_DATASTORE]
   -folder=               Inventory folder [GOVC_FOLDER]
   -host=                 Host system [GOVC_HOST]
+  -m=false               Verify checksum of uploaded files against manifest (.mf)
   -name=                 Name to use for new entity
   -options=              Options spec file path for VM deployment
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
@@ -3111,6 +3112,7 @@ Options:
   -ds=                   Datastore [GOVC_DATASTORE]
   -folder=               Inventory folder [GOVC_FOLDER]
   -host=                 Host system [GOVC_HOST]
+  -m=false               Verify checksum of uploaded files against manifest (.mf)
   -name=                 Name to use for new entity
   -options=              Options spec file path for VM deployment
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]

--- a/govc/test/images/update.sh
+++ b/govc/test/images/update.sh
@@ -7,6 +7,12 @@ pushd $(dirname $0)
 base_url=https://github.com/dougm/packer-ttylinux/releases/download/16.1u2
 ttylinux="ttylinux-pc_i486-16.1"
 files="${ttylinux}.iso ${ttylinux}-live.ova ${ttylinux}.ova"
+tarbin="tar"
+if [ "$(uname)" = "Darwin" ]; then
+  # macOS BSD tar creates additional entries that govc tar archive reader
+  # chokes on (instead of ignoring). Use GNU tar instead.
+  tarbin="gtar"
+fi
 
 for name in $files ; do
   wget -qO $name $base_url/$name
@@ -15,6 +21,17 @@ done
 wget -qN https://github.com/icebreaker/floppybird/raw/master/build/floppybird.img
 
 # extract ova so we can also use the .vmdk and .ovf files directly
-tar -xvf ${ttylinux}.ova
+$tarbin -xvf ${ttylinux}.ova
+
+# create an ova with "bad" checksum in manifest by
+# modifying/replacing .mf in copy of ${ttylinux}.ova
+mkdir -p "$(pwd)/tmp"
+$tarbin xv -C "$(pwd)/tmp" -f ${ttylinux}.ova
+pushd "$(pwd)/tmp"
+sed 's/=.*$/= 5e82716003a1bff5b1d27bbd7d1e83addc881503/g' < ${ttylinux}.mf > ${ttylinux}-bad-checksum.mf
+mv ${ttylinux}-bad-checksum.mf ${ttylinux}.mf
+popd
+$tarbin cv -C "$(pwd)/tmp" -f ${ttylinux}-bad-checksum.ova .
+rm -fr "$(pwd)/tmp"
 
 popd

--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -42,6 +42,16 @@ load test_helper
   assert_success
 }
 
+@test "import.ova with checksum validation" {
+  vcsim_env -app 1
+
+  run govc import.ova -name=bad-checksum-vm -m "$GOVC_IMAGES/$TTYLINUX_NAME-bad-checksum.ova"
+  assert_failure # vmdk checksum mismatch
+
+  run govc import.ova -name=good-checksum-vm -m "$GOVC_IMAGES/$TTYLINUX_NAME.ova"
+  assert_success
+}
+
 @test "import.ova with iso" {
   vcsim_env
 

--- a/nfc/lease.go
+++ b/nfc/lease.go
@@ -71,17 +71,17 @@ func (l *Lease) Complete(ctx context.Context) error {
 }
 
 // GetManifest wraps methods.GetManifest
-func (l *Lease) GetManifest(ctx context.Context) error {
+func (l *Lease) GetManifest(ctx context.Context) ([]types.HttpNfcLeaseManifestEntry, error) {
 	req := types.HttpNfcLeaseGetManifest{
 		This: l.Reference(),
 	}
 
-	_, err := methods.HttpNfcLeaseGetManifest(ctx, l.c, &req)
+	res, err := methods.HttpNfcLeaseGetManifest(ctx, l.c, &req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return res.Returnval, nil
 }
 
 // Progress wraps methods.Progress


### PR DESCRIPTION
## Description

This patch enhances govc import.ova command to validate the checksum of an uploaded file (e.g. .vmdk file in .ova) - as computed by the remote server with the checksum listed in the ova manifest (.mf file in .ova). govc import.ova takes a new optional flag to indicate strict checksum validation.
(This govc enhancement needed a small tweak in nfc/lease.go code to actually return manifest data in GetManifest() API.)

This patch also modifies simulator to compute checksum of uploaded file and return that metadata through HttpNfcLeaseGetManifest() call.

govc ova import test now has a new sub-test to test for ova with valid checksum and ova with invalid checksum.

Closes: #1978

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- Ran govc ova import existing tests as well as newly added tests
```
$ make install && govc/test/images/update.sh && govc/test/import.bats
...
 ✓ import.ova
 ✓ import.ova with checksum validation
 ✓ import.ova with iso
 ✓ import.ovf
 ✓ import.ovf -host.ipath
 ✓ import.ovf with name in options
 ✓ import.ovf with import.spec result
 ✓ import.ovf with name as argument
 - import.vmdk (skipped: GOVC_TEST_URL not set)
 ✓ import duplicate dvpg names

10 tests, 0 failures, 1 skipped
```

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged