### PR TITLE
api: support find.Network by cluster path

### DIFF
--- a/find/finder.go
+++ b/find/finder.go
@@ -798,6 +798,7 @@ func (f *Finder) NetworkList(ctx context.Context, path string) ([]object.Network
 // Examples:
 // - Name:                "dvpg-1"
 // - Inventory Path:      "vds-1/dvpg-1"
+// - Cluster Path:        "/dc-1/host/cluster-1/dvpg-1"
 // - ManagedObject ID:    "DistributedVirtualPortgroup:dvportgroup-53"
 // - Logical Switch UUID: "da2a59b8-2450-4cb2-b5cc-79c4c1d2144c"
 // - Segment ID:          "/infra/segments/vnet_ce50e69b-1784-4a14-9206-ffd7f1f146f7"

--- a/find/finder.go
+++ b/find/finder.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2020 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -784,6 +784,11 @@ func (f *Finder) NetworkList(ctx context.Context, path string) ([]object.Network
 	}
 
 	if len(ns) == 0 {
+		net, nerr := f.networkByID(ctx, path)
+		if nerr == nil {
+			return []object.NetworkReference{net}, nil
+		}
+
 		return nil, &NotFoundError{"network", path}
 	}
 
@@ -805,12 +810,6 @@ func (f *Finder) NetworkList(ctx context.Context, path string) ([]object.Network
 func (f *Finder) Network(ctx context.Context, path string) (object.NetworkReference, error) {
 	networks, err := f.NetworkList(ctx, path)
 	if err != nil {
-		if _, ok := err.(*NotFoundError); ok {
-			net, nerr := f.networkByID(ctx, path)
-			if nerr == nil {
-				return net, nil
-			}
-		}
 		return nil, err
 	}
 

--- a/find/finder_test.go
+++ b/find/finder_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package find_test // TODO: move ../simulator/finder_test.go tests here
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+func TestFindNetwork(t *testing.T) {
+	model := simulator.VPX()
+	model.PortgroupNSX = 3
+
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c)
+		pc := property.DefaultCollector(c)
+
+		pgs, err := finder.NetworkList(ctx, "DC0_NSXPG*")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Rename DC0_NSXPG1 to DC0_NSXPG0 so we have a duplicate name
+		task, err := pgs[1].(*object.DistributedVirtualPortgroup).Rename(ctx, pgs[0].(*object.DistributedVirtualPortgroup).Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = task.Wait(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// 2 PGs, same switch, same name
+		pgs, err = finder.NetworkList(ctx, "DC0_NSXPG0")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(pgs) != 2 {
+			t.Fatalf("expected 2 NSX PGs, got %d", len(pgs))
+		}
+
+		for _, pg := range pgs {
+			// Using InventoryPath fails as > 1 are found
+			_, err = finder.Network(ctx, pg.GetInventoryPath())
+			if _, ok := err.(*find.MultipleFoundError); !ok {
+				t.Fatalf("expected MultipleFoundError, got %s", err)
+			}
+
+			// Find by MOID
+			_, err = finder.Network(ctx, pg.Reference().String())
+			if err != nil {
+				t.Errorf("find by moid: %s", err)
+			}
+
+			// Find by Switch UUID
+			var props mo.DistributedVirtualPortgroup
+			err = pc.RetrieveOne(ctx, pg.Reference(), []string{"config.logicalSwitchUuid", "config.segmentId"}, &props)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			net, err := finder.Network(ctx, props.Config.LogicalSwitchUuid)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if net.Reference() != pg.Reference() {
+				t.Errorf("%s vs %s", net.Reference(), pg.Reference())
+			}
+
+			net, err = finder.Network(ctx, props.Config.SegmentId)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			networks, err := finder.NetworkList(ctx, props.Config.SegmentId)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(networks) != 1 {
+				t.Errorf("expected 1 network, found %d", len(networks))
+			}
+		}
+	}, model)
+}

--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -197,6 +197,11 @@ load test_helper
   assert_success # switch_name/portgroup_name is unique
   grep -v "invalid NetworkMapping.Name" <<<"$output"
 
+  options=$(jq ".NetworkMapping[].Network = \"/DC0/host/DC0_C0/DC0_DVPG0\"" <<<"$spec")
+
+  run govc import.ovf -name ttylinux3 -options - "$ovf" <<<"$options"
+  assert_success # cluster path is unique
+
   switch=$(govc find -i network -name DVS0)
   id=$(govc find -i network -config.distributedVirtualSwitch "$switch" -name NSX-dvpg)
   options=$(jq ".NetworkMapping[].Network = \"$id\"" <<<"$spec")

--- a/list/lister.go
+++ b/list/lister.go
@@ -312,6 +312,7 @@ func (l Lister) ListComputeResource(ctx context.Context) ([]Element, error) {
 
 	fields := []string{
 		"host",
+		"network",
 		"resourcePool",
 	}
 
@@ -327,6 +328,7 @@ func (l Lister) ListComputeResource(ctx context.Context) ([]Element, error) {
 
 	childTypes := []string{
 		"HostSystem",
+		"Network",
 		"ResourcePool",
 	}
 

--- a/list/lister.go
+++ b/list/lister.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/simulator/finder_test.go
+++ b/simulator/finder_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/simulator/finder_test.go
+++ b/simulator/finder_test.go
@@ -69,7 +69,7 @@ func TestFinderVPX(t *testing.T) {
 		{"ManagedObjectList", "/F[01]", 2},
 		{"ManagedObjectListChildren", "/*", m.Datacenter + 3},
 		{"ManagedObjectListChildren", "/*/*", 19},
-		{"ManagedObjectListChildren", "/*/*/*", 25},
+		{"ManagedObjectListChildren", "/*/*/*", 31},
 		{"FolderList", "/*", m.Folder},
 		{"DatacenterList", "/F0/*", 1},
 		{"DatacenterList", "/DC0", 1},


### PR DESCRIPTION
## Description

Datacenter's network folder may contain items with the same name.
For clusters that have one such instance of a given network name, the cluster inventory path will be unique.

Example:
```console
% govc ls -l -t DistributedVirtualPortgroup /DC/host/compute-cluster
/DC/host/dev-cluster/vnet-domain-c9:f6555e6e-051f-4eec-9275-78ba7f689335-test-gc-e2e-demo-ns-91610-0 (DistributedVirtualPortgroup)
/DC/host/dev-cluster/seg-domain-c9:f6555e6e-051f-4eec-9275-78ba7f689335-test-gc-e2e-demo-ns-0 (DistributedVirtualPortgroup)
/DC/host/dev-cluster/vm-domain-c9:f6555e6e-051f-4eec-9275-78ba7f689335-vif-default-network-0 (DistributedVirtualPortgroup)
/DC/host/dev-cluster/containerswitchavi-1 (DistributedVirtualPortgroup)
/DC/host/dev-cluster/containerswitch-1 (DistributedVirtualPortgroup)
/DC/host/dev-cluster/dvpg-vmotion-1 (DistributedVirtualPortgroup)
/DC/host/dev-cluster/wcp_vds_1-DVUplinks-34 (DistributedVirtualPortgroup)
```
api: support find.NetworkList by ID

Rather than limit by ID search to find.Network, move the logic to NetworkList to support both methods.

Add finder_test (meant to include with PR #2626)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change
