### PR TITLE
govc: Add feature VM IOMMU enablement support

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -5606,6 +5606,7 @@ Options:
   -e=[]                          ExtraConfig. <key>=<value>
   -f=[]                          ExtraConfig. <key>=<absolute path to file>
   -g=                            Guest OS
+  -iommu-enabled=<nil>           Enable IOMMU
   -latency=                      Latency sensitivity (low|normal|high)
   -m=0                           Size in MB of memory
   -mem.limit=<nil>               Memory limit in MB

--- a/govc/vm/change.go
+++ b/govc/vm/change.go
@@ -178,6 +178,8 @@ func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
 	f.Var(flags.NewOptionalBool(&cmd.MemoryHotAddEnabled), "memory-hot-add-enabled", "Enable memory hot add")
 	f.Var(flags.NewOptionalBool(&cmd.MemoryReservationLockedToMax), "memory-pin", "Reserve all guest memory")
 	f.Var(flags.NewOptionalBool(&cmd.CpuHotAddEnabled), "cpu-hot-add-enabled", "Enable CPU hot add")
+	cmd.Flags = &types.VirtualMachineFlagInfo{}
+	f.Var(flags.NewOptionalBool(&cmd.Flags.VvtdEnabled), "iommu-enabled", "Enable IOMMU")
 
 	f.StringVar(&cmd.hwUpgradePolicy, "scheduled-hw-upgrade-policy", "", fmt.Sprintf("Schedule hardware upgrade policy (%s)", strings.Join(hwUpgradePolicies, "|")))
 }
@@ -226,6 +228,10 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
 	setAllocation(&cmd.MemoryAllocation)
 	if reflect.DeepEqual(cmd.Tools, new(types.ToolsConfigInfo)) {
 		cmd.Tools = nil // no flags set, avoid sending <tools/> in the request
+	}
+
+	if reflect.DeepEqual(cmd.Flags, new(types.VirtualMachineFlagInfo)) {
+		cmd.Flags = nil // no flags set, avoid sending <flags/> in the request
 	}
 
 	if err = cmd.setLatency(); err != nil {


### PR DESCRIPTION
Closes: #3055

## Description

Add VM IOMMU enablement support in govc

Closes: #3055 

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Test vm.change usage command output
```
[ ~/github/govmomi/govc ]# ./govc vm.change
Usage: ./govc vm.change [OPTIONS]

Change VM configuration.

To add ExtraConfig variables that can read within the guest, use the 'guestinfo.' prefix.

Examples:
  govc vm.change -vm $vm -mem.reservation 2048
  govc vm.change -vm $vm -e smc.present=TRUE -e ich7m.present=TRUE
  # Enable both cpu and memory hotplug on a guest:
  govc vm.change -vm $vm -cpu-hot-add-enabled -memory-hot-add-enabled
  govc vm.change -vm $vm -e guestinfo.vmname $vm
  # Read the contents of a file and use them as ExtraConfig value
  govc vm.change -vm $vm -f guestinfo.data="$(realpath .)/vmdata.config"
  # Read the variable set above inside the guest:
  vmware-rpctool "info-get guestinfo.vmname"
  govc vm.change -vm $vm -latency high
  govc vm.change -vm $vm -latency normal
  govc vm.change -vm $vm -uuid 4139c345-7186-4924-a842-36b69a24159b
  govc vm.change -vm $vm -scheduled-hw-upgrade-policy always

Options:
  -annotation=                                  VM description
  -c=0                                          Number of CPUs
  -cert=                                        Certificate [GOVC_CERTIFICATE]
  -cpu-hot-add-enabled=<nil>                    Enable CPU hot add
  -cpu.limit=<nil>                              CPU limit in MHz
  -cpu.reservation=<nil>                        CPU reservation in MHz
  -cpu.shares=                                  CPU shares level or number
  -dc=                                          Datacenter [GOVC_DATACENTER]
  -debug=false                                  Store debug logs [GOVC_DEBUG]
  -dump=false                                   Enable Go output
  -e=[]                                         ExtraConfig. <key>=<value>
  -f=[]                                         ExtraConfig. <key>=<absolute path to file>
  -g=                                           Guest OS
  -iommu-enabled=<nil>                          Enable IOMMU
  -json=false                                   Enable JSON output
  -k=false                                      Skip verification of server certificate [GOVC_INSECURE]
  -key=                                         Private key [GOVC_PRIVATE_KEY]
  -latency=                                     Latency sensitivity (low|normal|high)
  -m=0                                          Size in MB of memory
  -mem.limit=<nil>                              Memory limit in MB
  -mem.reservation=<nil>                        Memory reservation in MB
  -mem.shares=                                  Memory shares level or number
  -memory-hot-add-enabled=<nil>                 Enable memory hot add
  -memory-pin=<nil>                             Reserve all guest memory
  -name=                                        Display name
  -nested-hv-enabled=<nil>                      Enable nested hardware-assisted virtualization
  -persist-session=true                         Persist session to disk [GOVC_PERSIST_SESSION]
  -scheduled-hw-upgrade-policy=                 Schedule hardware upgrade policy (onSoftPowerOff|never|always)
  -sync-time-with-host=<nil>                    Enable SyncTimeWithHost
  -tls-ca-certs=                                TLS CA certificates file [GOVC_TLS_CA_CERTS]
  -tls-known-hosts=                             TLS known hosts file [GOVC_TLS_KNOWN_HOSTS]
  -trace=false                                  Write SOAP/REST traffic to stderr
  -u=https://@dfwl1r1c2-vc0.eng.vmware.com/sdk  ESX or vCenter URL [GOVC_URL]
  -uuid=                                        BIOS UUID
  -verbose=false                                Write request/response data to stderr
  -vim-namespace=vim25                          Vim namespace [GOVC_VIM_NAMESPACE]
  -vim-version=7.0                              Vim version [GOVC_VIM_VERSION]
  -vm=                                          Virtual machine [GOVC_VM]
  -vm.dns=                                      Find VM by FQDN
  -vm.ip=                                       Find VM by IP address
  -vm.ipath=                                    Find VM by inventory path
  -vm.path=                                     Find VM by path to .vmx file
  -vm.uuid=                                     Find VM by UUID
  -vpmc-enabled=<nil>                           Enable CPU performance counters
  -xml=false                                    Enable XML output
```
- [x] Test IOMMU enablement on a VM
```
[ ~/github/govmomi/govc ]# ./govc vm.change -vm $vm -iommu-enabled=False
[ ~/github/govmomi/govc ]# echo $?
0
[ ~/github/govmomi/govc ]# ./govc vm.change -vm $vm -iommu-enabled=True
[ ~/github/govmomi/govc ]# echo $?
0
```
![image](https://user-images.githubusercontent.com/2253270/221751578-b4f0f9d9-4591-44df-8ad4-28b77e7f4ae3.png)


## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged