### PR TITLE
Issue 3117 : Introduce host.pnic.lldp option to simulate lldp neighbour information published for given pnic

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1788,11 +1788,16 @@ Add hosts to DVS.
 
 Examples:
   govc dvs.add -dvs dvsName -pnic vmnic1 hostA hostB hostC
+ 
+  Optional Parameter: -portgroup <pgname> 
+  Makes sure that hosts gets added to only specified portgroup of DVS
+  
 
 Options:
   -dvs=                  DVS path
   -host=                 Host system [GOVC_HOST]
   -pnic=vmnic0           Name of the host physical NIC
+  -portgroup=            DVS portgroup name
 ```
 
 ## dvs.change

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1854,6 +1854,11 @@ The '-auto-expand' option is labeled in the UI as "Port allocation".
 The default value is false, behaves as the UI labeled "Fixed" choice.
 When given '-auto-expand=true', behaves as the UI labeled "Elastic" choice.
 
+The '-uplink' is optional argument. Absence of '-uplink' argument sets <nil> value
+When given '-uplink' without value sets uplink field to true
+When given '-uplink=false' sets uplink field to false
+When given '-uplink=true' sets uplink field to true
+
 Examples:
   govc dvs.create DSwitch
   govc dvs.portgroup.add -dvs DSwitch -type earlyBinding -nports 16 ExternalNetwork
@@ -1865,6 +1870,7 @@ Options:
   -dvs=                  DVS path
   -nports=128            Number of ports
   -type=earlyBinding     Portgroup type (earlyBinding|lateBinding|ephemeral)
+  -uplink=<nil>          uplink=true means uplink Portgroup
   -vlan=0                VLAN ID
   -vlan-mode=vlan        vlan mode (vlan|trunking)
   -vlan-range=0-4094     VLAN Ranges with comma delimited
@@ -1885,6 +1891,7 @@ Options:
   -auto-expand=<nil>     Ignore the limit on the number of ports
   -nports=0              Number of ports
   -type=earlyBinding     Portgroup type (earlyBinding|lateBinding|ephemeral)
+  -uplink=<nil>          uplink=true means uplink Portgroup
   -vlan=0                VLAN ID
   -vlan-mode=vlan        vlan mode (vlan|trunking)
   -vlan-range=0-4094     VLAN Ranges with comma delimited

--- a/govc/dvs/add.go
+++ b/govc/dvs/add.go
@@ -67,7 +67,11 @@ func (cmd *add) Description() string {
 	return `Add hosts to DVS.
 
 Examples:
