### PR TITLE
chore: Dockerfile & steps for generating types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,10 @@ doc: install
 doc: ## Generates govc USAGE.md
 	./govc/usage.sh > ./govc/USAGE.md
 
+.PHONY: generate-types
+generate-types: ## Generate the types
+	$(MAKE) -C ./gen/ $@
+
 
 ## --------------------------------------
 ## Tests

--- a/gen/.gitignore
+++ b/gen/.gitignore
@@ -1,2 +1,3 @@
 sdk/
 rbvmomi/
+.Gemfile.lock.tmp

--- a/gen/Dockerfile
+++ b/gen/Dockerfile
@@ -1,0 +1,76 @@
+## The version of Go from which this image is based.
+ARG GO_VERSION=1.20.6
+
+## Docker image used as base of this image.
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}
+
+
+## --------------------------------------
+## Multi-platform support
+## --------------------------------------
+
+ARG TARGETOS
+ARG TARGETARCH
+
+
+## --------------------------------------
+## Environment variables
+## --------------------------------------
+
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
+
+
+## --------------------------------------
+## Update the apt cache & essentials
+## --------------------------------------
+RUN apt-get update && \
+    apt-get install -y build-essential curl
+
+
+## --------------------------------------
+## Install the version of openssl
+## required by ruby 2.x, which is
+## required to generate the types
+## --------------------------------------
+RUN mkdir -p /opt/src /opt/lib && \
+    curl -sSL https://www.openssl.org/source/openssl-1.1.1g.tar.gz | \
+    tar -C /opt/src -xz && \
+    cd /opt/src/openssl-1.1.1g && \
+    ./config --prefix=/opt/lib/openssl-1.1.1g \
+             --openssldir=/opt/lib/openssl-1.1.1g && \
+    make && \
+    make install && \
+    rm -fr /opt/lib/openssl-1.1.1g/certs && \
+    ln -s /etc/ssl/certs /opt/lib/openssl-1.1.1g/certs
+
+
+## --------------------------------------
+## Install Ruby & Bundler
+## --------------------------------------
+
+ENV PATH="/root/.rbenv/shims:${PATH}" \
+    RUBY_CONFIGURE_OPTS="--with-openssl-dir=/opt/lib/openssl-1.1.1g"
+
+RUN apt-get install -y rbenv && \
+    rbenv install 2.7.6 && \
+    rbenv rehash && \
+    rbenv global 2.7.6 && \
+    gem install bundler
+
+
+## --------------------------------------
+## Configure the working directory
+## --------------------------------------
+
+WORKDIR /govmomi/gen
+
+
+## --------------------------------------
+## Cache the gen program dependencies
+## --------------------------------------
+
+COPY Gemfile Gemfile.lock .
+RUN go install golang.org/x/tools/cmd/goimports@latest && \
+    bundle update --bundler && \
+    bundle install

--- a/gen/Makefile
+++ b/gen/Makefile
@@ -1,0 +1,58 @@
+# Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# If you update this file, please follow
+# https://www.thapaliya.com/en/writings/well-documented-makefiles/
+
+# Ensure Make is run with bash shell as some syntax below is bash-specific
+SHELL := /usr/bin/env bash
+
+# Print the help/usage when make is executed without any other arguments
+.DEFAULT_GOAL := help
+
+
+## --------------------------------------
+## Help
+## --------------------------------------
+
+.PHONY: help
+help: ## Display usage
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make [target] \033[36m\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+
+## --------------------------------------
+## Image
+## --------------------------------------
+
+IMAGE_NAME ?= govmomi-gen-types
+IMAGE_TAG ?= latest
+IMAGE ?= $(IMAGE_NAME):$(IMAGE_TAG)
+
+.PHONY: image-build
+image-build: ## Build the image for generating types
+	docker build -t $(IMAGE) .
+
+
+## --------------------------------------
+## Generate
+## --------------------------------------
+
+ABS_PATH_PARENT_DIR := $(abspath $(dir $(shell pwd)))
+
+#
+# Please note the use of the .Gemfile.lock.tmp file below. This is to prevent
+# the container from modifying the local copy of the Gemfile.lock that would
+# otherwise be bind mounted into the container courtesy of the first bind mount.
+#
+
+.PHONY: generate-types
+generate-types: image-build
+generate-types: ## Generate the types
+	@cp -f Gemfile.lock .Gemfile.lock.tmp
+	docker run -it --rm \
+	  -v $(ABS_PATH_PARENT_DIR):/govmomi \
+	  -v $(ABS_PATH_PARENT_DIR)/gen/.Gemfile.lock.tmp:/govmomi/gen/Gemfile.lock \
+	  $(IMAGE) \
+	  /bin/bash -c 'bundle update --bundler && bundle install && ./gen.sh'
+
+

--- a/gen/README.md
+++ b/gen/README.md
@@ -1,0 +1,27 @@
+# Generating the types
+
+This document describes how a VMware engineer can generate the vim types from internal builds:
+
+## Requirements
+
+* Docker
+
+## Steps
+
+1. Find the desired build of `vcenter-all`.
+2. Click on the `vsphere-h5client` dependency.
+3. Click on the `vimbase` dependency.
+4. Download the published deliverable `wsdl.zip` and inflate it into the directory `./gen/sdk`.
+5. Navigate back to the `vsphere-h5client` dependency.
+6. Click on the `eam-vcenter` dependency.
+7. Download the published deliverable `eam-wsdl.zip` and copy its `eam-messagetypes.xsd` and `eam-types.xsd` files into the directory `./gen/sdk`.
+8. Open a terminal window.
+9. Run `make generate-types`.
+
+    ---
+
+    :warning: **Please note**
+
+    This can take a while the first time because it has to build the image used to generate the types, and building the image includes building OpenSSL and Ruby2, since the GoVmomi generator requires Ruby2, and Ruby2 requires an older version of OpenSSL than is available on recent container images.
+
+    ---

--- a/gen/gen.sh
+++ b/gen/gen.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2014-2022 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,14 @@
 # limitations under the License.
 
 set -e
+
+ensure_rb_vmodl() {
+  mkdir -p ./rbvmomi
+  [ -f ./rbvmomi/vmodl.db ] || \
+    curl -sSLo \
+      ./rbvmomi/vmodl.db \
+      https://github.com/vmware-archive/rbvmomi/raw/master/vmodl.db
+}
 
 generate() {
   dst="$1"
@@ -46,6 +54,28 @@ generate() {
     popd >/dev/null
   done
 }
+
+update_vim_version() {
+  sed -i'.bak' -e 's~^[[:blank:]]\{1,\}Version[[:blank:]]\{1,\}=.\{1,\}$~Version = '"\"${1}\""'~g' ../vim25/client.go
+  rm -f ../vim25/client.go.bak
+  go fmt ../vim25/client.go
+}
+
+#
+# Make sure the vmodl.db file exists.
+#
+ensure_rb_vmodl
+
+#
+# The VIM API version used by the vim25 client.
+#
+VIM_VERSION="${VIM_VERSION:-8.0.0.1}"
+
+#
+# Update the vim25 client's VIM version.
+#
+update_vim_version "${VIM_VERSION}"
+
 
 #
 # All types derive from vSphere 8.0 GA, vcenter-all build 20519528.


### PR DESCRIPTION
## Description

This patch:

* Introduces a cross-arch `./gen/Dockerfile` for generating the vim types.
* Documents the process at `./gen/README.md`.
* Introduces a Makefile target `generate-types` for generating the vim types.
* Enables `./gen/gen.sh` to automatically update the VIM version in `vim25/client.go`.
* Ensures `./gen/rbvmomi/vmodl.db` is downloaded if it does not already exist when generating types.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update
- [x] Build related change

## How Has This Been Tested?

`make generate-types`

## Checklist:

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged