### PR TITLE
vcsim: Handle prepare guest operations when svm is nil

### DIFF
--- a/simulator/container_virtual_machine.go
+++ b/simulator/container_virtual_machine.go
@@ -131,7 +131,7 @@ func (svm *simVM) syncNetworkConfigToVMGuestProperties() error {
 }
 
 func (svm *simVM) prepareGuestOperation(auth types.BaseGuestAuthentication) types.BaseMethodFault {
-	if svm != nil && (svm.c == nil || svm.c.id == "") {
+	if svm == nil || svm.c == nil || svm.c.id == "" {
 		return new(types.GuestOperationsUnavailable)
 	}
 


### PR DESCRIPTION
## Description

It appears that the simulated VM logic is supposed to handle cases when svm (the receiver) is nil (eg. when you spin up a VM without using a backing container. (I think this might have been introduced by fdb4d84763b8b28f3dc94b1a2a0b0f60aae2eb55 )

This would lead to a panic due to the conditional in question attempting to access svm.vm.Runtime.PowerState immediately after.

Inverting the check to return GuestOperationsUnavailable if `svm == nil` seems the simplest way to address this. To my knowledge, Go will short circuit evaluation.

## Type of change

Please mark options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- Used a go workspace, updated a vcsim based unit test involving guest file transfer. Verified that test no longer panicked, but returned a GuestOperationsUnavailable soap fault.

(still trying to find a unit test in govmomi that would be impacted by this. I guess most tests use container backed VMs?) 

## Checklist:

- [X] My code follows the `CONTRIBUTION` [guidelines] of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works - will defer for now, this seems to be an untested path and my main priority was to avoid vcsim panics.
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
