### PR TITLE
govc: Add device protocol configuration for vm.network.add

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1419,6 +1419,7 @@ Options:
   -net=                  Network [GOVC_NETWORK]
   -net.adapter=e1000     Network adapter type
   -net.address=          Network hardware address
+  -net.protocol=         Network device protocol. Applicable to vmxnet3vrdma. Default to 'rocev2'
   -vm=                   Virtual machine [GOVC_VM]
 ```
 
@@ -3470,6 +3471,7 @@ Options:
   -net=                  Network [GOVC_NETWORK]
   -net.adapter=e1000     Network adapter type
   -net.address=          Network hardware address
+  -net.protocol=         Network device protocol. Applicable to vmxnet3vrdma. Default to 'rocev2'
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
 ```
 
@@ -5700,6 +5702,7 @@ Options:
   -net=                  Network [GOVC_NETWORK]
   -net.adapter=e1000     Network adapter type
   -net.address=          Network hardware address
+  -net.protocol=         Network device protocol. Applicable to vmxnet3vrdma. Default to 'rocev2'
   -on=true               Power on VM
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
   -snapshot=             Snapshot name to clone from
@@ -5771,6 +5774,7 @@ Options:
   -net=                  Network [GOVC_NETWORK]
   -net.adapter=e1000     Network adapter type
   -net.address=          Network hardware address
+  -net.protocol=         Network device protocol. Applicable to vmxnet3vrdma. Default to 'rocev2'
   -on=true               Power on VM
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
   -version=              ESXi hardware version [5.0|5.5|6.0|6.5|6.7|7.0]
@@ -5985,6 +5989,7 @@ Options:
   -net=                  Network [GOVC_NETWORK]
   -net.adapter=e1000     Network adapter type
   -net.address=          Network hardware address
+  -net.protocol=         Network device protocol. Applicable to vmxnet3vrdma. Default to 'rocev2'
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
   -vm=                   Virtual machine [GOVC_VM]
 ```
@@ -6137,6 +6142,7 @@ Options:
   -net=                  Network [GOVC_NETWORK]
   -net.adapter=e1000     Network adapter type
   -net.address=          Network hardware address
+  -net.protocol=         Network device protocol. Applicable to vmxnet3vrdma. Default to 'rocev2'
   -vm=                   Virtual machine [GOVC_VM]
 ```
 
@@ -6159,6 +6165,7 @@ Options:
   -net=                  Network [GOVC_NETWORK]
   -net.adapter=e1000     Network adapter type
   -net.address=          Network hardware address
+  -net.protocol=         Network device protocol. Applicable to vmxnet3vrdma. Default to 'rocev2'
   -vm=                   Virtual machine [GOVC_VM]
 ```
 

--- a/govc/flags/network.go
+++ b/govc/flags/network.go
@@ -36,6 +36,7 @@ type NetworkFlag struct {
 	adapter string
 	address string
 	isset   bool
+	proto   string
 }
 
 var networkFlagKey = flagKey("network")
@@ -62,6 +63,7 @@ func (flag *NetworkFlag) Register(ctx context.Context, f *flag.FlagSet) {
 		f.Var(flag, "net", usage)
 		f.StringVar(&flag.adapter, "net.adapter", "e1000", "Network adapter type")
 		f.StringVar(&flag.address, "net.address", "", "Network hardware address")
+		f.StringVar(&flag.proto, "net.protocol", "", fmt.Sprintf("Network device protocol. Applicable to vmxnet3vrdma. Default to '%s'", string(types.VirtualVmxnet3VrdmaOptionDeviceProtocolsRocev2)))
 	})
 }
 
@@ -119,6 +121,18 @@ func (flag *NetworkFlag) Device() (types.BaseVirtualDevice, error) {
 	device, err := object.EthernetCardTypes().CreateEthernetCard(flag.adapter, backing)
 	if err != nil {
 		return nil, err
+	}
+
+	if a, ok := device.(*types.VirtualVmxnet3Vrdma); ok {
+		if flag.proto != "" {
+			if flag.proto != string(types.VirtualVmxnet3VrdmaOptionDeviceProtocolsRocev2) &&
+				flag.proto != string(types.VirtualVmxnet3VrdmaOptionDeviceProtocolsRocev1) {
+				return nil, fmt.Errorf("invalid device protocol '%s'", flag.proto)
+			}
+			a.DeviceProtocol = flag.proto
+		}
+	} else if flag.proto != "" {
+		return nil, fmt.Errorf("device protocol is only supported for vmxnet3vrdma at the moment")
 	}
 
 	if flag.address == "-" {

--- a/govc/test/network.bats
+++ b/govc/test/network.bats
@@ -140,7 +140,7 @@ load test_helper
 }
 
 @test "network adapter" {
-  vcsim_env -esx
+  vcsim_env
 
   vm=$(new_id)
   run govc vm.create -on=false -net.adapter=enoent $vm
@@ -164,6 +164,26 @@ load test_helper
   # validate each NIC has a unique MAC
   macs=$(govc device.info -vm "$vm" -json ethernet-* | jq -r .Devices[].macAddress | uniq | wc -l)
   assert_equal 2 "$macs"
+
+  # validate -net.protocol. VM Network not compatible with vmxnet3vrdma, so create on dvgp under existing DVS0
+  run govc dvs.portgroup.add -dvs DVS0 -type ephemeral NSX-dvpg
+  assert_success
+
+  # add a valid vmxnet3vrdma adapter with valid protocal
+  run govc vm.network.add -vm $vm -net.adapter vmxnet3vrdma -net "DVS0/NSX-dvpg" -net.protocol=rocev2
+  assert_success
+
+  # add a valid vmxnet3vrdma adapter with valid protocal
+  run govc vm.network.add -vm $vm -net.adapter vmxnet3vrdma -net "DVS0/NSX-dvpg" -net.protocol=rocev1
+  assert_success
+
+  # invalid value for -net.protocol
+  run govc vm.network.add -vm $vm -net.adapter vmxnet3vrdma -net "DVS0/NSX-dvpg" -net.protocol=what
+  assert_failure "govc: invalid device protocol 'what'"
+
+  # invalid combination for -net.adapter and -net.protocol
+  run govc vm.network.add -vm $vm -net.adapter e1000e -net "DVS0/NSX-dvpg" -net.protocol=rocev2
+  assert_failure "govc: device protocol is only supported for vmxnet3vrdma at the moment"
 }
 
 @test "network flag required" {


### PR DESCRIPTION
## Description

When user add network adapter type `vmxnet3vrdma`, they can configure the protocol `rocev2/rocev1`. This is only supported on adapter type `vmxnet3vrdma`.

Closes: #https://github.com/vmware/govmomi/issues/3167

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Test Description 1
Built on a linux machine. Example output

Correct help message
```
kubo@keDgLYFEehvWP:~/govmomi/govc$ ./govc vm.network.add  --help
Usage: ./govc vm.network.add [OPTIONS]

Add network adapter to VM.
...
  -net.address=                   Network hardware address
  -net.protocol=                  Network device protocol. Applicable to vmxnet3vrdma. Default to 'rocev2'
```

Attempt to add adapter with protocol
```
## ensure no regression
kubo@keDgLYFEehvWP:~/govmomi/govc$ ./govc vm.network.add -vm test -net "port-group-vlan-101" -net.adapter vmxnet3vrdma
kubo@keDgLYFEehvWP:~/govmomi/govc$ ./govc vm.network.add -vm test -net "port-group-vlan-101" -net.adapter e1000e
kubo@keDgLYFEehvWP:~/govmomi/govc$

## valid input

kubo@keDgLYFEehvWP:~/govmomi/govc$ ./govc vm.network.add -vm test -net "port-group-vlan-101" -net.adapter vmxnet3vrdma -net.protocol rocev2
kubo@keDgLYFEehvWP:~/govmomi/govc$ ./govc vm.network.add -vm test -net "port-group-vlan-101" -net.adapter vmxnet3vrdma -net.protocol rocev1

## invalid protocol
kubo@keDgLYFEehvWP:~/govmomi/govc$ ./govc vm.network.add -vm test -net "port-group-vlan-101" -net.adapter vmxnet3vrdma -net.protocol rocev0
./govc: invalid device protocol 'rocev0'

## invalid protocol&adapter combination
kubo@keDgLYFEehvWP:~/govmomi/govc$ ./govc vm.network.add -vm test -net "port-group-vlan-101" -net.adapter e1000e -net.protocol rocev1
./govc: device protocol is only suppported for vmxnet3vrdma at the moment
```


- [ ] Test Description 2

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged