### PR TITLE
govc: Fix memory aliasing in for loop (gosec G601)

### DIFF
--- a/govc/vm/snapshot/tree.go
+++ b/govc/vm/snapshot/tree.go
@@ -85,6 +85,8 @@ func (cmd *tree) Process(ctx context.Context) error {
 
 func (cmd *tree) write(level int, parent string, pref *types.ManagedObjectReference, st []types.VirtualMachineSnapshotTree) {
 	for _, s := range st {
+		s := s // avoid implicit memory aliasing
+
 		sname := s.Name
 
 		if cmd.fullPath && parent != "" {


### PR DESCRIPTION
## Description

Explicitly reassign the iteration variable used for listing virtual machine snapshots to fix the `gosec` G601 "Implicit memory aliasing in for loop" error.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [x] `go build ./...`
- [x] `go test -v ./govc`

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
