### PR TITLE
vcsim: EnvironmentBrowser improvements

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -363,11 +363,14 @@ but appear via `govc $cmd -h`:
  - [vm.network.add](#vmnetworkadd)
  - [vm.network.change](#vmnetworkchange)
  - [vm.option.info](#vmoptioninfo)
+ - [vm.option.ls](#vmoptionls)
  - [vm.power](#vmpower)
  - [vm.question](#vmquestion)
  - [vm.rdm.attach](#vmrdmattach)
  - [vm.rdm.ls](#vmrdmls)
  - [vm.register](#vmregister)
+ - [vm.target.cap.ls](#vmtargetcapls)
+ - [vm.target.info](#vmtargetinfo)
  - [vm.unregister](#vmunregister)
  - [vm.upgrade](#vmupgrade)
  - [vm.vnc](#vmvnc)
@@ -6370,6 +6373,23 @@ Examples:
 Options:
   -cluster=              Cluster [GOVC_CLUSTER]
   -host=                 Host system [GOVC_HOST]
+  -id=                   Option descriptor key
+  -vm=                   Virtual machine [GOVC_VM]
+```
+
+## vm.option.ls
+
+```
+Usage: govc vm.option.ls [OPTIONS]
+
+List VM config option keys for CLUSTER.
+
+Examples:
+  govc vm.option.ls -cluster C0
+
+Options:
+  -cluster=              Cluster [GOVC_CLUSTER]
+  -host=                 Host system [GOVC_HOST]
   -vm=                   Virtual machine [GOVC_VM]
 ```
 
@@ -6457,6 +6477,52 @@ Options:
   -name=                 Name of the VM
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
   -template=false        Mark VM as template
+```
+
+## vm.target.cap.ls
+
+```
+Usage: govc vm.target.cap.ls [OPTIONS]
+
+List VM config target capabilities.
+
+The config target data contains capabilities about the execution environment for a VM
+in the given CLUSTER, and optionally for a specific HOST.
+
+Examples:
+  govc vm.target.cap.ls -cluster C0
+  govc vm.target.cap.ls -host my_hostname
+  govc vm.target.cap.ls -vm my_vm
+
+Options:
+  -cluster=              Cluster [GOVC_CLUSTER]
+  -host=                 Host system [GOVC_HOST]
+  -vm=                   Virtual machine [GOVC_VM]
+```
+
+## vm.target.info
+
+```
+Usage: govc vm.target.info [OPTIONS]
+
+VM config target info.
+
+The config target data contains information about the execution environment for a VM
+in the given CLUSTER, and optionally for a specific HOST.
+
+Examples:
+  govc vm.target.info -cluster C0
+  govc vm.target.info -host my_hostname
+  govc vm.target.info -vm my_vm
+
+Options:
+  -cluster=              Cluster [GOVC_CLUSTER]
+  -datastore=true        Include Datastores
+  -device=true           Include Devices
+  -disk=false            Include Disks
+  -host=                 Host system [GOVC_HOST]
+  -network=true          Include Networks
+  -vm=                   Virtual machine [GOVC_VM]
 ```
 
 ## vm.unregister

--- a/govc/device/pci/add.go
+++ b/govc/device/pci/add.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2020 VMware, Inc. All Rights Reserved.
+Copyright (c) 2020-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -104,7 +104,7 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	vmConfigOptions, err := vm.QueryConfigTarget(ctx)
+	vmConfigOptions, err := queryConfigTarget(ctx, vm)
 	if err != nil {
 		return err
 	}

--- a/govc/device/pci/ls.go
+++ b/govc/device/pci/ls.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2020 VMware, Inc. All Rights Reserved.
+Copyright (c) 2020-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,6 +26,7 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -71,7 +72,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	vmConfigOptions, err := vm.QueryConfigTarget(ctx)
+	vmConfigOptions, err := queryConfigTarget(ctx, vm)
 	if err != nil {
 		return err
 	}
@@ -92,4 +93,12 @@ func (r *infoResult) Write(w io.Writer) error {
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", info.SystemId, pd.Id, pd.VendorName, pd.DeviceName)
 	}
 	return tw.Flush()
+}
+
+func queryConfigTarget(ctx context.Context, m *object.VirtualMachine) (*types.ConfigTarget, error) {
+	b, err := m.EnvironmentBrowser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return b.QueryConfigTarget(ctx, nil)
 }

--- a/govc/flags/env.go
+++ b/govc/flags/env.go
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type EnvBrowser struct {
+	*ClusterFlag
+	*HostSystemFlag
+	*VirtualMachineFlag
+}
+
+func (cmd *EnvBrowser) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.VirtualMachineFlag, ctx = NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *EnvBrowser) Process(ctx context.Context) error {
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.VirtualMachineFlag.Process(ctx)
+}
+
+func (cmd *EnvBrowser) Browser(ctx context.Context) (*object.EnvironmentBrowser, error) {
+	c, err := cmd.VirtualMachineFlag.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return nil, err
+	}
+	if vm != nil {
+		return vm.EnvironmentBrowser(ctx)
+	}
+
+	host, err := cmd.HostSystemIfSpecified()
+	if err != nil {
+		return nil, err
+	}
+
+	if host != nil {
+		var h mo.HostSystem
+		err = host.Properties(ctx, host.Reference(), []string{"parent"}, &h)
+		if err != nil {
+			return nil, err
+		}
+
+		return object.NewComputeResource(c, *h.Parent).EnvironmentBrowser(ctx)
+	}
+
+	finder, ferr := cmd.ClusterFlag.Finder()
+	if ferr != nil {
+		return nil, ferr
+	}
+
+	cr, ferr := finder.ComputeResourceOrDefault(ctx, cmd.ClusterFlag.Name)
+	if ferr != nil {
+		return nil, ferr
+	}
+
+	return cr.EnvironmentBrowser(ctx)
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -112,6 +112,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/vm/option"
 	_ "github.com/vmware/govmomi/govc/vm/rdm"
 	_ "github.com/vmware/govmomi/govc/vm/snapshot"
+	_ "github.com/vmware/govmomi/govc/vm/target"
 	_ "github.com/vmware/govmomi/govc/volume"
 	_ "github.com/vmware/govmomi/govc/volume/snapshot"
 	_ "github.com/vmware/govmomi/govc/vsan"

--- a/govc/object/save.go
+++ b/govc/object/save.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -113,11 +113,29 @@ func saveDVS(ctx context.Context, c *vim25.Client, ref types.ManagedObjectRefere
 }
 
 func saveEnvironmentBrowser(ctx context.Context, c *vim25.Client, ref types.ManagedObjectReference) ([]saveMethod, error) {
-	res, err := methods.QueryConfigOption(ctx, c, &types.QueryConfigOption{This: ref})
-	if err != nil {
-		return nil, err
+	var save []saveMethod
+	{
+		res, err := methods.QueryConfigOption(ctx, c, &types.QueryConfigOption{This: ref})
+		if err != nil {
+			return nil, err
+		}
+		save = append(save, saveMethod{"QueryConfigOption", res})
 	}
-	return []saveMethod{{"QueryConfigOption", res}}, nil
+	{
+		res, err := methods.QueryConfigTarget(ctx, c, &types.QueryConfigTarget{This: ref})
+		if err != nil {
+			return nil, err
+		}
+		save = append(save, saveMethod{"QueryConfigTarget", res})
+	}
+	{
+		res, err := methods.QueryTargetCapabilities(ctx, c, &types.QueryTargetCapabilities{This: ref})
+		if err != nil {
+			return nil, err
+		}
+		save = append(save, saveMethod{"QueryTargetCapabilities", res})
+	}
+	return save, nil
 }
 
 func saveHostNetworkSystem(ctx context.Context, c *vim25.Client, ref types.ManagedObjectReference) ([]saveMethod, error) {

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -1114,6 +1114,22 @@ load test_helper
   [ ${#lines[@]} -ge 100 ]
 }
 
+@test "vm.target.info" {
+  vcsim_env
+
+  run govc vm.target.info -host "$GOVC_HOST"
+  assert_success
+
+  run govc vm.target.info -cluster "$(dirname "$GOVC_HOST")"
+  assert_success
+
+  run govc vm.target.info -vm DC0_H0_VM0
+  assert_success
+
+  run govc vm.target.info -json
+  assert_success
+}
+
 @test "vm.customize" {
   vcsim_env
 

--- a/govc/vm/option/ls.go
+++ b/govc/vm/option/ls.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package option
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ls struct {
+	flags.EnvBrowser
+}
+
+func init() {
+	cli.Register("vm.option.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.EnvBrowser.Register(ctx, f)
+}
+
+func (cmd *ls) Description() string {
+	return `List VM config option keys for CLUSTER.
+
+Examples:
+  govc vm.option.ls -cluster C0`
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	b, err := cmd.Browser(ctx)
+	if err != nil {
+		return err
+	}
+
+	opts, err := b.QueryConfigOptionDescriptor(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cmd.VirtualMachineFlag.WriteResult(&lsResult{opts})
+}
+
+type lsResult struct {
+	opts []types.VirtualMachineConfigOptionDescriptor
+}
+
+func (r *lsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, d := range r.opts {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\n", d.Key, d.Description)
+	}
+
+	return tw.Flush()
+}
+
+func (r *lsResult) Dump() interface{} {
+	return r.opts
+}
+
+func (r *lsResult) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.opts)
+}

--- a/govc/vm/rdm/attach.go
+++ b/govc/vm/rdm/attach.go
@@ -81,7 +81,7 @@ func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	vmConfigOptions, err := vm.QueryConfigTarget(ctx)
+	vmConfigOptions, err := queryConfigTarget(ctx, vm)
 	if err != nil {
 		return err
 	}

--- a/govc/vm/rdm/ls.go
+++ b/govc/vm/rdm/ls.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,6 +27,7 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -75,7 +76,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	vmConfigOptions, err := vm.QueryConfigTarget(ctx)
+	vmConfigOptions, err := queryConfigTarget(ctx, vm)
 	if err != nil {
 		return err
 	}
@@ -106,4 +107,12 @@ func (r *infoResult) Write(w io.Writer) error {
 		fmt.Fprintf(tw, "  UIDS:\t%s\n", strings.Join(uids, " ,"))
 	}
 	return tw.Flush()
+}
+
+func queryConfigTarget(ctx context.Context, m *object.VirtualMachine) (*types.ConfigTarget, error) {
+	b, err := m.EnvironmentBrowser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return b.QueryConfigTarget(ctx, nil)
 }

--- a/govc/vm/target/capabilities.go
+++ b/govc/vm/target/capabilities.go
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package target
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"reflect"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type capls struct {
+	flags.EnvBrowser
+}
+
+func init() {
+	cli.Register("vm.target.cap.ls", &capls{})
+}
+
+func (cmd *capls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.EnvBrowser.Register(ctx, f)
+}
+
+func (cmd *capls) Description() string {
+	return `List VM config target capabilities.
+
+The config target data contains capabilities about the execution environment for a VM
+in the given CLUSTER, and optionally for a specific HOST.
+
+Examples:
+  govc vm.target.cap.ls -cluster C0
+  govc vm.target.cap.ls -host my_hostname
+  govc vm.target.cap.ls -vm my_vm`
+}
+
+func (cmd *capls) Run(ctx context.Context, f *flag.FlagSet) error {
+	b, err := cmd.Browser(ctx)
+	if err != nil {
+		return err
+	}
+
+	host, err := cmd.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	cap, err := b.QueryTargetCapabilities(ctx, host)
+	if err != nil {
+		return err
+	}
+
+	return cmd.VirtualMachineFlag.WriteResult(&caplsResult{cap})
+}
+
+type caplsResult struct {
+	*types.HostCapability
+}
+
+func (r *caplsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	cap := reflect.ValueOf(r.HostCapability).Elem()
+	kind := cap.Type()
+
+	for i := 0; i < cap.NumField(); i++ {
+		field := cap.Field(i)
+
+		if kind.Field(i).Anonymous {
+			continue
+		}
+		if field.Kind() == reflect.Pointer {
+			if field.IsNil() {
+				continue
+			}
+			field = field.Elem()
+		}
+
+		fmt.Fprintf(tw, "%s:\t%v\n", kind.Field(i).Name, field.Interface())
+	}
+
+	return tw.Flush()
+}
+
+func (r *caplsResult) Dump() interface{} {
+	return r.HostCapability
+}

--- a/govc/vm/target/info.go
+++ b/govc/vm/target/info.go
@@ -1,0 +1,145 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package target
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	flags.EnvBrowser
+
+	datastore bool
+	network   bool
+	disk      bool
+	device    bool
+}
+
+func init() {
+	cli.Register("vm.target.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.EnvBrowser.Register(ctx, f)
+
+	f.BoolVar(&cmd.datastore, "datastore", true, "Include Datastores")
+	f.BoolVar(&cmd.network, "network", true, "Include Networks")
+	f.BoolVar(&cmd.disk, "disk", false, "Include Disks")
+	f.BoolVar(&cmd.device, "device", true, "Include Devices")
+}
+
+func (cmd *info) Description() string {
+	return `VM config target info.
+
+The config target data contains information about the execution environment for a VM
+in the given CLUSTER, and optionally for a specific HOST.
+
+Examples:
+  govc vm.target.info -cluster C0
+  govc vm.target.info -host my_hostname
+  govc vm.target.info -vm my_vm`
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	b, err := cmd.Browser(ctx)
+	if err != nil {
+		return err
+	}
+
+	host, err := cmd.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	target, err := b.QueryConfigTarget(ctx, host)
+	if err != nil {
+		return err
+	}
+
+	if cmd.network == false {
+		target.Network = nil
+		target.DistributedVirtualPortgroup = nil
+		target.DistributedVirtualSwitch = nil
+		target.OpaqueNetwork = nil
+		target.LegacyNetworkInfo = nil
+	}
+
+	if cmd.datastore == false {
+		target.Datastore = nil
+	}
+
+	if cmd.disk == false {
+		target.ScsiDisk = nil
+		target.IdeDisk = nil
+	}
+
+	return cmd.VirtualMachineFlag.WriteResult(&infoResult{target})
+}
+
+type infoResult struct {
+	*types.ConfigTarget
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "CPUs:\t%d\n", r.ConfigTarget.NumCpus)
+	fmt.Fprintf(tw, "CPU cores:\t%d\n", r.ConfigTarget.NumCpuCores)
+
+	for _, ds := range r.ConfigTarget.Datastore {
+		fmt.Fprintf(tw, "Datastore:\t%s\n", ds.Name)
+		fmt.Fprintf(tw, "  Capacity:\t%s\n", units.ByteSize(ds.Datastore.Capacity))
+		fmt.Fprintf(tw, "  Free:\t%s\n", units.ByteSize(ds.Datastore.FreeSpace))
+		fmt.Fprintf(tw, "  Uncommitted:\t%s\n", units.ByteSize(ds.Datastore.Uncommitted))
+	}
+
+	for _, net := range r.ConfigTarget.Network {
+		fmt.Fprintf(tw, "Network:\t%s\n", net.Name)
+	}
+
+	for _, net := range r.ConfigTarget.DistributedVirtualPortgroup {
+		if net.UplinkPortgroup {
+			continue
+		}
+		fmt.Fprintf(tw, "Network:\t%s\n", net.PortgroupName)
+		fmt.Fprintf(tw, "  Switch:\t%s\n", net.SwitchName)
+	}
+
+	for _, disk := range r.ConfigTarget.ScsiPassthrough {
+		fmt.Fprintf(tw, "SCSI passthrough:\t%s\n", disk.Name)
+		fmt.Fprintf(tw, "  Unit:\t%d\n", disk.PhysicalUnitNumber)
+	}
+
+	for _, clock := range r.ConfigTarget.PrecisionClockInfo {
+		fmt.Fprintf(tw, "PrecisionClock:\t%s\n", clock.SystemClockProtocol)
+	}
+
+	return tw.Flush()
+}
+
+func (r *infoResult) Dump() interface{} {
+	return r.ConfigTarget
+}

--- a/object/compute_resource.go
+++ b/object/compute_resource.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,6 +18,7 @@ package object
 
 import (
 	"context"
+	"fmt"
 	"path"
 
 	"github.com/vmware/govmomi/property"
@@ -82,6 +83,21 @@ func (c ComputeResource) Datastores(ctx context.Context) ([]*Datastore, error) {
 	}
 
 	return dss, nil
+}
+
+func (c ComputeResource) EnvironmentBrowser(ctx context.Context) (*EnvironmentBrowser, error) {
+	var cr mo.ComputeResource
+
+	err := c.Properties(ctx, c.Reference(), []string{"environmentBrowser"}, &cr)
+	if err != nil {
+		return nil, err
+	}
+
+	if cr.EnvironmentBrowser == nil {
+		return nil, fmt.Errorf("%s: nil environmentBrowser", c.Reference())
+	}
+
+	return NewEnvironmentBrowser(c.c, *cr.EnvironmentBrowser), nil
 }
 
 func (c ComputeResource) ResourcePool(ctx context.Context) (*ResourcePool, error) {

--- a/object/environment_browser.go
+++ b/object/environment_browser.go
@@ -1,0 +1,98 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type EnvironmentBrowser struct {
+	Common
+}
+
+func NewEnvironmentBrowser(c *vim25.Client, ref types.ManagedObjectReference) *EnvironmentBrowser {
+	return &EnvironmentBrowser{
+		Common: NewCommon(c, ref),
+	}
+}
+
+func (b EnvironmentBrowser) QueryConfigTarget(ctx context.Context, host *HostSystem) (*types.ConfigTarget, error) {
+	req := types.QueryConfigTarget{
+		This: b.Reference(),
+	}
+
+	if host != nil {
+		ref := host.Reference()
+		req.Host = &ref
+	}
+
+	res, err := methods.QueryConfigTarget(ctx, b.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (b EnvironmentBrowser) QueryTargetCapabilities(ctx context.Context, host *HostSystem) (*types.HostCapability, error) {
+	req := types.QueryTargetCapabilities{
+		This: b.Reference(),
+	}
+
+	if host != nil {
+		ref := host.Reference()
+		req.Host = &ref
+	}
+
+	res, err := methods.QueryTargetCapabilities(ctx, b.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (b EnvironmentBrowser) QueryConfigOption(ctx context.Context, spec *types.EnvironmentBrowserConfigOptionQuerySpec) (*types.VirtualMachineConfigOption, error) {
+	req := types.QueryConfigOptionEx{
+		This: b.Reference(),
+		Spec: spec,
+	}
+
+	res, err := methods.QueryConfigOptionEx(ctx, b.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (b EnvironmentBrowser) QueryConfigOptionDescriptor(ctx context.Context) ([]types.VirtualMachineConfigOptionDescriptor, error) {
+	req := types.QueryConfigOptionDescriptor{
+		This: b.Reference(),
+	}
+
+	res, err := methods.QueryConfigOptionDescriptor(ctx, b.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -438,6 +438,17 @@ func (v VirtualMachine) Device(ctx context.Context) (VirtualDeviceList, error) {
 	return VirtualDeviceList(o.Config.Hardware.Device), nil
 }
 
+func (v VirtualMachine) EnvironmentBrowser(ctx context.Context) (*EnvironmentBrowser, error) {
+	var vm mo.VirtualMachine
+
+	err := v.Properties(ctx, v.Reference(), []string{"environmentBrowser"}, &vm)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewEnvironmentBrowser(v.c, vm.EnvironmentBrowser), nil
+}
+
 func (v VirtualMachine) HostSystem(ctx context.Context) (*HostSystem, error) {
 	var o mo.VirtualMachine
 
@@ -916,27 +927,6 @@ func (v VirtualMachine) Unregister(ctx context.Context) error {
 
 	_, err := methods.UnregisterVM(ctx, v.Client(), &req)
 	return err
-}
-
-// QueryEnvironmentBrowser is a helper to get the environmentBrowser property.
-func (v VirtualMachine) QueryConfigTarget(ctx context.Context) (*types.ConfigTarget, error) {
-	var vm mo.VirtualMachine
-
-	err := v.Properties(ctx, v.Reference(), []string{"environmentBrowser"}, &vm)
-	if err != nil {
-		return nil, err
-	}
-
-	req := types.QueryConfigTarget{
-		This: vm.EnvironmentBrowser,
-	}
-
-	res, err := methods.QueryConfigTarget(ctx, v.Client(), &req)
-	if err != nil {
-		return nil, err
-	}
-
-	return res.Returnval, nil
 }
 
 func (v VirtualMachine) MountToolsInstaller(ctx context.Context) error {

--- a/scripts/license.sh
+++ b/scripts/license.sh
@@ -17,11 +17,7 @@ git diff --name-status main | awk '{print $2}' | while read file; do
     yearA=${years[0]}
     yearB=${years[$((${num_years}-1))]}
 
-    if [ ${yearA} == ${yearB} ]; then
-      export YEARS="${yearA}"
-    else
-      export YEARS="${yearA}-${yearB}"
-    fi
+    export YEARS="${yearA}-${yearB}"
   fi
 
   case "$file" in

--- a/simulator/environment_browser.go
+++ b/simulator/environment_browser.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,10 @@ import (
 type EnvironmentBrowser struct {
 	mo.EnvironmentBrowser
 
-	types.QueryConfigOptionResponse
+	QueryConfigTargetResponse           types.QueryConfigTargetResponse
+	QueryConfigOptionResponse           types.QueryConfigOptionResponse
+	QueryConfigOptionDescriptorResponse types.QueryConfigOptionDescriptorResponse
+	QueryTargetCapabilitiesResponse     types.QueryTargetCapabilitiesResponse
 }
 
 func newEnvironmentBrowser() *types.ManagedObjectReference {
@@ -135,7 +138,13 @@ func (b *EnvironmentBrowser) QueryConfigOptionEx(req *types.QueryConfigOptionEx)
 
 func (b *EnvironmentBrowser) QueryConfigOptionDescriptor(ctx *Context, req *types.QueryConfigOptionDescriptor) soap.HasFault {
 	body := &methods.QueryConfigOptionDescriptorBody{
-		Res: new(types.QueryConfigOptionDescriptorResponse),
+		Res: &types.QueryConfigOptionDescriptorResponse{
+			Returnval: b.QueryConfigOptionDescriptorResponse.Returnval,
+		},
+	}
+
+	if body.Res.Returnval != nil {
+		return body
 	}
 
 	body.Res.Returnval = []types.VirtualMachineConfigOptionDescriptor{{
@@ -154,12 +163,18 @@ func (b *EnvironmentBrowser) QueryConfigOptionDescriptor(ctx *Context, req *type
 func (b *EnvironmentBrowser) QueryConfigTarget(ctx *Context, req *types.QueryConfigTarget) soap.HasFault {
 	body := &methods.QueryConfigTargetBody{
 		Res: &types.QueryConfigTargetResponse{
-			Returnval: &types.ConfigTarget{
-				SmcPresent: types.NewBool(false),
-			},
+			Returnval: b.QueryConfigTargetResponse.Returnval,
 		},
 	}
-	target := body.Res.Returnval
+
+	if body.Res.Returnval != nil {
+		return body
+	}
+
+	target := &types.ConfigTarget{
+		SmcPresent: types.NewBool(false),
+	}
+	body.Res.Returnval = target
 
 	var hosts []types.ManagedObjectReference
 	if req.Host == nil {
@@ -229,6 +244,25 @@ func (b *EnvironmentBrowser) QueryConfigTarget(ctx *Context, req *types.QueryCon
 				})
 			}
 		}
+	}
+
+	return body
+}
+
+func (b *EnvironmentBrowser) QueryTargetCapabilities(ctx *Context, req *types.QueryTargetCapabilities) soap.HasFault {
+	body := &methods.QueryTargetCapabilitiesBody{
+		Res: &types.QueryTargetCapabilitiesResponse{
+			Returnval: b.QueryTargetCapabilitiesResponse.Returnval,
+		},
+	}
+
+	if body.Res.Returnval != nil {
+		return body
+	}
+
+	body.Res.Returnval = &types.HostCapability{
+		VmotionSupported:         true,
+		MaintenanceModeSupported: true,
 	}
 
 	return body


### PR DESCRIPTION
## Description

vcsim: add EnvironmentBrowser methods and record/replay support

api: add object.EnvironmentBrowser helper methods

govc: add vm.option.ls, vm.target.info and vm.target.cap.ls commands

BREAKING: removed object.VirtualMachine.QueryConfigTarget method
- Use object.VirtualMachine.EnvironmentBrowser().QueryConfigTarget instead

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Added new bats tests.

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged