### PR TITLE
Fix datacenter output on govc

### DIFF
--- a/govc/datacenter/info.go
+++ b/govc/datacenter/info.go
@@ -163,7 +163,7 @@ func (r *infoResult) Write(w io.Writer) error {
 
 		manager := view.NewManager(r.client)
 
-		v, err := manager.CreateContainerView(r.ctx, r.client.ServiceContent.RootFolder, []string{"VirtualMachine"}, true)
+		v, err := manager.CreateContainerView(r.ctx, o.Reference(), []string{"VirtualMachine"}, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

`govc datacenter.info` is printing the wrong VM count, as it is doing the query based on root folder and not on the used datacenter reference.

This way, with multiple datacenters the count will be always the total of VMs regardless of what datacenter they are, instead of a per dc count.

This PR fixes this count, setting the right property on Containerview to use the datacenter and not the root folder

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] Test Description 1
- [ ] Test Description 2

## Checklist:

- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
