### PR TITLE
vcsim: Fix [BUG] vcsim raises TypeError for RemoveSnapshotTask

### DIFF
--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -111,7 +111,7 @@ func (v *VirtualMachineSnapshot) removeSnapshotFiles(ctx *Context) types.BaseMet
 }
 
 func (v *VirtualMachineSnapshot) RemoveSnapshotTask(ctx *Context, req *types.RemoveSnapshot_Task) soap.HasFault {
-	task := CreateTask(v, "removeSnapshot", func(t *Task) (types.AnyType, types.BaseMethodFault) {
+	task := CreateTask(v.Vm, "removeSnapshot", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		var changes []types.PropertyChange
 
 		vm := ctx.Map.Get(v.Vm).(*VirtualMachine)


### PR DESCRIPTION
## Description

Applying the confirmed fix for [RevertToSnapshotTask](https://github.com/vmware/govmomi/pull/2292/files#diff-7720135e571206f9738817ceaa27adc9faf2b64bd649e0d3c42f052b4de8c279R150) to [RemoveSnapshotTask](https://github.com/vmware/govmomi/blob/44d6f8d509be126e200c4a29973d83170357d616/simulator/snapshot.go#L114).

Closes: #3298

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Using vcsim:

1. Create a snapshot.
2. Wait for the create snapshot task to complete.
3. Attempt to delete the snapshot.
4. Wait for the remove snapshot task to complete.

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
