### PR TITLE
Bypass lookup svc for STS and SSOadmin clients

### DIFF
--- a/internal/helpers_test.go
+++ b/internal/helpers_test.go
@@ -14,10 +14,16 @@ limitations under the License.
 package internal_test
 
 import (
+	"fmt"
+	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/vmware/govmomi/internal"
 	"github.com/vmware/govmomi/simulator/esx"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
 )
 
 func TestHostSystemManagementIPs(t *testing.T) {
@@ -29,4 +35,25 @@ func TestHostSystemManagementIPs(t *testing.T) {
 	if ips[0].String() != "127.0.0.1" {
 		t.Fatalf("Expected management ip %s, got %s", "127.0.0.1", ips[0].String())
 	}
+}
+
+func TestUsingVCEnvoySidecar(t *testing.T) {
+	t.Run("VC HTTPS port", func(t *testing.T) {
+		scheme := "https"
+		hostname := "my-vcenter"
+		port := 443
+		u := &url.URL{Scheme: scheme, Host: fmt.Sprintf("%s:%d", hostname, port)}
+		client := &vim25.Client{Client: soap.NewClient(u, true)}
+		usingSidecar := internal.UsingEnvoySidecar(client)
+		require.False(t, usingSidecar)
+	})
+	t.Run("Envoy sidecar", func(t *testing.T) {
+		scheme := "http"
+		hostname := "localhost"
+		port := 1080
+		u := &url.URL{Scheme: scheme, Host: fmt.Sprintf("%s:%d", hostname, port)}
+		client := &vim25.Client{Client: soap.NewClient(u, true)}
+		usingSidecar := internal.UsingEnvoySidecar(client)
+		require.True(t, usingSidecar)
+	})
 }

--- a/lookup/client_test.go
+++ b/lookup/client_test.go
@@ -30,31 +30,16 @@ import (
 	"github.com/vmware/govmomi/sts"
 	"github.com/vmware/govmomi/vim25"
 
-	_ "github.com/vmware/govmomi/lookup/simulator"
+	lsim "github.com/vmware/govmomi/lookup/simulator"
 	_ "github.com/vmware/govmomi/ssoadmin/simulator"
 	_ "github.com/vmware/govmomi/sts/simulator"
 )
-
-// make the path of all lookup service urls invalid
-func breakLookupServiceURLs() {
-	setting := simulator.Map.OptionManager().Setting
-
-	for _, s := range setting {
-		o := s.GetOptionValue()
-		if strings.HasSuffix(o.Key, ".uri") {
-			val := o.Value.(string)
-			u, _ := url.Parse(val)
-			u.Path = "/enoent" + u.Path
-			o.Value = u.String()
-		}
-	}
-}
 
 // test lookup.EndpointURL usage by the ssoadmin and sts clients
 func TestEndpointURL(t *testing.T) {
 	// these client calls should fail since we'll break the URL paths
 	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
-		breakLookupServiceURLs()
+		lsim.BreakLookupServiceURLs()
 
 		{
 			_, err := ssoadmin.NewClient(ctx, vc)

--- a/lookup/simulator/simulator.go
+++ b/lookup/simulator/simulator.go
@@ -17,6 +17,8 @@ limitations under the License.
 package simulator
 
 import (
+	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/vmware/govmomi/lookup"
@@ -174,4 +176,19 @@ func (s *ServiceRegistration) List(req *types.List) soap.HasFault {
 	}
 
 	return body
+}
+
+// BreakLookupServiceURLs makes the path of all lookup service urls invalid
+func BreakLookupServiceURLs() {
+	setting := simulator.Map.OptionManager().Setting
+
+	for _, s := range setting {
+		o := s.GetOptionValue()
+		if strings.HasSuffix(o.Key, ".uri") {
+			val := o.Value.(string)
+			u, _ := url.Parse(val)
+			u.Path = "/enoent" + u.Path
+			o.Value = u.String()
+		}
+	}
 }

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -876,9 +876,10 @@ func (m *Model) Run(f func(context.Context, *vim25.Client) error) error {
 		if err != nil {
 			return err
 		}
+		// Only force TLS if the provided model didn't have any Service.
+		m.Service.TLS = new(tls.Config)
 	}
 
-	m.Service.TLS = new(tls.Config)
 	m.Service.RegisterEndpoints = true
 
 	s := m.Service.NewServer()

--- a/ssoadmin/client_test.go
+++ b/ssoadmin/client_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,47 +14,57 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ssoadmin
+package ssoadmin_test
 
 import (
 	"context"
-	"log"
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	lsim "github.com/vmware/govmomi/lookup/simulator"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/ssoadmin"
+	_ "github.com/vmware/govmomi/ssoadmin/simulator"
+	"github.com/vmware/govmomi/ssoadmin/types"
+	_ "github.com/vmware/govmomi/sts/simulator"
 	"github.com/vmware/govmomi/vim25"
-	"github.com/vmware/govmomi/vim25/soap"
 )
 
 func TestClient(t *testing.T) {
-	ctx := context.Background()
-	url := os.Getenv("GOVC_TEST_URL")
-	if url == "" {
-		t.SkipNow()
-	}
+	t.Run("Happy path using lookup service", func(t *testing.T) {
+		simulator.Test(func(ctx context.Context, client *vim25.Client) {
+			c, err := ssoadmin.NewClient(ctx, client)
+			require.NoError(t, err)
 
-	u, err := soap.ParseURL(url)
-	if err != nil {
-		t.Fatal(err)
-	}
+			verifyClient(t, ctx, c)
+		})
+	})
+	t.Run("With Envoy sidecar and a malfunctioning lookup service, ssoadmin client creation should still succeed", func(t *testing.T) {
+		model := simulator.VPX()
+		model.Create()
+		simulator.Test(func(ctx context.Context, client *vim25.Client) {
+			// Map Envoy sidecar on the same port as the vcsim client.
+			os.Setenv("GOVMOMI_ENVOY_SIDECAR_PORT", client.Client.URL().Port())
+			os.Setenv("GOVMOMI_ENVOY_SIDECAR_HOST", client.Client.URL().Hostname())
 
-	c, err := vim25.NewClient(ctx, soap.NewClient(u, true))
-	if err != nil {
-		log.Fatal(err)
-	}
+			lsim.BreakLookupServiceURLs()
 
-	if !c.IsVC() {
-		t.SkipNow()
-	}
+			c, err := ssoadmin.NewClient(ctx, client)
+			require.NoError(t, err)
 
-	admin, err := NewClient(ctx, c)
-	if err != nil {
-		t.Fatal(err)
-	}
+			verifyClient(t, ctx, c)
+		}, model)
+	})
+}
 
-	if err = admin.Login(ctx); err == nil {
-		t.Error("expected error") // soap.Header.Security not set
-	}
+func verifyClient(t *testing.T, ctx context.Context, c *ssoadmin.Client) {
+	err := c.CreatePersonUser(ctx, "testuser", types.AdminPersonDetails{FirstName: "test", LastName: "user"}, "password")
+	require.NoError(t, err)
 
-	// sts/client_test.go tests the success paths
+	user, err := c.FindUser(ctx, "testuser")
+	require.NoError(t, err)
+	require.Equal(t, &types.AdminUser{Id: types.PrincipalId{Name: "testuser", Domain: "vsphere.local"}, Kind: "person"}, user)
+
 }

--- a/ssoadmin/simulator/simulator.go
+++ b/ssoadmin/simulator/simulator.go
@@ -31,7 +31,7 @@ import (
 func init() {
 	simulator.RegisterEndpoint(func(s *simulator.Service, r *simulator.Registry) {
 		if r.IsVPX() {
-			s.RegisterSDK(New(r, s.Listen))
+			s.RegisterSDK(New(r, s.Listen), ssoadmin.SystemPath)
 		}
 	})
 }

--- a/sts/simulator/simulator.go
+++ b/sts/simulator/simulator.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/sts"
 	"github.com/vmware/govmomi/sts/internal"
 	"github.com/vmware/govmomi/vim25/soap"
 	vim "github.com/vmware/govmomi/vim25/types"
@@ -36,6 +37,7 @@ func init() {
 		if r.IsVPX() {
 			path, handler := New(s.Listen, r.OptionManager().Setting)
 			s.Handle(path, handler)
+			s.Handle(sts.SystemPath, handler)
 		}
 	})
 }


### PR DESCRIPTION
## Description

- For local clients on vCenter, lookup service can be omitted and local Envoy processes can be used instead, along with 'system-' prefixed variants of SSOAdmin/STS. This avoids the need to discover the vCenter SSO domain and avoids an extra round trip.

- Also extends simulator to allow aliasing the same SDK to multiple paths as part of the RegisterSDK() method. Moves vimService, ssoadmin, STS simulators to this model.

- Using an env var with a fallback default to allow testing.

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- Existing unit tests
- On VC: created a client pointing at localhost:1080 and verified that lookup service was not used.
- Added unit tests that break lookup service URLs and ensure that ssoadmin/sts clients still work.

## Checklist:

- [X] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged