### PR TITLE
govc: camelCase json output

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -392,7 +392,7 @@ System information including the name, type, version, and build number.
 
 Examples:
   govc about
-  govc about -json | jq -r .About.productLineId
+  govc about -json | jq -r .about.productLineId
 
 Options:
   -c=false               Include client info
@@ -411,7 +411,7 @@ If the '-k' flag is provided, about.cert will return with exit code 0 in this ca
 The SHA1 thumbprint can also be used as '-thumbprint' for the 'host.add' and 'cluster.add' commands.
 
 Examples:
-  govc about.cert -k -json | jq -r .ThumbprintSHA1
+  govc about.cert -k -json | jq -r .thumbprintSHA1
   govc about.cert -k -show | sudo tee /usr/local/share/ca-certificates/host.crt
   govc about.cert -k -thumbprint | tee -a ~/.govmomi/known_hosts
 
@@ -853,7 +853,7 @@ Cluster resource usage summary.
 Examples:
   govc cluster.usage ClusterName
   govc cluster.usage -S ClusterName # summarize shared storage only
-  govc cluster.usage -json ClusterName | jq -r .CPU.Summary.Usage
+  govc cluster.usage -json ClusterName | jq -r .cpu.summary.usage
 
 Options:
   -S=false               Exclude host local storage
@@ -1425,9 +1425,9 @@ Device info for VM.
 Examples:
   govc device.info -vm $name
   govc device.info -vm $name disk-*
-  govc device.info -vm $name -json disk-* | jq -r .Devices[].backing.uuid
-  govc device.info -vm $name -json 'disk-*' | jq -r .Devices[].backing.fileName # vmdk path
-  govc device.info -vm $name -json ethernet-0 | jq -r .Devices[].macAddress
+  govc device.info -vm $name -json disk-* | jq -r .devices[].backing.uuid
+  govc device.info -vm $name -json 'disk-*' | jq -r .devices[].backing.fileName # vmdk path
+  govc device.info -vm $name -json ethernet-0 | jq -r .devices[].macAddress
 
 Options:
   -net=                  Network [GOVC_NETWORK]
@@ -1447,7 +1447,7 @@ List devices for VM.
 Examples:
   govc device.ls -vm $name
   govc device.ls -vm $name disk-*
-  govc device.ls -vm $name -json | jq '.Devices[].Name'
+  govc device.ls -vm $name -json | jq '.devices[].name'
 
 Options:
   -boot=false            List devices configured in the VM's boot options
@@ -4188,7 +4188,7 @@ Examples:
   govc object.collect -s vm/my-vm summary.runtime.host | xargs govc ls -L # inventory path of VM's host
   govc object.collect -dump -o "network/VM Network" # output Managed Object structure as Go code
   govc object.collect -json $vm config | \ # use -json + jq to search array elements
-    jq -r '.[] | select(.Val.Hardware.Device[].MacAddress == "00:0c:29:0c:73:c0") | .Val.Name'
+    jq -r '.[] | select(.val.hardware.device[].macAddress == "00:0c:29:0c:73:c0") | .val.name'
 
 Options:
   -O=false               Output the CreateFilter request itself
@@ -6183,7 +6183,7 @@ List IPs for VM.
 By default the vm.ip command depends on vmware-tools to report the 'guest.ipAddress' field and will
 wait until it has done so.  This value can also be obtained using:
 
-  govc vm.info -json $vm | jq -r .VirtualMachines[].guest.ipAddress
+  govc vm.info -json $vm | jq -r .virtualMachines[].guest.ipAddress
 
 When given the '-a' flag, only IP addresses for which there is a corresponding virtual nic are listed.
 If there are multiple nics, the listed addresses will be comma delimited.  The '-a' flag depends on
@@ -6193,7 +6193,7 @@ by tools for which there is no virtual nic are not included, for example that of
 
 These values can also be obtained using:
 
-  govc vm.info -json $vm | jq -r .VirtualMachines[].guest.net[].ipConfig.ipAddress[].ipAddress
+  govc vm.info -json $vm | jq -r .virtualMachines[].guest.net[].ipConfig.ipAddress[].ipAddress
 
 When given the '-n' flag, filters '-a' behavior to the nic specified by MAC address or device name.
 

--- a/govc/about/cert.go
+++ b/govc/about/cert.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -62,7 +62,7 @@ If the '-k' flag is provided, about.cert will return with exit code 0 in this ca
 The SHA1 thumbprint can also be used as '-thumbprint' for the 'host.add' and 'cluster.add' commands.
 
 Examples:
-  govc about.cert -k -json | jq -r .ThumbprintSHA1
+  govc about.cert -k -json | jq -r .thumbprintSHA1
   govc about.cert -k -show | sudo tee /usr/local/share/ca-certificates/host.crt
   govc about.cert -k -thumbprint | tee -a ~/.govmomi/known_hosts`
 }

--- a/govc/about/command.go
+++ b/govc/about/command.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -59,7 +59,7 @@ System information including the name, type, version, and build number.
 
 Examples:
   govc about
-  govc about -json | jq -r .About.productLineId`
+  govc about -json | jq -r .about.productLineId`
 }
 
 func (cmd *about) Process(ctx context.Context) error {
@@ -96,9 +96,9 @@ func (cmd *about) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	Content *types.ServiceContent `json:",omitempty"`
-	About   *types.AboutInfo      `json:",omitempty"`
-	Client  *soap.Client          `json:",omitempty"`
+	Content *types.ServiceContent `json:"content,omitempty"`
+	About   *types.AboutInfo      `json:"about,omitempty"`
+	Client  *soap.Client          `json:"client,omitempty"`
 	a       *types.AboutInfo
 }
 

--- a/govc/cluster/override/info.go
+++ b/govc/cluster/override/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -58,15 +58,15 @@ func (cmd *info) Process(ctx context.Context) error {
 
 type Override struct {
 	id            types.ManagedObjectReference
-	Name          string
-	Host          string                            `json:",omitempty"`
-	DRS           *types.ClusterDrsVmConfigInfo     `json:",omitempty"`
-	DAS           *types.ClusterDasVmConfigInfo     `json:",omitempty"`
-	Orchestration *types.ClusterVmOrchestrationInfo `json:",omitempty"`
+	Name          string                            `json:"name"`
+	Host          string                            `json:"host,omitempty"`
+	DRS           *types.ClusterDrsVmConfigInfo     `json:"drs,omitempty"`
+	DAS           *types.ClusterDasVmConfigInfo     `json:"das,omitempty"`
+	Orchestration *types.ClusterVmOrchestrationInfo `json:"orchestration,omitempty"`
 }
 
 type infoResult struct {
-	Overrides map[string]*Override
+	Overrides map[string]*Override `json:"overrides"`
 }
 
 func (r *infoResult) Write(w io.Writer) error {

--- a/govc/cluster/usage.go
+++ b/govc/cluster/usage.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+Copyright (c) 2020-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -57,7 +57,7 @@ func (cmd *usage) Description() string {
 Examples:
   govc cluster.usage ClusterName
   govc cluster.usage -S ClusterName # summarize shared storage only
-  govc cluster.usage -json ClusterName | jq -r .CPU.Summary.Usage`
+  govc cluster.usage -json ClusterName | jq -r .cpu.summary.usage`
 }
 
 func (cmd *usage) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -124,18 +124,18 @@ func (cmd *usage) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type ResourceUsageSummary struct {
-	Used     string
-	Free     string
-	Capacity string
-	Usage    string
+	Used     string `json:"used"`
+	Free     string `json:"free"`
+	Capacity string `json:"capacity"`
+	Usage    string `json:"usage"`
 }
 
 type ResourceUsage struct {
-	Used     int64
-	Free     int64
-	Capacity int64
-	Usage    float64
-	Summary  ResourceUsageSummary
+	Used     int64                `json:"used"`
+	Free     int64                `json:"free"`
+	Capacity int64                `json:"capacity"`
+	Usage    float64              `json:"usage"`
+	Summary  ResourceUsageSummary `json:"summary"`
 }
 
 func (r *ResourceUsage) summarize(f func(int64) string) {
@@ -163,9 +163,9 @@ func size(val int64) string {
 }
 
 type Usage struct {
-	Memory  ResourceUsage
-	CPU     ResourceUsage
-	Storage ResourceUsage
+	Memory  ResourceUsage `json:"memory"`
+	CPU     ResourceUsage `json:"cpu"`
+	Storage ResourceUsage `json:"storage"`
 }
 
 func (r *Usage) Write(w io.Writer) error {

--- a/govc/datacenter/info.go
+++ b/govc/datacenter/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -132,7 +132,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	Datacenters []mo.Datacenter
+	Datacenters []mo.Datacenter `json:"datacenters"`
 	objects     []*object.Datacenter
 	finder      *find.Finder
 	ctx         context.Context

--- a/govc/datastore/cluster/info.go
+++ b/govc/datastore/cluster/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -107,7 +107,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	Clusters []mo.StoragePod
+	Clusters []mo.StoragePod `json:"clusters"`
 	objects  []*object.StoragePod
 }
 

--- a/govc/datastore/info.go
+++ b/govc/datastore/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -180,7 +180,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	Datastores []mo.Datastore
+	Datastores []mo.Datastore `json:"datastores"`
 	objects    []*object.Datastore
 }
 

--- a/govc/device/info.go
+++ b/govc/device/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -76,9 +76,9 @@ func (cmd *info) Description() string {
 Examples:
   govc device.info -vm $name
   govc device.info -vm $name disk-*
-  govc device.info -vm $name -json disk-* | jq -r .Devices[].backing.uuid
-  govc device.info -vm $name -json 'disk-*' | jq -r .Devices[].backing.fileName # vmdk path
-  govc device.info -vm $name -json ethernet-0 | jq -r .Devices[].macAddress`
+  govc device.info -vm $name -json disk-* | jq -r .devices[].backing.uuid
+  govc device.info -vm $name -json 'disk-*' | jq -r .devices[].backing.fileName # vmdk path
+  govc device.info -vm $name -json ethernet-0 | jq -r .devices[].macAddress`
 }
 
 func match(p string, devices object.VirtualDeviceList) object.VirtualDeviceList {
@@ -166,8 +166,8 @@ func toInfoList(devices object.VirtualDeviceList) []infoDevice {
 }
 
 type infoDevice struct {
-	Name string
-	Type string
+	Name string `json:"name"`
+	Type string `json:"type"`
 	types.BaseVirtualDevice
 }
 
@@ -183,7 +183,7 @@ func (d *infoDevice) MarshalJSON() ([]byte, error) {
 }
 
 type infoResult struct {
-	Devices []infoDevice
+	Devices []infoDevice `json:"devices"`
 	// need the full list of devices to lookup attached devices and controllers
 	list object.VirtualDeviceList
 }

--- a/govc/device/ls.go
+++ b/govc/device/ls.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -58,7 +58,7 @@ func (cmd *ls) Description() string {
 Examples:
   govc device.ls -vm $name
   govc device.ls -vm $name disk-*
-  govc device.ls -vm $name -json | jq '.Devices[].Name'`
+  govc device.ls -vm $name -json | jq '.devices[].name'`
 }
 
 func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -102,9 +102,9 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type lsDevice struct {
-	Name    string
-	Type    string
-	Summary string
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Summary string `json:"summary"`
 }
 
 func toLsList(devices object.VirtualDeviceList) []lsDevice {
@@ -122,7 +122,7 @@ func toLsList(devices object.VirtualDeviceList) []lsDevice {
 }
 
 type lsResult struct {
-	Devices []lsDevice
+	Devices []lsDevice `json:"devices"`
 	list    object.VirtualDeviceList
 }
 

--- a/govc/device/pci/ls.go
+++ b/govc/device/pci/ls.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2020 VMware, Inc. All Rights Reserved.
+Copyright (c) 2020-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -80,7 +80,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	PciDevices []types.BaseVirtualMachinePciPassthroughInfo
+	PciDevices []types.BaseVirtualMachinePciPassthroughInfo `json:"pciDevices"`
 }
 
 func (r *infoResult) Write(w io.Writer) error {

--- a/govc/disk/ls.go
+++ b/govc/disk/ls.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -75,7 +75,7 @@ Examples:
 
 type VStorageObject struct {
 	types.VStorageObject
-	Tags []types.VslmTagEntry
+	Tags []types.VslmTagEntry `json:"tags"`
 }
 
 func (o *VStorageObject) tags() string {
@@ -88,7 +88,7 @@ func (o *VStorageObject) tags() string {
 
 type lsResult struct {
 	cmd     *ls
-	Objects []VStorageObject
+	Objects []VStorageObject `json:"objects"`
 }
 
 func (r *lsResult) Write(w io.Writer) error {

--- a/govc/disk/snapshot/ls.go
+++ b/govc/disk/snapshot/ls.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -59,7 +59,7 @@ Examples:
 }
 
 type lsResult struct {
-	Info *types.VStorageObjectSnapshotInfo
+	Info *types.VStorageObjectSnapshotInfo `json:"info"`
 	cmd  *ls
 }
 

--- a/govc/dvs/portgroup/info.go
+++ b/govc/dvs/portgroup/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2015-2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -96,7 +96,7 @@ Examples:
 }
 
 type infoResult struct {
-	Port []types.DistributedVirtualPort
+	Port []types.DistributedVirtualPort `json:"port"`
 	cmd  *info
 }
 

--- a/govc/events/command.go
+++ b/govc/events/command.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -133,12 +133,12 @@ func (cmd *events) printEvents(ctx context.Context, obj *types.ManagedObjectRefe
 }
 
 type record struct {
-	Object      string `json:",omitempty"`
-	Type        string `json:",omitempty"`
-	CreatedTime time.Time
-	Category    string
-	Message     string
-	Key         int32 `json:",omitempty"`
+	Object      string    `json:"object,omitempty"`
+	Type        string    `json:"type,omitempty"`
+	CreatedTime time.Time `json:"createdTime"`
+	Category    string    `json:"category"`
+	Message     string    `json:"message"`
+	Key         int32     `json:"key,omitempty"`
 
 	event types.BaseEvent
 }

--- a/govc/extension/info.go
+++ b/govc/extension/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -100,7 +100,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	Extensions []types.Extension
+	Extensions []types.Extension `json:"extensions"`
 }
 
 func (r *infoResult) Write(w io.Writer) error {

--- a/govc/fields/info.go
+++ b/govc/fields/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -64,15 +64,15 @@ Examples:
 }
 
 type Info struct {
-	Object types.ManagedObjectReference
-	Path   string
-	Name   string
-	Key    string
-	Value  string
+	Object types.ManagedObjectReference `json:"object"`
+	Path   string                       `json:"path"`
+	Name   string                       `json:"name"`
+	Key    string                       `json:"key"`
+	Value  string                       `json:"value"`
 }
 
 type infoResult struct {
-	Info []Info
+	Info []Info `json:"info"`
 }
 
 func (r *infoResult) Write(w io.Writer) error {

--- a/govc/folder/info.go
+++ b/govc/folder/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -122,7 +122,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	Folders []mo.Folder
+	Folders []mo.Folder `json:"folders"`
 	objects []*object.Folder
 }
 

--- a/govc/host/date/info.go
+++ b/govc/host/date/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -65,8 +65,8 @@ func (cmd *info) Process(ctx context.Context) error {
 
 type dateInfo struct {
 	types.HostDateTimeInfo
-	Service *types.HostService
-	Current *time.Time
+	Service *types.HostService `json:"service"`
+	Current *time.Time         `json:"current"`
 }
 
 func (info *dateInfo) servers() string {

--- a/govc/host/esxcli/command.go
+++ b/govc/host/esxcli/command.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,33 +31,33 @@ type Command struct {
 }
 
 type CommandInfoItem struct {
-	Name        string `xml:"name"`
-	DisplayName string `xml:"displayName"`
-	Help        string `xml:"help"`
+	Name        string `xml:"name" json:"name"`
+	DisplayName string `xml:"displayName" json:"displayName"`
+	Help        string `xml:"help" json:"help"`
 }
 
 type CommandInfoParam struct {
 	CommandInfoItem
-	Aliases []string `xml:"aliases"`
-	Flag    bool     `xml:"flag"`
+	Aliases []string `xml:"aliases" json:"aliases"`
+	Flag    bool     `xml:"flag" json:"flag"`
 }
 
 type CommandInfoHint struct {
-	Key   string `xml:"key"`
-	Value string `xml:"value"`
+	Key   string `xml:"key" json:"key"`
+	Value string `xml:"value" json:"value"`
 }
 
 type CommandInfoHints []CommandInfoHint
 
 type CommandInfoMethod struct {
 	CommandInfoItem
-	Param []CommandInfoParam `xml:"param"`
-	Hints CommandInfoHints   `xml:"hints"`
+	Param []CommandInfoParam `xml:"param" json:"param"`
+	Hints CommandInfoHints   `xml:"hints" json:"hints"`
 }
 
 type CommandInfo struct {
 	CommandInfoItem
-	Method []*CommandInfoMethod `xml:"method"`
+	Method []*CommandInfoMethod `xml:"method" json:"method"`
 }
 
 func NewCommand(args []string) *Command {

--- a/govc/host/esxcli/executor.go
+++ b/govc/host/esxcli/executor.go
@@ -27,8 +27,8 @@ import (
 )
 
 type Fault struct {
-	Message string
-	Detail  string
+	Message string `json:"message"`
+	Detail  string `json:"detail"`
 }
 
 func (f Fault) Error() string {

--- a/govc/host/esxcli/firewall_info.go
+++ b/govc/host/esxcli/firewall_info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,9 +19,9 @@ package esxcli
 import "github.com/vmware/govmomi/object"
 
 type FirewallInfo struct {
-	Loaded        bool
-	Enabled       bool
-	DefaultAction string
+	Loaded        bool   `json:"loaded"`
+	Enabled       bool   `json:"enabled"`
+	DefaultAction string `json:"defaultAction"`
 }
 
 // GetFirewallInfo via 'esxcli network firewall get'

--- a/govc/host/esxcli/response.go
+++ b/govc/host/esxcli/response.go
@@ -24,9 +24,9 @@ import (
 type Values map[string][]string
 
 type Response struct {
-	Info   *CommandInfoMethod
-	Values []Values
-	String string
+	Info   *CommandInfoMethod `json:"info"`
+	Values []Values           `json:"values"`
+	String string             `json:"string"`
 }
 
 func (v Values) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {

--- a/govc/host/info.go
+++ b/govc/host/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -120,7 +120,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	HostSystems []mo.HostSystem
+	HostSystems []mo.HostSystem `json:"hostSystems"`
 	objects     []*object.HostSystem
 }
 

--- a/govc/host/portgroup/info.go
+++ b/govc/host/portgroup/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -97,7 +97,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	Portgroup []types.HostPortGroup
+	Portgroup []types.HostPortGroup `json:"portgroup"`
 }
 
 func (r *infoResult) Write(w io.Writer) error {

--- a/govc/host/vnic/hint.go
+++ b/govc/host/vnic/hint.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2022-2022 VMware, Inc. All Rights Reserved.
+Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -52,7 +52,7 @@ Examples:
 }
 
 type hintResult struct {
-	Hint []types.PhysicalNicHintInfo
+	Hint []types.PhysicalNicHintInfo `json:"hint"`
 }
 
 func (i *hintResult) Write(w io.Writer) error {

--- a/govc/host/vnic/info.go
+++ b/govc/host/vnic/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2015-2019 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -53,16 +53,16 @@ func (cmd *info) Process(ctx context.Context) error {
 }
 
 type Info struct {
-	Device   string
-	Network  string
-	Switch   string
-	Address  string
-	Stack    string
-	Services []string
+	Device   string   `json:"device"`
+	Network  string   `json:"network"`
+	Switch   string   `json:"switch"`
+	Address  string   `json:"address"`
+	Stack    string   `json:"stack"`
+	Services []string `json:"services"`
 }
 
 type infoResult struct {
-	Info []Info
+	Info []Info `json:"info"`
 }
 
 func (i *infoResult) Write(w io.Writer) error {

--- a/govc/host/vswitch/info.go
+++ b/govc/host/vswitch/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -88,7 +88,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	Vswitch []types.HostVirtualSwitch
+	Vswitch []types.HostVirtualSwitch `json:"vswitch"`
 }
 
 func (r *infoResult) Write(w io.Writer) error {

--- a/govc/library/info.go
+++ b/govc/library/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2018-2022 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -93,7 +93,7 @@ Examples:
 }
 
 type infoResultsWriter struct {
-	Result []finder.FindResult
+	Result []finder.FindResult `json:"result"`
 	m      *library.Manager
 	cmd    *info
 }

--- a/govc/library/session/ls.go
+++ b/govc/library/session/ls.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -60,7 +60,7 @@ Examples:
 }
 
 type info struct {
-	Sessions []*library.Session
+	Sessions []*library.Session `json:"sessions"`
 	kind     string
 }
 

--- a/govc/library/vmtx_item_info.go
+++ b/govc/library/vmtx_item_info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+Copyright (c) 2021-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ type vmtxItemInfo struct {
 }
 
 type vmtxItemInfoResultsWriter struct {
-	Result *vcenter.TemplateInfo
+	Result *vcenter.TemplateInfo `json:"result"`
 	m      *vcenter.Manager
 	cmd    *vmtxItemInfo
 }

--- a/govc/metric/info.go
+++ b/govc/metric/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -73,20 +73,20 @@ func (cmd *info) Process(ctx context.Context) error {
 }
 
 type EntityDetail struct {
-	Realtime   bool
-	Historical bool
-	Instance   []string
+	Realtime   bool     `json:"realtime"`
+	Historical bool     `json:"historical"`
+	Instance   []string `json:"instance"`
 }
 
 type MetricInfo struct {
-	Counter          *types.PerfCounterInfo
-	Enabled          []string
-	PerDeviceEnabled []string
-	Detail           *EntityDetail
+	Counter          *types.PerfCounterInfo `json:"counter"`
+	Enabled          []string               `json:"enabled"`
+	PerDeviceEnabled []string               `json:"perDeviceEnabled"`
+	Detail           *EntityDetail          `json:"detail"`
 }
 
 type infoResult struct {
-	Info []*MetricInfo
+	Info []*MetricInfo `json:"info"`
 	cmd  *info
 }
 

--- a/govc/metric/sample.go
+++ b/govc/metric/sample.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -97,7 +97,7 @@ type sampleResult struct {
 	cmd      *sample
 	m        *performance.Manager
 	counters map[string]*types.PerfCounterInfo
-	Sample   []performance.EntityMetric
+	Sample   []performance.EntityMetric `json:"sample"`
 }
 
 func (r *sampleResult) name(e types.ManagedObjectReference) string {

--- a/govc/namespace/cluster/ls.go
+++ b/govc/namespace/cluster/ls.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+Copyright (c) 2020-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -70,7 +70,7 @@ Examples:
 
 type lsWriter struct {
 	cmd     *ls
-	Cluster []namespace.ClusterSummary
+	Cluster []namespace.ClusterSummary `json:"cluster"`
 }
 
 func (r *lsWriter) Write(w io.Writer) error {

--- a/govc/namespace/service/info.go
+++ b/govc/namespace/service/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+Copyright (c) 2021-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -64,7 +64,7 @@ Examples:
 
 type infoWriter struct {
 	cmd     *info
-	Service namespace.SupervisorServiceInfo
+	Service namespace.SupervisorServiceInfo `json:"service"`
 }
 
 func (r *infoWriter) Write(w io.Writer) error {

--- a/govc/namespace/service/ls.go
+++ b/govc/namespace/service/ls.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+Copyright (c) 2021-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -68,7 +68,7 @@ Examples:
 
 type lsWriter struct {
 	cmd     *ls
-	Service []namespace.SupervisorServiceSummary
+	Service []namespace.SupervisorServiceSummary `json:"service"`
 }
 
 func (r *lsWriter) Write(w io.Writer) error {

--- a/govc/object/collect.go
+++ b/govc/object/collect.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2016-2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -112,7 +112,7 @@ Examples:
   govc object.collect -s vm/my-vm summary.runtime.host | xargs govc ls -L # inventory path of VM's host
   govc object.collect -dump -o "network/VM Network" # output Managed Object structure as Go code
   govc object.collect -json $vm config | \ # use -json + jq to search array elements
-    jq -r '.[] | select(.Val.Hardware.Device[].MacAddress == "00:0c:29:0c:73:c0") | .Val.Name'`, atable)
+    jq -r '.[] | select(.val.hardware.device[].macAddress == "00:0c:29:0c:73:c0") | .val.name'`, atable)
 }
 
 var stringer = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()

--- a/govc/pool/info.go
+++ b/govc/pool/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -164,7 +164,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	ResourcePools []mo.ResourcePool
+	ResourcePools []mo.ResourcePool `json:"resourcePools"`
 	objects       []*object.ResourcePool
 }
 

--- a/govc/storage/policy/info.go
+++ b/govc/storage/policy/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+Copyright (c) 2020-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -80,13 +80,13 @@ Examples:
 }
 
 type Policy struct {
-	Profile              types.BasePbmProfile
-	CompliantVM          []string
-	CompatibleDatastores []string
+	Profile              types.BasePbmProfile `json:"profile"`
+	CompliantVM          []string             `json:"compliantVM"`
+	CompatibleDatastores []string             `json:"compatibleDatastores"`
 }
 
 type infoResult struct {
-	Policies []Policy
+	Policies []Policy `json:"policies"`
 	cmd      *info
 }
 

--- a/govc/storage/policy/ls.go
+++ b/govc/storage/policy/ls.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+Copyright (c) 2020-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -104,7 +104,7 @@ func ListProfiles(ctx context.Context, c *pbm.Client, name string) ([]types.Base
 }
 
 type lsResult struct {
-	Profile []types.BasePbmProfile
+	Profile []types.BasePbmProfile `json:"profile"`
 	cmd     *ls
 }
 

--- a/govc/task/recent.go
+++ b/govc/task/recent.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -176,7 +176,7 @@ func (cmd *recent) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type taskResult struct {
-	Tasks []types.TaskInfo
+	Tasks []types.TaskInfo `json:"tasks"`
 	last  string
 	name  func(info *types.TaskInfo) string
 }

--- a/govc/test/cli.bats
+++ b/govc/test/cli.bats
@@ -28,13 +28,13 @@ load test_helper
   run govc about -dump -l
   assert_success
 
-  version=$(govc about -json -c | jq -r .Client.Version)
+  version=$(govc about -json -c | jq -r .client.version)
   assert_equal 8.0.2.0 "$version" # govc's default version
 
-  version=$(govc about -json -c -vim-version "" | jq -r .Client.Version)
+  version=$(govc about -json -c -vim-version "" | jq -r .client.version)
   assert_equal uE53DA "$version" # vcsim's service version
 
-  version=$(govc about -json -c -vim-version 6.8.2 | jq -r .Client.Version)
+  version=$(govc about -json -c -vim-version 6.8.2 | jq -r .client.version)
   assert_equal 6.8.2 "$version" # client specified version
 
   run govc about -trace

--- a/govc/test/cluster.bats
+++ b/govc/test/cluster.bats
@@ -197,7 +197,7 @@ _EOF_
   assert_failure # no changes specified
 
   # DRS override
-  query=".Overrides[] | select(.Name == \"DC0_C0_RP0_VM0\") | .DRS.enabled"
+  query=".overrides[] | select(.name == \"DC0_C0_RP0_VM0\") | .drs.enabled"
 
   run govc cluster.override.change -vm DC0_C0_RP0_VM0 -drs-enabled=false
   assert_success
@@ -211,7 +211,7 @@ _EOF_
   assert_success
 
   # DAS override
-  query=".Overrides[] | select(.Name == \"DC0_C0_RP0_VM0\") | .DAS.dasSettings.restartPriority"
+  query=".overrides[] | select(.name == \"DC0_C0_RP0_VM0\") | .das.dasSettings.restartPriority"
 
   [ "$(govc cluster.override.info -json | jq -r "$query")" != "high" ]
 
@@ -220,13 +220,13 @@ _EOF_
   [ "$(govc cluster.override.info -json | jq -r "$query")" == "high" ]
 
   # Orchestration override
-  query=".Overrides[] | select(.Name == \"DC0_C0_RP0_VM0\") | .Orchestration.vmReadiness.postReadyDelay"
+  query=".overrides[] | select(.name == \"DC0_C0_RP0_VM0\") | .orchestration.vmReadiness.postReadyDelay"
 
   run govc cluster.override.change -vm DC0_C0_RP0_VM0 -ha-additional-delay 60
   assert_success
   [ "$(govc cluster.override.info -json | jq -r "$query")" == "60" ]
 
-  query=".Overrides[] | select(.Name == \"DC0_C0_RP0_VM0\") | .Orchestration.vmReadiness.readyCondition"
+  query=".overrides[] | select(.name == \"DC0_C0_RP0_VM0\") | .orchestration.vmReadiness.readyCondition"
 
   run govc cluster.override.change -vm DC0_C0_RP0_VM0 -ha-ready-condition poweredOn
   assert_success
@@ -252,8 +252,8 @@ _EOF_
     ip=$(govc object.collect -o -json host/DC0_C0/10.0.0.42 | jq -r .config.network.vnic[].spec.ip.ipAddress)
 
     assert_equal 10.0.0.42 "$ip"
-    govc host.info -json '*' | jq -r .HostSystems[].config.network.vnic[].spec.ip
-    name=$(govc host.info -json -host.ip 10.0.0.42 | jq -r .HostSystems[].name)
+    govc host.info -json '*' | jq -r .hostSystems[].config.network.vnic[].spec.ip
+    name=$(govc host.info -json -host.ip 10.0.0.42 | jq -r .hostSystems[].name)
     assert_equal 10.0.0.42 "$name"
 }
 
@@ -266,7 +266,7 @@ _EOF_
   run govc cluster.usage DC0_C0
   assert_success
 
-  memory=$(govc cluster.usage -json DC0_C0 | jq -r .Memory.Summary.Usage)
+  memory=$(govc cluster.usage -json DC0_C0 | jq -r .memory.summary.usage)
   [ "$memory" = "34.3" ]
 }
 

--- a/govc/test/datastore.bats
+++ b/govc/test/datastore.bats
@@ -38,7 +38,7 @@ upload_file() {
 }
 
 @test "datastore.ls-R" {
-  esx_env
+  vcsim_env -esx
 
   dir=$(new_id)
 
@@ -57,26 +57,26 @@ upload_file() {
 
   # without -R
   json=$(govc datastore.ls -json -l -p "$dir")
-  result=$(jq -r .[].File[].Path <<<"$json" | wc -l)
+  result=$(jq -r .[].file[].path <<<"$json" | wc -l)
   [ "$result" -eq 6 ]
 
-  result=$(jq -r .[].FolderPath <<<"$json" | wc -l)
+  result=$(jq -r .[].folderPath <<<"$json" | wc -l)
   [ "$result" -eq 1 ]
 
   # with -R
   json=$(govc datastore.ls -json -l -p -R "$dir")
-  result=$(jq -r .[].File[].Path <<<"$json" | wc -l)
+  result=$(jq -r .[].file[].path <<<"$json" | wc -l)
   [ "$result" -eq 15 ]
 
-  result=$(jq -r .[].FolderPath <<<"$json" | wc -l)
+  result=$(jq -r .[].folderPath <<<"$json" | wc -l)
   [ "$result" -eq 7 ]
 
   # with -R -a
   json=$(govc datastore.ls -json -l -p -R -a "$dir")
-  result=$(jq -r .[].File[].Path <<<"$json" | wc -l)
+  result=$(jq -r .[].file[].path <<<"$json" | wc -l)
   [ "$result" -eq 21 ]
 
-  result=$(jq -r .[].FolderPath <<<"$json" | wc -l)
+  result=$(jq -r .[].folderPath <<<"$json" | wc -l)
   [ "$result" -eq 10 ]
 }
 
@@ -378,13 +378,13 @@ upload_file() {
   run govc datastore.disk.create -size 10MB "$vmdk"
   assert_success
 
-  type=$(govc datastore.disk.info -json "$vmdk" | jq -r .[].DiskType)
+  type=$(govc datastore.disk.info -json "$vmdk" | jq -r .[].diskType)
   [ "$type" = "thin" ]
 
   run govc datastore.disk.inflate "$vmdk"
   assert_success
 
-  type=$(govc datastore.disk.info -json "$vmdk" | jq -r .[].DiskType)
+  type=$(govc datastore.disk.info -json "$vmdk" | jq -r .[].diskType)
   [ "$type" = "eagerZeroedThick" ]
 
   run govc datastore.disk.shrink "$vmdk"

--- a/govc/test/disk.bats
+++ b/govc/test/disk.bats
@@ -190,7 +190,7 @@ load test_helper
   run govc disk.ls
   assert_success
 
-  path=$(govc disk.ls -json "$id" | jq -r .Objects[].config.backing.filePath)
+  path=$(govc disk.ls -json "$id" | jq -r .objects[].config.backing.filePath)
   run govc datastore.rm "$path"
   assert_success
 

--- a/govc/test/events.bats
+++ b/govc/test/events.bats
@@ -17,11 +17,11 @@ load test_helper
   [ ${#lines[@]} -le $nevents ]
 
   # test keys in json
-  [ "$(govc events -l -n 1 -json | jq -r 'has("CreatedTime")')" = "true" ]
-  [ "$(govc events -l -n 1 -json | jq -r 'has("Category")')" = "true" ]
-  [ "$(govc events -l -n 1 -json | jq -r 'has("Message")')" = "true" ]
-  [ "$(govc events -l -n 1 -json | jq -r 'has("Type")')" = "true" ]
-  [ "$(govc events -l -n 1 -json | jq -r 'has("Key")')" = "true" ]
+  [ "$(govc events -l -n 1 -json | jq -r 'has("createdTime")')" = "true" ]
+  [ "$(govc events -l -n 1 -json | jq -r 'has("category")')" = "true" ]
+  [ "$(govc events -l -n 1 -json | jq -r 'has("message")')" = "true" ]
+  [ "$(govc events -l -n 1 -json | jq -r 'has("type")')" = "true" ]
+  [ "$(govc events -l -n 1 -json | jq -r 'has("key")')" = "true" ]
 }
 
 @test "events host" {
@@ -33,7 +33,7 @@ load test_helper
 }
 
 @test "events vm" {
-  esx_env
+  vcsim_env
 
   vm=$(new_id)
 
@@ -58,7 +58,7 @@ load test_helper
   [ ${#lines[@]} -gt $nevents ]
   nevents=${#lines[@]}
 
-  run govc events vm
+  run govc events vm/*
   assert_success
   [ ${#lines[@]} -ge $nevents ]
 
@@ -79,7 +79,7 @@ load test_helper
 }
 
 @test "events json" {
-  esx_env
+  vcsim_env
 
   # make sure we fmt.Printf properly
   govc events | grep -v '%!s(MISSING)'

--- a/govc/test/extension.bats
+++ b/govc/test/extension.bats
@@ -34,17 +34,17 @@ EOS
   assert_line "Name: $id"
 
   json=$(govc extension.info -json $id)
-  label=$(jq -r .Extensions[].Description.Label <<<"$json")
+  label=$(jq -r .extensions[].description.label <<<"$json")
   assert_equal "govc" "$label"
 
   # change label and update extension
-  json=$(jq -r '.Extensions[] | .Description.Label = "novc"' <<<"$json")
+  json=$(jq -r '.extensions[] | .description.label = "novc"' <<<"$json")
   run govc extension.register -update $id <<<"$json"
   assert_success
 
   # check label changed in info output
   json=$(govc extension.info -json $id)
-  label=$(jq -r .Extensions[].Description.Label <<<"$json")
+  label=$(jq -r .extensions[].description.label <<<"$json")
   assert_equal "novc" "$label"
 
   # set extension certificate to generated certificate

--- a/govc/test/fields.bats
+++ b/govc/test/fields.bats
@@ -38,7 +38,7 @@ load test_helper
   run govc fields.info -n $val vm/$vm_id
   assert_success
 
-  info=$(govc vm.info -json $vm_id | jq .VirtualMachines[0].customValue[0])
+  info=$(govc vm.info -json $vm_id | jq .virtualMachines[0].customValue[0])
 
   ikey=$(jq -r .key <<<"$info")
   assert_equal $key $ikey

--- a/govc/test/guest_operations_test.sh
+++ b/govc/test/guest_operations_test.sh
@@ -60,7 +60,7 @@ EOF
   govc guest.ls "$script" | grep 65534
   govc guest.chmod 0755 "$script"
   pid=$(govc guest.start "$script" '>&' /tmp/disk.log)
-  status=$(govc guest.ps -p "$pid" -json -X | jq .ProcessInfo[].ExitCode)
+  status=$(govc guest.ps -p "$pid" -json -X | jq .processInfo[].exitCode)
   govc guest.download /tmp/disk.log -
   if [ "$status" -ne "0" ] ; then
     exit 1
@@ -77,7 +77,7 @@ EOF
   govc guest.download /etc/motd - | grep -v Chop
 
   pid=$(govc guest.start /bin/sync)
-  status=$(govc guest.ps -p "$pid" -json -X | jq .ProcessInfo[].ExitCode)
+  status=$(govc guest.ps -p "$pid" -json -X | jq .processInfo[].exitCode)
   if [ "$status" -ne "0" ] ; then
     exit 1
   fi
@@ -91,7 +91,7 @@ EOF
   echo "Verifying data persistence..."
   govc guest.download /etc/motd - | grep $grepf Chop
   pid=$(govc guest.start /bin/mount /dev/hdb1 /data)
-  status=$(govc guest.ps -p "$pid" -json -X | jq .ProcessInfo[].ExitCode)
+  status=$(govc guest.ps -p "$pid" -json -X | jq .processInfo[].exitCode)
 
   if [ "$persist" = "true" ] ; then
     govc guest.ls /data

--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -16,7 +16,7 @@ load test_helper
   assert_success
 
   # link ovf/ova to datastore so we can test with an http source
-  dir=$(govc datastore.info -json | jq -r .Datastores[].info.url)
+  dir=$(govc datastore.info -json | jq -r .datastores[].info.url)
   ln -s "$GOVC_IMAGES/$TTYLINUX_NAME."* "$dir"
 
   run govc import.spec "https://$(govc env GOVC_URL)/folder/$TTYLINUX_NAME.ovf"

--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -184,7 +184,7 @@ load test_helper
   library_id="$output"
 
   # link ovf/ova to datastore so we can test library.import with an http source
-  dir=$(govc datastore.info -json | jq -r .Datastores[].info.url)
+  dir=$(govc datastore.info -json | jq -r .datastores[].info.url)
   ln -s "$GOVC_IMAGES/$TTYLINUX_NAME."* "$dir"
 
   run govc library.import -pull my-content "https://$(govc env GOVC_URL)/folder/$TTYLINUX_NAME.ovf"

--- a/govc/test/license.bats
+++ b/govc/test/license.bats
@@ -4,7 +4,7 @@ load test_helper
 
 # These tests should only run against a server running an evaluation license.
 verify_evaluation() {
-  if [ "$(govc license.ls -json | jq -r .[0].EditionKey)" != "eval" ]; then
+  if [ "$(govc license.ls -json | jq -r .[0].editionKey)" != "eval" ]; then
     skip "requires evaluation license"
   fi
 }
@@ -56,7 +56,7 @@ get_nlabel() {
   assert_success
 
   # Expect the test instance to run in evaluation mode
-  assert_equal "Evaluation Mode" "$(get_key 00000-00000-00000-00000-00000 <<<$output | jq -r ".Name")"
+  assert_equal "Evaluation Mode" "$(get_key 00000-00000-00000-00000-00000 <<<$output | jq -r ".name")"
 }
 
 @test "license.decode" {

--- a/govc/test/network.bats
+++ b/govc/test/network.bats
@@ -162,7 +162,7 @@ load test_helper
   assert_equal "VirtualE1000e" $(collapse_ws $type)
 
   # validate each NIC has a unique MAC
-  macs=$(govc device.info -vm "$vm" -json ethernet-* | jq -r .Devices[].macAddress | uniq | wc -l)
+  macs=$(govc device.info -vm "$vm" -json ethernet-* | jq -r .devices[].macAddress | uniq | wc -l)
   assert_equal 2 "$macs"
 
   # validate -net.protocol. VM Network not compatible with vmxnet3vrdma, so create on dvgp under existing DVS0
@@ -196,7 +196,7 @@ load test_helper
 }
 
 @test "network change hardware address" {
-  esx_env
+  vcsim_env -esx
 
   mac="00:00:0f$(dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 ":%02x"')"
   vm=$(new_id)
@@ -242,10 +242,10 @@ load test_helper
   info=$(govc dvs.portgroup.info "$id" | grep VlanId: | uniq | grep 3123)
   [ -n "$info" ]
 
-  info=$(govc dvs.portgroup.info -json "$id" | jq  '.Port[].config.setting.vlan | select(.vlanId == 3123)')
+  info=$(govc dvs.portgroup.info -json "$id" | jq  '.port[].config.setting.vlan | select(.vlanId == 3123)')
   [ -n "$info" ]
 
-  info=$(govc dvs.portgroup.info -json "$id" | jq  '.Port[].config.setting.Vlan | select(.vlanId == 7777)')
+  info=$(govc dvs.portgroup.info -json "$id" | jq  '.port[].config.setting.Vlan | select(.vlanId == 7777)')
   [ -z "$info" ]
 
   run govc object.destroy "network/${id}-ExternalNetwork" "network/${id}-InternalNetwork" "network/${id}"

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -59,11 +59,11 @@ EOF
   run curl -skf "$url/debug/vars"
   assert_success
 
-  model=$(curl -sfk "$url/debug/vars" | jq .vcsim.Model)
-  [ "$(jq .Datacenter <<<"$model")" == "2" ]
-  [ "$(jq .Cluster <<<"$model")" == "6" ]
-  [ "$(jq .Machine <<<"$model")" == "0" ]
-  [ "$(jq .Datastore <<<"$model")" == "0" ]
+  model=$(curl -sfk "$url/debug/vars" | jq .vcsim.model)
+  [ "$(jq .datacenter <<<"$model")" == "2" ]
+  [ "$(jq .cluster <<<"$model")" == "6" ]
+  [ "$(jq .machine <<<"$model")" == "0" ]
+  [ "$(jq .datastore <<<"$model")" == "0" ]
 
   run govc about
   assert_success
@@ -102,7 +102,7 @@ EOF
 
   VCSIM_HOST_PORT_UNIQUE=true vcsim_start -l "$url"
 
-  hosts=$(curl -sk "https://$url/debug/vars" | jq .vcsim.Model.Host)
+  hosts=$(curl -sk "https://$url/debug/vars" | jq .vcsim.model.host)
   ports=$(govc object.collect -s -type h / summary.config.port | uniq -u | wc -l)
   assert_equal "$ports" "$hosts" # all host ports should be unique
   grep -v "$port" <<<"$ports" # host ports should not include vcsim port

--- a/govc/test/vsan.bats
+++ b/govc/test/vsan.bats
@@ -7,7 +7,7 @@ load test_helper
 
   run govc vsan.info -json DC0_C0
   assert_success
-  config=$(jq .Clusters[].Info.UnmapConfig <<<"$output")
+  config=$(jq .clusters[].info.UnmapConfig <<<"$output")
   assert_equal null "$config"
 
   run govc vsan.change DC0_C0
@@ -19,6 +19,6 @@ load test_helper
   run govc vsan.info -json DC0_C0
   assert_success
 
-  config=$(jq .Clusters[].Info.UnmapConfig.Enable <<<"$output")
+  config=$(jq .clusters[].info.UnmapConfig.Enable <<<"$output")
   assert_equal true "$config"
 }

--- a/govc/vcsa/proxy/proxy.go
+++ b/govc/vcsa/proxy/proxy.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+Copyright (c) 2021-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -64,8 +64,8 @@ Examples:
 }
 
 type proxyResult struct {
-	Proxy   *vnetworking.ProxyList
-	NoProxy []string
+	Proxy   *vnetworking.ProxyList `json:"proxy"`
+	NoProxy []string               `json:"noProxy"`
 }
 
 func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {

--- a/govc/vm/guest/ps.go
+++ b/govc/vm/guest/ps.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -159,7 +159,7 @@ func (cmd *ps) Run(ctx context.Context, f *flag.FlagSet) error {
 
 type psResult struct {
 	cmd         *ps
-	ProcessInfo []types.GuestProcessInfo
+	ProcessInfo []types.GuestProcessInfo `json:"processInfo"`
 }
 
 func (r *psResult) Write(w io.Writer) error {

--- a/govc/vm/info.go
+++ b/govc/vm/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -175,7 +175,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	VirtualMachines []mo.VirtualMachine
+	VirtualMachines []mo.VirtualMachine `json:"virtualMachines"`
 	objects         []*object.VirtualMachine
 	entities        map[types.ManagedObjectReference]string
 	cmd             *info

--- a/govc/vm/ip.go
+++ b/govc/vm/ip.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -68,7 +68,7 @@ func (cmd *ip) Description() string {
 By default the vm.ip command depends on vmware-tools to report the 'guest.ipAddress' field and will
 wait until it has done so.  This value can also be obtained using:
 
-  govc vm.info -json $vm | jq -r .VirtualMachines[].guest.ipAddress
+  govc vm.info -json $vm | jq -r .virtualMachines[].guest.ipAddress
 
 When given the '-a' flag, only IP addresses for which there is a corresponding virtual nic are listed.
 If there are multiple nics, the listed addresses will be comma delimited.  The '-a' flag depends on
@@ -78,7 +78,7 @@ by tools for which there is no virtual nic are not included, for example that of
 
 These values can also be obtained using:
 
-  govc vm.info -json $vm | jq -r .VirtualMachines[].guest.net[].ipConfig.ipAddress[].ipAddress
+  govc vm.info -json $vm | jq -r .virtualMachines[].guest.net[].ipConfig.ipAddress[].ipAddress
 
 When given the '-n' flag, filters '-a' behavior to the nic specified by MAC address or device name.
 

--- a/govc/vm/rdm/ls.go
+++ b/govc/vm/rdm/ls.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -87,7 +87,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type infoResult struct {
-	Disks []types.VirtualMachineScsiDiskDeviceInfo
+	Disks []types.VirtualMachineScsiDiskDeviceInfo `json:"disks"`
 }
 
 func (r *infoResult) Write(w io.Writer) error {

--- a/govc/volume/ls.go
+++ b/govc/volume/ls.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+Copyright (c) 2020-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -88,7 +88,7 @@ Examples:
 }
 
 type lsWriter struct {
-	Volume []types.CnsVolume
+	Volume []types.CnsVolume `json:"volume"`
 	cmd    *ls
 }
 

--- a/govc/volume/snapshot/create.go
+++ b/govc/volume/snapshot/create.go
@@ -71,7 +71,7 @@ Examples:
 }
 
 type createResult struct {
-	VolumeResults *types.CnsSnapshotCreateResult
+	VolumeResults *types.CnsSnapshotCreateResult `json:"volumeResults"`
 	cmd           *create
 }
 

--- a/govc/volume/snapshot/ls.go
+++ b/govc/volume/snapshot/ls.go
@@ -77,7 +77,7 @@ Examples:
 }
 
 type lsResult struct {
-	Entries []*types.CnsSnapshotQueryResultEntry
+	Entries []*types.CnsSnapshotQueryResultEntry `json:"entries"`
 	cmd     *ls
 }
 

--- a/govc/volume/snapshot/rm.go
+++ b/govc/volume/snapshot/rm.go
@@ -70,7 +70,7 @@ Examples:
 }
 
 type rmResult struct {
-	VolumeResults []*types.CnsSnapshotDeleteResult
+	VolumeResults []*types.CnsSnapshotDeleteResult `json:"volumeResults"`
 	cmd           *rm
 }
 

--- a/govc/vsan/info.go
+++ b/govc/vsan/info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+Copyright (c) 2021-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -98,12 +98,12 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type Cluster struct {
-	Path string
-	Info *types.VsanConfigInfoEx
+	Path string                  `json:"path"`
+	Info *types.VsanConfigInfoEx `json:"info"`
 }
 
 type infoResult struct {
-	Clusters []Cluster
+	Clusters []Cluster `json:"clusters"`
 }
 
 func (r *infoResult) Write(w io.Writer) error {

--- a/object/host_certificate_info.go
+++ b/object/host_certificate_info.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,10 +36,10 @@ import (
 type HostCertificateInfo struct {
 	types.HostCertificateManagerCertificateInfo
 
-	ThumbprintSHA1   string
-	ThumbprintSHA256 string
+	ThumbprintSHA1   string `json:"thumbprintSHA1"`
+	ThumbprintSHA256 string `json:"thumbprintSHA256"`
 
-	Err         error
+	Err         error             `json:"err"`
 	Certificate *x509.Certificate `json:"-"`
 
 	subjectName *pkix.Name

--- a/scripts/govc_bash_completion
+++ b/scripts/govc_bash_completion
@@ -69,7 +69,7 @@ _govc_complete()
             (( i++ ))
         done
 
-        CANDIDATES=( $(compgen -W "$(govc device.info -json -vm $vm disk-* | jq '.Devices[].DeviceInfo.Label' | sed 's/"//g')" -- ${cur}))
+        CANDIDATES=( $(compgen -W "$(govc device.info -json -vm $vm disk-* | jq '.devices[].deviceInfo.label' | sed 's/"//g')" -- ${cur}))
         if [ ${#CANDIDATES[*]} -eq 0 ]; then
             COMPREPLY=()
         else

--- a/scripts/license.sh
+++ b/scripts/license.sh
@@ -17,11 +17,7 @@ git diff --name-status main | awk '{print $2}' | while read file; do
     yearA=${years[0]}
     yearB=${years[$((${num_years}-1))]}
 
-    if [ ${yearA} == ${yearB} ]; then
-      export YEARS="${yearA}"
-    else
-      export YEARS="${yearA}-${yearB}"
-    fi
+    export YEARS="${yearA}-${yearB}"
   fi
 
   case "$file" in

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -75,32 +75,32 @@ type Model struct {
 
 	// Datacenter specifies the number of Datacenter entities to create
 	// Name prefix: DC, vcsim flag: -dc
-	Datacenter int
+	Datacenter int `json:"datacenter"`
 
 	// Portgroup specifies the number of DistributedVirtualPortgroup entities to create per Datacenter
 	// Name prefix: DVPG, vcsim flag: -pg
-	Portgroup int
+	Portgroup int `json:"portgroup"`
 
 	// PortgroupNSX specifies the number NSX backed DistributedVirtualPortgroup entities to create per Datacenter
 	// Name prefix: NSXPG, vcsim flag: -nsx-pg
-	PortgroupNSX int
+	PortgroupNSX int `json:"portgroupNSX"`
 
 	// OpaqueNetwork specifies the number of OpaqueNetwork entities to create per Datacenter,
 	// with Summary.OpaqueNetworkType set to nsx.LogicalSwitch and Summary.OpaqueNetworkId to a random uuid.
 	// Name prefix: NSX, vcsim flag: -nsx
-	OpaqueNetwork int
+	OpaqueNetwork int `json:"opaqueNetwork"`
 
 	// Host specifies the number of standalone HostSystems entities to create per Datacenter
 	// Name prefix: H, vcsim flag: -standalone-host
-	Host int `json:",omitempty"`
+	Host int `json:"host,omitempty"`
 
 	// Cluster specifies the number of ClusterComputeResource entities to create per Datacenter
 	// Name prefix: C, vcsim flag: -cluster
-	Cluster int
+	Cluster int `json:"cluster"`
 
 	// ClusterHost specifies the number of HostSystems entities to create within a Cluster
 	// Name prefix: H, vcsim flag: -host
-	ClusterHost int `json:",omitempty"`
+	ClusterHost int `json:"clusterHost,omitempty"`
 
 	// Pool specifies the number of ResourcePool entities to create per Cluster
 	// Note that every cluster has a root ResourcePool named "Resources", as real vCenter does.
@@ -110,13 +110,13 @@ type Model struct {
 	// Note that this flag is not effective on standalone hosts.
 	// For example: /DC0/host/DC0_C0/Resources/DC0_C0_RP1
 	// Name prefix: RP, vcsim flag: -pool
-	Pool int
+	Pool int `json:"pool"`
 
 	// Datastore specifies the number of Datastore entities to create
 	// Each Datastore will have temporary local file storage and will be mounted
 	// on every HostSystem created by the ModelConfig
 	// Name prefix: LocalDS, vcsim flag: -ds
-	Datastore int
+	Datastore int `json:"datastore"`
 
 	// Machine specifies the number of VirtualMachine entities to create per
 	// ResourcePool. If the pool flag is specified, the specified number of virtual
@@ -125,21 +125,21 @@ type Model struct {
 	// prefixed with RP0. On standalone hosts, machines are always deployed into the
 	// root resource pool without any prefix.
 	// Name prefix: VM, vcsim flag: -vm
-	Machine int
+	Machine int `json:"machine"`
 
 	// Folder specifies the number of Datacenter to place within a Folder.
 	// This includes a folder for the Datacenter itself and its host, vm, network and datastore folders.
 	// All resources for the Datacenter are placed within these folders, rather than the top-level folders.
 	// Name prefix: F, vcsim flag: -folder
-	Folder int
+	Folder int `json:"folder"`
 
 	// App specifies the number of VirtualApp to create per Cluster
 	// Name prefix: APP, vcsim flag: -app
-	App int
+	App int `json:"app"`
 
 	// Pod specifies the number of StoragePod to create per Cluster
 	// Name prefix: POD, vcsim flag: -pod
-	Pod int
+	Pod int `json:"pod"`
 
 	// Delay configurations
 	DelayConfig DelayConfig `json:"-"`

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -577,8 +577,8 @@ func (r *Registry) MarshalJSON() ([]byte, error) {
 	defer r.m.Unlock()
 
 	vars := struct {
-		Objects int
-		Locks   int
+		Objects int `json:"objects"`
+		Locks   int `json:"locks"`
 	}{
 		len(r.objects),
 		len(r.locks),

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -338,8 +338,8 @@ func (r *response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 // About generates some info about the simulator.
 func (s *Service) About(w http.ResponseWriter, r *http.Request) {
 	var about struct {
-		Methods []string
-		Types   []string
+		Methods []string `json:"methods"`
+		Types   []string `json:"types"`
 	}
 
 	seen := make(map[string]bool)

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -196,8 +196,8 @@ func main() {
 		count := model.Count()
 
 		return struct {
-			Registry *simulator.Registry
-			Model    *simulator.Model
+			Registry *simulator.Registry `json:"registry"`
+			Model    *simulator.Model    `json:"model"`
 		}{
 			simulator.Map,
 			&count,

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -79,10 +79,10 @@ type Client struct {
 	hostsMu sync.Mutex
 	hosts   map[string]string
 
-	Namespace string // Vim namespace
-	Version   string // Vim version
-	Types     types.Func
-	UserAgent string
+	Namespace string     `json:"namespace"` // Vim namespace
+	Version   string     `json:"version"`   // Vim version
+	Types     types.Func `json:"types"`
+	UserAgent string     `json:"userAgent"`
 
 	cookie          string
 	insecureCookies bool
@@ -487,11 +487,11 @@ func (c *Client) URL() *url.URL {
 }
 
 type marshaledClient struct {
-	Cookies  []*http.Cookie
-	URL      *url.URL
-	Insecure bool
-	Version  string
-	UseJSON  bool
+	Cookies  []*http.Cookie `json:"cookies"`
+	URL      *url.URL       `json:"url"`
+	Insecure bool           `json:"insecure"`
+	Version  string         `json:"version"`
+	UseJSON  bool           `json:"useJSON"`
 }
 
 // MarshalJSON writes the Client configuration to JSON.


### PR DESCRIPTION
PR #3007 added camelCase json tags for generated types BREAKING: This change adds camelCase (lower-case 1st character) json tags for govc types

Fixes #3243
Fixes #3242
Fixes #3241

Tags were added using:
```console
% gomodifytags -w -transform camelcase -add-tags json -all -skip-unexported -file ...
```