### PR TITLE
vcsim: add guest.net.ipConfig

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -267,6 +267,15 @@ EOF
   netip=$(govc object.collect -json -o vm/$vm guest.net | jq -r .Guest.net[].ipAddress[0])
   [ "$netip" = "$ip" ]
 
+  run govc vm.ip $vm # covers VirtualMachine.WaitForIP
+  assert_success "$ip"
+
+  run govc vm.ip -a $vm # covers VirtualMachine.WaitForNetIP
+  assert_success "$ip"
+
+  run govc vm.ip -n ethernet-0 $vm # covers VirtualMachine.WaitForNetIP
+  assert_success "$ip"
+
   run govc vm.power -s $vm
   assert_success
 

--- a/simulator/container.go
+++ b/simulator/container.go
@@ -114,6 +114,20 @@ func (c *container) inspect(vm *VirtualMachine) error {
 			net := &vm.Guest.Net[0]
 			net.IpAddress = []string{s.IPAddress}
 			net.MacAddress = s.MacAddress
+			net.IpConfig = &types.NetIpConfigInfo{
+				IpAddress: []types.NetIpConfigInfoIpAddress{{
+					IpAddress:    s.IPAddress,
+					PrefixLength: int32(s.IPPrefixLen),
+					State:        string(types.NetIpConfigInfoIpAddressStatusPreferred),
+				}},
+			}
+		}
+
+		for _, d := range vm.Config.Hardware.Device {
+			if eth, ok := d.(types.BaseVirtualEthernetCard); ok {
+				eth.GetVirtualEthernetCard().MacAddress = s.MacAddress
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

This is needed to support the VirtualMachine.WaitForNetIP helper against vcsim

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Added tests to vcsim.bats that cover `VirtualMachine.WaitForIP()`

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged