### PR TITLE
vcsim: Add RUN.env flag to inject environment variables to container-backed VM

### DIFF
--- a/simulator/container.go
+++ b/simulator/container.go
@@ -275,6 +275,11 @@ func (c *container) start(ctx *Context, vm *VirtualMachine) {
 			containerPort := sKey[len(sKey)-1]
 			ports[containerPort] = val.Value.(string)
 		}
+		if strings.HasPrefix(val.Key, "RUN.env.") {
+			sKey := strings.Split(val.Key, ".")
+			envKey := sKey[len(sKey)-1]
+			env = append(env, "--env", fmt.Sprintf("%s=%s", envKey, val.Value.(string)))
+		}
 		if strings.HasPrefix(val.Key, "guestinfo.") {
 			key := strings.Replace(strings.ToUpper(val.Key), ".", "_", -1)
 			env = append(env, "--env", fmt.Sprintf("VMX_%s=%s", key, val.Value.(string)))


### PR DESCRIPTION
## Description

Howdy! One more quick feature that I found useful in some of my local testing, though perhaps I misunderstood if there's an existing way to do this. It seemed that for container-backed VMs in vcsim, there was no way to inject a 1:1 environment variable, only using the `guestinfo.ABC` flag which would then translate the key for the environment variable to something along the lines of `VMX_GUESTINFO_ABC `.

For some context where this became useful to me, in the process of automating with vcsim, I needed to provide a few environment variables when the container was first started to configure the software that was running inside.

Feel free to close if this isn't useful, though!

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] Test Description 1
- [ ] Test Description 2

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged