### PR TITLE
Use socat with govc-tests

### DIFF
--- a/.github/workflows/govmomi-govc-tests.yaml
+++ b/.github/workflows/govmomi-govc-tests.yaml
@@ -72,6 +72,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.go-version }}-
 
+      - name: Install socat
+        run: |
+          sudo apt-get update -y && \
+          sudo apt-get install -y socat
+
       - name: Run ${{ matrix.cmd }}
         run: |
           make ${{ matrix.cmd }}

--- a/govc/test/test_helper.bash
+++ b/govc/test/test_helper.bash
@@ -56,7 +56,12 @@ vcsim_start() {
 
     vcsim -l 127.0.0.1:0 -E "$GOVC_SIM_ENV" "$@" &
 
-    eval "$(cat "$GOVC_SIM_ENV")"
+    # Use socat with -T1 so the command will time out in -T seconds
+    # to prevent tests from hanging occasionally in GitHub Actions.
+    # This may still result in a failed test, but it won't block and
+    # should identify the cause of the hanging tests on GH Actions as
+    # related to the theorized issue of the named pipe used here.
+    eval "$(socat -u -T1 $GOVC_SIM_ENV -)"
 }
 
 vcsim_stop() {


### PR DESCRIPTION
## Description

This patch introduces socat for reading the vC Sim env var named pipe in the govc-tests. Socat allows for a timeout if reading the named pipe hangs, which we suspect may be the cause of the hung tests in the govc-test GH action workflow. This won't necessarily fix the tests from failing, but if the named pipe is the issue, the tests should no longer fail due to a timeout we have been unable to root cause with any certainty.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

I plan to run this PR's test GH actions a few times to verify this prevents the ever-present hang.

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged