### PR TITLE
vcsim: Fix RefreshDatastore to return a valid response

### DIFF
--- a/simulator/datastore.go
+++ b/simulator/datastore.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -83,6 +83,7 @@ func (ds *Datastore) RefreshDatastore(*types.RefreshDatastore) soap.HasFault {
 
 	info.Timestamp = types.NewTime(time.Now())
 
+	r.Res = &types.RefreshDatastoreResponse{}
 	return r
 }
 

--- a/simulator/datastore_test.go
+++ b/simulator/datastore_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
@@ -85,7 +86,12 @@ func TestRefreshDatastore(t *testing.T) {
 			},
 		}
 
-		res := ds.RefreshDatastore(nil)
+		r := ds.RefreshDatastore(nil)
+		res, ok := r.(*methods.RefreshDatastoreBody)
+		if !ok {
+			t.Fatalf("Unexpected response type: %T", r)
+		}
+
 		err := res.Fault()
 
 		if test.fail {
@@ -95,6 +101,9 @@ func TestRefreshDatastore(t *testing.T) {
 		} else {
 			if err != nil {
 				t.Error(err)
+			}
+			if res.Res == nil {
+				t.Errorf("Invalid response: %v", res)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Fixed the implementation of `RefreshDatastore` in the VC simulator to set the response field when there is no fault (i.e. happy path) in order to avoid serialization problems.

Closes: #3198

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [x] Modified the existing unit test for `RefreshDatastore` to validate the response field.
- [x] Developer testing via standalone govmomi-based client against vcsim.

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