-  govc dvs.add -dvs dvsName -pnic vmnic1 hostA hostB hostC`
+  govc dvs.add -dvs dvsName -pnic vmnic1 hostA hostB hostC
+ 
+  Optional Parameter: -portgroup <pgname> 
+  Makes sure that hosts gets added to only specified portgroup of DVS
+  `
 }
 
 func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {

--- a/govc/dvs/portgroup/add.go
+++ b/govc/dvs/portgroup/add.go
@@ -63,6 +63,11 @@ The '-auto-expand' option is labeled in the UI as "Port allocation".
 The default value is false, behaves as the UI labeled "Fixed" choice.
 When given '-auto-expand=true', behaves as the UI labeled "Elastic" choice.
 
+The '-uplink' is optional argument. Absence of '-uplink' argument sets <nil> value
+When given '-uplink' without value sets uplink field to true
+When given '-uplink=false' sets uplink field to false
+When given '-uplink=true' sets uplink field to true
+
 Examples:
   govc dvs.create DSwitch
   govc dvs.portgroup.add -dvs DSwitch -type earlyBinding -nports 16 ExternalNetwork

--- a/govc/dvs/portgroup/spec.go
+++ b/govc/dvs/portgroup/spec.go
@@ -63,6 +63,7 @@ func (spec *DVPortgroupConfigSpec) Register(ctx context.Context, f *flag.FlagSet
 	f.Var(flags.NewInt32(&vlanId), "vlan", "VLAN ID")
 	f.StringVar(&vlanRange, "vlan-range", "0-4094", "VLAN Ranges with comma delimited")
 	f.StringVar(&vlanMode, "vlan-mode", "vlan", fmt.Sprintf("vlan mode (%s)", strings.Join(vlanModes, "|")))
+	f.Var(flags.NewOptionalBool(&spec.Uplink), "uplink", "uplink=true means uplink Portgroup")
 	f.Var(flags.NewOptionalBool(&spec.AutoExpand), "auto-expand", "Ignore the limit on the number of ports")
 }
 

--- a/govc/host/pnic/change.go
+++ b/govc/host/pnic/change.go
@@ -1,0 +1,130 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pnic
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type pnicChange struct {
+	*flags.HostSystemFlag
+
+	chassisID  string
+	portID     string
+	systemName string
+	nicName    string
+}
+
+func init() {
+	cli.Register("host.pnic.lldp", &pnicChange{})
+}
+
+func (cmd *pnicChange) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.nicName, "nic", "vmnic0", "nic name")
+	f.StringVar(&cmd.chassisID, "chassisID", "", "chassis id")
+	f.StringVar(&cmd.portID, "portID", "", "port id")
+	f.StringVar(&cmd.systemName, "systemName", "", "system name")
+}
+
+func (cmd *pnicChange) Process(ctx context.Context) error {
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *pnicChange) Usage() string {
+	return "DEVICE"
+}
+
+func (cmd *pnicChange) Description() string {
+	return `Connect pnic to lldp endpoint.
+
+Examples:
+  govc host.pnic.lldp -nic vmnic0 -chassisID 11:AB:CD:E1:23:12 -portID Eth12 -systemName LeafSwitch10 -host DC0_H0`
+}
+
+func (cmd *pnicChange) Connect(ctx context.Context, parent *object.HostNetworkSystem) error {
+	var spec types.HostPnicLLDPEndpointSpec
+	spec.ChassisID = cmd.chassisID
+	spec.PortID = cmd.portID
+	spec.NicName = cmd.nicName
+	spec.SystemName = cmd.systemName
+
+	req := types.ConnectPnicLLDPEndpoint_Task{
+		This: parent.Reference(),
+		Spec: spec,
+	}
+
+	res, err := methods.ConnectPnicLLDPEndpoint_Task(ctx, parent.Client(), &req)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger(fmt.Sprintf("connect pnic to lldp %v\n", cmd.chassisID))
+	defer logger.Wait()
+
+	task := object.NewTask(parent.Client(), res.Returnval)
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}
+
+func (cmd *pnicChange) Run(ctx context.Context, f *flag.FlagSet) error {
+	fmt.Printf("args %v : %v : %v : %v\n", f.Arg(0), f.Arg(1), f.Arg(2), f.Arg(3))
+	fmt.Printf("cmd %+v\n", cmd)
+	hs, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("host system %+v\n", hs)
+
+	var host mo.HostSystem
+	err = hs.Properties(ctx, hs.Reference(), nil, &host)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("-----> host: %+v\n", host.Config.Network.Pnic)
+	found := false
+	for _, pnic := range host.Config.Network.Pnic {
+		if pnic.Device == cmd.nicName {
+			found = true
+		}
+	}
+	if !found {
+		return fmt.Errorf("nic %v is not preset in host %v", cmd.nicName, host)
+	}
+
+	ns, err := cmd.HostNetworkSystem()
+	if err != nil {
+		return err
+	}
+
+	return cmd.Connect(ctx, ns)
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -59,6 +59,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/host/firewall"
 	_ "github.com/vmware/govmomi/govc/host/maintenance"
 	_ "github.com/vmware/govmomi/govc/host/option"
+	_ "github.com/vmware/govmomi/govc/host/pnic"
 	_ "github.com/vmware/govmomi/govc/host/portgroup"
 	_ "github.com/vmware/govmomi/govc/host/service"
 	_ "github.com/vmware/govmomi/govc/host/storage"

--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -46,6 +46,7 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.Add
 			pg := &DistributedVirtualPortgroup{}
 			pg.Name = spec.Name
 			pg.Entity().Name = pg.Name
+
 			// Standard AddDVPortgroupTask() doesn't allow duplicate names, but NSX 3.0 does create some DVPGs with the same name.
 			// Allow duplicate names using this prefix so we can reproduce and test this condition.
 			if strings.HasPrefix(pg.Name, "NSX-") || spec.BackingType == string(types.DistributedVirtualPortgroupBackingTypeNsx) {

--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -46,7 +46,6 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.Add
 			pg := &DistributedVirtualPortgroup{}
 			pg.Name = spec.Name
 			pg.Entity().Name = pg.Name
-
 			// Standard AddDVPortgroupTask() doesn't allow duplicate names, but NSX 3.0 does create some DVPGs with the same name.
 			// Allow duplicate names using this prefix so we can reproduce and test this condition.
 			if strings.HasPrefix(pg.Name, "NSX-") || spec.BackingType == string(types.DistributedVirtualPortgroupBackingTypeNsx) {
@@ -87,6 +86,7 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.Add
 				LogicalSwitchUuid:            spec.LogicalSwitchUuid,
 				SegmentId:                    spec.SegmentId,
 				BackingType:                  spec.BackingType,
+				Uplink:                       spec.Uplink,
 			}
 
 			if pg.Config.LogicalSwitchUuid != "" {

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -606,7 +606,7 @@ func (f *Folder) CreateDVSTask(ctx *Context, req *types.CreateDVS_Task) soap.Has
 			ProductInfo: req.Spec.ProductInfo,
 			Description: spec.Description,
 		}
-
+		dvs.portConnDetails = make(map[string]map[string]connecteeDetails)
 		configInfo := &types.VMwareDVSConfigInfo{
 			DVSConfigInfo: types.DVSConfigInfo{
 				Uuid:                                dvs.Uuid,

--- a/simulator/portgroup.go
+++ b/simulator/portgroup.go
@@ -48,6 +48,7 @@ func (s *DistributedVirtualPortgroup) ReconfigureDVPortgroupTask(ctx *Context, r
 		s.Config.LogicalSwitchUuid = req.Spec.LogicalSwitchUuid
 		s.Config.BackingType = req.Spec.BackingType
 
+		s.Config.Uplink = req.Spec.Uplink
 		return nil, nil
 	})
 

--- a/vim25/methods/methods.go
+++ b/vim25/methods/methods.go
@@ -603,6 +603,26 @@ func AddStandaloneHost_Task(ctx context.Context, r soap.RoundTripper, req *types
 	return resBody.Res, nil
 }
 
+type ConnectPnicLLDPEndpoint_TaskBody struct {
+	Req    *types.ConnectPnicLLDPEndpoint_Task         `xml:"urn:vim25 ConnectPnicLLDPEndpoint_Task,omitempty"`
+	Res    *types.ConnectPnicLLDPEndpoint_TaskResponse `xml:"ConnectPnicLLDPEndpoint_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ConnectPnicLLDPEndpoint_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ConnectPnicLLDPEndpoint_Task(ctx context.Context, r soap.RoundTripper, req *types.ConnectPnicLLDPEndpoint_Task) (*types.ConnectPnicLLDPEndpoint_TaskResponse, error) {
+	var reqBody, resBody ConnectPnicLLDPEndpoint_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type AddVirtualNicBody struct {
 	Req    *types.AddVirtualNic         `xml:"urn:vim25 AddVirtualNic,omitempty"`
 	Res    *types.AddVirtualNicResponse `xml:"AddVirtualNicResponse,omitempty"`

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -22116,6 +22116,34 @@ func init() {
 	t["HostConnectInfoNetworkInfo"] = reflect.TypeOf((*HostConnectInfoNetworkInfo)(nil)).Elem()
 }
 
+type ConnectPnicLLDPEndpointType struct {
+	This ManagedObjectReference   `xml:"_this" json:"-"`
+	Spec HostPnicLLDPEndpointSpec `xml:"spec" json:"spec"`
+}
+
+func init() {
+	t["ConnectPnicLLDPEndpointType"] = reflect.TypeOf((*ConnectPnicLLDPEndpointType)(nil)).Elem()
+}
+
+type ConnectPnicLLDPEndpoint_Task ConnectPnicLLDPEndpointType
+
+func init() {
+	t["ConnectPnicLLDPEndpoint_Task"] = reflect.TypeOf((*ConnectPnicLLDPEndpoint_Task)(nil)).Elem()
+}
+
+type ConnectPnicLLDPEndpoint_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval" json:"returnval"`
+}
+
+type HostPnicLLDPEndpointSpec struct {
+	DynamicData
+
+	ChassisID  string
+	PortID     string
+	SystemName string
+	NicName    string
+}
+
 type HostConnectSpec struct {
 	DynamicData
 

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -12550,6 +12550,7 @@ type DVPortgroupConfigSpec struct {
 	VendorSpecificConfig         []DistributedVirtualSwitchKeyedOpaqueBlob `xml:"vendorSpecificConfig,omitempty" json:"vendorSpecificConfig,omitempty"`
 	AutoExpand                   *bool                                     `xml:"autoExpand" json:"autoExpand,omitempty"`
 	VmVnicNetworkResourcePoolKey string                                    `xml:"vmVnicNetworkResourcePoolKey,omitempty" json:"vmVnicNetworkResourcePoolKey,omitempty"`
+	Uplink                       *bool                                     `xml:"uplink" json:"uplink,omitempty"`
 	TransportZoneUuid            string                                    `xml:"transportZoneUuid,omitempty" json:"transportZoneUuid,omitempty"`
 	TransportZoneName            string                                    `xml:"transportZoneName,omitempty" json:"transportZoneName,omitempty"`
 	LogicalSwitchUuid            string                                    `xml:"logicalSwitchUuid,omitempty" json:"logicalSwitchUuid,omitempty"`


### PR DESCRIPTION
## Description

We have added a way by which we are able to associate lldp neighbour information with a given pnic of host.
With this we can return lldp neighbour information from QueryNetworkHint method.

Sample command:
govc host.pnic.lldp -nic vmnic0 -chassisID 11:AB:CD:E1:23:12 -portID Eth12 -systemName LeafSwitch10 -host DC0_H0

Closes: #3117

## Type of change

Please mark options that are relevant:

- [N] Bug fix (non-breaking change which fixes an issue)
- [Y] New feature (non-breaking change which adds functionality)
- [N] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [N] This change requires a documentation update
- [N] Build related change

## How Has This Been Tested?

Introduced bunch of test cases to validate the output of QueryNetworkHint method.

- [ ] Test Description 1
- [ ] Test Description 2

## Checklist:

- [Y] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [Y] I have commented my code, particularly in hard-to-understand areas
- [Y] I have made corresponding changes to the documentation
- [Y] I have added tests that prove my fix is effective or that my feature works
- [Y] New and existing unit tests pass locally with my changes
- [Y] Any dependent changes have been merged