### PR TITLE
fix: case insensitive govc import.ova PropertyMapping

### DIFF
--- a/govc/importx/options.go
+++ b/govc/importx/options.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,8 +29,39 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+type KeyValue struct {
+	Key   string
+	Value string
+}
+
+// case insensitive for Key + Value
+func (kv *KeyValue) UnmarshalJSON(b []byte) error {
+	e := struct {
+		types.KeyValue
+		Key   *string
+		Value *string
+	}{
+		types.KeyValue{}, &kv.Key, &kv.Value,
+	}
+
+	err := json.Unmarshal(b, &e)
+	if err != nil {
+		return err
+	}
+
+	if kv.Key == "" {
+		kv.Key = e.KeyValue.Key // "key"
+	}
+
+	if kv.Value == "" {
+		kv.Value = e.KeyValue.Value // "value"
+	}
+
+	return nil
+}
+
 type Property struct {
-	types.KeyValue
+	KeyValue
 	Spec *ovf.Property `json:",omitempty"`
 }
 

--- a/govc/importx/options_test.go
+++ b/govc/importx/options_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importx_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/vmware/govmomi/govc/importx"
+)
+
+func TestDecodeOptions(t *testing.T) {
+	spec := []byte(`{
+  "DiskProvisioning": "flat",
+  "IPAllocationPolicy": "dhcpPolicy",
+  "IPProtocol": "IPv4",
+  "PropertyMapping": [
+    {
+      "Key": "ntp_server",
+      "Value": "time.vmware.com"
+    },
+    {
+      "key": "enable_ssh",
+      "value": "True"
+    }
+  ],
+  "NetworkMapping": [
+    {
+      "Name": "VM Network",
+      "Network": ""
+    }
+  ],
+  "MarkAsTemplate": false,
+  "PowerOn": false,
+  "InjectOvfEnv": false,
+  "WaitForIP": false,
+  "Name": null
+}
+`)
+	var opts importx.Options
+	err := json.NewDecoder(bytes.NewReader(spec)).Decode(&opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// KeyValue are case insensitive
+	for i, p := range opts.PropertyMapping {
+		if p.Key == "" {
+			t.Errorf("empty PropertyMapping[%d].Key", i)
+		}
+		if p.Value == "" {
+			t.Errorf("empty PropertyMapping[%d].Value", i)
+		}
+	}
+}

--- a/govc/importx/ovf.go
+++ b/govc/importx/ovf.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -161,7 +161,10 @@ func (cmd *ovfx) Prepare(f *flag.FlagSet) (string, error) {
 
 func (cmd *ovfx) Map(op []Property) (p []types.KeyValue) {
 	for _, v := range op {
-		p = append(p, v.KeyValue)
+		p = append(p, types.KeyValue{
+			Key:   v.Key,
+			Value: v.Value,
+		})
 	}
 
 	return

--- a/govc/importx/spec.go
+++ b/govc/importx/spec.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015-2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -171,7 +171,7 @@ func (cmd *spec) Map(e *ovf.Envelope) (res []Property) {
 				k = fmt.Sprintf("%s.%s", k, *p.Instance)
 			}
 
-			np := Property{KeyValue: types.KeyValue{Key: k, Value: d}}
+			np := Property{KeyValue: KeyValue{Key: k, Value: d}}
 			if cmd.Verbose() {
 				np.Spec = &p.Property[i]
 			}


### PR DESCRIPTION
v0.31.0 changed the json case of generated types, which breaks existing PropertyMapping used in the -options input spec

Fixes #3245
