### PR TITLE
vcsim: set StandbyMode default to "none"

### DIFF
--- a/simulator/esx/host_system.go
+++ b/simulator/esx/host_system.go
@@ -53,7 +53,7 @@ var HostSystem = mo.HostSystem{
 		DynamicData:       types.DynamicData{},
 		ConnectionState:   "connected",
 		PowerState:        "poweredOn",
-		StandbyMode:       "",
+		StandbyMode:       "none",
 		InMaintenanceMode: false,
 		BootTime:          (*time.Time)(nil),
 		HealthSystemRuntime: &types.HealthSystemRuntime{


### PR DESCRIPTION
## Description

according [Enum HostStandbyMode(vim.HostSystem.StandbyMode)](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/c476b64b-c93c-4b21-9d76-be14da0148f9/04ca12ad-59b9-4e1c-8232-fd3d4276e52c/SDK/vsphere-ws/docs/ReferenceGuide/vim.HostSystem.StandbyMode.html), StandByMode should not be empty.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

we noticed it when we tried to replace a "real test vcenter" with vcsim

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~Any dependent changes have been merged~~