### PR TITLE
Issue 3064 : Introduced optional parameter -portgroup in dvs.add command

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1853,6 +1853,11 @@ The '-auto-expand' option is labeled in the UI as "Port allocation".
 The default value is false, behaves as the UI labeled "Fixed" choice.
 When given '-auto-expand=true', behaves as the UI labeled "Elastic" choice.
 
+The '-uplink' is optional argument. Absence of '-uplink' argument sets <nil> value
+When given '-uplink' without value sets uplink field to true
+When given '-uplink=false' sets uplink field to false
+When given '-uplink=true' sets uplink field to true
+
 Examples:
   govc dvs.create DSwitch
   govc dvs.portgroup.add -dvs DSwitch -type earlyBinding -nports 16 ExternalNetwork
@@ -1864,6 +1869,7 @@ Options:
   -dvs=                  DVS path
   -nports=128            Number of ports
   -type=earlyBinding     Portgroup type (earlyBinding|lateBinding|ephemeral)
+  -uplink=<nil>          uplink=true means uplink Portgroup
   -vlan=0                VLAN ID
   -vlan-mode=vlan        vlan mode (vlan|trunking)
   -vlan-range=0-4094     VLAN Ranges with comma delimited
@@ -1884,6 +1890,7 @@ Options:
   -auto-expand=<nil>     Ignore the limit on the number of ports
   -nports=0              Number of ports
   -type=earlyBinding     Portgroup type (earlyBinding|lateBinding|ephemeral)
+  -uplink=<nil>          uplink=true means uplink Portgroup
   -vlan=0                VLAN ID
   -vlan-mode=vlan        vlan mode (vlan|trunking)
   -vlan-range=0-4094     VLAN Ranges with comma delimited

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1787,11 +1787,16 @@ Add hosts to DVS.
 
 Examples:
   govc dvs.add -dvs dvsName -pnic vmnic1 hostA hostB hostC
+ 
+  Optional Parameter: -portgroup <pgname> 
+  Makes sure that hosts gets added to only specified portgroup of DVS
+  
 
 Options:
   -dvs=                  DVS path
   -host=                 Host system [GOVC_HOST]
   -pnic=vmnic0           Name of the host physical NIC
+  -portgroup=            DVS portgroup name
 ```
 
 ## dvs.change

--- a/govc/dvs/add.go
+++ b/govc/dvs/add.go
@@ -67,7 +67,11 @@ func (cmd *add) Description() string {
 	return `Add hosts to DVS.
 
 Examples:
-  govc dvs.add -dvs dvsName -pnic vmnic1 hostA hostB hostC`
+  govc dvs.add -dvs dvsName -pnic vmnic1 hostA hostB hostC
+ 
+  Optional Parameter: -portgroup <pgname> 
+  Makes sure that hosts gets added to only specified portgroup of DVS
+  `
 }
 
 func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {

--- a/govc/dvs/portgroup/add.go
+++ b/govc/dvs/portgroup/add.go
@@ -63,6 +63,11 @@ The '-auto-expand' option is labeled in the UI as "Port allocation".
 The default value is false, behaves as the UI labeled "Fixed" choice.
 When given '-auto-expand=true', behaves as the UI labeled "Elastic" choice.
 
+The '-uplink' is optional argument. Absence of '-uplink' argument sets <nil> value
+When given '-uplink' without value sets uplink field to true
+When given '-uplink=false' sets uplink field to false
+When given '-uplink=true' sets uplink field to true
+
 Examples:
   govc dvs.create DSwitch
   govc dvs.portgroup.add -dvs DSwitch -type earlyBinding -nports 16 ExternalNetwork

--- a/govc/dvs/portgroup/spec.go
+++ b/govc/dvs/portgroup/spec.go
@@ -63,6 +63,7 @@ func (spec *DVPortgroupConfigSpec) Register(ctx context.Context, f *flag.FlagSet
 	f.Var(flags.NewInt32(&vlanId), "vlan", "VLAN ID")
 	f.StringVar(&vlanRange, "vlan-range", "0-4094", "VLAN Ranges with comma delimited")
 	f.StringVar(&vlanMode, "vlan-mode", "vlan", fmt.Sprintf("vlan mode (%s)", strings.Join(vlanModes, "|")))
+	f.Var(flags.NewOptionalBool(&spec.Uplink), "uplink", "uplink=true means uplink Portgroup")
 	f.Var(flags.NewOptionalBool(&spec.AutoExpand), "auto-expand", "Ignore the limit on the number of ports")
 }
 

--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -46,6 +46,7 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.Add
 			pg := &DistributedVirtualPortgroup{}
 			pg.Name = spec.Name
 			pg.Entity().Name = pg.Name
+
 			// Standard AddDVPortgroupTask() doesn't allow duplicate names, but NSX 3.0 does create some DVPGs with the same name.
 			// Allow duplicate names using this prefix so we can reproduce and test this condition.
 			if strings.HasPrefix(pg.Name, "NSX-") || spec.BackingType == string(types.DistributedVirtualPortgroupBackingTypeNsx) {

--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -46,7 +46,6 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.Add
 			pg := &DistributedVirtualPortgroup{}
 			pg.Name = spec.Name
 			pg.Entity().Name = pg.Name
-
 			// Standard AddDVPortgroupTask() doesn't allow duplicate names, but NSX 3.0 does create some DVPGs with the same name.
 			// Allow duplicate names using this prefix so we can reproduce and test this condition.
 			if strings.HasPrefix(pg.Name, "NSX-") || spec.BackingType == string(types.DistributedVirtualPortgroupBackingTypeNsx) {
@@ -87,6 +86,7 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.Add
 				LogicalSwitchUuid:            spec.LogicalSwitchUuid,
 				SegmentId:                    spec.SegmentId,
 				BackingType:                  spec.BackingType,
+				Uplink:                       spec.Uplink,
 			}
 
 			if pg.Config.LogicalSwitchUuid != "" {

--- a/simulator/portgroup.go
+++ b/simulator/portgroup.go
@@ -48,6 +48,7 @@ func (s *DistributedVirtualPortgroup) ReconfigureDVPortgroupTask(ctx *Context, r
 		s.Config.LogicalSwitchUuid = req.Spec.LogicalSwitchUuid
 		s.Config.BackingType = req.Spec.BackingType
 
+		s.Config.Uplink = req.Spec.Uplink
 		return nil, nil
 	})
 

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -12550,6 +12550,7 @@ type DVPortgroupConfigSpec struct {
 	VendorSpecificConfig         []DistributedVirtualSwitchKeyedOpaqueBlob `xml:"vendorSpecificConfig,omitempty" json:"vendorSpecificConfig,omitempty"`
 	AutoExpand                   *bool                                     `xml:"autoExpand" json:"autoExpand,omitempty"`
 	VmVnicNetworkResourcePoolKey string                                    `xml:"vmVnicNetworkResourcePoolKey,omitempty" json:"vmVnicNetworkResourcePoolKey,omitempty"`
+	Uplink                       *bool                                     `xml:"uplink" json:"uplink,omitempty"`
 	TransportZoneUuid            string                                    `xml:"transportZoneUuid,omitempty" json:"transportZoneUuid,omitempty"`
 	TransportZoneName            string                                    `xml:"transportZoneName,omitempty" json:"transportZoneName,omitempty"`
 	LogicalSwitchUuid            string                                    `xml:"logicalSwitchUuid,omitempty" json:"logicalSwitchUuid,omitempty"`


### PR DESCRIPTION
## Description

dvs.add command adds given host(s) to all portgroups part of dvs. However, there is need of way to add host to specific dvs portgroup

A optional parameter -portgroup <port_group_name> in dvs.add command, so the new command would look like below
./govc dvs.add -dc=test_dc -dvs test_dvs -host=test_host1 -pnic=vmnic0 -portgroup test_dvs_pg1 test_host1

Closes: #3064 

## Type of change

Please mark options that are relevant:

- [✕] Bug fix (non-breaking change which fixes an issue)
- [✓] New feature (non-breaking change which adds functionality)
- [✕] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [✕] This change requires a documentation update
- [✕] Build related change

## How Has This Been Tested?

- [✓] TestDVSAddHostToSpecificPortgroup --> Added unit test to verify hosts get added to specified dvs portgroup which is specified in config spec. 

## Checklist:

- [✓] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [✓] I have commented my code, particularly in hard-to-understand areas
- [✓] I have made corresponding changes to the documentation
- [✓] I have added tests that prove my fix is effective or that my feature works
- [✓] New and existing unit tests pass locally with my changes
- [✓] Any dependent changes have been merged