### PR TITLE
govc: Add support for CNS volume snapshots

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,7 +6,10 @@
 Abhijeet Kasurde <akasurde@redhat.com>
 abrarshivani <abrarshivani@users.noreply.github.com>
 Adam Chalkley <atc0005@users.noreply.github.com>
+Adam Fowler <adam@adamfowler.org>
 Adam Shannon <adamkshannon@gmail.com>
+Akanksha Panse <pansea@vmware.com>
+akutz <akutz@users.noreply.github.com>
 Al Biheiri <abiheiri@apple.com>
 Alessandro Cortiana <alessandro.cortiana@gmail.com>
 Alex <puzo2002@gmail.com>
@@ -28,6 +31,7 @@ aniketGslab <aniket.shinde@gslab.com>
 Ankit Vaidya <vaidyaa@vmware.com>
 Ankur Huralikoppi <huralikoppia@vmware.com>
 Anna Carrigan <anna.carrigan@hpe.com>
+Antony Saba <awsaba@gmail.com>
 Ariel Chinn <arielchinn@gmail.com>
 Arran Walker <arran.walker@zopa.com>
 Artem Anisimov <aanisimov@inbox.ru>
@@ -41,19 +45,23 @@ Ben Corrie <bcorrie@vmware.com>
 Ben Vickers <bvickers@pivotal.io>
 Benjamin Davini <davinib@vmware.com>
 Benjamin Peterson <benjamin@python.org>
+Benjamin Vickers <bvickers@vmware.com>
 Bhavya Choudhary <bhavyac@vmware.com>
 Bob Killen <killen.bob@gmail.com>
 Brad Fitzpatrick <bradfitz@golang.org>
+Brian Rak <brak@vmware.com>
 brian57860 <brian57860@users.noreply.github.com>
 Bruce Downs <bruceadowns@gmail.com>
-Cédric Blomart <cblomart@gmail.com>
+Bryan Venteicher <bryanventeicher@gmail.com>
 Cheng Cheng <chengch@vmware.com>
 Chethan Venkatesh <chethanv@vmware.com>
+Choudhury Sarada Prasanna Nanda <cspn@google.com>
 Chris Marchesi <chrism@vancluevertech.com>
 Christian Höltje <docwhat@gerf.org>
 Clint Greenwood <cgreenwood@vmware.com>
 cpiment <pimentel.carlos@gmail.com>
 CuiHaozhi <cuihaozhi@chinacloud.com.cn>
+Cédric Blomart <cblomart@gmail.com>
 Dan Ilan <danilan@google.com>
 Dan Norris <protochron@users.noreply.github.com>
 Daniel Frederick Crisman <daniel@crisman.org>
@@ -66,19 +74,24 @@ David Gress <gressd@vmware.com>
 David Stark <dave@davidstark.name>
 Davide Agnello <dagnello@hp.com>
 Davinder Kumar <davinderk@vmware.com>
+Defa <zhoudefa666@163.com>
 demarey <christophe.demarey@inria.fr>
 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 Deric Crago <deric.crago@gmail.com>
+ditsuke <ditsuke@protonmail.com>
 Divyen Patel <divyenp@vmware.com>
 Dnyanesh Gate <dnyanesh.gate@druva.com>
 Doug MacEachern <dougm@vmware.com>
 East <60801291+houfangdong@users.noreply.github.com>
 Eloy Coto <eloy.coto@gmail.com>
+embano1 <embano1@users.noreply.github.com>
+Eng Zer Jun <engzerjun@gmail.com>
 Eric Edens <ericedens@google.com>
 Eric Graham <16710890+Pheric@users.noreply.github.com>
 Eric Gray <egray@vmware.com>
 Eric Yutao <eric.yutao@gmail.com>
 Erik Hollensbe <github@hollensbe.org>
+Essodjolo KAHANAM <essodjolo@kahanam.com>
 Ethan Kaley <ethan.kaley@emc.com>
 Evan Chu <echu@vmware.com>
 Fabio Rapposelli <fabio@vmware.com>
@@ -92,11 +105,14 @@ Gavrie Philipson <gavrie.philipson@elastifile.com>
 George Hicken <ghicken@vmware.com>
 Gerrit Renker <Gerrit.Renker@ctl.io>
 gthombare <gthombare@vmware.com>
+Hakan Halil <hhalil@vmware.com>
 HakanSunay <hakansunay@abv.bg>
 Hasan Mahmood <mahmoodh@vmware.com>
+Haydon Ryan <haydon.ryan@gmail.com>
 Heiko Reese <hreese@users.noreply.github.com>
 Henrik Hodne <henrik@travis-ci.com>
 hkumar <hkumar@vmware.com>
+Hrabur Stoyanov <hstoyanov@vmware.com>
 hui luo <luoh@vmware.com>
 Ian Eyberg <ian@deferpanic.com>
 Isaac Rodman <isaac@eyz.us>
@@ -109,12 +125,13 @@ Jeremy Canady <jcanady@jackhenry.com>
 jeremy-clerc <jeremy@clerc.io>
 Jiatong Wang <wjiatong@vmware.com>
 jingyizPensando <jingyiz@pensando.io>
-João Pereira <joaodrp@gmail.com>
 Jonas Ausevicius <jonas.ausevicius@virtustream.com>
 Jorge Sevilla <jorge.sevilla@rstor.io>
+João Pereira <joaodrp@gmail.com>
 Julien PILLON <jpillon@lesalternatives.org>
 Justin J. Novack <jnovack@users.noreply.github.com>
 kayrus <kay.diam@gmail.com>
+Keenan Brock <keenan@thebrocks.net>
 Kevin George <georgek@vmware.com>
 Knappek <andy.knapp.ak@gmail.com>
 Leslie Wang <qiwa@pensando.io>
@@ -124,13 +141,18 @@ Liping Xue <lipingx@vmware.com>
 Louie Jiang <jiangl@vmware.com>
 Luther Monson <luther.monson@gmail.com>
 Madanagopal Arunachalam <marunachalam@vmware.com>
+makelarisjr <8687447+makelarisjr@users.noreply.github.com>
+Manuel Grandeit <m.grandeit@gmail.com>
 maplain <fangyuanl@vmware.com>
 Marc Carmier <mcarmier@gmail.com>
 Marcus Tan <marcus.tan@rubrik.com>
 Maria Ntalla <maria.ntalla@gmail.com>
 Marin Atanasov Nikolov <mnikolov@vmware.com>
 Mario Trangoni <mjtrangoni@gmail.com>
+Mark Dechiaro <mdechiaro@users.noreply.github.com>
 Mark Peek <markpeek@vmware.com>
+Mark Rexwinkel <Mark.Rexwinkel@elekta.com>
+martin <martin@catai.org>
 Matt Clay <matt@mystile.com>
 Matt Moore <mattmoor@vmware.com>
 Matt Moriarity <matt@mattmoriarity.com>
@@ -138,14 +160,20 @@ Matthew Cosgrove <matthew.cosgrove@dell.com>
 mbhadale <mbhadale@vmware.com>
 Merlijn Sebrechts <merlijn.sebrechts@gmail.com>
 Mevan Samaratunga <mevansam@gmail.com>
+Michael Gasch <15986659+embano1@users.noreply.github.com>
 Michael Gasch <mgasch@vmware.com>
 Michal Jankowski <mjankowski@vmware.com>
+Mike Schinkel <mike@newclarity.net>
 Mincho Tonev <mtonev@vmware.com>
 mingwei <mingwei@smartx.com>
 Nicolas Lamirault <nicolas.lamirault@gmail.com>
+nikhaild <84156354+nikhaild@users.noreply.github.com>
 Nikhil Kathare <nikhil.kathare@netapp.com>
 Nikhil R Deshpande <ndeshpande@vmware.com>
 Nikolas Grottendieck <git@nikolasgrottendieck.com>
+Nils Elde <nils.elde@sscinc.com>
+nirbhay <nirbhay.bagmar@nutanix.com>
+Nobuhiro MIKI <nmiki@yahoo-corp.jp>
 Om Kumar <om.kumar@hpe.com>
 Omar Kohl <omarkohl@gmail.com>
 Parham Alvani <parham.alvani@gmail.com>
@@ -153,15 +181,24 @@ Parveen Chahal <parkuma@microsoft.com>
 Paul Martin <25058109+rawstorage@users.noreply.github.com>
 Pierre Gronlier <pierre.gronlier@corp.ovh.com>
 Pieter Noordhuis <pnoordhuis@vmware.com>
+pradeepj <50135054+pradeep288@users.noreply.github.com>
+Pranshu Jain <jpranshu@vmware.com>
 prydin <prydin@vmware.com>
 rconde01 <rconde01@hotmail.com>
 rHermes <teodor_spaeren@riseup.net>
+Rianto Wahyudi <rwahyudi@gmail.com>
+Ricardo Katz <rkatz@vmware.com>
+Robin Watkins <robwatkins@gmail.com>
 Rowan Jacobs <rojacobs@pivotal.io>
 Roy Ling <royling0024@gmail.com>
 rsikdar <rsikdar@berkeley.edu>
 runner.mei <runner.mei@gmail.com>
+Ryan Johnson <johnsonryan@vmware.com>
+S R Ashrith <sashrith@vmware.com>
 S.Çağlar Onur <conur@vmware.com>
 Saad Malik <saad@spectrocloud.com>
+Sam Zhu <zhusa@zhusa-a02.vmware.com>
+samzhu333 <45263849+samzhu333@users.noreply.github.com>
 Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>
 Scott Holden <scott@nullops.io>
 Sergey Ignatov <sergey.ignatov@jetbrains.com>
@@ -172,11 +209,15 @@ Shaozhen Ding <dsz0111@gmail.com>
 Shawn Neal <sneal@sneal.net>
 shylasrinivas <sshyla@vmware.com>
 sky-joker <sky.jokerxx@gmail.com>
+smaftoul <samuel.maftoul@gmail.com>
+smahadik <smahadik@vmware.com>
 Sten Feldman <exile@chamber.ee>
 Stepan Mazurov <smazurov@gmail.com>
 Steve Purcell <steve@sanityinc.com>
+Sudhindra Aithal <sudhiaithal@pensando.io>
 SUMIT AGRAWAL <asumit@vmware.com>
-Syuparn <s.hello.spagetti@gmail.com>
+Sunny Carter <sunny.carter@metaswitch.com>
+syuparn <s.hello.spagetti@gmail.com>
 Takaaki Furukawa <takaaki.frkw@gmail.com>
 Tamas Eger <tamas.eger@bitrise.io>
 Tanay Kothari <tkothari@vmware.com>
@@ -189,6 +230,7 @@ Tjeu Kayim <15987676+TjeuKayim@users.noreply.github.com>
 Toomas Pelberg <toomas.pelberg@playtech.com>
 Trevor Dawe <trevor.dawe@gmail.com>
 tshihad <tshihad9@gmail.com>
+Ueli Banholzer <ueli@whatwedo.ch>
 Uwe Bessle <Uwe.Bessle@iteratec.de>
 Vadim Egorov <vegorov@vmware.com>
 Vikram Krishnamurthy <vikramkrishnamu@vmware.com>
@@ -198,14 +240,17 @@ Waldek Maleska <w.maleska@gmail.com>
 William Lam <wlam@vmware.com>
 Witold Krecicki <wpk@culm.net>
 xing-yang <xingyang105@gmail.com>
+xinyanw409 <wxinyan@vmware.com>
 Yang Yang <yangy@vmware.com>
 yangxi <yangxi@vmware.com>
 Yann Hodique <yhodique@google.com>
 Yash Nitin Desai <desaiy@vmware.com>
 Yassine TIJANI <ytijani@vmware.com>
+Yi Jiang <yijiang@vmware.com>
 yiyingy <yiyingy@vmware.com>
 ykakarap <yuva2811@gmail.com>
 Yogesh Sobale <6104071+ysobale@users.noreply.github.com>
+Your Name <you@example.com>
 Yue Yin <yueyin@yuyin-a01.vmware.com>
 Yun Zhou <yunz@vmware.com>
 Yuya Kusakabe <yuya.kusakabe@gmail.com>

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -361,6 +361,9 @@ but appear via `govc $cmd -h`:
  - [vm.vnc](#vmvnc)
  - [volume.ls](#volumels)
  - [volume.rm](#volumerm)
+ - [volume.snapshot.create](#volumesnapshotcreate)
+ - [volume.snapshot.ls](#volumesnapshotls)
+ - [volume.snapshot.rm](#volumesnapshotrm)
  - [vsan.change](#vsanchange)
  - [vsan.info](#vsaninfo)
 
@@ -6333,6 +6336,59 @@ consider using 'govc disk.ls -R' to reconcile the datastore inventory.
 
 Examples:
   govc volume.rm f75989dc-95b9-4db7-af96-8583f24bc59d
+
+Options:
+```
+
+## volume.snapshot.create
+
+```
+Usage: govc volume.snapshot.create [OPTIONS] [ID] [DESC]
+
+Create snapshot of volume ID with description DESC.
+
+Examples:
+  govc volume.snapshot.create df86393b-5ae0-4fca-87d0-b692dbc67d45 my-snapshot
+  govc volume.snapshot.create -i df86393b-5ae0-4fca-87d0-b692dbc67d45 my-snapshot
+
+Options:
+  -i=false               Output snapshot ID and volume ID only
+```
+
+## volume.snapshot.ls
+
+```
+Usage: govc volume.snapshot.ls [OPTIONS] [ID]...
+
+List all snapshots of volume ID.
+
+Use a list of volume IDs to list all snapshots of multiple volumes at once.
+
+Examples:
+  govc volume.snapshot.ls df86393b-5ae0-4fca-87d0-b692dbc67d45
+  govc volume.snapshot.ls -i df86393b-5ae0-4fca-87d0-b692dbc67d45
+  govc volume.snapshot.ls -l df86393b-5ae0-4fca-87d0-b692dbc67d45
+  govc volume.snapshot.ls -l $(govc volume.ls -i)
+
+Options:
+  -i=false               List snapshot ID and volume ID only
+  -l=false               Long listing format
+```
+
+## volume.snapshot.rm
+
+```
+Usage: govc volume.snapshot.rm [OPTIONS] [SNAP_ID VOL_ID]...
+
+Remove snapshot SNAP_ID from volume VOL_ID.
+
+Use a list of [SNAP_ID VOL_ID] pairs to remove multiple snapshots at once.
+
+Examples:
+  govc volume.snapshot.rm f75989dc-95b9-4db7-af96-8583f24bc59d df86393b-5ae0-4fca-87d0-b692dbc67d45
+  govc volume.snapshot.rm $(govc volume.snapshot.ls -i df86393b-5ae0-4fca-87d0-b692dbc67d45)
+  govc volume.snapshot.rm $(govc volume.snapshot.create -i df86393b-5ae0-4fca-87d0-b692dbc67d45 my-snapshot)
+  govc volume.snapshot.rm $(govc volume.snapshot.ls -i $(govc volume.ls -i))
 
 Options:
 ```

--- a/govc/main.go
+++ b/govc/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2022 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -110,6 +110,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/vm/rdm"
 	_ "github.com/vmware/govmomi/govc/vm/snapshot"
 	_ "github.com/vmware/govmomi/govc/volume"
+	_ "github.com/vmware/govmomi/govc/volume/snapshot"
 	_ "github.com/vmware/govmomi/govc/vsan"
 )
 

--- a/govc/test/volume.bats
+++ b/govc/test/volume.bats
@@ -8,3 +8,16 @@ load test_helper
   run govc volume.ls
   assert_success ""
 }
+
+@test "volume.snapshot" {
+  vcsim_env
+
+  run govc volume.snapshot.ls
+  assert_failure
+
+  run govc volume.snapshot.rm
+  assert_failure
+
+  run govc volume.snapshot.create
+  assert_failure
+}

--- a/govc/volume/snapshot/create.go
+++ b/govc/volume/snapshot/create.go
@@ -1,0 +1,129 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type create struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	id bool
+}
+
+func init() {
+	cli.Register("volume.snapshot.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.id, "i", false, "Output snapshot ID and volume ID only")
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *create) Usage() string {
+	return "[ID] [DESC]"
+}
+
+func (cmd *create) Description() string {
+	return `Create snapshot of volume ID with description DESC.
+
+Examples:
+  govc volume.snapshot.create df86393b-5ae0-4fca-87d0-b692dbc67d45 my-snapshot
+  govc volume.snapshot.create -i df86393b-5ae0-4fca-87d0-b692dbc67d45 my-snapshot`
+}
+
+type createResult struct {
+	VolumeResults *types.CnsSnapshotCreateResult
+	cmd           *create
+}
+
+func (r *createResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(r.cmd.Out, 2, 0, 2, ' ', 0)
+	if r.cmd.id {
+		fmt.Fprintf(tw, "%s\t%s", r.VolumeResults.Snapshot.SnapshotId.Id,
+			r.VolumeResults.Snapshot.VolumeId.Id)
+	} else {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s", r.VolumeResults.Snapshot.SnapshotId.Id,
+			r.VolumeResults.Snapshot.Description, r.VolumeResults.Snapshot.VolumeId.Id,
+			r.VolumeResults.Snapshot.CreateTime.Format(time.Stamp))
+	}
+	fmt.Fprintln(tw)
+	return tw.Flush()
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if len(f.Args()) != 2 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.CnsClient()
+	if err != nil {
+		return err
+	}
+
+	spec := types.CnsSnapshotCreateSpec{
+		VolumeId: types.CnsVolumeId{
+			Id: f.Arg(0),
+		},
+		Description: f.Arg(1),
+	}
+
+	task, err := c.CreateSnapshots(ctx, []types.CnsSnapshotCreateSpec{spec})
+	if err != nil {
+		return err
+	}
+
+	info, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	if res, ok := info.Result.(types.CnsVolumeOperationBatchResult); ok {
+		if vres, ok := res.VolumeResults[0].(*types.CnsSnapshotCreateResult); ok {
+			if vres.CnsSnapshotOperationResult.Fault != nil {
+				return errors.New(vres.CnsSnapshotOperationResult.Fault.LocalizedMessage)
+			}
+			return cmd.WriteResult(&createResult{VolumeResults: vres, cmd: cmd})
+		}
+	}
+
+	return nil
+}

--- a/govc/volume/snapshot/ls.go
+++ b/govc/volume/snapshot/ls.go
@@ -1,0 +1,157 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	long bool
+	id   bool
+}
+
+func init() {
+	cli.Register("volume.snapshot.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing format")
+	f.BoolVar(&cmd.id, "i", false, "List snapshot ID and volume ID only")
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *ls) Usage() string {
+	return "[ID]..."
+}
+
+func (cmd *ls) Description() string {
+	return `List all snapshots of volume ID.
+
+Use a list of volume IDs to list all snapshots of multiple volumes at once.
+
+Examples:
+  govc volume.snapshot.ls df86393b-5ae0-4fca-87d0-b692dbc67d45
+  govc volume.snapshot.ls -i df86393b-5ae0-4fca-87d0-b692dbc67d45
+  govc volume.snapshot.ls -l df86393b-5ae0-4fca-87d0-b692dbc67d45
+  govc volume.snapshot.ls -l $(govc volume.ls -i)`
+}
+
+type lsResult struct {
+	Entries []*types.CnsSnapshotQueryResultEntry
+	cmd     *ls
+}
+
+func (r *lsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(r.cmd.Out, 2, 0, 2, ' ', 0)
+	if r.cmd.id {
+		for _, e := range r.Entries {
+			fmt.Fprintf(tw, "%s\t%s", e.Snapshot.SnapshotId.Id, e.Snapshot.VolumeId.Id)
+			fmt.Fprintln(tw)
+		}
+		return tw.Flush()
+	}
+
+	for _, e := range r.Entries {
+		fmt.Fprintf(tw, "%s\t%s", e.Snapshot.SnapshotId.Id, e.Snapshot.Description)
+		if r.cmd.long {
+			fmt.Fprintf(tw, "\t%s\t%s", e.Snapshot.VolumeId.Id, e.Snapshot.CreateTime.Format(time.Stamp))
+		}
+		fmt.Fprintln(tw)
+	}
+	return tw.Flush()
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	if len(f.Args()) < 1 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.CnsClient()
+	if err != nil {
+		return err
+	}
+
+	result := lsResult{cmd: cmd}
+
+	for _, id := range f.Args() {
+		spec := types.CnsSnapshotQueryFilter{
+			SnapshotQuerySpecs: []types.CnsSnapshotQuerySpec{
+				{
+					VolumeId: types.CnsVolumeId{
+						Id: id,
+					},
+				},
+			},
+		}
+
+		for {
+			task, err := c.QuerySnapshots(ctx, spec)
+			if err != nil {
+				return err
+			}
+
+			info, err := task.WaitForResult(ctx, nil)
+			if err != nil {
+				return err
+			}
+
+			res, ok := info.Result.(types.CnsSnapshotQueryResult)
+			if ok {
+				for i, e := range res.Entries {
+					if e.Error != nil {
+						return errors.New(e.Error.LocalizedMessage)
+					}
+					result.Entries = append(result.Entries, &res.Entries[i])
+				}
+			}
+
+			if res.Cursor.Offset == res.Cursor.TotalRecords {
+				break
+			}
+
+			spec.Cursor = &res.Cursor
+		}
+	}
+
+	return cmd.WriteResult(&result)
+}

--- a/govc/volume/snapshot/rm.go
+++ b/govc/volume/snapshot/rm.go
@@ -1,0 +1,143 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type rm struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("volume.snapshot.rm", &rm{})
+}
+
+func (cmd *rm) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *rm) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *rm) Usage() string {
+	return "[SNAP_ID VOL_ID]..."
+}
+
+func (cmd *rm) Description() string {
+	return `Remove snapshot SNAP_ID from volume VOL_ID.
+
+Use a list of [SNAP_ID VOL_ID] pairs to remove multiple snapshots at once.
+
+Examples:
+  govc volume.snapshot.rm f75989dc-95b9-4db7-af96-8583f24bc59d df86393b-5ae0-4fca-87d0-b692dbc67d45
+  govc volume.snapshot.rm $(govc volume.snapshot.ls -i df86393b-5ae0-4fca-87d0-b692dbc67d45)
+  govc volume.snapshot.rm $(govc volume.snapshot.create -i df86393b-5ae0-4fca-87d0-b692dbc67d45 my-snapshot)
+  govc volume.snapshot.rm $(govc volume.snapshot.ls -i $(govc volume.ls -i))`
+}
+
+type rmResult struct {
+	VolumeResults []*types.CnsSnapshotDeleteResult
+	cmd           *rm
+}
+
+func (r *rmResult) Write(w io.Writer) error {
+	var err error = nil
+	tw := tabwriter.NewWriter(r.cmd.Out, 2, 0, 2, ' ', 0)
+	for _, s := range r.VolumeResults {
+		fmt.Fprintf(tw, "%s\t%s", s.SnapshotId.Id, s.VolumeId.Id)
+		if s.Fault != nil {
+			if err == nil {
+				err = errors.New(s.Fault.LocalizedMessage)
+			}
+			fmt.Fprintf(tw, "\t%s", s.Fault.LocalizedMessage)
+		}
+		fmt.Fprintln(tw)
+	}
+	tw.Flush()
+	return err
+}
+
+func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
+	if len(f.Args()) < 2 || len(f.Args())%2 != 0 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.CnsClient()
+	if err != nil {
+		return err
+	}
+
+	result := rmResult{cmd: cmd}
+
+	for i := 0; i < len(f.Args()); i += 2 {
+		spec := types.CnsSnapshotDeleteSpec{
+			VolumeId: types.CnsVolumeId{
+				Id: f.Arg(i + 1),
+			},
+			SnapshotId: types.CnsSnapshotId{
+				Id: f.Arg(i),
+			},
+		}
+
+		task, err := c.DeleteSnapshots(ctx, []types.CnsSnapshotDeleteSpec{spec})
+		if err != nil {
+			return err
+		}
+
+		info, err := task.WaitForResult(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		if res, ok := info.Result.(types.CnsVolumeOperationBatchResult); ok {
+			if len(res.VolumeResults) > 0 {
+				if sdr, ok := res.VolumeResults[0].(*types.CnsSnapshotDeleteResult); ok {
+					if sdr.Fault != nil {
+						if len(f.Args()) == 2 {
+							return errors.New(sdr.Fault.LocalizedMessage)
+						}
+						sdr.SnapshotId.Id = f.Arg(i)
+						sdr.VolumeId.Id = f.Arg(i + 1)
+					}
+					result.VolumeResults = append(result.VolumeResults, sdr)
+				}
+			}
+		}
+	}
+
+	return cmd.WriteResult(&result)
+}


### PR DESCRIPTION
## Description

Adds support for interacting with snapshots of CNS volumes by implementing the following commands:
- `govc volume.snapshot.create ID DESC`
Creates a snapshot of the CNS volume with volume id `ID` with the description `DESC`.
- `govc volume.snapshot.ls ID`
Lists all snaphots of the CNS volume with volume id `ID`
- `govc volume.snapshot.rm SNAP_ID VOL_ID`
Removes the snapshot with snapshot id `SNAP_ID` from the CNS volume with the volume id `VOL_ID`

The commands `volume.snapshot.ls` and `volume.snapshot.rm` support batch operations that make it possible to list all snapshots of multiple volumes or delete multiple snapshots at once. For example it's possible to delete all snapshots of all volumes using `govc volume.snapshot.rm $(govc volume.snapshot.ls -i $(govc volume.ls -i))`.

All commands return the results of the operation, i.e. listing the delted or created snapshots.

On error, the commands `volume.snapshot.ls` and `volume.snapshot.create` return immediatly while the command `volume.snapshot.rm` returns after all the input has been processed. This is done to be able to provide feedback in case only a few delete operation from a larger list fail.

Only a very basic BATS test case has been added since the standard vsim environment does not contain a CNS volume which could have been used for snapshot operations.

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

Tested on a live vSphere cluster running vCenter v7.0.3

- [x] List all snapshots from all CNS volumes
```
$ govc volume.snapshot.ls -l $(govc volume.ls -i)
4c35232b-692a-4008-9e14-99dfab529bed  snapshot-535503cf-547c-435f-9222-39d8910f0576-d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7  d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7  Mar 15 13:45:52
ae385bb0-81b9-4b91-82dd-10d20afc9961  snapshot-8e21ff38-380a-4b7a-8c59-3e14387a9768-d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7  d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7  Mar 15 14:09:05
4ad63cae-b0a5-4eca-8df9-4d6ed2913c50  snapshot-a98aa867-7ef5-45a6-ba14-b28a145ab867-d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7  d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7  Mar 15 14:13:16
1d8e401b-c1b7-4771-802a-050e892166db  snapshot-f00c21de-1068-4f73-9d2d-4d7846d203d5-bf10a2c8-23e5-4bcb-983f-2358d9f77151  bf10a2c8-23e5-4bcb-983f-2358d9f77151  Mar 20 06:04:17
b6c248d5-c8b5-4059-a732-83b9715381de  snapshot-5287f7f6-11ff-4c93-9ade-4405ca18b3c4-31833215-4b10-4e2d-8cd4-3a9fd2c4f8af  31833215-4b10-4e2d-8cd4-3a9fd2c4f8af  Mar 27 15:43:46
66aa3e6e-467b-41c8-b7f5-6dfa8de95058  snapshot-60fff95b-ee35-4b1a-8917-3cec9b362486-31833215-4b10-4e2d-8cd4-3a9fd2c4f8af  31833215-4b10-4e2d-8cd4-3a9fd2c4f8af  Mar 28 15:32:18
3d8636d3-b7eb-4e8a-8428-4c0134473e27  snapshot-46213458-8ec2-483b-b7a1-651a50a13af1-8568053e-4d6b-4684-af5f-8505d6f98b0e  8568053e-4d6b-4684-af5f-8505d6f98b0e  Mar 15 13:46:02
7afc8c06-9c48-4c73-911b-f38333779d39  snapshot-2f614f9a-89fc-475a-8f56-2d8d4f768f8d-8568053e-4d6b-4684-af5f-8505d6f98b0e  8568053e-4d6b-4684-af5f-8505d6f98b0e  Mar 15 14:09:15
66bbc2e1-aeee-4c33-95a3-b96a91610daa  snapshot-9b6d68bc-f5e8-4eee-b97c-fa8fc007c6b6-8568053e-4d6b-4684-af5f-8505d6f98b0e  8568053e-4d6b-4684-af5f-8505d6f98b0e  Mar 15 14:13:26
35fea4f4-a074-4455-91a0-d3db0308f8c2  snapshot-b48c5cf7-399d-411c-83e7-333c67c95afd-1914fee1-9030-44c2-8444-a5a4928100e5  1914fee1-9030-44c2-8444-a5a4928100e5  Mar 27 15:45:53
000f81a8-6f01-4996-92e9-b916335b82f6  snapshot-9fa75bde-42c2-4b79-8c45-7bf2ebb59b46-1b929050-75a0-48a3-9de0-ecfdc0418440  1b929050-75a0-48a3-9de0-ecfdc0418440  Mar 27 15:48:19
8d0e27f1-82fe-4bd1-a479-38e31aee9c02  snapshot-1c107c91-b6b9-43f5-ad89-8375c272a814-ad44e8b2-a8f5-4940-abca-82f6c8edbfad  ad44e8b2-a8f5-4940-abca-82f6c8edbfad  Mar 27 15:52:50
```
- [x] List all snapshots from a specific CNS volume
```
$ govc volume.snapshot.ls -l d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7
4c35232b-692a-4008-9e14-99dfab529bed  snapshot-535503cf-547c-435f-9222-39d8910f0576-d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7  d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7  Mar 15 13:45:52
ae385bb0-81b9-4b91-82dd-10d20afc9961  snapshot-8e21ff38-380a-4b7a-8c59-3e14387a9768-d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7  d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7  Mar 15 14:09:05
4ad63cae-b0a5-4eca-8df9-4d6ed2913c50  snapshot-a98aa867-7ef5-45a6-ba14-b28a145ab867-d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7  d6d6ff5f-b2eb-4446-9ce2-980d65d6cfc7  Mar 15 14:13:16
```
- [x] Create a snapshot on a CNS volume
```
$ govc volume.snapshot.ls -l d3c769bd-bb70-474b-bc31-fbe005a013ac
$ govc volume.snapshot.create d3c769bd-bb70-474b-bc31-fbe005a013ac my-snapshot
d63b1690-f049-4d28-a8be-35f0ce5fb058  my-snapshot  d3c769bd-bb70-474b-bc31-fbe005a013ac  Apr  1 21:02:19
$ govc volume.snapshot.ls -l d3c769bd-bb70-474b-bc31-fbe005a013ac
d63b1690-f049-4d28-a8be-35f0ce5fb058  my-snapshot  d3c769bd-bb70-474b-bc31-fbe005a013ac  Apr  1 21:02:19
```
- [x] Remove a snapshot from a CNS volume
```
$ govc volume.snapshot.ls -l d3c769bd-bb70-474b-bc31-fbe005a013ac
d63b1690-f049-4d28-a8be-35f0ce5fb058  my-snapshot  d3c769bd-bb70-474b-bc31-fbe005a013ac  Apr  1 21:02:19
$ govc volume.snapshot.rm d63b1690-f049-4d28-a8be-35f0ce5fb058 d3c769bd-bb70-474b-bc31-fbe005a013ac
d63b1690-f049-4d28-a8be-35f0ce5fb058  d3c769bd-bb70-474b-bc31-fbe005a013ac
$ govc volume.snapshot.ls -l d3c769bd-bb70-474b-bc31-fbe005a013ac
$ 
```
- [x] Remove a list of snapshots from a CNS volume
```
$ govc volume.snapshot.ls -l d3c769bd-bb70-474b-bc31-fbe005a013ac
$ govc volume.snapshot.create d3c769bd-bb70-474b-bc31-fbe005a013ac my-snapshot-001
1ad5fd95-f804-4065-baae-3a59aefc0d14  my-snapshot-001  d3c769bd-bb70-474b-bc31-fbe005a013ac  Apr  1 21:07:00
$ govc volume.snapshot.create d3c769bd-bb70-474b-bc31-fbe005a013ac my-snapshot-002
792dbf5f-8d9b-4d6f-b8b3-80d75f31548b  my-snapshot-002  d3c769bd-bb70-474b-bc31-fbe005a013ac  Apr  1 21:07:08
$ govc volume.snapshot.create d3c769bd-bb70-474b-bc31-fbe005a013ac my-snapshot-003
3e002e3c-3e16-4c01-88d5-8a0ab9601838  my-snapshot-003  d3c769bd-bb70-474b-bc31-fbe005a013ac  Apr  1 21:07:16
$ govc volume.snapshot.create d3c769bd-bb70-474b-bc31-fbe005a013ac my-snapshot-004
47a2d468-cc99-43d1-bf14-0b252f54b3d9  my-snapshot-004  d3c769bd-bb70-474b-bc31-fbe005a013ac  Apr  1 21:07:24
$ govc volume.snapshot.ls -l d3c769bd-bb70-474b-bc31-fbe005a013ac
1ad5fd95-f804-4065-baae-3a59aefc0d14  my-snapshot-001  d3c769bd-bb70-474b-bc31-fbe005a013ac  Apr  1 21:07:00
792dbf5f-8d9b-4d6f-b8b3-80d75f31548b  my-snapshot-002  d3c769bd-bb70-474b-bc31-fbe005a013ac  Apr  1 21:07:08
3e002e3c-3e16-4c01-88d5-8a0ab9601838  my-snapshot-003  d3c769bd-bb70-474b-bc31-fbe005a013ac  Apr  1 21:07:16
47a2d468-cc99-43d1-bf14-0b252f54b3d9  my-snapshot-004  d3c769bd-bb70-474b-bc31-fbe005a013ac  Apr  1 21:07:24
$ govc volume.snapshot.rm $(govc volume.snapshot.ls -i d3c769bd-bb70-474b-bc31-fbe005a013ac)
1ad5fd95-f804-4065-baae-3a59aefc0d14  d3c769bd-bb70-474b-bc31-fbe005a013ac
792dbf5f-8d9b-4d6f-b8b3-80d75f31548b  d3c769bd-bb70-474b-bc31-fbe005a013ac
3e002e3c-3e16-4c01-88d5-8a0ab9601838  d3c769bd-bb70-474b-bc31-fbe005a013ac
47a2d468-cc99-43d1-bf14-0b252f54b3d9  d3c769bd-bb70-474b-bc31-fbe005a013ac
$ govc volume.snapshot.ls -l d3c769bd-bb70-474b-bc31-fbe005a013ac
$ 
```
## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged