### PR TITLE
vcsim: Fix PropertyCollector to handle empty property

### DIFF
--- a/simulator/property_collector.go
+++ b/simulator/property_collector.go
@@ -248,10 +248,16 @@ func toString(v *string) string {
 }
 
 func lcFirst(s string) string {
+	if len(s) < 1 {
+		return s
+	}
 	return strings.ToLower(s[:1]) + s[1:]
 }
 
 func ucFirst(s string) string {
+	if len(s) < 1 {
+		return s
+	}
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 

--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -1709,3 +1709,45 @@ func TestPropertyCollectorNoPathSet(t *testing.T) {
 		t.Fatalf("len(content)=%d", len(content))
 	}
 }
+
+func TestLcFirst(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{input: "ABC", expected: "aBC"},
+		{input: "abc", expected: "abc"},
+		{input: "", expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			actual := lcFirst(tt.input)
+
+			if actual != tt.expected {
+				t.Errorf("%q != %q", actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUcFirst(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{input: "ABC", expected: "ABC"},
+		{input: "abc", expected: "Abc"},
+		{input: "", expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			actual := ucFirst(tt.input)
+
+			if actual != tt.expected {
+				t.Errorf("%q != %q", actual, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes RetrievePropertiesEx in vcsim to handle empty property name (like `.`).

Closes: #3275

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] run vcsim manually to check it can handle empty property name

```bash
$ ./govmomi/vcsim/vcsim &
$ govc object.collect VirtualMachine:vm-55 .
```

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
