### PR TITLE
vim25/soap: add ability to check whether a thumbprint is known to the soap client

### DIFF
--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -318,6 +318,20 @@ func (c *Client) Thumbprint(host string) string {
 	return c.hosts[host]
 }
 
+// KnownThumbprint checks whether the provided thumbprint is known to this client.
+func (c *Client) KnownThumbprint(tp string) bool {
+	c.hostsMu.Lock()
+	defer c.hostsMu.Unlock()
+
+	for _, v := range c.hosts {
+		if v == tp {
+			return true
+		}
+	}
+
+	return false
+}
+
 // LoadThumbprints from file with the give name.
 // If name is empty or name does not exist this function will return nil.
 func (c *Client) LoadThumbprints(file string) error {


### PR DESCRIPTION
## Description

This change adds the ability to check whether a given thumbprint is known to the soap client.

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Isolated testing of the implemented func that traverses a map. None of the other thumbprint-related funcs have unit tests, so decided not to add anything new just to iterate over the values of a map.

## Checklist:

- [X] My code follows the `CONTRIBUTION` [guidelines] of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
