### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/govc/cli/command.go
+++ b/govc/cli/command.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -195,7 +194,7 @@ func Run(args []string) int {
 	}
 
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
-	fs.SetOutput(ioutil.Discard)
+	fs.SetOutput(io.Discard)
 
 	ctx := context.Background()
 

--- a/govc/extension/setcert.go
+++ b/govc/extension/setcert.go
@@ -26,7 +26,7 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"os"
 	"strings"
@@ -150,7 +150,7 @@ func (cmd *setcert) Run(ctx context.Context, f *flag.FlagSet) error {
 	key := f.Arg(0)
 
 	if cmd.cert == "-" {
-		b, err := ioutil.ReadAll(os.Stdin)
+		b, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/govc/host/cert/install.go
+++ b/govc/host/cert/install.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -80,7 +79,7 @@ func (cmd *install) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 		cert = buf.String()
 	} else {
-		b, err := ioutil.ReadFile(filepath.Clean(name))
+		b, err := os.ReadFile(filepath.Clean(name))
 		if err != nil {
 			return err
 		}

--- a/govc/importx/archive.go
+++ b/govc/importx/archive.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -63,7 +62,7 @@ func (f *ArchiveFlag) ReadOvf(fpath string) ([]byte, error) {
 	}
 	defer r.Close()
 
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 func (f *ArchiveFlag) ReadEnvelope(data []byte) (*ovf.Envelope, error) {

--- a/govc/library/export.go
+++ b/govc/library/export.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -108,7 +107,7 @@ func (cmd *export) Run(ctx context.Context, f *flag.FlagSet) error {
 	var log io.Writer = os.Stdout
 	isStdout := one && dst == "-"
 	if isStdout {
-		log = ioutil.Discard
+		log = io.Discard
 	}
 
 	session, err := m.CreateLibraryItemDownloadSession(ctx, library.Session{

--- a/govc/library/trust/create.go
+++ b/govc/library/trust/create.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -73,7 +72,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 		cert = buf.String()
 	} else {
-		b, err := ioutil.ReadFile(filepath.Clean(name))
+		b, err := os.ReadFile(filepath.Clean(name))
 		if err != nil {
 			return err
 		}

--- a/govc/namespace/service/create.go
+++ b/govc/namespace/service/create.go
@@ -21,7 +21,7 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
@@ -71,7 +71,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		return fmt.Errorf("only vsphere specs are accepted right now")
 	}
 
-	manifestFile, err := ioutil.ReadFile(manifest[0])
+	manifestFile, err := os.ReadFile(manifest[0])
 	if err != nil {
 		return fmt.Errorf("failed to read manifest file: %s", err)
 	}

--- a/govc/session/login.go
+++ b/govc/session/login.go
@@ -23,7 +23,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -373,7 +372,7 @@ func (cmd *login) Run(ctx context.Context, f *flag.FlagSet) error {
 		switch cmd.method {
 		case http.MethodPost, http.MethodPut, http.MethodPatch:
 			// strings.Reader here as /api wants a Content-Length header
-			b, err := ioutil.ReadAll(os.Stdin)
+			b, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				return err
 			}

--- a/govc/vm/change.go
+++ b/govc/vm/change.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 
@@ -58,7 +58,7 @@ func (e *extraConfigFile) Set(v string) error {
 
 	var fileContents = ""
 	if len(r[1]) > 0 {
-		contents, err := ioutil.ReadFile(r[1])
+		contents, err := os.ReadFile(r[1])
 		if err != nil {
 			return fmt.Errorf("failed to parse extraConfigFile '%s': %w", v, err)
 		}

--- a/session/cache/session.go
+++ b/session/cache/session.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/user"
@@ -187,7 +186,7 @@ func localTicket(ctx context.Context, m *session.Manager) (*url.Userinfo, error)
 		return nil, err
 	}
 
-	password, err := ioutil.ReadFile(ticket.PasswordFilePath)
+	password, err := os.ReadFile(ticket.PasswordFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/session/manager.go
+++ b/session/manager.go
@@ -18,7 +18,6 @@ package session
 
 import (
 	"context"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -47,7 +46,7 @@ func Secret(value string) (string, error) {
 	if len(value) == 0 {
 		return value, nil
 	}
-	contents, err := ioutil.ReadFile(value)
+	contents, err := os.ReadFile(value)
 	if err != nil {
 		if os.IsPermission(err) {
 			return "", err

--- a/simulator/feature_test.go
+++ b/simulator/feature_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -101,14 +100,14 @@ func Example_runContainer() {
 			log.Fatal(err)
 		}
 		f, _ := dc.Folders(ctx)
-		dir, err := ioutil.TempDir("", "example")
+		dir, err := os.MkdirTemp("", "example")
 		if err != nil {
 			log.Fatal(err)
 		}
 		os.Chmod(dir, 0755)
 		fpath := filepath.Join(dir, "index.html")
 		fcontent := "foo"
-		ioutil.WriteFile(fpath, []byte(fcontent), 0644)
+		os.WriteFile(fpath, []byte(fcontent), 0644)
 		// just in case umask gets in the way
 		os.Chmod(fpath, 0644)
 		defer os.RemoveAll(dir)

--- a/simulator/host_datastore_browser.go
+++ b/simulator/host_datastore_browser.go
@@ -17,7 +17,6 @@ limitations under the License.
 package simulator
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -149,7 +148,7 @@ func (s *searchDatastore) queryMatch(file os.FileInfo) bool {
 }
 
 func (s *searchDatastore) search(ds *types.ManagedObjectReference, folder string, dir string) error {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		tracef("search %s: %s", dir, err)
 		return err
@@ -162,11 +161,11 @@ func (s *searchDatastore) search(ds *types.ManagedObjectReference, folder string
 
 	for _, file := range files {
 		name := file.Name()
-
-		if s.queryMatch(file) {
+		info, _ := file.Info()
+		if s.queryMatch(info) {
 			for _, m := range s.SearchSpec.MatchPattern {
 				if ok, _ := path.Match(m, name); ok {
-					s.addFile(file, &res)
+					s.addFile(info, &res)
 					break
 				}
 			}

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -368,7 +367,7 @@ func (m *Model) decode(path string, data interface{}) error {
 func (m *Model) loadMethod(obj mo.Reference, dir string) error {
 	dir = filepath.Join(dir, obj.Reference().Encode())
 
-	info, err := ioutil.ReadDir(dir)
+	info, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -823,7 +822,7 @@ func (m *Model) CreateInfrastructure(ctx *Context) error {
 }
 
 func (m *Model) createTempDir(dc string, name string) (string, error) {
-	dir, err := ioutil.TempDir("", fmt.Sprintf("govcsim-%s-%s-", dc, name))
+	dir, err := os.MkdirTemp("", fmt.Sprintf("govcsim-%s-%s-", dc, name))
 	if err == nil {
 		m.dirs = append(m.dirs, dir)
 	}

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -26,7 +26,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -98,7 +97,7 @@ type Server struct {
 // New returns an initialized simulator Service instance
 func New(instance *ServiceInstance) *Service {
 	s := &Service{
-		readAll: ioutil.ReadAll,
+		readAll: io.ReadAll,
 		sm:      Map.SessionManager(),
 		sdk:     make(map[string]*Registry),
 	}
@@ -772,7 +771,7 @@ func (s *Server) CertificateFile() (string, error) {
 		return s.caFile, nil
 	}
 
-	f, err := ioutil.TempFile("", "vcsim-")
+	f, err := os.CreateTemp("", "vcsim-")
 	if err != nil {
 		return "", err
 	}

--- a/simulator/simulator_test.go
+++ b/simulator/simulator_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -306,7 +305,7 @@ func TestServeHTTPS(t *testing.T) {
 	ts := s.NewServer()
 	defer ts.Close()
 
-	ts.Config.ErrorLog = log.New(ioutil.Discard, "", 0) // silence benign "TLS handshake error" log messages
+	ts.Config.ErrorLog = log.New(io.Discard, "", 0) // silence benign "TLS handshake error" log messages
 
 	ctx := context.Background()
 

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -19,7 +19,6 @@ package simulator
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -916,7 +915,7 @@ func (vm *VirtualMachine) RefreshStorageInfo(ctx *Context, req *types.RefreshSto
 			continue
 		}
 
-		files, err := ioutil.ReadDir(directory)
+		files, err := os.ReadDir(directory)
 		if err != nil {
 			body.Fault_ = Fault("", ctx.Map.FileManager().fault(directory, err, new(types.CannotAccessFile)))
 			return body
@@ -927,8 +926,8 @@ func (vm *VirtualMachine) RefreshStorageInfo(ctx *Context, req *types.RefreshSto
 				Datastore: p.Datastore,
 				Path:      strings.TrimPrefix(file.Name(), datastore.Info.GetDatastoreInfo().Url),
 			}
-
-			vm.addFileLayoutEx(datastorePath, file.Size())
+			info, _ := file.Info()
+			vm.addFileLayoutEx(datastorePath, info.Size())
 		}
 	}
 

--- a/sts/signer.go
+++ b/sts/signer.go
@@ -28,7 +28,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	mrand "math/rand"
 	"net"
 	"net/http"
@@ -270,7 +269,7 @@ func (s *Signer) SignRequest(req *http.Request) error {
 				return fmt.Errorf("sts: getting http.Request body: %s", rerr)
 			}
 			defer r.Close()
-			body, rerr = ioutil.ReadAll(r)
+			body, rerr = io.ReadAll(r)
 			if rerr != nil {
 				return fmt.Errorf("sts: reading http.Request body: %s", rerr)
 			}

--- a/toolbox/command.go
+++ b/toolbox/command.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -322,7 +321,7 @@ func (c *CommandServer) CreateTemporaryFile(header vix.CommandRequestHeader, dat
 		return nil, err
 	}
 
-	f, err := ioutil.TempFile(r.DirectoryPath, r.FilePrefix+"vmware")
+	f, err := os.CreateTemp(r.DirectoryPath, r.FilePrefix+"vmware")
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +341,7 @@ func (c *CommandServer) CreateTemporaryDirectory(header vix.CommandRequestHeader
 		return nil, err
 	}
 
-	name, err := ioutil.TempDir(r.DirectoryPath, r.FilePrefix+"vmware")
+	name, err := os.MkdirTemp(r.DirectoryPath, r.FilePrefix+"vmware")
 	if err != nil {
 		return nil, err
 	}
@@ -501,9 +500,13 @@ func (c *CommandServer) ListFiles(header vix.CommandRequestHeader, data []byte) 
 
 	if info.IsDir() {
 		dir = r.GuestPathName
-		files, err = ioutil.ReadDir(r.GuestPathName)
+		entries, err := os.ReadDir(r.GuestPathName)
 		if err != nil {
 			return nil, err
+		}
+		for _, entry := range entries {
+			file, _ := entry.Info()
+			files = append(files, file)
 		}
 	} else {
 		dir = filepath.Dir(r.GuestPathName)

--- a/toolbox/command_test.go
+++ b/toolbox/command_test.go
@@ -23,7 +23,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -105,7 +105,7 @@ func TestVixRelayedCommandHandler(t *testing.T) {
 	Trace = true
 	if !testing.Verbose() {
 		// cover Trace paths but discard output
-		traceLog = ioutil.Discard
+		traceLog = io.Discard
 	}
 
 	in := new(mockChannelIn)
@@ -298,7 +298,7 @@ func TestVixInitiateFileTransfer(t *testing.T) {
 
 	request := new(vix.ListFilesRequest)
 
-	f, err := ioutil.TempFile("", "toolbox")
+	f, err := os.CreateTemp("", "toolbox")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -345,7 +345,7 @@ func TestVixInitiateFileTransferWrite(t *testing.T) {
 
 	request := new(vix.InitiateFileTransferToGuestRequest)
 
-	f, err := ioutil.TempFile("", "toolbox")
+	f, err := os.CreateTemp("", "toolbox")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -894,7 +894,7 @@ func TestVixFileChangeAttributes(t *testing.T) {
 
 	c := NewCommandClient()
 
-	f, err := ioutil.TempFile("", "toolbox-")
+	f, err := os.CreateTemp("", "toolbox-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/toolbox/hgfs/archive.go
+++ b/toolbox/hgfs/archive.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"net/url"
@@ -139,7 +138,7 @@ func (h *ArchiveHandler) newArchiveFromGuest(u *url.URL) (File, error) {
 	}
 
 	var z io.Writer = w
-	var c io.Closer = ioutil.NopCloser(nil)
+	var c io.Closer = io.NopCloser(nil)
 
 	switch u.Query().Get("format") {
 	case "tgz":
@@ -194,7 +193,7 @@ func (h *ArchiveHandler) newArchiveToGuest(u *url.URL) (File, error) {
 		c := func() error {
 			// Drain the pipe of tar trailer data (two null blocks)
 			if cerr == nil {
-				_, _ = io.Copy(ioutil.Discard, a.Reader)
+				_, _ = io.Copy(io.Discard, a.Reader)
 			}
 			return nil
 		}

--- a/toolbox/hgfs/archive_test.go
+++ b/toolbox/hgfs/archive_test.go
@@ -22,7 +22,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -36,7 +35,7 @@ import (
 func TestReadArchive(t *testing.T) {
 	Trace = testing.Verbose()
 
-	dir, err := ioutil.TempDir("", "toolbox-")
+	dir, err := os.MkdirTemp("", "toolbox-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +49,7 @@ func TestReadArchive(t *testing.T) {
 		for _, p := range dirs {
 			data := bytes.NewBufferString(strings.Repeat("X", i+1024))
 
-			f, ferr := ioutil.TempFile(p, fmt.Sprintf("file-%d-", i))
+			f, ferr := os.CreateTemp(p, fmt.Sprintf("file-%d-", i))
 			if ferr != nil {
 				t.Fatal(ferr)
 			}
@@ -147,7 +146,7 @@ func TestReadArchive(t *testing.T) {
 		files = append(files, header.Name)
 
 		if header.Typeflag == tar.TypeReg {
-			_, err = io.Copy(ioutil.Discard, tr)
+			_, err = io.Copy(io.Discard, tr)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -169,7 +168,7 @@ func TestReadArchive(t *testing.T) {
 func TestWriteArchive(t *testing.T) {
 	Trace = testing.Verbose()
 
-	dir, err := ioutil.TempDir("", "toolbox-")
+	dir, err := os.MkdirTemp("", "toolbox-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +281,7 @@ func TestWriteArchive(t *testing.T) {
 		t.Errorf("status=%d", status)
 	}
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		t.Error(err)
 	}

--- a/toolbox/hgfs/server_test.go
+++ b/toolbox/hgfs/server_test.go
@@ -18,7 +18,6 @@ package hgfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -341,7 +340,7 @@ func TestWriteV3(t *testing.T) {
 
 	Trace = testing.Verbose()
 
-	f, err := ioutil.TempFile("", "toolbox")
+	f, err := os.CreateTemp("", "toolbox")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/toolbox/process/process.go
+++ b/toolbox/process/process.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -392,7 +391,7 @@ func (m *Manager) Stat(u *url.URL) (os.FileInfo, error) {
 
 	pf := &File{
 		name:   name,
-		Closer: ioutil.NopCloser(nil), // via hgfs, nop for stdout and stderr
+		Closer: io.NopCloser(nil), // via hgfs, nop for stdout and stderr
 	}
 
 	var r *bytes.Buffer

--- a/toolbox/service_test.go
+++ b/toolbox/service_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"flag"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -195,7 +194,7 @@ func TestServiceErrors(t *testing.T) {
 	Trace = true
 	if !testing.Verbose() {
 		// cover TraceChannel but discard output
-		traceLog = ioutil.Discard
+		traceLog = io.Discard
 	}
 
 	netInterfaceAddrs = func() ([]net.Addr, error) {

--- a/vapi/rest/client.go
+++ b/vapi/rest/client.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -195,7 +194,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 		case http.StatusNoContent:
 		case http.StatusBadRequest:
 			// TODO: structured error types
-			detail, err := ioutil.ReadAll(res.Body)
+			detail, err := io.ReadAll(res.Body)
 			if err != nil {
 				return err
 			}

--- a/vapi/rest/client_test.go
+++ b/vapi/rest/client_test.go
@@ -19,7 +19,7 @@ package rest_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -90,7 +90,7 @@ func TestWithHeaders(t *testing.T) {
 		}
 
 		// Read the raw response.
-		data, err := ioutil.ReadAll(&res.Buffer)
+		data, err := io.ReadAll(&res.Buffer)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -28,7 +28,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -1802,7 +1801,7 @@ func (s *handler) libraryDeploy(ctx context.Context, c *vim25.Client, lib *libra
 	}
 
 	name := item.ovf()
-	desc, err := ioutil.ReadFile(filepath.Join(libraryPath(lib, item.ID), name))
+	desc, err := os.ReadFile(filepath.Join(libraryPath(lib, item.ID), name))
 	if err != nil {
 		return nil, err
 	}

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -267,7 +266,7 @@ func (c *Client) SetRootCAs(pemPaths string) error {
 	pool := x509.NewCertPool()
 
 	for _, name := range filepath.SplitList(pemPaths) {
-		pem, err := ioutil.ReadFile(filepath.Clean(name))
+		pem, err := os.ReadFile(filepath.Clean(name))
 		if err != nil {
 			return err
 		}

--- a/vim25/soap/json_client_test.go
+++ b/vim25/soap/json_client_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -86,7 +85,7 @@ func TestGetResultPtr(t *testing.T) {
 func TestErrorUnmarshal(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("content-type", "application/json")
-	body := ioutil.NopCloser(strings.NewReader(`{
+	body := io.NopCloser(strings.NewReader(`{
 		"_typeName": "InvalidLogin",
 		"faultstring": "Cannot complete login due to an incorrect user name or password."
 	}`))
@@ -140,7 +139,7 @@ func TestErrorUnmarshal(t *testing.T) {
 func TestSuccessUnmarshal(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("content-type", "application/json")
-	body := ioutil.NopCloser(strings.NewReader(`{
+	body := io.NopCloser(strings.NewReader(`{
 		"_typeName": "UserSession",
 		"key": "527025b6-f0f4-144e-0d36-a7aaf2eb21da",
 		"userName": "VSPHERE.LOCAL\\Administrator",
@@ -242,7 +241,7 @@ func TestFullRequestCycle(t *testing.T) {
 			return &http.Response{
 				StatusCode:    200,
 				Header:        headers,
-				Body:          ioutil.NopCloser(strings.NewReader(body)),
+				Body:          io.NopCloser(strings.NewReader(body)),
 				ContentLength: 100, // Fake length to avoid check for empty body
 			}, nil
 		},


### PR DESCRIPTION
## Description
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16


Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] Test Description 1
- [ ] Test Description 2

## Checklist:

- [ ] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged