### PR TITLE
api: set inventory path in SearchIndex.FindByInventoryPath

### DIFF
--- a/object/search_index.go
+++ b/object/search_index.go
@@ -93,7 +93,18 @@ func (s SearchIndex) FindByInventoryPath(ctx context.Context, path string) (Refe
 	if res.Returnval == nil {
 		return nil, nil
 	}
-	return NewReference(s.c, *res.Returnval), nil
+
+	r := NewReference(s.c, *res.Returnval)
+
+	type common interface {
+		SetInventoryPath(string)
+	}
+
+	if c, ok := r.(common); ok {
+		c.SetInventoryPath(path)
+	}
+
+	return r, nil
 }
 
 // FindByIp finds a virtual machine or host by IP address.

--- a/object/search_index_test.go
+++ b/object/search_index_test.go
@@ -60,9 +60,12 @@ func TestSearch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, ok = ref.(*Network)
+	network, ok := ref.(*Network)
 	if !ok {
 		t.Errorf("Expected Network: %#v", ref)
+	}
+	if network.GetInventoryPath() != "/ha-datacenter/network/VM Network" {
+		t.Errorf("%q != %q\n", network.GetInventoryPath(), "/ha-datacenter/network/VM Network")
 	}
 
 	crs, err := folders.HostFolder.Children(context.Background())


### PR DESCRIPTION
## Description

This enables ` SearchIndex.FindByInventoryPath` to set inventory path to the returned object.

Closes: #3095

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Add UnitTest

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged