### PR TITLE
govc: Command to print device/backings model as tree

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/xlab/treeprint v1.2.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d h1:4E8RufAN3UQ/weB6AnQ4y5miZCO0Yco8ZdGId41WuQs=
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dougm/pretty v0.0.0-20171025230240-2ee9d7453c02 h1:tR3jsKPiO/mb6ntzk/dJlHZtm37CPfVp1C9KIo534+4=
@@ -22,13 +23,18 @@ github.com/rasky/go-xdr v0.0.0-20170217172119-4930550ba2e2 h1:lbe6PJ3nOQAUvpx9P3
 github.com/rasky/go-xdr v0.0.0-20170217172119-4930550ba2e2/go.mod h1:Nfe4efndBz4TibWycNE+lqyJZiMX4ycx+QKV8Ta0f/o=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728 h1:sH9mEk+flyDxiUa5BuPiuhDETMbzrt9A20I2wktMvRQ=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
+github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
+github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -96,6 +96,7 @@ but appear via `govc $cmd -h`:
  - [device.floppy.insert](#devicefloppyinsert)
  - [device.info](#deviceinfo)
  - [device.ls](#devicels)
+ - [device.model.tree](#devicemodeltree)
  - [device.pci.add](#devicepciadd)
  - [device.pci.ls](#devicepcils)
  - [device.pci.remove](#devicepciremove)
@@ -1442,6 +1443,23 @@ Examples:
 Options:
   -boot=false            List devices configured in the VM's boot options
   -vm=                   Virtual machine [GOVC_VM]
+```
+
+## device.model.tree
+
+```
+Usage: govc device.model.tree [OPTIONS]
+
+Print the device model as a tree.
+
+Examples:
+  govc device.model.tree
+  govc device.model.tree VirtualEthernetCard
+  govc device.model.tree -backings
+  govc device.model.tree -backings VirtualDiskRawDiskVer2BackingInfo
+
+Options:
+  -backings=false  Print the devices backings
 ```
 
 ## device.pci.add

--- a/govc/device/model/tree.go
+++ b/govc/device/model/tree.go
@@ -1,0 +1,195 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"reflect"
+	"sort"
+	"unsafe"
+
+	"github.com/xlab/treeprint"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type tree struct {
+	backings bool
+}
+
+func init() {
+	cli.Register("device.model.tree", &tree{})
+}
+
+func (cmd *tree) Register(ctx context.Context, f *flag.FlagSet) {
+	f.BoolVar(&cmd.backings, "backings", false, "Print the devices backings")
+}
+
+func (cmd *tree) Description() string {
+	return `Print the device model as a tree.
+
+Examples:
+  govc device.model.tree
+  govc device.model.tree VirtualEthernetCard
+  govc device.model.tree -backings
+  govc device.model.tree -backings VirtualDiskRawDiskVer2BackingInfo`
+}
+
+func (cmd *tree) Process(ctx context.Context) error {
+	return nil
+}
+
+func (cmd *tree) Run(ctx context.Context, f *flag.FlagSet) error {
+
+	typeName := f.Arg(0)
+
+	var node treeprint.Tree
+	if cmd.backings {
+		node = getTree[
+			types.BaseVirtualDeviceBackingInfo,
+			types.VirtualDeviceBackingInfo,
+		]()
+	} else {
+		node = getTree[
+			types.BaseVirtualDevice,
+			types.VirtualDevice,
+		]()
+	}
+
+	if typeName != "" {
+		var found treeprint.Tree
+		node.VisitAll(func(n *treeprint.Node) {
+			if n.Value == typeName {
+				found = n
+			}
+		})
+		if found == nil {
+			return fmt.Errorf("%q not found", typeName)
+		}
+		node = found
+		node = node.Branch()
+	}
+
+	fmt.Print(node.String())
+
+	return nil
+}
+
+//go:linkname typelinks reflect.typelinks
+func typelinks() (sections []unsafe.Pointer, offset [][]int32)
+
+//go:linkname add reflect.add
+func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer
+
+// typeEmbeds returns true if a embeds any of the b's.
+func typeEmbeds(a reflect.Type, b ...reflect.Type) bool {
+	for i := range b {
+		if _, ok := a.FieldByName(b[i].Name()); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// typeEmbeddedBy returns true if a is embedded by any of the b's.
+func typeEmbeddedBy(a reflect.Type, b ...reflect.Type) bool {
+	for i := range b {
+		if _, ok := b[i].FieldByName(a.Name()); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func getTree[T, K any]() treeprint.Tree {
+	var (
+		rootObj       K
+		rootType      = reflect.TypeOf(rootObj)
+		allTypes      = []reflect.Type{}
+		embedsTypeMap = map[reflect.Type][]reflect.Type{}
+		rootIfaceType = reflect.TypeOf((*T)(nil)).Elem()
+	)
+
+	sections, offsets := typelinks()
+	for i := range sections {
+		base := sections[i]
+		for _, offset := range offsets[i] {
+			typeAddr := add(base, uintptr(offset), "")
+			typ3 := reflect.TypeOf(*(*any)(unsafe.Pointer(&typeAddr)))
+			if typ3.Implements(rootIfaceType) {
+				realType := reflect.Zero(typ3.Elem()).Type()
+				allTypes = append(allTypes, realType)
+				embedsTypeMap[realType] = []reflect.Type{}
+			}
+		}
+	}
+
+	// Create the child->parents map.
+	for i := range allTypes {
+		a := allTypes[i]
+		for b := range embedsTypeMap {
+			if typeEmbeds(a, b) {
+				embedsTypeMap[a] = append(embedsTypeMap[a], b)
+			}
+		}
+	}
+
+	// Each child should have a single parent.
+	for child, parents := range embedsTypeMap {
+		notAncestors := []reflect.Type{}
+		for i := range parents {
+			p := parents[i]
+			if !typeEmbeddedBy(p, parents...) {
+				notAncestors = append(notAncestors, p)
+			}
+		}
+		embedsTypeMap[child] = notAncestors
+	}
+
+	// Create the parent->children map.
+	typeMap := map[string][]string{}
+	for child, parents := range embedsTypeMap {
+		for i := range parents {
+			p := parents[i]
+			typeMap[p.Name()] = append(typeMap[p.Name()], child.Name())
+		}
+	}
+
+	// Sort the children for each parent by name.
+	for _, children := range typeMap {
+		sort.Strings(children)
+	}
+
+	var buildTree func(parent string, tree treeprint.Tree) treeprint.Tree
+	buildTree = func(parent string, tree treeprint.Tree) treeprint.Tree {
+		children := typeMap[parent]
+		for i := range children {
+			child := children[i]
+			if _, childIsParentToo := typeMap[child]; childIsParentToo {
+				buildTree(child, tree.AddBranch(child))
+			} else {
+				tree.AddNode(child)
+			}
+		}
+		return tree
+	}
+
+	return buildTree(rootType.Name(), treeprint.NewWithRoot(rootType.Name()))
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/device/cdrom"
 	_ "github.com/vmware/govmomi/govc/device/clock"
 	_ "github.com/vmware/govmomi/govc/device/floppy"
+	_ "github.com/vmware/govmomi/govc/device/model"
 	_ "github.com/vmware/govmomi/govc/device/pci"
 	_ "github.com/vmware/govmomi/govc/device/scsi"
 	_ "github.com/vmware/govmomi/govc/device/serial"


### PR DESCRIPTION
## Description

This patch introduces the `govc device.model.tree [-backings]` command for printing either the VirtualDevice or VirtualDeviceBackingInfo type hierarchy as a tree.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

1. Built `govc` with:

    ```shell
    make -C govc install
    ```

2. Ran `govc device.model.tree`:

    ```shell
    VirtualDevice
    ├── VirtualCdrom
    ├── VirtualController
    │   ├── VirtualIDEController
    │   ├── VirtualNVDIMMController
    │   ├── VirtualNVMEController
    │   ├── VirtualPCIController
    │   ├── VirtualPS2Controller
    │   ├── VirtualSATAController
    │   │   └── VirtualAHCIController
    │   ├── VirtualSCSIController
    │   │   ├── ParaVirtualSCSIController
    │   │   ├── VirtualBusLogicController
    │   │   ├── VirtualLsiLogicController
    │   │   └── VirtualLsiLogicSASController
    │   ├── VirtualSIOController
    │   ├── VirtualUSBController
    │   └── VirtualUSBXHCIController
    ├── VirtualDisk
    ├── VirtualEthernetCard
    │   ├── VirtualE1000
    │   ├── VirtualE1000e
    │   ├── VirtualPCNet32
    │   ├── VirtualSriovEthernetCard
    │   └── VirtualVmxnet
    │       ├── VirtualVmxnet2
    │       └── VirtualVmxnet3
    │           └── VirtualVmxnet3Vrdma
    ├── VirtualFloppy
    ├── VirtualKeyboard
    ├── VirtualMachineVMCIDevice
    ├── VirtualMachineVMIROM
    ├── VirtualMachineVideoCard
    ├── VirtualNVDIMM
    ├── VirtualPCIPassthrough
    ├── VirtualParallelPort
    ├── VirtualPointingDevice
    ├── VirtualPrecisionClock
    ├── VirtualSCSIPassthrough
    ├── VirtualSerialPort
    ├── VirtualSoundCard
    │   ├── VirtualEnsoniq1371
    │   ├── VirtualHdAudioCard
    │   └── VirtualSoundBlaster16
    ├── VirtualTPM
    ├── VirtualUSB
    └── VirtualWDT
    ```

3. Ran `govc device.model.tree -backings`:

    ```shell
    VirtualDeviceBackingInfo
    ├── VirtualDeviceDeviceBackingInfo
    │   ├── VirtualCdromAtapiBackingInfo
    │   ├── VirtualCdromPassthroughBackingInfo
    │   ├── VirtualDiskRawDiskVer2BackingInfo
    │   │   └── VirtualDiskPartitionedRawDiskVer2BackingInfo
    │   ├── VirtualEthernetCardLegacyNetworkBackingInfo
    │   ├── VirtualEthernetCardNetworkBackingInfo
    │   ├── VirtualFloppyDeviceBackingInfo
    │   ├── VirtualPCIPassthroughDeviceBackingInfo
    │   ├── VirtualPCIPassthroughDynamicBackingInfo
    │   ├── VirtualParallelPortDeviceBackingInfo
    │   ├── VirtualPointingDeviceDeviceBackingInfo
    │   ├── VirtualSCSIPassthroughDeviceBackingInfo
    │   ├── VirtualSerialPortDeviceBackingInfo
    │   ├── VirtualSoundCardDeviceBackingInfo
    │   ├── VirtualUSBRemoteHostBackingInfo
    │   └── VirtualUSBUSBBackingInfo
    ├── VirtualDeviceFileBackingInfo
    │   ├── VirtualCdromIsoBackingInfo
    │   ├── VirtualDiskFlatVer1BackingInfo
    │   ├── VirtualDiskFlatVer2BackingInfo
    │   ├── VirtualDiskLocalPMemBackingInfo
    │   ├── VirtualDiskRawDiskMappingVer1BackingInfo
    │   ├── VirtualDiskSeSparseBackingInfo
    │   ├── VirtualDiskSparseVer1BackingInfo
    │   ├── VirtualDiskSparseVer2BackingInfo
    │   ├── VirtualFloppyImageBackingInfo
    │   ├── VirtualNVDIMMBackingInfo
    │   ├── VirtualParallelPortFileBackingInfo
    │   └── VirtualSerialPortFileBackingInfo
    ├── VirtualDevicePipeBackingInfo
    │   └── VirtualSerialPortPipeBackingInfo
    ├── VirtualDeviceRemoteDeviceBackingInfo
    │   ├── VirtualCdromRemoteAtapiBackingInfo
    │   ├── VirtualCdromRemotePassthroughBackingInfo
    │   ├── VirtualFloppyRemoteDeviceBackingInfo
    │   └── VirtualUSBRemoteClientBackingInfo
    ├── VirtualDeviceURIBackingInfo
    │   └── VirtualSerialPortURIBackingInfo
    ├── VirtualEthernetCardDistributedVirtualPortBackingInfo
    ├── VirtualEthernetCardOpaqueNetworkBackingInfo
    ├── VirtualPCIPassthroughDvxBackingInfo
    ├── VirtualPCIPassthroughPluginBackingInfo
    │   └── VirtualPCIPassthroughVmiopBackingInfo
    ├── VirtualPrecisionClockSystemClockBackingInfo
    ├── VirtualSerialPortThinPrintBackingInfo
    └── VirtualSriovEthernetCardSriovBackingInfo
    ```

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
