### PR TITLE
chore: Update anyURI to url.URL

### DIFF
--- a/gen/vim_wsdl.rb
+++ b/gen/vim_wsdl.rb
@@ -275,7 +275,7 @@ class Simple
       when "base64Binary"
         t = "[]byte"
       when "anyURI"
-        t = "string"
+        t = "url.URL"
       else
         raise "unknown type: %s" % t
       end

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"net/url"
 	"reflect"
 	"time"
 )
@@ -1629,7 +1630,7 @@ func init() {
 }
 
 type ArrayOfAnyURI struct {
-	AnyURI []string `xml:"anyURI,omitempty" json:"_value"`
+	AnyURI []url.URL `xml:"anyURI,omitempty" json:"_value"`
 }
 
 func init() {
@@ -5277,7 +5278,7 @@ func init() {
 }
 
 type ArrayOfUri struct {
-	Uri []string `xml:"uri,omitempty" json:"_value"`
+	Uri []url.URL `xml:"uri,omitempty" json:"_value"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

This patch updates the existence of anyURI from the WSDL to be a url.URL instead of a string. Please note this is potentially a breaking change and consumers of GoVmomi will need to update any place they expected anyURI to be a string.

Please note we should not yet merge this PR as @dougm highlighted this type was originally `url.URL` but was changed in https://github.com/vmware/govmomi/pull/1100. Until we recall why, we do not want to merge this PR.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [x] `go build ./...`
- [x] `go test -v ./vim25/types`
- [x] GitHub actions.

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged