### PR TITLE
add cnssyncdatastore API bindings

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -44,6 +44,10 @@ var (
 		Type:  "CnsVolumeManager",
 		Value: "cns-volume-manager",
 	}
+	CnsDebugManagerInstance = vimtypes.ManagedObjectReference{
+		Type:  "CnsDebugManager",
+		Value: "cns-debug-manager",
+	}
 )
 
 type Client struct {
@@ -277,6 +281,23 @@ func (c *Client) ReconfigVolumePolicy(ctx context.Context, PolicyReconfigSpecs [
 		VolumePolicyReconfigSpecs: PolicyReconfigSpecs,
 	}
 	res, err := methods.CnsReconfigVolumePolicy(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(c.vim25Client, res.Returnval), nil
+}
+
+// SyncDatastore calls the CnsSyncDatastore API
+// Note: To be used only by VMware's internal support tools.
+// This API triggers a manual sync of internal CNS and FCD DBs which otherwise happens periodially,
+// with fullsync it forces synchronization of complete tables.
+func (c *Client) SyncDatastore(ctx context.Context, dsURL string, fullSync bool) (*object.Task, error) {
+	req := cnstypes.CnsSyncDatastore{
+		This:         CnsDebugManagerInstance,
+		DatastoreUrl: dsURL,
+		FullSync:     &fullSync,
+	}
+	res, err := methods.CnsSyncDatastore(ctx, c, &req)
 	if err != nil {
 		return nil, err
 	}

--- a/cns/methods/methods.go
+++ b/cns/methods/methods.go
@@ -346,3 +346,24 @@ func CnsReconfigVolumePolicy(ctx context.Context, r soap.RoundTripper, req *type
 
 	return resBody.Res, nil
 }
+
+type CnsSyncDatastoreBody struct {
+	Req    *types.CnsSyncDatastore         `xml:"urn:vsan CnsSyncDatastore,omitempty"`
+	Res    *types.CnsSyncDatastoreResponse `xml:"urn:vsan CnsSyncDatastoreResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsSyncDatastoreBody) Fault() *soap.Fault { return b.Fault_ }
+
+// Note: To be used only by VMware's internal support tools.
+func CnsSyncDatastore(ctx context.Context, r soap.RoundTripper, req *types.CnsSyncDatastore) (*types.CnsSyncDatastoreResponse, error) {
+	var reqBody, resBody CnsSyncDatastoreBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -909,3 +909,23 @@ type CnsVolumePolicyReconfigSpec struct {
 func init() {
 	types.Add("vsan:CnsVolumePolicyReconfigSpec", reflect.TypeOf((*CnsVolumePolicyReconfigSpec)(nil)).Elem())
 }
+
+type CnsSyncDatastore CnsSyncDatastoreRequestType
+
+func init() {
+	types.Add("vsan:CnsSyncDatastore", reflect.TypeOf((*CnsSyncDatastore)(nil)).Elem())
+}
+
+type CnsSyncDatastoreRequestType struct {
+	This         types.ManagedObjectReference `xml:"_this"`
+	DatastoreUrl string                       `xml:"datastoreUrl,omitempty"`
+	FullSync     *bool                        `xml:"fullSync"`
+}
+
+func init() {
+	types.Add("vsan:CnsSyncDatastoreRequestType", reflect.TypeOf((*CnsSyncDatastoreRequestType)(nil)).Elem())
+}
+
+type CnsSyncDatastoreResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval"`
+}


### PR DESCRIPTION
## Description

This PR adds cnssyncdatastore API bindings and tests in client_test.go

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?
Added new block in client_test.go for this API
- [x] Invoke the API on the given datastore URL
- [x] Invoke the API on the given datastore URL with fullsync

```bash
sashrith@sashrithELVDQ ~/csi/govmomi cnssyncdatastore ⇡ ❯ export CNS_DATACENTER="VSAN-DC"                 
export CNS_DATASTORE="vsanDatastore"
sashrith@sashrithELVDQ ~/csi/govmomi cnssyncdatastore ⇡ ❯ go test -v 2>&1 >~/testrun1.log

sashrith@sashrithELVDQ ~/csi/govmomi/cns cnssyncdatastore* ⇡ 1m 27s ❯  tail ~/testrun1.log                             
        }
    client_test.go:934: Deleting volume: [{DynamicData:{} Id:51014d9f-a965-4caf-b670-6d908b2eb105}]
    client_test.go:958: Volume: "51014d9f-a965-4caf-b670-6d908b2eb105" deleted sucessfully
    client_test.go:1360: Calling syncDatastore on ds:///vmfs/volumes/vsan:52ab2468c4163429-c857b052f6187fc6/ ...
    client_test.go:1375: syncDatastore on ds:///vmfs/volumes/vsan:52ab2468c4163429-c857b052f6187fc6/ successful
    client_test.go:1377: Calling syncDatastore on ds:///vmfs/volumes/vsan:52ab2468c4163429-c857b052f6187fc6/ with fullsync...
    client_test.go:1392: syncDatastore on ds:///vmfs/volumes/vsan:52ab2468c4163429-c857b052f6187fc6/ with full sync successful
--- PASS: TestClient (85.44s)
PASS
ok  	github.com/vmware/govmomi/cns	85.893s
sashrith@sashrithELVDQ ~/csi/govmomi/cns cnssyncdatastore* ⇡ ❯


    client_test.go:958: Volume: "51014d9f-a965-4caf-b670-6d908b2eb105" deleted sucessfully
    client_test.go:1360: Calling syncDatastore on ds:///vmfs/volumes/vsan:52ab2468c4163429-c857b052f6187fc6/ ...
    client_test.go:1375: syncDatastore on ds:///vmfs/volumes/vsan:52ab2468c4163429-c857b052f6187fc6/ successful
    client_test.go:1377: Calling syncDatastore on ds:///vmfs/volumes/vsan:52ab2468c4163429-c857b052f6187fc6/ with fullsync...
    client_test.go:1392: syncDatastore on ds:///vmfs/volumes/vsan:52ab2468c4163429-c857b052f6187fc6/ with full sync successful
--- PASS: TestClient (85.44s)
PASS
ok      github.com/vmware/govmomi/cns   85.893s
```

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged