### PR TITLE
Trim leading slash on soap path

### DIFF
--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -114,6 +114,7 @@ func ParseURL(s string) (*url.URL, error) {
 			s = "https://" + s
 		}
 
+		s := strings.TrimSuffix(s, "/")
 		u, err = url.Parse(s)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description

When passing an endpoint as `https://some.vcenter.tld/` to govc (or soap client), it will consider the leading / as part of the path and not add the `/sdk`.

This leads to errors when consuming vCenter API.

While passing the leading "/" may be desired, I'm not sure if there's a better way to turn this error more intuitive.

This PR also adds some unit tests on ParseURL function

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- Added unit tests
- Tested soap.ParseURL with and without the change, and passing the URL as `https://some.vcenter.tld` with and without the leading path. Without the change, it always gets an unauthorized access

## Checklist:

- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
