### PR TITLE
[simulator] Introduce separation between NewServiceInstance function invocation & infra creation

### DIFF
--- a/simulator/model.go
+++ b/simulator/model.go
@@ -477,7 +477,10 @@ func (m *Model) Create() error {
 	ctx := SpoofContext()
 	m.Service = New(NewServiceInstance(ctx, m.ServiceContent, m.RootFolder))
 	ctx.Map = Map
+	return m.CreateInfrastructure(ctx)
+}
 
+func (m *Model) CreateInfrastructure(ctx *Context) error {
 	client := m.Service.client
 	root := object.NewRootFolder(client)
 


### PR DESCRIPTION
## Description

When we invoke simulator model's `Create` function, there is no way of passing simulator context and in `NewServiceInstance` function we end up overwriting global registry, as referenced below :
```
func NewServiceInstance(ctx *Context, content types.ServiceContent, folder mo.Folder) *ServiceInstance {
	// TODO: This function ignores the passed in Map and operates on the
	// global Map.
	Map = NewRegistry()
	ctx.Map = Map

	s := &ServiceInstance{}

	s.Self = vim25.ServiceInstance
	s.Content = content

	Map.Put(s)
```
ref : https://github.com/vmware/govmomi/blob/c63291aa18123977bb7a143222437d37613c9da6/simulator/service_instance.go#L36

We can go around this issue and create our own `ServiceInstance` for a model without overwriting global registry but this also means we are unable to leverage the infrastructure creation logic using Service's client which resides in `Create` function. Hence it's best to break it down into two functions.

Alternatively, we can update  `NewServiceInstance` to leverage registry passed in Context but that would require changes in multiple places and in nested functions, given that can break existing pipelines or create regression. For now its best to break this function down into two.

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] Test Description 1
- [ ] Test Description 2

## Checklist:

- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
