### PR TITLE
fix: byte, float and int (de) serialization

### DIFF
--- a/vim25/json/discriminator.go
+++ b/vim25/json/discriminator.go
@@ -480,15 +480,15 @@ func discriminatorParseTypeName(
 		// type is a pointer.
 		n, p := indirectTypeName(tn)
 
-		// First look up the type in the built-in type registry.
-		t, ok := discriminatorTypeRegistry[n]
+		var t reflect.Type
+		ok := false
+		// look up the type in the external registry to allow name override.
+		if typeFn != nil {
+			t, ok = typeFn(n)
+		}
 		if !ok {
-			// If not found in the type registry then see if the type
-			// is returne from the optional type function.
-			if typeFn == nil {
-				return nil, false
-			}
-			if t, ok = typeFn(n); !ok {
+			// Use the built-in registry if the external registry fails
+			if t, ok = discriminatorTypeRegistry[n]; !ok {
 				return nil, false
 			}
 		}

--- a/vim25/types/json_encoding.go
+++ b/vim25/types/json_encoding.go
@@ -31,11 +31,12 @@ const (
 
 var discriminatorTypeRegistry = map[string]reflect.Type{
 	"boolean": reflect.TypeOf(true),
-	"byte":    reflect.TypeOf(int8(0)),
+	"byte":    reflect.TypeOf(uint8(0)),
 	"short":   reflect.TypeOf(int16(0)),
 	"int":     reflect.TypeOf(int32(0)),
 	"long":    reflect.TypeOf(int64(0)),
-	"float":   reflect.TypeOf(float64(0)),
+	"float":   reflect.TypeOf(float32(0)),
+	"double":  reflect.TypeOf(float64(0)),
 	"string":  reflect.TypeOf(""),
 }
 
@@ -61,11 +62,12 @@ func NewJSONDecoder(r io.Reader) *json.Decoder {
 // VMOMI primitive names
 var discriminatorNamesRegistry = map[reflect.Type]string{
 	reflect.TypeOf(true):       "boolean",
-	reflect.TypeOf(int8(0)):    "byte",
+	reflect.TypeOf(uint8(0)):   "byte",
 	reflect.TypeOf(int16(0)):   "short",
 	reflect.TypeOf(int32(0)):   "int",
 	reflect.TypeOf(int64(0)):   "long",
-	reflect.TypeOf(float64(0)): "float",
+	reflect.TypeOf(float32(0)): "float",
+	reflect.TypeOf(float64(0)): "double",
 	reflect.TypeOf(""):         "string",
 }
 

--- a/vim25/types/json_encoding_test.go
+++ b/vim25/types/json_encoding_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionValueSerialization(t *testing.T) {
+	options := []struct {
+		name    string
+		wire    string
+		binding OptionValue
+	}{
+		{
+			name: "boolean",
+			wire: `{"_typeName": "OptionValue","key": "option1",
+				"value": {"_typeName": "boolean","_value": true}
+			}`,
+			binding: OptionValue{Key: "option1", Value: true},
+		},
+		{
+			name: "byte",
+			wire: `{"_typeName": "OptionValue","key": "option1",
+				"value": {"_typeName": "byte","_value": 16}
+			}`,
+			binding: OptionValue{Key: "option1", Value: uint8(16)},
+		},
+		{
+			name: "short",
+			wire: `{"_typeName": "OptionValue","key": "option1",
+				"value": {"_typeName": "short","_value": 300}
+			}`,
+			binding: OptionValue{Key: "option1", Value: int16(300)},
+		},
+		{
+			name: "int",
+			wire: `{"_typeName": "OptionValue","key": "option1",
+				"value": {"_typeName": "int","_value": 300}}`,
+			binding: OptionValue{Key: "option1", Value: int32(300)},
+		},
+		{
+			name: "long",
+			wire: `{"_typeName": "OptionValue","key": "option1",
+				"value": {"_typeName": "long","_value": 300}}`,
+			binding: OptionValue{Key: "option1", Value: int64(300)},
+		},
+		{
+			name: "float",
+			wire: `{"_typeName": "OptionValue","key": "option1",
+				"value": {"_typeName": "float","_value": 30.5}}`,
+			binding: OptionValue{Key: "option1", Value: float32(30.5)},
+		},
+		{
+			name: "double",
+			wire: `{"_typeName": "OptionValue","key": "option1",
+				"value": {"_typeName": "double","_value": 12.2}}`,
+			binding: OptionValue{Key: "option1", Value: float64(12.2)},
+		},
+		{
+			name: "string",
+			wire: `{"_typeName": "OptionValue","key": "option1",
+				"value": {"_typeName": "string","_value": "test"}}`,
+			binding: OptionValue{Key: "option1", Value: "test"},
+		},
+	}
+
+	for _, opt := range options {
+		t.Run("Serialize "+opt.name, func(t *testing.T) {
+			r := strings.NewReader(opt.wire)
+			dec := NewJSONDecoder(r)
+			v := OptionValue{}
+			e := dec.Decode(&v)
+			if e != nil {
+				assert.Fail(t, "Cannot read json", "json %v err %v", opt.wire, e)
+				return
+			}
+			assert.Equal(t, opt.binding, v)
+		})
+
+		t.Run("De-serialize "+opt.name, func(t *testing.T) {
+			var w bytes.Buffer
+			enc := NewJSONEncoder(&w)
+			enc.Encode(opt.binding)
+			s := w.String()
+			assert.JSONEq(t, opt.wire, s)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Added mapping for float.
Fixed the mappings for byte to use uint8.
Changed type name lookup order to use the external mapping before built-in table. This fixes int deserialization.

Closes: #3121

## Type of change

Please mark options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [X] Added OptionValue (De)serialization tests 
- [X] Run locally `go test ./...`

## Checklist:

- [X] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged