### PR TITLE
govc: dont check poweredOn for vm.console vmrc requests

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -979,12 +979,18 @@ load test_helper
   vm=$(new_empty_vm)
 
   run govc vm.console "$vm"
+  assert_success
+
+  run govc vm.console -wss "$vm"
   assert_failure
 
   run govc vm.power -on "$vm"
   assert_success
 
   run govc vm.console "$vm"
+  assert_success
+
+  run govc vm.console -wss "$vm"
   assert_success
 
   run govc vm.console -capture - "$vm"

--- a/govc/vm/console.go
+++ b/govc/vm/console.go
@@ -97,7 +97,7 @@ func (cmd *console) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	if state != types.VirtualMachinePowerStatePoweredOn {
+	if ((cmd.capture != "" || cmd.wss) && state != types.VirtualMachinePowerStatePoweredOn) {
 		return fmt.Errorf("vm is not powered on (%s)", state)
 	}
 


### PR DESCRIPTION
## Description

The poweredOn check makes sense with wss, capture and h5 arguments - but not if you want the plain VMRC link, since that works perfectly fine with powered off VMs.

Closes: #2127

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

connecting to a powered off machine:

- [x] with -wss should return an error
- [x] without -wss works

## Checklist:

(not necessary things strikethrough, if you do not agree, please tell me)

- [x] My code follows the `CONTRIBUTION` [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged