### PR TITLE
govc: add sso.idp.ldap.update command

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -284,6 +284,7 @@ but appear via `govc $cmd -h`:
  - [sso.group.update](#ssogroupupdate)
  - [sso.idp.default.ls](#ssoidpdefaultls)
  - [sso.idp.default.update](#ssoidpdefaultupdate)
+ - [sso.idp.ldap.update](#ssoidpldapupdate)
  - [sso.idp.ls](#ssoidpls)
  - [sso.lpp.info](#ssolppinfo)
  - [sso.lpp.update](#ssolppupdate)
@@ -4798,6 +4799,28 @@ Examples:
   govc sso.idp.default.update NAME
 
 Options:
+```
+
+## sso.idp.ldap.update
+
+```
+Usage: govc sso.idp.ldap.update [OPTIONS] NAME
+
+Update SSO ldap identity provider source.
+
+Examples:
+  govc sso.idp.ldap.update  -FriendlyName CORPLOCAL corp.local
+
+Options:
+  -AuthPassword=               Password
+  -AuthUsername=               Username
+  -DomainAlias=                DomainAlias
+  -FailoverUrl=                FailoverUrl
+  -FriendlyName=               FriendlyName
+  -GroupBaseDn=                GroupBaseDn
+  -PrimaryUrl=                 PrimaryUrl
+  -ServerType=ActiveDirectory  ServerType
+  -UserBaseDn=                 UserBaseDn
 ```
 
 ## sso.idp.ls

--- a/govc/sso/idp/ldap_update.go
+++ b/govc/sso/idp/ldap_update.go
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package idp
+
+import (
+	"context"
+	"flag"
+	"reflect"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/govc/sso"
+	"github.com/vmware/govmomi/ssoadmin"
+	"github.com/vmware/govmomi/ssoadmin/types"
+)
+
+type ldapUpdate struct {
+	*flags.ClientFlag
+	serverType string
+	alias      string
+	idpDetails types.LdapIdentitySourceDetails
+	auth       types.SsoAdminIdentitySourceManagementServiceAuthenticationCredentails
+}
+
+func (cmd *ldapUpdate) Usage() string {
+	return "NAME"
+}
+
+func (cmd *ldapUpdate) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.serverType, "ServerType", "ActiveDirectory", "ServerType")
+	f.StringVar(&cmd.alias, "DomainAlias", "", "DomainAlias")
+	f.StringVar(&cmd.idpDetails.FriendlyName, "FriendlyName", "", "FriendlyName")
+	f.StringVar(&cmd.idpDetails.UserBaseDn, "UserBaseDn", "", "UserBaseDn")
+	f.StringVar(&cmd.idpDetails.GroupBaseDn, "GroupBaseDn", "", "GroupBaseDn")
+	f.StringVar(&cmd.idpDetails.PrimaryURL, "PrimaryUrl", "", "PrimaryUrl")
+	f.StringVar(&cmd.idpDetails.FailoverURL, "FailoverUrl", "", "FailoverUrl")
+	f.StringVar(&cmd.auth.Username, "AuthUsername", "", "Username")
+	f.StringVar(&cmd.auth.Password, "AuthPassword", "", "Password")
+}
+
+type lidpupd struct {
+	ldapUpdate
+}
+
+func init() {
+	cli.Register("sso.idp.ldap.update", &lidpupd{})
+}
+
+func (cmd *lidpupd) Description() string {
+	return `Update SSO ldap identity provider source.
+
+Examples:
+  govc sso.idp.ldap.update  -FriendlyName CORPLOCAL corp.local`
+}
+
+func smerge(src *string, current string) {
+	if *src == "" {
+		*src = current
+	}
+}
+
+func (cmd *lidpupd) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+	idpname := f.Arg(0)
+	return sso.WithClient(ctx, cmd.ClientFlag, func(c *ssoadmin.Client) error {
+		sources, err := c.IdentitySources(ctx)
+		if err != nil {
+			return err
+		}
+
+		GetLdapIdentitySourceByName := func(i []types.LdapIdentitySource, name string) *types.LdapIdentitySource {
+			var n []types.LdapIdentitySource
+			for _, e := range i {
+				if e.Name == name {
+					n = append(n, e)
+				}
+			}
+			if len(n) != 1 {
+				return nil
+			}
+			return &n[0]
+		}
+
+		currentidp := GetLdapIdentitySourceByName(sources.LDAPS, idpname)
+		if currentidp == nil {
+			return c.RegisterLdap(ctx, cmd.serverType, idpname, cmd.alias, cmd.idpDetails, cmd.auth)
+		}
+
+		if cmd.auth.Username != "" && cmd.auth.Password != "" {
+			updateLdapAuthnErr := c.UpdateLdapAuthnType(ctx, idpname, cmd.auth)
+			if updateLdapAuthnErr != nil {
+				return updateLdapAuthnErr
+			}
+		}
+
+		IsAnyIdpDetails := func(d types.LdapIdentitySourceDetails) bool {
+			values := reflect.ValueOf(cmd.idpDetails)
+			for i := 0; i < values.NumField(); i++ {
+				if values.Field(i).Interface() != "" {
+					return true
+				}
+			}
+			return false
+		}
+		if IsAnyIdpDetails(cmd.idpDetails) {
+			smerge(&cmd.idpDetails.FriendlyName, currentidp.Details.FriendlyName)
+			smerge(&cmd.idpDetails.UserBaseDn, currentidp.Details.UserBaseDn)
+			smerge(&cmd.idpDetails.GroupBaseDn, currentidp.Details.GroupBaseDn)
+			smerge(&cmd.idpDetails.PrimaryURL, currentidp.Details.PrimaryURL)
+			smerge(&cmd.idpDetails.FailoverURL, currentidp.Details.FailoverURL)
+			updateLdapErr := c.UpdateLdap(ctx, idpname, cmd.idpDetails)
+			if updateLdapErr != nil {
+				return updateLdapErr
+			}
+		}
+		return nil
+	})
+}

--- a/ssoadmin/client.go
+++ b/ssoadmin/client.go
@@ -533,3 +533,41 @@ func (c *Client) SetDefaultDomains(ctx context.Context, domain string) error {
 	_, err := methods.SetDefaultDomains(ctx, c, &req)
 	return err
 }
+
+func (c *Client) RegisterLdap(ctx context.Context, stype string, name string, alias string, details types.LdapIdentitySourceDetails, auth types.SsoAdminIdentitySourceManagementServiceAuthenticationCredentails) error {
+	req := types.RegisterLdap{
+		This:               c.ServiceContent.IdentitySourceManagementService,
+		ServerType:         stype,
+		DomainName:         name,
+		DomainAlias:        alias,
+		Details:            details,
+		AuthenticationType: "password",
+		AuthnCredentials:   &auth,
+	}
+
+	_, err := methods.RegisterLdap(ctx, c, &req)
+	return err
+}
+
+func (c *Client) UpdateLdap(ctx context.Context, name string, details types.LdapIdentitySourceDetails) error {
+	req := types.UpdateLdap{
+		This:       c.ServiceContent.IdentitySourceManagementService,
+		DomainName: name,
+		Details:    details,
+	}
+
+	_, err := methods.UpdateLdap(ctx, c, &req)
+	return err
+}
+
+func (c *Client) UpdateLdapAuthnType(ctx context.Context, name string, auth types.SsoAdminIdentitySourceManagementServiceAuthenticationCredentails) error {
+	req := types.UpdateLdapAuthnType{
+		This:               c.ServiceContent.IdentitySourceManagementService,
+		DomainName:         name,
+		AuthenticationType: "password",
+		AuthnCredentials:   &auth,
+	}
+
+	_, err := methods.UpdateLdapAuthnType(ctx, c, &req)
+	return err
+}

--- a/ssoadmin/methods/methods.go
+++ b/ssoadmin/methods/methods.go
@@ -1223,6 +1223,26 @@ func ProbeConnectivity(ctx context.Context, r soap.RoundTripper, req *types.Prob
 	return resBody.Res, nil
 }
 
+type RegisterLdapBody struct {
+	Req    *types.RegisterLdap         `xml:"urn:sso RegisterLdap,omitempty"`
+	Res    *types.RegisterLdapResponse `xml:"urn:sso RegisterLdapResponse,omitempty"`
+	Fault_ *soap.Fault                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RegisterLdapBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RegisterLdap(ctx context.Context, r soap.RoundTripper, req *types.RegisterLdap) (*types.RegisterLdapResponse, error) {
+	var reqBody, resBody RegisterLdapBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type RemoveFromLocalGroupBody struct {
 	Req    *types.RemoveFromLocalGroup         `xml:"urn:sso RemoveFromLocalGroup,omitempty"`
 	Res    *types.RemoveFromLocalGroupResponse `xml:"urn:sso RemoveFromLocalGroupResponse,omitempty"`
@@ -1613,6 +1633,46 @@ func (b *UpdateExternalDomainDetailsBody) Fault() *soap.Fault { return b.Fault_ 
 
 func UpdateExternalDomainDetails(ctx context.Context, r soap.RoundTripper, req *types.UpdateExternalDomainDetails) (*types.UpdateExternalDomainDetailsResponse, error) {
 	var reqBody, resBody UpdateExternalDomainDetailsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateLdapBody struct {
+	Req    *types.UpdateLdap         `xml:"urn:sso UpdateLdap,omitempty"`
+	Res    *types.UpdateLdapResponse `xml:"urn:sso UpdateLdapResponse,omitempty"`
+	Fault_ *soap.Fault               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateLdapBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateLdap(ctx context.Context, r soap.RoundTripper, req *types.UpdateLdap) (*types.UpdateLdapResponse, error) {
+	var reqBody, resBody UpdateLdapBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateLdapAuthnTypeBody struct {
+	Req    *types.UpdateLdapAuthnType         `xml:"urn:sso UpdateLdapAuthnType,omitempty"`
+	Res    *types.UpdateLdapAuthnTypeResponse `xml:"urn:sso UpdateLdapAuthnTypeResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateLdapAuthnTypeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateLdapAuthnType(ctx context.Context, r soap.RoundTripper, req *types.UpdateLdapAuthnType) (*types.UpdateLdapAuthnTypeResponse, error) {
+	var reqBody, resBody UpdateLdapAuthnTypeBody
 
 	reqBody.Req = req
 

--- a/ssoadmin/types/types.go
+++ b/ssoadmin/types/types.go
@@ -1534,6 +1534,29 @@ func init() {
 type ProbeConnectivityResponse struct {
 }
 
+type RegisterLdap RegisterLdapRequestType
+
+func init() {
+	types.Add("sso:RegisterLdap", reflect.TypeOf((*RegisterLdap)(nil)).Elem())
+}
+
+type RegisterLdapRequestType struct {
+	This               types.ManagedObjectReference                                      `xml:"_this"`
+	ServerType         string                                                            `xml:"serverType"`
+	DomainName         string                                                            `xml:"domainName"`
+	DomainAlias        string                                                            `xml:"domainAlias,omitempty"`
+	Details            LdapIdentitySourceDetails                                         `xml:"details"`
+	AuthenticationType string                                                            `xml:"authenticationType"`
+	AuthnCredentials   *SsoAdminIdentitySourceManagementServiceAuthenticationCredentails `xml:"authnCredentials,omitempty"`
+}
+
+func init() {
+	types.Add("sso:RegisterLdapRequestType", reflect.TypeOf((*RegisterLdapRequestType)(nil)).Elem())
+}
+
+type RegisterLdapResponse struct {
+}
+
 type RemoveFromLocalGroup RemoveFromLocalGroupRequestType
 
 func init() {
@@ -1817,6 +1840,17 @@ func init() {
 type SetSignerIdentityResponse struct {
 }
 
+type SsoAdminIdentitySourceManagementServiceAuthenticationCredentails struct {
+	types.DynamicData
+
+	Username string `xml:"username"`
+	Password string `xml:"password"`
+}
+
+func init() {
+	types.Add("sso:SsoAdminIdentitySourceManagementServiceAuthenticationCredentails", reflect.TypeOf((*SsoAdminIdentitySourceManagementServiceAuthenticationCredentails)(nil)).Elem())
+}
+
 type SsoAdminServiceInstance SsoAdminServiceInstanceRequestType
 
 func init() {
@@ -1909,6 +1943,45 @@ func init() {
 }
 
 type UpdateExternalDomainDetailsResponse struct {
+}
+
+type UpdateLdap UpdateLdapRequestType
+
+func init() {
+	types.Add("sso:UpdateLdap", reflect.TypeOf((*UpdateLdap)(nil)).Elem())
+}
+
+type UpdateLdapRequestType struct {
+	This       types.ManagedObjectReference `xml:"_this"`
+	DomainName string                       `xml:"name"`
+	Details    LdapIdentitySourceDetails    `xml:"details"`
+}
+
+func init() {
+	types.Add("sso:UpdateLdapRequestType", reflect.TypeOf((*UpdateLdapRequestType)(nil)).Elem())
+}
+
+type UpdateLdapResponse struct {
+}
+
+type UpdateLdapAuthnType UpdateLdapAuthnTypeRequestType
+
+func init() {
+	types.Add("sso:UpdateLdapAuthnType", reflect.TypeOf((*UpdateLdapAuthnType)(nil)).Elem())
+}
+
+type UpdateLdapAuthnTypeRequestType struct {
+	This               types.ManagedObjectReference                                      `xml:"_this"`
+	DomainName         string                                                            `xml:"name"`
+	AuthenticationType string                                                            `xml:"authnType"`
+	AuthnCredentials   *SsoAdminIdentitySourceManagementServiceAuthenticationCredentails `xml:"authnCredentials,omitempty"`
+}
+
+func init() {
+	types.Add("sso:UpdateLdapAuthnTypeRequestType", reflect.TypeOf((*UpdateLdapAuthnTypeRequestType)(nil)).Elem())
+}
+
+type UpdateLdapAuthnTypeResponse struct {
 }
 
 type UpdateLocalGroupDetails UpdateLocalGroupDetailsRequestType


### PR DESCRIPTION
Closes: #3057

## Description
It extends the govc functionality with the following methods:
- RegisterLdap
- UpdateLdap
- UpdateLdapAuthnType

It adds a command sso.idp.ldap.update to add/update LDAP sso idp

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?
- [X] sso.idp.ldap.update
```
abo@mitac:~/Code/govmomi/govc$ go run . sso.idp.ls
Name          Server URL                        Type             Domain         Alias
-             -                                 System Domain    vsphere.local
-             -                                 Local OS         dafak
corp.local    ldap://powershell.corp.local:389  ActiveDirectory  corp.local      CLOUD
corp.locala   ldap://powershell.corp.local:389  ActiveDirectory  corp.locala
corp.localo   ldap://powershell.corp.local:389  ActiveDirectory  corp.localo
corp.localzz  ldap://powershell.corp.local:389  ActiveDirectory  corp.localzz    CLOUD7
corp.lozzz    ldap://powershell.corp.local:389  ActiveDirectory  corp.lozzz     corp.lozzz
corp.localz   ldap://powershell.corp.local:389  ActiveDirectory  corp.localz     CLOUD5
corp.locasss  ldap://powershell.corp.local:389  ActiveDirectory  corp.locasss
abo@mitac:~/Code/govmomi/govc$
abo@mitac:~/Code/govmomi/govc$ go run . sso.idp.ldap.update -FriendlyName  CLOUD55 -UserBaseDn DC=corp,DC=local -GroupBaseDn DC=corp,DC=local -PrimaryUrl ldap://powershell.corp.local:389 -AuthUsername administrator@corp.local -AuthPassword *** corp.test
abo@mitac:~/Code/govmomi/govc$ go run . sso.idp.ls
Name          Server URL                        Type             Domain         Alias
-             -                                 System Domain    vsphere.local
-             -                                 Local OS         dafak
corp.local    ldap://powershell.corp.local:389  ActiveDirectory  corp.local      CLOUD
corp.locala   ldap://powershell.corp.local:389  ActiveDirectory  corp.locala
corp.localo   ldap://powershell.corp.local:389  ActiveDirectory  corp.localo
corp.localzz  ldap://powershell.corp.local:389  ActiveDirectory  corp.localzz    CLOUD7
corp.lozzz    ldap://powershell.corp.local:389  ActiveDirectory  corp.lozzz     corp.lozzz
corp.localz   ldap://powershell.corp.local:389  ActiveDirectory  corp.localz     CLOUD5
corp.test     ldap://powershell.corp.local:389  ActiveDirectory  corp.test
corp.locasss  ldap://powershell.corp.local:389  ActiveDirectory  corp.locasss

```
- [X] sso.idp.ls -json to verify how the idp has been added
```
{
        "Name": "corp.test",
        "Domains": [
          {
            "Name": "corp.test",
            "Alias": ""
          }
        ],
        "Type": "ActiveDirectory",
        "Details": {
          "FriendlyName": " CLOUD55",
          "UserBaseDn": "DC=corp,DC=local",
          "GroupBaseDn": "DC=corp,DC=local",
          "PrimaryURL": "ldap://powershell.corp.local:389",
          "FailoverURL": ""
        },
        "AuthenticationDetails": {
          "AuthenticationType": "PASSWORD",
          "Username": "administrator@corp.local"
        }
      },

```
## Checklist:

- [X] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged