### PR TITLE
govc: Add -file flag to cluster.module.rm to delete a list of cluster modules read from a file

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -586,10 +586,14 @@ Usage: govc cluster.module.rm [OPTIONS] ID
 
 Delete cluster module ID.
 
+If ID is "-", read a list from stdin.
+
 Examples:
   govc cluster.module.rm module_id
+  govc cluster.module.rm - < input-file.txt
 
 Options:
+  -ignore-not-found=false  Treat "404 Not Found" as a successful delete.
 ```
 
 ## cluster.module.vm.add

--- a/govc/test/cluster.bats
+++ b/govc/test/cluster.bats
@@ -326,6 +326,30 @@ _EOF_
 
   run govc cluster.module.ls -id $id
   assert_failure
+
+  run govc cluster.module.rm "does_not_exist"
+  assert_failure
+
+  run govc cluster.module.rm --ignore-not-found "does_not_exist"
+  assert_success
+
+  run govc cluster.module.create -cluster DC0_C0
+  assert_success
+
+  id="$output"
+
+  run govc cluster.module.create -cluster DC0_C0
+  assert_success
+
+  id2="$output"
+
+  run govc cluster.module.rm --ignore-not-found "-" <<_EOF_
+$id
+does_not_exist
+$id2
+_EOF_
+  assert_success
+
 }
 
 @test "cluster.mv" {


### PR DESCRIPTION
## Description

This PR adds a `-file` flag to the `govc cluster.module.rm` command.

Deleting lots of cluster modules takes a long time.

E.g. deleting 10k cluster modules using bash and the current implementation would take ~5 mins. Example command:
```sh
while read -r ID; do govc cluster.module.rm $ID ; done < modules.txt
```

With this PR the following would do the same and only take ~30s:

```sh
govc cluster.module.rm - < modules.txt
```

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Created 10k cluster modules and deleted using the new flag
  - extracted all existing modules via `govc cluster.module.ls | awk '{print $2}' > modules.txt`
  - ran `govc cluster.module.rm -file modules.txt`

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
