### PR TITLE
api: disable HTTP Keep-Alive for direct ESX connections

### DIFF
--- a/guest/toolbox/client.go
+++ b/guest/toolbox/client.go
@@ -284,6 +284,7 @@ func (c *Client) Download(ctx context.Context, src string) (io.ReadCloser, int64
 	}
 
 	p := soap.DefaultDownload
+	p.Close = true // disable Keep-Alive connection to ESX
 
 	if internal.UsingEnvoySidecar(c.ProcessManager.Client()) {
 		vc = internal.ClientWithEnvoyHostGateway(vc)
@@ -345,6 +346,8 @@ func (c *Client) Upload(ctx context.Context, src io.Reader, dst string, p soap.U
 	if err != nil {
 		return err
 	}
+
+	p.Close = true // disable Keep-Alive connection to ESX
 
 	if internal.UsingEnvoySidecar(c.ProcessManager.Client()) {
 		vc = internal.ClientWithEnvoyHostGateway(vc)

--- a/object/datastore.go
+++ b/object/datastore.go
@@ -278,7 +278,10 @@ func (d Datastore) uploadTicket(ctx context.Context, path string, param *soap.Up
 		return nil, nil, err
 	}
 
-	p.Ticket = ticket
+	if ticket != nil {
+		p.Ticket = ticket
+		p.Close = true // disable Keep-Alive connection to ESX
+	}
 
 	return u, &p, nil
 }
@@ -294,7 +297,10 @@ func (d Datastore) downloadTicket(ctx context.Context, path string, param *soap.
 		return nil, nil, err
 	}
 
-	p.Ticket = ticket
+	if ticket != nil {
+		p.Ticket = ticket
+		p.Close = true // disable Keep-Alive connection to ESX
+	}
 
 	return u, &p, nil
 }

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -727,6 +727,7 @@ type Upload struct {
 	Headers       map[string]string
 	Ticket        *http.Cookie
 	Progress      progress.Sinker
+	Close         bool
 }
 
 var DefaultUpload = Upload{
@@ -754,7 +755,7 @@ func (c *Client) Upload(ctx context.Context, f io.Reader, u *url.URL, param *Upl
 	}
 
 	req = req.WithContext(ctx)
-
+	req.Close = param.Close
 	req.ContentLength = param.ContentLength
 	req.Header.Set("Content-Type", param.Type)
 
@@ -812,6 +813,7 @@ type Download struct {
 	Ticket   *http.Cookie
 	Progress progress.Sinker
 	Writer   io.Writer
+	Close    bool
 }
 
 var DefaultDownload = Download{
@@ -826,6 +828,7 @@ func (c *Client) DownloadRequest(ctx context.Context, u *url.URL, param *Downloa
 	}
 
 	req = req.WithContext(ctx)
+	req.Close = param.Close
 
 	for k, v := range param.Headers {
 		req.Header.Add(k, v)


### PR DESCRIPTION
guest file transfer and ticketed datastore file transfer use direct ESX connections. The connection should be only be used for a single request, ensure this by disabling client side.
