### PR TITLE
fix: maxSample defaults to 0 when not specified by client so no samples are returned

### DIFF
--- a/simulator/performance_manager.go
+++ b/simulator/performance_manager.go
@@ -202,7 +202,7 @@ func (p *PerformanceManager) QueryPerf(ctx *Context, req *types.QueryPerf) soap.
 			interval = 20 // TODO: Determine from entity type
 		}
 		n := 1 + int32(end.Sub(start).Seconds())/interval
-		if n > qs.MaxSample {
+		if qs.MaxSample > 0 && n > qs.MaxSample {
 			n = qs.MaxSample
 		}
 


### PR DESCRIPTION
## Description

In performance_manager QueryPerf, only limit the number of samples generated to maxSample when maxSample is greater than 0 and the number of samples to generate is greater than maxSample.

Closes: #3097

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [x] Added unit tests test case
- [x] Custom vCenter client application querying performance counters and inspecting the returned data

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged