### PR TITLE
vcsim: async guest shutdown and standby

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -283,6 +283,10 @@ EOF
   run govc vm.power -s $vm
   assert_success
 
+  # wait for power state == off after guest shutdown above
+  run govc object.collect -s vm/$vm -runtime.powerState poweredOff
+  assert_success
+
   run docker inspect -f '{{.State.Status}}' "$name"
   assert_success "exited"
 


### PR DESCRIPTION
GuestShutdown and GuestStandby methods don't block when called in real vCenter, but the VM power state transition won't happen until somtime after the guest has actually shutdown. It is also possible for shutdown to hang indefinitely. To simulate such behavior, an internal task is now used to transition state, which can be optionally delayed.
