### PR TITLE
Add default PerfManager.historicalInterval values to the simulator

### DIFF
--- a/simulator/esx/performance_manager.go
+++ b/simulator/esx/performance_manager.go
@@ -18,6 +18,20 @@ package esx
 
 import "github.com/vmware/govmomi/vim25/types"
 
+// HistoricalInterval is the default template for the PerformanceManager historicalInterval property.
+// Capture method:
+//
+//	govc object.collect -s -dump PerformanceManager:ha-perfmgr historicalInterval
+var HistoricalInterval = []types.PerfInterval{
+	{
+		Enabled:        true,
+		Key:            1,
+		Length:         129600,
+		Name:           "PastDay",
+		SamplingPeriod: 300,
+	},
+}
+
 // PerfCounter is the default template for the PerformanceManager perfCounter property.
 // Capture method:
 //

--- a/simulator/performance_manager.go
+++ b/simulator/performance_manager.go
@@ -44,25 +44,28 @@ var historicProviderSummary = types.PerfProviderSummary{
 
 type PerformanceManager struct {
 	mo.PerformanceManager
-	vmMetrics         []types.PerfMetricId
-	hostMetrics       []types.PerfMetricId
-	rpMetrics         []types.PerfMetricId
-	clusterMetrics    []types.PerfMetricId
-	datastoreMetrics  []types.PerfMetricId
-	datacenterMetrics []types.PerfMetricId
-	perfCounterIndex  map[int32]types.PerfCounterInfo
-	metricData        map[string]map[int32][]int64
+	historicalInterval []types.PerfInterval
+	vmMetrics          []types.PerfMetricId
+	hostMetrics        []types.PerfMetricId
+	rpMetrics          []types.PerfMetricId
+	clusterMetrics     []types.PerfMetricId
+	datastoreMetrics   []types.PerfMetricId
+	datacenterMetrics  []types.PerfMetricId
+	perfCounterIndex   map[int32]types.PerfCounterInfo
+	metricData         map[string]map[int32][]int64
 }
 
 func (m *PerformanceManager) init(r *Registry) {
 	if r.IsESX() {
 		m.PerfCounter = esx.PerfCounter
+		m.historicalInterval = esx.HistoricalInterval
 		m.hostMetrics = esx.HostMetrics
 		m.vmMetrics = esx.VmMetrics
 		m.rpMetrics = esx.ResourcePoolMetrics
 		m.metricData = esx.MetricData
 	} else {
 		m.PerfCounter = vpx.PerfCounter
+		m.historicalInterval = vpx.HistoricalInterval
 		m.hostMetrics = vpx.HostMetrics
 		m.vmMetrics = vpx.VmMetrics
 		m.rpMetrics = vpx.ResourcePoolMetrics

--- a/simulator/vpx/performance_manager.go
+++ b/simulator/vpx/performance_manager.go
@@ -18,6 +18,45 @@ package vpx
 
 import "github.com/vmware/govmomi/vim25/types"
 
+// HistoricalInterval is the default template for the PerformanceManager historicalInterval property.
+// Capture method:
+//
+//	govc object.collect -s -dump PerformanceManager:Perfmgr historicalInterval
+var HistoricalInterval = []types.PerfInterval{
+	{
+		Enabled:        true,
+		Key:            1,
+		Length:         86400,
+		Level:          1,
+		Name:           "Past Day",
+		SamplingPeriod: 300,
+	},
+	{
+		Enabled:        true,
+		Key:            2,
+		Length:         604800,
+		Level:          1,
+		Name:           "Past Week",
+		SamplingPeriod: 1800,
+	},
+	{
+		Enabled:        true,
+		Key:            1,
+		Length:         2592000,
+		Level:          1,
+		Name:           "Past Month",
+		SamplingPeriod: 7200,
+	},
+	{
+		Enabled:        true,
+		Key:            1,
+		Length:         31536000,
+		Level:          1,
+		Name:           "Past Year",
+		SamplingPeriod: 86400,
+	},
+}
+
 // PerfCounter is the default template for the PerformanceManager perfCounter property.
 // Capture method:
 //   govc object.collect -s -dump PerformanceManager:PerfMgr perfCounter


### PR DESCRIPTION
## Description

For the simulator, default historical intervals are currently blank. This is causing one of our processes to fail.

I'm new to go, so it would be great if someone can point me to another property that I can base this upon.

Thank you for any pointers.

### Before

- `vcsim`
- govc metric.interval.info

results are empty

### Work around

- `vcsim`
- `govc object.save -d my-vcenter` (in a separate terminal)
- stop the simulator
- edit `my-vcenter/0009-PerformanceManager-PerfMgr.xml`
  - add `<propSet><name>historicalInterval</name>` 
- `vcsim -load my-vcenter`    

### After

*WIP*: This is still returning an empty historical 

Can someone point me to how to connect the historicalIntervals to these new values?
Or if this is not a good approach, an alternative would be great.
Or a way to populate these values from the command line?

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines](https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged