### PR TITLE
Add ServerGuid to generated MoRef type

### DIFF
--- a/gen/vim_wsdl.rb
+++ b/gen/vim_wsdl.rb
@@ -469,6 +469,7 @@ class ComplexType < Simple
       extension = @node.at_xpath(".//xsd:extension")
       type = extension["base"].split(":", 2)[1]
       io.print "Value %s `xml:\",chardata\" json:\"value\"`\n" % type
+      io.print "ServerGUID %s `xml:\"serverGuid,attr,omitempty\" json:\"serverGuid,omitempty\"`\n" % type
     end
 
     def peek

--- a/vapi/internal/internal.go
+++ b/vapi/internal/internal.go
@@ -59,7 +59,10 @@ type AssociatedObject struct {
 
 // Reference implements mo.Reference
 func (o AssociatedObject) Reference() types.ManagedObjectReference {
-	return types.ManagedObjectReference(o)
+	return types.ManagedObjectReference{
+		Type:  o.Type,
+		Value: o.Value,
+	}
 }
 
 // Association for tag-association requests.
@@ -69,9 +72,11 @@ type Association struct {
 
 // NewAssociation returns an Association, converting ref to an AssociatedObject.
 func NewAssociation(ref mo.Reference) Association {
-	obj := AssociatedObject(ref.Reference())
 	return Association{
-		ObjectID: &obj,
+		ObjectID: &AssociatedObject{
+			Type:  ref.Reference().Type,
+			Value: ref.Reference().Value,
+		},
 	}
 }
 

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -266,14 +266,22 @@ func (s *handler) AttachedObjects(tag vim.VslmTagEntry) ([]vim.ManagedObjectRefe
 	}
 	var ids []vim.ManagedObjectReference
 	for id := range s.Association[t.ID] {
-		ids = append(ids, vim.ManagedObjectReference(id))
+		ids = append(
+			ids,
+			vim.ManagedObjectReference{
+				Type:  id.Type,
+				Value: id.Value,
+			})
 	}
 	return ids, nil
 }
 
 // AttachedTags is meant for internal use via simulator.Registry.tagManager
 func (s *handler) AttachedTags(ref vim.ManagedObjectReference) ([]vim.VslmTagEntry, vim.BaseMethodFault) {
-	oid := internal.AssociatedObject(ref)
+	oid := internal.AssociatedObject{
+		Type:  ref.Type,
+		Value: ref.Value,
+	}
 	var tags []vim.VslmTagEntry
 	for id, objs := range s.Association {
 		if objs[oid] {
@@ -294,7 +302,10 @@ func (s *handler) AttachTag(ref vim.ManagedObjectReference, tag vim.VslmTagEntry
 	if t == nil {
 		return new(vim.NotFound)
 	}
-	s.Association[t.ID][internal.AssociatedObject(ref)] = true
+	s.Association[t.ID][internal.AssociatedObject{
+		Type:  ref.Type,
+		Value: ref.Value,
+	}] = true
 	return nil
 }
 
@@ -304,7 +315,10 @@ func (s *handler) DetachTag(id vim.ManagedObjectReference, tag vim.VslmTagEntry)
 	if t == nil {
 		return new(vim.NotFound)
 	}
-	delete(s.Association[t.ID], internal.AssociatedObject(id))
+	delete(s.Association[t.ID], internal.AssociatedObject{
+		Type:  id.Type,
+		Value: id.Value,
+	})
 	return nil
 }
 
@@ -1924,7 +1938,10 @@ func (s *handler) libraryItemOVFID(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				return err
 			}
-			id := vcenter.ResourceID(info.Entity)
+			id := vcenter.ResourceID{
+				Type:  info.Entity.Type,
+				Value: info.Entity.Value,
+			}
 			d.Succeeded = true
 			d.ResourceID = &id
 			return nil

--- a/vapi/tags/tag_association.go
+++ b/vapi/tags/tag_association.go
@@ -81,7 +81,11 @@ func (c *Manager) AttachTagToMultipleObjects(ctx context.Context, tagID string, 
 
 	var ids []internal.AssociatedObject
 	for i := range refs {
-		ids = append(ids, internal.AssociatedObject(refs[i].Reference()))
+		ref := refs[i].Reference()
+		ids = append(ids, internal.AssociatedObject{
+			Type:  ref.Type,
+			Value: ref.Value,
+		})
 	}
 
 	spec := struct {
@@ -116,7 +120,10 @@ func (c *Manager) AttachMultipleTagsToObject(ctx context.Context, tagIDs []strin
 		}
 	}
 
-	obj := internal.AssociatedObject(ref.Reference())
+	obj := internal.AssociatedObject{
+		Type:  ref.Reference().Type,
+		Value: ref.Reference().Value,
+	}
 	spec := struct {
 		ObjectID internal.AssociatedObject `json:"object_id"`
 		TagIDs   []string                  `json:"tag_ids"`
@@ -166,7 +173,10 @@ func (c *Manager) DetachMultipleTagsFromObject(ctx context.Context, tagIDs []str
 		}
 	}
 
-	obj := internal.AssociatedObject(ref.Reference())
+	obj := internal.AssociatedObject{
+		Type:  ref.Reference().Type,
+		Value: ref.Reference().Value,
+	}
 	spec := struct {
 		ObjectID internal.AssociatedObject `json:"object_id"`
 		TagIDs   []string                  `json:"tag_ids"`
@@ -337,7 +347,11 @@ func (t *AttachedTags) UnmarshalJSON(b []byte) error {
 func (c *Manager) ListAttachedTagsOnObjects(ctx context.Context, objectID []mo.Reference) ([]AttachedTags, error) {
 	var ids []internal.AssociatedObject
 	for i := range objectID {
-		ids = append(ids, internal.AssociatedObject(objectID[i].Reference()))
+		ref := objectID[i].Reference()
+		ids = append(ids, internal.AssociatedObject{
+			Type:  ref.Type,
+			Value: ref.Value,
+		})
 	}
 
 	spec := struct {

--- a/vapi/vcenter/vcenter_ovf.go
+++ b/vapi/vcenter/vcenter_ovf.go
@@ -297,8 +297,10 @@ func (c *Manager) DeployLibraryItem(ctx context.Context, libraryItemID string, d
 		return nil, err
 	}
 	if res.Succeeded {
-		ref := types.ManagedObjectReference(*res.ResourceID)
-		return &ref, nil
+		return &types.ManagedObjectReference{
+			Type:  res.ResourceID.Type,
+			Value: res.ResourceID.Value,
+		}, nil
 	}
 	return nil, res.Error
 }

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -31937,8 +31937,9 @@ func init() {
 }
 
 type ManagedObjectReference struct {
-	Type  string `xml:"type,attr" json:"type"`
-	Value string `xml:",chardata" json:"value"`
+	Type       string `xml:"type,attr" json:"type"`
+	Value      string `xml:",chardata" json:"value"`
+	ServerGUID string `xml:"serverGuid,attr,omitempty" json:"serverGuid,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

This patch manually introduces the ServerGuid field to the generated types.ManagedObjectReference type. This field is used internally at VMware and not part of the public WSDL, but given internal projects make use of this field, it is helpful for GoVmomi to know about it so it can be part of serialization/deserialization for both XML and JSON.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

By running the new unit tests:

```shell
$ go test -v -run TestManagedObjectReference -count 1 ./vim25/types
=== RUN   TestManagedObjectReference
=== RUN   TestManagedObjectReference/with_server_GUID
=== RUN   TestManagedObjectReference/with_server_GUID/xml
=== RUN   TestManagedObjectReference/with_server_GUID/json
=== RUN   TestManagedObjectReference/sans_server_GUID
=== RUN   TestManagedObjectReference/sans_server_GUID/xml
=== RUN   TestManagedObjectReference/sans_server_GUID/json
--- PASS: TestManagedObjectReference (0.00s)
    --- PASS: TestManagedObjectReference/with_server_GUID (0.00s)
        --- PASS: TestManagedObjectReference/with_server_GUID/xml (0.00s)
        --- PASS: TestManagedObjectReference/with_server_GUID/json (0.00s)
    --- PASS: TestManagedObjectReference/sans_server_GUID (0.00s)
        --- PASS: TestManagedObjectReference/sans_server_GUID/xml (0.00s)
        --- PASS: TestManagedObjectReference/sans_server_GUID/json (0.00s)
PASS
ok  	github.com/vmware/govmomi/vim25/types	0.169s
```



## Checklist:

- [ ] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged