### PR TITLE
fix: Use fmt.Fprintln in debug LogWriterCloser to prevent hanging

### DIFF
--- a/vim25/debug/log.go
+++ b/vim25/debug/log.go
@@ -30,8 +30,7 @@ func NewLogWriterCloser() *LogWriterCloser {
 }
 
 func (lwc *LogWriterCloser) Write(p []byte) (n int, err error) {
-	fmt.Fprint(os.Stderr, string(Scrub(p)))
-	return len(p), nil
+	return fmt.Fprintln(os.Stderr, string(Scrub(p)))
 }
 
 func (lwc *LogWriterCloser) Close() error {
@@ -42,6 +41,10 @@ type LogProvider struct {
 }
 
 func (s *LogProvider) NewFile(p string) io.WriteCloser {
+	// Print the name of the file we would be creating
+	if _, err := fmt.Fprintln(os.Stderr, p); err != nil {
+		return nil
+	}
 	return NewLogWriterCloser()
 }
 


### PR DESCRIPTION
Closes: #3099

## Description

This PR changes the calls for `fmt.Fprint` to `fmt.Fprintln`, and adds an additional `fmt.Fprintln` to restore functionality of printing simulated file names in the LogWriterCloser/LogProvider for soap debugging.

Closes: #3099 

## Type of change

Please mark options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [X] I ran this with the rancher-machine vmwarevsphere driver and observed it no longer hangs on creating new machines.
- [ ] Test Description 2

## Checklist:

- [X] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [?] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged