### PR TITLE
Add opentelemetry collector contrib as Notable User in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Refer to the [CHANGELOG][govmomi-changelog] for version to version changes.
 * [Kubernetes vSphere Cloud Provider][project-k8s-cloud-provider]
 * [Kubernetes Cluster API][project-k8s-cluster-api]
 * [OPS][project-nanovms-ops]
+* [OpenTelemetry Collector Contrib][opentelemetry-collector-contrib]
 * [Packer Plugin for VMware vSphere][project-hashicorp-packer-plugin-vsphere]
 * [Rancher][project-rancher]
 * [Terraform Provider for VMware vSphere][project-hashicorp-terraform-provider-vsphere]
@@ -102,6 +103,7 @@ Follows pyvmomi and rbvmomi: language prefix + the vSphere acronym "VM Object Ma
 [go-reference]: https://pkg.go.dev/github.com/vmware/govmomi
 [go-report-card]: https://goreportcard.com/report/github.com/vmware/govmomi
 [go-version]: https://github.com/vmware/govmomi
+[opentelemetry-collector-contrib]: https://github.com/open-telemetry/opentelemetry-collector-contrib
 [project-docker-linuxKit]: https://github.com/linuxkit/linuxkit/tree/master/src/cmd/linuxkit
 [project-elastic-agent]: https://github.com/elastic/integrations/tree/main/packages/vsphere
 [project-gru]: https://github.com/dnaeon/gru


### PR DESCRIPTION
## Description

We've been using govmomi to great success for quite a while for the vcenterreceiver component of opentelemetry's contrib distribution. Was hoping to that we could be listed as another success story in the notable users of the great library that has been built here https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/vcenterreceiver 🚀 

If there is a process for this let me know, but figured I'd just shout out the great work and usefulness of this library 😄 


Closes:   didn't think an issue was necessary but happy to create one :) 

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Feel free to see change here: https://github.com/schmikei/govmomi/tree/notable-user-otel-contrib

## Checklist:

- [ ] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged