### PR TITLE
Allow picking datastore upload URL scheme by env

### DIFF
--- a/govc/test/datastore.bats
+++ b/govc/test/datastore.bats
@@ -188,7 +188,7 @@ upload_file() {
 }
 
 @test "datastore.upload" {
-  esx_env
+  vcsim_env -esx
 
   name=$(new_id)
   echo -n "Hello world" | govc datastore.upload - "$name"
@@ -196,6 +196,12 @@ upload_file() {
   run govc datastore.download "$name" -
   assert_success
   assert_output "Hello world"
+
+  run env GOVMOMI_DATASTORE_ACCESS_SCHEME=invalid govc datastore.upload datastore.bats datastore.bats
+  assert_failure
+
+  run env GOVMOMI_DATASTORE_ACCESS_SCHEME=https govc datastore.upload datastore.bats datastore.bats
+  assert_success
 }
 
 @test "datastore.tail" {

--- a/object/datastore.go
+++ b/object/datastore.go
@@ -83,8 +83,14 @@ func (d Datastore) Path(path string) string {
 func (d Datastore) NewURL(path string) *url.URL {
 	u := d.c.URL()
 
+	scheme := u.Scheme
+	// In rare cases where vCenter and ESX are accessed using different schemes.
+	if overrideScheme := os.Getenv("GOVMOMI_DATASTORE_ACCESS_SCHEME"); overrideScheme != "" {
+		scheme = overrideScheme
+	}
+
 	return &url.URL{
-		Scheme: u.Scheme,
+		Scheme: scheme,
 		Host:   u.Host,
 		Path:   fmt.Sprintf("/folder/%s", path),
 		RawQuery: url.Values{


### PR DESCRIPTION


## Description

When constructing the datastore URL using a *soap.Client, there may be edge cases where VC and ESX schemes differ. Allow using an environment variable to override this instead of assuming homogeneous schemes.


Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- Update the vcsim datastore bats test to test this.
- Also updated the same bats test to use vcsim instead of just ESX for datastore upload.
- Verified that a client using HTTP to VC (via govmomi.NewClient()) and HTTPS to ESX worked as expected during datastore file upload.

## Checklist:

- [X] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged