### PR TITLE
Remove spacing in new pull request template contribution checklist item

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,11 +28,11 @@ details for your test configuration.
 
 ## Checklist:
 
-- [ ] My code follows the `CONTRIBUTION`
-  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
-  this project
+- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged
+
+[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
## Description

The current pull request template has the contribution guidelines on 3 lines. To me, this looks a little sloppy.

I change the line so it it is a single line in both markdown and the html output.
If you prefer it be formatted as a single line without the link pulled out, just let me know.

Heh, describing a change to the PR template in a PR is a little meta.

Before
======

- [x] My code follows the `CONTRIBUTION`
  [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of
  this project

After
=====

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project

---


## Type of change

Please mark options that are relevant:

This is a documentation/github only change

## How Has This Been Tested?

I modified this PR comment to follow the format.
I viewed with a markdown editor

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md