### PR TITLE
fix: expose util for rest status return

### DIFF
--- a/vapi/rest/client.go
+++ b/vapi/rest/client.go
@@ -155,6 +155,14 @@ func (e *statusError) Error() string {
 	return fmt.Sprintf("%s %s: %s", e.res.Request.Method, e.res.Request.URL, e.res.Status)
 }
 
+func IsStatusError(err error, code int) bool {
+	statusErr, ok := err.(*statusError)
+	if !ok || statusErr == nil || statusErr.res == nil {
+		return false
+	}
+	return statusErr.res.StatusCode == code
+}
+
 // RawResponse may be used with the Do method as the resBody argument in order
 // to capture the raw response data.
 type RawResponse struct {

--- a/vapi/rest/client_test.go
+++ b/vapi/rest/client_test.go
@@ -27,9 +27,8 @@ import (
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vapi/internal"
 	"github.com/vmware/govmomi/vapi/rest"
-	"github.com/vmware/govmomi/vim25"
-
 	_ "github.com/vmware/govmomi/vapi/simulator"
+	"github.com/vmware/govmomi/vim25"
 )
 
 func TestSession(t *testing.T) {
@@ -57,6 +56,12 @@ func TestSession(t *testing.T) {
 
 		if session == nil {
 			t.Fatal("expected non-nil session")
+		}
+
+		path := c.Resource("/xpto/bla")
+		err = c.Do(ctx, path.Request(http.MethodGet), nil)
+		if !rest.IsStatusError(err, http.StatusNotFound) {
+			t.Fatal("expecting error to be 'StatusNotFound'", err)
 		}
 	})
 }


### PR DESCRIPTION
Closes: #3309

## Description

During the implementation of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2535 we have realized it is hard to check what was the error returned from the rest/http layer of vAPI.

This PR creates a util function that can be used to check if a returned error from rest contains a specific http Status code.

Closes: #3309

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Extended current rest Session test to also do an invalid internal call and check the returned error

## Checklist:

- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
