### PR TITLE
govc/library: fix dropped error

### DIFF
--- a/govc/library/import.go
+++ b/govc/library/import.go
@@ -168,7 +168,9 @@ func (cmd *item) Run(ctx context.Context, f *flag.FlagSet) error {
 	session, err := m.CreateLibraryItemUpdateSession(ctx, library.Session{
 		LibraryItemID: cmd.ID,
 	})
-
+	if err != nil {
+		return err
+	}
 	if cmd.pull {
 		_, err = m.AddLibraryItemFileFromURI(ctx, session, filepath.Base(file), file)
 		if err != nil {


### PR DESCRIPTION
This fixes a dropped `err` variable in `govc/library`.
