### PR TITLE
Bug #3208 - Clone template fails when using 'cluster' option

### DIFF
--- a/govc/vm/clone.go
+++ b/govc/vm/clone.go
@@ -220,6 +220,10 @@ func (cmd *clone) Run(ctx context.Context, f *flag.FlagSet) error {
 			if cmd.ResourcePool, err = cmd.ResourcePoolFlag.ResourcePool(); err != nil {
 				return err
 			}
+		} else {
+			if cmd.ResourcePool, err = cmd.Cluster.ResourcePool(ctx); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

The fix in https://github.com/vmware/govmomi/pull/1938 may have broken the cloning VM from a template when using the 'cluster' option as shown in #3208 
This fix uses the resource pool from the Cluster when cloning template into a VM.

Closes: #3208 

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The fix has been tested towards vSphere 6.3

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- No dependent changes

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
