### PR TITLE
chore: bats related fixes

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -128,7 +128,7 @@ EOF
   run govc object.collect -s $vm summary.guest.ipAddress
   assert_success "10.0.0.1"
 
-  netip=$(govc object.collect -json -s $vm guest.net | jq -r .[].val.GuestNicInfo[].ipAddress[0])
+  netip=$(govc object.collect -json -o $vm guest.net | jq -r .Guest.net[].ipAddress[0])
   [ "$netip" = "10.0.0.1" ]
 
   run govc vm.info -vm.ip 10.0.0.1
@@ -264,7 +264,7 @@ EOF
   run govc object.collect -s vm/$vm summary.guest.ipAddress
   assert_success "$ip"
 
-  netip=$(govc object.collect -json -s vm/$vm guest.net | jq -r .[].val.GuestNicInfo[].ipAddress[0])
+  netip=$(govc object.collect -json -o vm/$vm guest.net | jq -r .Guest.net[].ipAddress[0])
   [ "$netip" = "$ip" ]
 
   run govc vm.power -s $vm
@@ -304,7 +304,7 @@ EOF
   assert_success
 
   ip=$(govc object.collect -s vm/$vm guest.ipAddress)
-  run curl -f "http://$ip/vcsim.bats"
+  run docker run --rm curlimages/curl curl -f "http://$ip/vcsim.bats"
   assert_success
 
   # test suspend/resume

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -825,7 +825,7 @@ load test_helper
   # test that each vm has a unique vmdk path
   for item in fileName uuid;  do
     items=$(govc object.collect -json -type m / config.hardware.device | \
-              jq ".changeSet[].val.VirtualDevice[].backing.$item | select(. != null)")
+              jq ".changeSet[].val._value[].backing.$item | select(. != null)")
 
     nitems=$(wc -l <<<"$items")
     uitems=$(sort -u <<<"$items" | wc -l)

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -145,14 +145,6 @@ func main() {
 	}
 
 	var err error
-	out := os.Stdout
-
-	if *env != "-" {
-		out, err = os.OpenFile(*env, os.O_WRONLY, 0)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
 
 	if err = updateHostTemplate(u.Host); err != nil {
 		log.Fatal(err)
@@ -222,7 +214,19 @@ func main() {
 		}
 	}
 
-	fmt.Fprintf(out, "export GOVC_URL=%s GOVC_SIM_PID=%d\n", s.URL, os.Getpid())
+	out := os.Stdout
+
+	if *env != "-" {
+		out, err = os.OpenFile(*env, os.O_WRONLY, 0)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	_, err = fmt.Fprintf(out, "export GOVC_URL=%s GOVC_SIM_PID=%d\n", s.URL, os.Getpid())
+	if err != nil {
+		log.Fatal(err)
+	}
 	if out != os.Stdout {
 		err = out.Close()
 		if err != nil {
@@ -233,7 +237,7 @@ func main() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 	if *stdinExit {
-		fmt.Fprintf(out, "Press any key to exit")
+		fmt.Println("Press any key to exit")
 		go func() {
 			os.Stdin.Read(make([]byte, 1))
 			sig <- syscall.SIGTERM


### PR DESCRIPTION
## Description

- Commit 1991de51 recently changed the json tag for ArrayOf types

- Fix 'vcsim run container' test when using MacOS / Docker desktop

- Change vcsim/main.go to open the fifo after its running

The vcsim/main.go change may fix the random hangs we see in GH Actions. I was seeing random hangs locally when running all bats tests on MacOS.  Each time, the bats tests would be hung reading from the fifo here: https://github.com/vmware/govmomi/blob/99336079d7934f742f729c3d74ebdf8e4bdd6f4a/govc/test/test_helper.bash#L59

Not certain this will fix the random hangs in GH Actions, but there's no reason to open the fifo for writing until we have the data that'll be written to it anyhow.