### PR TITLE
govcsim: Add CSV format support to QueryPerf API; Closes #3103

### DIFF
--- a/simulator/performance_manager.go
+++ b/simulator/performance_manager.go
@@ -19,6 +19,7 @@ package simulator
 import (
 	"math/rand"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/vmware/govmomi/simulator/esx"
@@ -174,9 +175,6 @@ func (p *PerformanceManager) QueryPerf(ctx *Context, req *types.QueryPerf) soap.
 	body.Res.Returnval = make([]types.BasePerfEntityMetricBase, len(req.QuerySpec))
 
 	for i, qs := range req.QuerySpec {
-		metrics := new(types.PerfEntityMetric)
-		metrics.Entity = qs.Entity
-
 		// Get metric data for this entity type
 		metricData, ok := p.metricData[qs.Entity.Type]
 		if !ok {
@@ -206,6 +204,9 @@ func (p *PerformanceManager) QueryPerf(ctx *Context, req *types.QueryPerf) soap.
 			n = qs.MaxSample
 		}
 
+		metrics := new(types.PerfEntityMetric)
+		metrics.Entity = qs.Entity
+
 		// Loop through each interval "tick"
 		metrics.SampleInfo = make([]types.PerfSampleInfo, n)
 		metrics.Value = make([]types.BasePerfMetricSeries, len(qs.MetricId))
@@ -213,10 +214,11 @@ func (p *PerformanceManager) QueryPerf(ctx *Context, req *types.QueryPerf) soap.
 			metrics.SampleInfo[tick] = types.PerfSampleInfo{Timestamp: end.Add(time.Duration(-interval*tick) * time.Second), Interval: interval}
 		}
 
+		series := make([]*types.PerfMetricIntSeries, len(qs.MetricId))
 		for j, mid := range qs.MetricId {
 			// Create list of metrics for this tick
-			series := &types.PerfMetricIntSeries{Value: make([]int64, n)}
-			series.Id = mid
+			series[j] = &types.PerfMetricIntSeries{Value: make([]int64, n)}
+			series[j].Id = mid
 			points := metricData[mid.CounterId]
 			offset := int64(start.Unix()) / int64(interval)
 
@@ -237,11 +239,56 @@ func (p *PerformanceManager) QueryPerf(ctx *Context, req *types.QueryPerf) soap.
 				} else {
 					p = 0
 				}
-				series.Value[tick] = p
+				series[j].Value[tick] = p
 			}
-			metrics.Value[j] = series
+			metrics.Value[j] = series[j]
 		}
-		body.Res.Returnval[i] = metrics
+
+		if qs.Format == string(types.PerfFormatCsv) {
+			metricsCsv := new(types.PerfEntityMetricCSV)
+			metricsCsv.Entity = qs.Entity
+
+			//PerfSampleInfo encoded in the following CSV format: [interval1], [date1], [interval2], [date2], and so on.
+			metricsCsv.SampleInfoCSV = sampleInfoCSV(metrics)
+			metricsCsv.Value = make([]types.PerfMetricSeriesCSV, len(qs.MetricId))
+
+			for j, mid := range qs.MetricId {
+				seriesCsv := &types.PerfMetricSeriesCSV{Value: ""}
+				seriesCsv.Id = mid
+				seriesCsv.Value = valueCSV(series[j])
+				metricsCsv.Value[j] = *seriesCsv
+			}
+
+			body.Res.Returnval[i] = metricsCsv
+		} else {
+			body.Res.Returnval[i] = metrics
+		}
 	}
 	return body
+}
+
+// sampleInfoCSV converts the SampleInfo field to a CSV string
+func sampleInfoCSV(m *types.PerfEntityMetric) string {
+	values := make([]string, len(m.SampleInfo)*2)
+
+	i := 0
+	for _, s := range m.SampleInfo {
+		values[i] = strconv.Itoa(int(s.Interval))
+		i++
+		values[i] = s.Timestamp.Format(time.RFC3339)
+		i++
+	}
+
+	return strings.Join(values, ",")
+}
+
+// valueCSV converts the Value field to a CSV string
+func valueCSV(s *types.PerfMetricIntSeries) string {
+	values := make([]string, len(s.Value))
+
+	for i := range s.Value {
+		values[i] = strconv.FormatInt(s.Value[i], 10)
+	}
+
+	return strings.Join(values, ",")
 }


### PR DESCRIPTION
## Description

Adds "csv" format support to the QueryPerf API implementation in govcsim; performance counter data is generated the same as before, but if the client specifies "csv" format, samples are converted to CSV before being returned, otherwise the "normal" format is returned (previous behaviour).

Closes: #3103

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] vmware client tool that requests performance counters in CSV format
- [ ] Unit tests

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged