### PR TITLE
Add default Historical Intervals to the simulator

### DIFF
--- a/simulator/esx/performance_manager.go
+++ b/simulator/esx/performance_manager.go
@@ -18,6 +18,20 @@ package esx
 
 import "github.com/vmware/govmomi/vim25/types"
 
+// HistoricalInterval is the default template for the PerformanceManager historicalInterval property.
+// Capture method:
+//
+//	govc object.collect -s -dump PerformanceManager:ha-perfmgr historicalInterval
+var HistoricalInterval = []types.PerfInterval{
+	{
+		Enabled:        true,
+		Key:            1,
+		Length:         129600,
+		Name:           "PastDay",
+		SamplingPeriod: 300,
+	},
+}
+
 // PerfCounter is the default template for the PerformanceManager perfCounter property.
 // Capture method:
 //

--- a/simulator/performance_manager.go
+++ b/simulator/performance_manager.go
@@ -57,12 +57,14 @@ type PerformanceManager struct {
 func (m *PerformanceManager) init(r *Registry) {
 	if r.IsESX() {
 		m.PerfCounter = esx.PerfCounter
+		m.HistoricalInterval = esx.HistoricalInterval
 		m.hostMetrics = esx.HostMetrics
 		m.vmMetrics = esx.VmMetrics
 		m.rpMetrics = esx.ResourcePoolMetrics
 		m.metricData = esx.MetricData
 	} else {
 		m.PerfCounter = vpx.PerfCounter
+		m.HistoricalInterval = vpx.HistoricalInterval
 		m.hostMetrics = vpx.HostMetrics
 		m.vmMetrics = vpx.VmMetrics
 		m.rpMetrics = vpx.ResourcePoolMetrics

--- a/simulator/vpx/performance_manager.go
+++ b/simulator/vpx/performance_manager.go
@@ -18,6 +18,45 @@ package vpx
 
 import "github.com/vmware/govmomi/vim25/types"
 
+// HistoricalInterval is the default template for the PerformanceManager historicalInterval property.
+// Capture method:
+//
+//	govc object.collect -s -dump PerformanceManager:Perfmgr historicalInterval
+var HistoricalInterval = []types.PerfInterval{
+	{
+		Enabled:        true,
+		Key:            1,
+		Length:         86400,
+		Level:          1,
+		Name:           "Past Day",
+		SamplingPeriod: 300,
+	},
+	{
+		Enabled:        true,
+		Key:            2,
+		Length:         604800,
+		Level:          1,
+		Name:           "Past Week",
+		SamplingPeriod: 1800,
+	},
+	{
+		Enabled:        true,
+		Key:            1,
+		Length:         2592000,
+		Level:          1,
+		Name:           "Past Month",
+		SamplingPeriod: 7200,
+	},
+	{
+		Enabled:        true,
+		Key:            1,
+		Length:         31536000,
+		Level:          1,
+		Name:           "Past Year",
+		SamplingPeriod: 86400,
+	},
+}
+
 // PerfCounter is the default template for the PerformanceManager perfCounter property.
 // Capture method:
 //   govc object.collect -s -dump PerformanceManager:PerfMgr perfCounter


### PR DESCRIPTION
## Description

This populates the historical intervals based upon the server type.

Currently a real vCenter server has this set with default values, but the simulator has it empty.

## Before

```
vcsim 127.0.0.1:9191 &
export GOVC_URL=https://user:pass@127.0.0.1:9191/sdk GOVC_INSECURE=true

govc metric.interval.info

m.pm.HistoricalInterval:  0
load HistoricalInterval
m.pm.HistoricalInterval (final):  0
```

## After

```
vcsim 127.0.0.1:9191 &
export GOVC_URL=https://user:pass@127.0.0.1:9191/sdk GOVC_INSECURE=true

govc metric.interval.info

performance/manager/HistoricalInterval
m.pm.HistoricalInterval:  0
load HistoricalInterval
m.pm.HistoricalInterval (final):  4
ID:                   300
  Enabled:            true
  Interval:           5m
  Available Samples:  288
  Name:               Past Day
  Level:              1
ID:                   1800
  Enabled:            true
  Interval:           30m
  Available Samples:  336
  Name:               Past Week
  Level:              1
ID:                   7200
  Enabled:            true
  Interval:           2h
  Available Samples:  360
  Name:               Past Month
  Level:              1
ID:                   86400
  Enabled:            true
  Interval:           24h
  Available Samples:  365
  Name:               Past Year
  Level:              1

```

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- shown in description

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
