### PR TITLE
add PbmQueryAssociatedProfiles method

### DIFF
--- a/pbm/simulator/simulator.go
+++ b/pbm/simulator/simulator.go
@@ -126,6 +126,13 @@ func (m *ProfileManager) PbmQueryAssociatedProfile(req *types.PbmQueryAssociated
 	return body
 }
 
+func (m *ProfileManager) PbmQueryAssociatedProfiles(req *types.PbmQueryAssociatedProfiles) soap.HasFault {
+	body := new(methods.PbmQueryAssociatedProfilesBody)
+	body.Res = new(types.PbmQueryAssociatedProfilesResponse)
+
+	return body
+}
+
 func (m *ProfileManager) PbmRetrieveContent(req *types.PbmRetrieveContent) soap.HasFault {
 	body := new(methods.PbmRetrieveContentBody)
 	if len(req.ProfileIds) == 0 {


### PR DESCRIPTION
## Description

This PR adds the PbmQueryAssociatedProfiles method, which is required to test CAPV machine provisioning with vcsim.
After this change will merge, it will be possible to:
- start using vcsim as a vCenter replacement while running CAPV e2e tests
- use vcsim to stress test CAPV without the need of real infrastructure
- use vcsim to improve the speed of CAPV local development iterations

cc @randomvariable @sbueringer @chrischdi 

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Code have been tested with a [CAPV fork](https://github.com/fabriziopandini/cluster-api-provider-vsphere/tree/vcsim-server) where I'm using vcsim for the use cases reported in the description

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
