### PR TITLE
vcsim: Fix -method-delay option to update task states

### DIFF
--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -143,6 +143,7 @@ func main() {
 			}
 		}
 		model.DelayConfig.MethodDelay = m
+		simulator.TaskDelay.MethodDelay = m
 	}
 
 	var err error


### PR DESCRIPTION
## Description

This PR fixes `-method-delay` option to delay task state updates

Closes: #3323

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] run vcsim manually to check task state updates

```bash
# delay PowerOff for 10 seconds
$ vcsim -method-delay "PowerOff:10000"

# create PowerOff task
$ govc vm.power -off -force DC0_H0_VM0
Powering off VirtualMachine:vm-55... OK

# get the task
$ govc tasks | grep PowerOff
PowerOff                                 vm-55                          vcsim                           12:26:39  12:26:39         - running [ 0% Task:task-66]
# 10 seconds later
$ govc tasks | grep PowerOff
PowerOff                                 vm-55                          vcsim                           12:26:39  12:26:39  12:26:49 success [10.0020702s]
```

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
