### PR TITLE
Add additional PBM methods

### DIFF
--- a/pbm/client.go
+++ b/pbm/client.go
@@ -285,3 +285,31 @@ func (c *Client) GetProfileNameByID(ctx context.Context, profileID string) (stri
 	}
 	return "", fmt.Errorf("no pbm profile found with id: %q", profileID)
 }
+
+func (c *Client) QueryAssociatedProfile(ctx context.Context, entity types.PbmServerObjectRef) ([]types.PbmProfileId, error) {
+	req := types.PbmQueryAssociatedProfile{
+		This:   c.ServiceContent.ProfileManager,
+		Entity: entity,
+	}
+
+	res, err := methods.PbmQueryAssociatedProfile(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (c *Client) QueryAssociatedProfiles(ctx context.Context, entities []types.PbmServerObjectRef) ([]types.PbmQueryProfileResult, error) {
+	req := types.PbmQueryAssociatedProfiles{
+		This:     c.ServiceContent.ProfileManager,
+		Entities: entities,
+	}
+
+	res, err := methods.PbmQueryAssociatedProfiles(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}


### PR DESCRIPTION
## Description

Some additional PBM/SPBM methods where not exposed. This methods should be used by CAPV later to query storage policy per disk, instead of getting the whole list of Entities and iterating over it

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Executed some local tests on this method to get the storage profile of virtual disks

## Checklist:

- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
