### PR TITLE
WiP -- govc: Cmd to enc data for VMs w TPM2 devs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d
 	github.com/dougm/pretty v0.0.0-20171025230240-2ee9d7453c02
 	github.com/google/go-cmp v0.5.9
+	github.com/google/go-tpm v0.0.0-00010101000000-000000000000
 	github.com/google/uuid v1.3.1
 	github.com/rasky/go-xdr v0.0.0-20170217172119-4930550ba2e2
 	github.com/stretchr/testify v1.8.4
@@ -17,6 +18,9 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/google/go-tpm => github.com/akutz/go-tpm v0.0.0-20230905164706-154640f5dc67

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d h1:4E8RufAN3UQ/weB6AnQ4y5miZCO0Yco8ZdGId41WuQs=
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
+github.com/akutz/go-tpm v0.0.0-20230905164706-154640f5dc67 h1:O1E36iZgkKOhi3KR+DPmiN7mkokL93QGBK1a56+eC2g=
+github.com/akutz/go-tpm v0.0.0-20230905164706-154640f5dc67/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -26,6 +28,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728 h1:sH9mEk+flyDxiUa5BuPiuhDETMbzrt9A20I2wktMvRQ=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -358,6 +358,9 @@ but appear via `govc $cmd -h`:
  - [vm.rdm.attach](#vmrdmattach)
  - [vm.rdm.ls](#vmrdmls)
  - [vm.register](#vmregister)
+ - [vm.tpm2.cert.get](#vmtpm2certget)
+ - [vm.tpm2.cert.ls](#vmtpm2certls)
+ - [vm.tpm2.seal](#vmtpm2seal)
  - [vm.unregister](#vmunregister)
  - [vm.upgrade](#vmupgrade)
  - [vm.vnc](#vmvnc)
@@ -6282,6 +6285,55 @@ Options:
   -name=                 Name of the VM
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
   -template=false        Mark VM as template
+```
+
+## vm.tpm2.cert.get
+
+```
+Usage: govc vm.tpm2.cert.get [OPTIONS]
+
+Get certificate by fingerprint.
+
+Examples:
+  govc vm.tpm2.cert.get -vm VM -fingerprint 41:5D:F1:AE:B9:F2:B1:22:9F:79:B7:FF:DA:55:5B:86
+
+Options:
+  -fingerprint=          Fingerprint of cert to get. Use vm.tpm2.ls to see available certs."
+  -vm=                   Virtual machine [GOVC_VM]
+```
+
+## vm.tpm2.cert.ls
+
+```
+Usage: govc vm.tpm2.cert.ls [OPTIONS]
+
+List endorsement key certificates.
+
+Examples:
+  govc vm.tpm2.cert.ls -vm VM
+  govc vm.tpm2.cert.ls -vm VM -G ecc
+
+Options:
+  -G=                    Public key algorithm. Either "rsa", "ecc", or "ecdsa"
+  -vm=                   Virtual machine [GOVC_VM]
+```
+
+## vm.tpm2.seal
+
+```
+Usage: govc vm.tpm2.seal [OPTIONS]
+
+Seal plain-text data to the VM's TPM2 endorsement key.
+
+Examples:
+  govc vm.tpm2.seal -vm VM -in plain.txt
+  echo "Hello, world" | govc vm.tpm2.seal -vm VM
+  echo "Seal with ECC." | govc vm.tpm2.seal -vm VM -G ecc
+
+Options:
+  -G=rsa                 Public key algorithm. Either "rsa", "ecc", or "ecdsa"
+  -in=-                  Input data. Defaults to STDIN via "-"
+  -vm=                   Virtual machine [GOVC_VM]
 ```
 
 ## vm.unregister

--- a/govc/main.go
+++ b/govc/main.go
@@ -109,6 +109,8 @@ import (
 	_ "github.com/vmware/govmomi/govc/vm/option"
 	_ "github.com/vmware/govmomi/govc/vm/rdm"
 	_ "github.com/vmware/govmomi/govc/vm/snapshot"
+	_ "github.com/vmware/govmomi/govc/vm/tpm2"
+	_ "github.com/vmware/govmomi/govc/vm/tpm2/cert"
 	_ "github.com/vmware/govmomi/govc/volume"
 	_ "github.com/vmware/govmomi/govc/volume/snapshot"
 	_ "github.com/vmware/govmomi/govc/vsan"

--- a/govc/vm/tpm2/cert/get.go
+++ b/govc/vm/tpm2/cert/get.go
@@ -1,0 +1,162 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cert
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type get struct {
+	*flags.VirtualMachineFlag
+	*flags.OutputFlag
+
+	fingerprint string
+}
+
+func init() {
+	cli.Register("vm.tpm2.cert.get", &get{})
+}
+
+func (cmd *get) Register(ctx context.Context, f *flag.FlagSet) {
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.fingerprint, "fingerprint", "",
+		`Fingerprint of cert to get. Use vm.tpm2.ls to see available certs."`)
+}
+
+func (cmd *get) Description() string {
+	return `Get certificate by fingerprint.
+
+Examples:
+  govc vm.tpm2.cert.get -vm VM -fingerprint 41:5D:F1:AE:B9:F2:B1:22:9F:79:B7:FF:DA:55:5B:86`
+}
+
+func (cmd *get) Process(ctx context.Context) error {
+
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *get) Run(ctx context.Context, f *flag.FlagSet) error {
+	if cmd.fingerprint == "" {
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	// Get the VM's EK.
+	var moVM mo.VirtualMachine
+	if err := vm.Properties(
+		ctx,
+		vm.Reference(),
+		[]string{"config.hardware.device"},
+		&moVM); err != nil {
+		return err
+	}
+
+	devices := object.VirtualDeviceList(moVM.Config.Hardware.Device)
+	selectedDevices := devices.SelectByType(&types.VirtualTPM{})
+	if len(selectedDevices) == 0 {
+		return fmt.Errorf("no VirtualTPM devices found")
+	}
+	if len(selectedDevices) > 1 {
+		return fmt.Errorf("multiple VirtualTPM devices found")
+	}
+
+	vtpmDev := selectedDevices[0].(*types.VirtualTPM)
+
+	var result getResult
+	for i := range vtpmDev.EndorsementKeyCertificate {
+		// Use DecodeString as Decode complains about trailing data.
+		derString := string(vtpmDev.EndorsementKeyCertificate[i])
+		derData, err := base64.StdEncoding.DecodeString(derString)
+		if err != nil {
+			return err
+		}
+		cert, err := x509.ParseCertificate(derData)
+		if err != nil {
+			return err
+		}
+
+		fingerprint := md5.Sum(cert.Raw)
+		var fingerprintBuf bytes.Buffer
+		for i, f := range fingerprint {
+			if i > 0 {
+				fmt.Fprintf(&fingerprintBuf, ":")
+			}
+			fmt.Fprintf(&fingerprintBuf, "%02X", f)
+		}
+
+		if cmd.fingerprint == fingerprintBuf.String() {
+			var pemBuf bytes.Buffer
+			block := &pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: cert.Raw,
+			}
+			if err := pem.Encode(&pemBuf, block); err != nil {
+				return err
+			}
+			result.PubCertPEM = pemBuf.Bytes()
+			break
+		}
+	}
+
+	if len(result.PubCertPEM) == 0 {
+		return fmt.Errorf("fingerprint %s not found", cmd.fingerprint)
+	}
+
+	return cmd.WriteResult(result)
+}
+
+type getResult struct {
+	PubCertPEM []byte `json:"pubCertPEM"`
+}
+
+func (r getResult) Write(w io.Writer) error {
+	_, err := fmt.Fprint(w, string(r.PubCertPEM))
+	return err
+}

--- a/govc/vm/tpm2/cert/ls.go
+++ b/govc/vm/tpm2/cert/ls.go
@@ -1,0 +1,183 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cert
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"crypto/x509"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ls struct {
+	*flags.VirtualMachineFlag
+	*flags.OutputFlag
+
+	alg string
+}
+
+func init() {
+	cli.Register("vm.tpm2.cert.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.alg, "G", "",
+		`Public key algorithm. Either "rsa", "ecc", or "ecdsa"`)
+}
+
+func (cmd *ls) Description() string {
+	return `List endorsement key certificates.
+
+Examples:
+  govc vm.tpm2.cert.ls -vm VM
+  govc vm.tpm2.cert.ls -vm VM -G ecc`
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	var alg x509.PublicKeyAlgorithm
+	switch strings.ToLower(cmd.alg) {
+	case "":
+		alg = x509.UnknownPublicKeyAlgorithm
+	case "rsa":
+		alg = x509.RSA
+	case "ecc", "ecdsa":
+		alg = x509.ECDSA
+	default:
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	// Get the VM's EK.
+	var moVM mo.VirtualMachine
+	if err := vm.Properties(
+		ctx,
+		vm.Reference(),
+		[]string{"config.hardware.device"},
+		&moVM); err != nil {
+		return err
+	}
+
+	devices := object.VirtualDeviceList(moVM.Config.Hardware.Device)
+	selectedDevices := devices.SelectByType(&types.VirtualTPM{})
+	if len(selectedDevices) == 0 {
+		return fmt.Errorf("no VirtualTPM devices found")
+	}
+	if len(selectedDevices) > 1 {
+		return fmt.Errorf("multiple VirtualTPM devices found")
+	}
+
+	vtpmDev := selectedDevices[0].(*types.VirtualTPM)
+
+	var result lsResult
+	for i := range vtpmDev.EndorsementKeyCertificate {
+		// Use DecodeString as Decode complains about trailing data.
+		derString := string(vtpmDev.EndorsementKeyCertificate[i])
+		derData, err := base64.StdEncoding.DecodeString(derString)
+		if err != nil {
+			return err
+		}
+		cert, err := x509.ParseCertificate(derData)
+		if err != nil {
+			return err
+		}
+
+		var skipCert bool
+		switch {
+		case alg == x509.RSA && cert.PublicKeyAlgorithm != x509.RSA:
+			skipCert = true
+		case alg == x509.ECDSA && cert.PublicKeyAlgorithm != x509.ECDSA:
+			skipCert = true
+		}
+		if skipCert {
+			continue
+		}
+
+		fingerprint := md5.Sum(cert.Raw)
+		var buf bytes.Buffer
+		for i, f := range fingerprint {
+			if i > 0 {
+				fmt.Fprintf(&buf, ":")
+			}
+			fmt.Fprintf(&buf, "%02X", f)
+		}
+
+		info := certInfo{Fingerprint: buf.String()}
+		switch cert.PublicKeyAlgorithm {
+		case x509.RSA:
+			info.Algorithm = "rsa"
+		case x509.ECDSA:
+			info.Algorithm = "ecc"
+		}
+		result = append(result, info)
+	}
+
+	return cmd.WriteResult(result)
+}
+
+type certInfo struct {
+	Algorithm   string `json:"algorithm"`
+	Fingerprint string `json:"fingerprint"`
+}
+
+type lsResult []certInfo
+
+func (r lsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "Algorithm\tFingerprint\n")
+	for i := range r {
+		fmt.Fprintf(tw, "%s\t%s\n", r[i].Algorithm, r[i].Fingerprint)
+	}
+	return tw.Flush()
+}

--- a/govc/vm/tpm2/seal.go
+++ b/govc/vm/tpm2/seal.go
@@ -1,0 +1,196 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpm2
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/google/go-tpm/tpm2"
+)
+
+type seal struct {
+	*flags.VirtualMachineFlag
+	*flags.OutputFlag
+
+	input string
+	alg   string
+}
+
+func init() {
+	cli.Register("vm.tpm2.seal", &seal{})
+}
+
+func (cmd *seal) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.input, "in", "-",
+		`Input data. Defaults to STDIN via "-"`)
+	f.StringVar(&cmd.alg, "G", "rsa",
+		`Public key algorithm. Either "rsa", "ecc", or "ecdsa"`)
+}
+
+func (cmd *seal) Description() string {
+	return `Seal plain-text data to the VM's TPM2 endorsement key.
+
+Examples:
+  govc vm.tpm2.seal -vm VM -in plain.txt
+  echo "Hello, world" | govc vm.tpm2.seal -vm VM
+  echo "Seal with ECC." | govc vm.tpm2.seal -vm VM -G ecc`
+}
+
+func (cmd *seal) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *seal) Run(ctx context.Context, f *flag.FlagSet) error {
+
+	var alg x509.PublicKeyAlgorithm
+	switch strings.ToLower(cmd.alg) {
+	case "rsa":
+		alg = x509.RSA
+	case "ecc", "ecdsa":
+		alg = x509.ECDSA
+	default:
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	// Read the plain-text data.
+	var plainTextFile *os.File
+	if cmd.input == "-" {
+		plainTextFile = os.Stdin
+	} else {
+		f, err := os.Open(cmd.input)
+		if err != nil {
+			return err
+		}
+		plainTextFile = f
+		defer f.Close()
+	}
+	plainTextData, err := io.ReadAll(plainTextFile)
+	if err != nil {
+		return err
+	}
+
+	// Get the VM's EK.
+	var moVM mo.VirtualMachine
+	if err := vm.Properties(
+		ctx,
+		vm.Reference(),
+		[]string{"config.hardware.device"},
+		&moVM); err != nil {
+		return err
+	}
+
+	devices := object.VirtualDeviceList(moVM.Config.Hardware.Device)
+	selectedDevices := devices.SelectByType(&types.VirtualTPM{})
+	if len(selectedDevices) == 0 {
+		return fmt.Errorf("no VirtualTPM devices found")
+	}
+	if len(selectedDevices) > 1 {
+		return fmt.Errorf("multiple VirtualTPM devices found")
+	}
+
+	vtpmDev := selectedDevices[0].(*types.VirtualTPM)
+
+	var ekCert *x509.Certificate
+	for i := range vtpmDev.EndorsementKeyCertificate {
+		// Use DecodeString as Decode complains about trailing data.
+		derString := string(vtpmDev.EndorsementKeyCertificate[i])
+		derData, err := base64.StdEncoding.DecodeString(derString)
+		if err != nil {
+			return err
+		}
+		cert, err := x509.ParseCertificate(derData)
+		if err != nil {
+			return err
+		}
+
+		if alg == x509.RSA && cert.PublicKeyAlgorithm == x509.RSA {
+			ekCert = cert
+		} else if alg == x509.ECDSA && cert.PublicKeyAlgorithm == x509.ECDSA {
+			ekCert = cert
+		}
+	}
+
+	if ekCert == nil {
+		return fmt.Errorf("unable to find ek certificate")
+	}
+
+	ek, err := tpm2.EKCertToTPMTPublic(*ekCert)
+	if err != nil {
+		return err
+	}
+
+	pub, priv, seed, err := tpm2.EKSeal(ek, plainTextData)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(sealResult{
+		Public:  base64.StdEncoding.EncodeToString(tpm2.Marshal(pub)),
+		Private: base64.StdEncoding.EncodeToString(tpm2.Marshal(priv)),
+		Seed:    base64.StdEncoding.EncodeToString(tpm2.Marshal(seed)),
+	})
+}
+
+type sealResult struct {
+	Public  string `json:"public"`
+	Private string `json:"private"`
+	Seed    string `json:"seed"`
+}
+
+func (r sealResult) Write(w io.Writer) error {
+	_, err := fmt.Fprintf(
+		w,
+		"%s@@NULL@@%s@@NULL@@%s",
+		r.Public,
+		r.Private,
+		r.Seed,
+	)
+	return err
+}


### PR DESCRIPTION
## Description

This patch introduces support for encrypting plain-text information for VMs with TPM2 devices without the system on which the command is run needing a TPM.

Please refer to https://github.com/google/go-tpm/pull/343 for more information.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Ran the command locally and tested it in conjunction with https://github.com/google/go-tpm/pull/343, ex.

1. From my local desktop, a macOS system with no TPM:

    ```shell
    $ echo "Hello, world" | govc vm.tpm2.seal -vm photon5-w-tpm     
    AE4ACAALAAAEAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAgLFQ7X8yj6G+bD0G6TihYVjTnLc29DEJKBE/LOIDWBXY=@@NULL@@AFkAIAnVMHKXQ45PqD6FkS6BcJx/BPaifUQ3adyOC9vKbzBWlcbEckvojXXsDH+xgY+IyIFVJKFHf/swIpxGa5Jxzp1a/Ltp58v1mLg9n8jyfIxRzBqFVM3NlQ==@@NULL@@AQA3Ega0AKIZM59bXGA26BQKt785XO3VhtmywvR1W4NDCYMpR+8BEk0zstEy0dROLpCd4ogKMN94JK7l0Rxs5dt4VP/A9Mz8cpityNyWkWYVd9vuB9vr7tE7QUKeRbYQ/h9rfg3LMDxDvvm2AcAT3Kkr8CEovJKtzrHz4Zf93UHiTNi5/AeQR7DOO68/X3VzwNHgniFzHwrHEXoVOD2BZmn0Viyu/G0hDKRXet2S5sfMMnsGpz0UsIJbd1Ydxttny/8G9bCRSpAq82evCSbO7TsVArTz2troJOfa3r2wqOJclhvb54NW3NpFqWs1OkDuD2V8lC5HEnzBEdaTAY//HS4T
    ```

2. From within the VM (using the program [`tpm2-ekunseal.sh`](https://github.com/akutz/go-tpm/blob/feature/enc-to-ek-sans-tpm/examples/tpm2-ekseal/tpm2-ekunseal.sh)):

    ```shell
    $ echo 'AE4ACAALAAAEAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAgLFQ7X8yj6G+bD0G6TihYVjTnLc29DEJKBE/LOIDWBXY=@@NULL@@AFkAIAnVMHKXQ45PqD6FkS6BcJx/BPaifUQ3adyOC9vKbzBWlcbEckvojXXsDH+xgY+IyIFVJKFHf/swIpxGa5Jxzp1a/Ltp58v1mLg9n8jyfIxRzBqFVM3NlQ==@@NULL@@AQA3Ega0AKIZM59bXGA26BQKt785XO3VhtmywvR1W4NDCYMpR+8BEk0zstEy0dROLpCd4ogKMN94JK7l0Rxs5dt4VP/A9Mz8cpityNyWkWYVd9vuB9vr7tE7QUKeRbYQ/h9rfg3LMDxDvvm2AcAT3Kkr8CEovJKtzrHz4Zf93UHiTNi5/AeQR7DOO68/X3VzwNHgniFzHwrHEXoVOD2BZmn0Viyu/G0hDKRXet2S5sfMMnsGpz0UsIJbd1Ydxttny/8G9bCRSpAq82evCSbO7TsVArTz2troJOfa3r2wqOJclhvb54NW3NpFqWs1OkDuD2V8lC5HEnzBEdaTAY//HS4T' | \
      tpm2-ekunseal.sh -0 2>/dev/null
    Hello, world.
    ```

There are also commands for listing and getting a VM's endorsement key certificates:

1. List the VM's EK certs:

    ```shell
    $ govc vm.tpm2.cert.ls -vm photon5-w-tpm                                                              
    Algorithm  Fingerprint
    rsa        41:5D:F1:AE:B9:F2:B1:22:9F:79:B7:FF:DA:55:5B:86
    ecc        28:54:DB:D8:40:6C:DA:5D:BA:66:87:96:AA:2E:55:1D
    ```

2. Or only list the certs of a particular type:

    ```shell
    $ govc vm.tpm2.cert.ls -vm photon5-w-tpm -G ecc
    Algorithm  Fingerprint
    ecc        28:54:DB:D8:40:6C:DA:5D:BA:66:87:96:AA:2E:55:1D
    ```

3. Once the fingerprint is known, it's also possible to get the certificate itself!

    ```shell
    $ govc vm.tpm2.cert.get -vm photon5-w-tpm -fingerprint 28:54:DB:D8:40:6C:DA:5D:BA:66:87:96:AA:2E:55:1D
    -----BEGIN CERTIFICATE-----
    MIIEbzCCAtegAwIBAgIJAPyDMhSaeSEEMA0GCSqGSIb3DQEBCwUAMIGoMQswCQYD
    VQQDDAJDQTEXMBUGCgmSJomT8ixkARkWB3ZzcGhlcmUxFTATBgoJkiaJk/IsZAEZ
    FgVsb2NhbDELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExKjAoBgNV
    BAoMIXNjMi0xMC0xODQtMTAzLTEyNi5lbmcudm13YXJlLmNvbTEbMBkGA1UECwwS
    Vk13YXJlIEVuZ2luZWVyaW5nMB4XDTIzMDgyOTIwMzg1NloXDTMzMDgxNzA4NDU0
    MVowSDEWMBQGBWeBBQIBDAtpZDo1NjRENTcwMDEWMBQGBWeBBQICDAtWTXdhcmUg
    VFBNMjEWMBQGBWeBBQIDDAtpZDowMDAyMDA2NTBZMBMGByqGSM49AgEGCCqGSM49
    AwEHA0IABD4/Q4n5Ju60174JndC/GOJmMwtK1jXbaGv8jJsJiC1ojL3bxR/agDSn
    zSejK/vMUtElZSXRyMi3oZ60sq6xOhyjggFEMIIBQDAOBgNVHQ8BAf8EBAMCAwgw
    WAYDVR0RAQH/BE4wTKRKMEgxFjAUBgVngQUCAQwLaWQ6NTY0RDU3MDAxFjAUBgVn
    gQUCAgwLVk13YXJlIFRQTTIxFjAUBgVngQUCAwwLaWQ6MDAwMjAwNjUwDAYDVR0T
    AQH/BAIwADAQBgNVHSUECTAHBgVngQUIATAhBgNVHQkEGjAYMBYGBWeBBQIQMQ0w
    CwwDMi4wAgEAAgF0MB0GA1UdDgQWBBSWtRzqfDcPeatHhgkhowb85EhyCDAfBgNV
    HSMEGDAWgBSmwq+iw85ovFyxi4MRmnn6yJbBizBRBggrBgEFBQcBAQRFMEMwQQYI
    KwYBBQUHMAKGNWh0dHBzOi8vc2MyLTEwLTE4NC0xMDMtMTI2LmVuZy52bXdhcmUu
    Y29tL2FmZC92ZWNzL2NhMA0GCSqGSIb3DQEBCwUAA4IBgQA5gMNkE+upkJFB6FBy
    aHbH2fraJ6tOgxMsbQvj2G1dqf7r8W9XJj2oHG+Q6wY42PKSDRVYNYBBkl739neP
    frS67zGbOOkmVp3CUzJjBaA7thFa6ZqS1h5NHokQ81gGFX7wzHrNIqokYIRlLaK3
    Be7XVHXJrEM6R+xi/s2ZmtR1I5JZLcKSZ5qFYvlKJoRX09pNyEE+DHNKm9MPU0ci
    cX10igdGhzeTTm7nvcblp8NLl9gEbcb+ej0E1doN9OYKz4vIcjfT5C5zwM0QnjSr
    QxTPbXMCVG78lB6UjsFS7hNp0qmU4EsS+qZyZIolArDRcjmyQK8X/JUukrPqVNze
    FOWVf13coOo5siUYBW5IfMoJ0BrLSyGrNuGgB5R0m/lxGeZQb5y/3YhlPn5af9FJ
    uutfgkJTREUMR/ue0PpOSPVAqccmpreFrBgU6iUsWYdBwjVU/59RUxdLRm8OfsnH
    ntuWJPjo3QV6kA7U4z53nPO6gULpn4sU9db5HnzRvUGePsQ=
    -----END CERTIFICATE-----
    ```

4. Which is handy when wanting to pipe the output to `openssl`:

    ```shell
    $ govc vm.tpm2.cert.get -vm photon5-w-tpm -fingerprint 28:54:DB:D8:40:6C:DA:5D:BA:66:87:96:AA:2E:55:1D | \
      openssl x509 -noout -text
    Certificate:
        Data:
            Version: 3 (0x2)
            Serial Number:
                fc:83:32:14:9a:79:21:04
            Signature Algorithm: sha256WithRSAEncryption
            Issuer: CN = CA, DC = vsphere, DC = local, C = US, ST = California, O = sc2-10-184-103-126.eng.vmware.com, OU = VMware Engineering
            Validity
                Not Before: Aug 29 20:38:56 2023 GMT
                Not After : Aug 17 08:45:41 2033 GMT
            Subject: 2.23.133.2.1 = id:564D5700, 2.23.133.2.2 = VMware TPM2, 2.23.133.2.3 = id:00020065
            Subject Public Key Info:
                Public Key Algorithm: id-ecPublicKey
                    Public-Key: (256 bit)
                    pub:
                        04:3e:3f:43:89:f9:26:ee:b4:d7:be:09:9d:d0:bf:
                        18:e2:66:33:0b:4a:d6:35:db:68:6b:fc:8c:9b:09:
                        88:2d:68:8c:bd:db:c5:1f:da:80:34:a7:cd:27:a3:
                        2b:fb:cc:52:d1:25:65:25:d1:c8:c8:b7:a1:9e:b4:
                        b2:ae:b1:3a:1c
                    ASN1 OID: prime256v1
                    NIST CURVE: P-256
            X509v3 extensions:
                X509v3 Key Usage: critical
                    Key Agreement
                X509v3 Subject Alternative Name: critical
                    DirName:/2.23.133.2.1=id:564D5700/2.23.133.2.2=VMware TPM2/2.23.133.2.3=id:00020065
                X509v3 Basic Constraints: critical
                    CA:FALSE
                X509v3 Extended Key Usage: 
                    2.23.133.8.1
                X509v3 Subject Directory Attributes: 
    0...2.0.....t   0.0...g....1
                X509v3 Subject Key Identifier: 
                    96:B5:1C:EA:7C:37:0F:79:AB:47:86:09:21:A3:06:FC:E4:48:72:08
                X509v3 Authority Key Identifier: 
                    A6:C2:AF:A2:C3:CE:68:BC:5C:B1:8B:83:11:9A:79:FA:C8:96:C1:8B
                Authority Information Access: 
                    CA Issuers - URI:https://sc2-10-184-103-126.eng.vmware.com/afd/vecs/ca
        Signature Algorithm: sha256WithRSAEncryption
        Signature Value:
            39:80:c3:64:13:eb:a9:90:91:41:e8:50:72:68:76:c7:d9:fa:
            da:27:ab:4e:83:13:2c:6d:0b:e3:d8:6d:5d:a9:fe:eb:f1:6f:
            57:26:3d:a8:1c:6f:90:eb:06:38:d8:f2:92:0d:15:58:35:80:
            41:92:5e:f7:f6:77:8f:7e:b4:ba:ef:31:9b:38:e9:26:56:9d:
            c2:53:32:63:05:a0:3b:b6:11:5a:e9:9a:92:d6:1e:4d:1e:89:
            10:f3:58:06:15:7e:f0:cc:7a:cd:22:aa:24:60:84:65:2d:a2:
            b7:05:ee:d7:54:75:c9:ac:43:3a:47:ec:62:fe:cd:99:9a:d4:
            75:23:92:59:2d:c2:92:67:9a:85:62:f9:4a:26:84:57:d3:da:
            4d:c8:41:3e:0c:73:4a:9b:d3:0f:53:47:22:71:7d:74:8a:07:
            46:87:37:93:4e:6e:e7:bd:c6:e5:a7:c3:4b:97:d8:04:6d:c6:
            fe:7a:3d:04:d5:da:0d:f4:e6:0a:cf:8b:c8:72:37:d3:e4:2e:
            73:c0:cd:10:9e:34:ab:43:14:cf:6d:73:02:54:6e:fc:94:1e:
            94:8e:c1:52:ee:13:69:d2:a9:94:e0:4b:12:fa:a6:72:64:8a:
            25:02:b0:d1:72:39:b2:40:af:17:fc:95:2e:92:b3:ea:54:dc:
            de:14:e5:95:7f:5d:dc:a0:ea:39:b2:25:18:05:6e:48:7c:ca:
            09:d0:1a:cb:4b:21:ab:36:e1:a0:07:94:74:9b:f9:71:19:e6:
            50:6f:9c:bf:dd:88:65:3e:7e:5a:7f:d1:49:ba:eb:5f:82:42:
            53:44:45:0c:47:fb:9e:d0:fa:4e:48:f5:40:a9:c7:26:a6:b7:
            85:ac:18:14:ea:25:2c:59:87:41:c2:35:54:ff:9f:51:53:17:
            4b:46:6f:0e:7e:c9:c7:9e:db:96:24:f8:e8:dd:05:7a:90:0e:
            d4:e3:3e:77:9c:f3:ba:81:42:e9:9f:8b:14:f5:d6:f9:1e:7c:
            d1:bd:41:9e:3e:c4
    ```

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged
  - [ ] https://github.com/google/go-tpm/pull/343

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
