### PR TITLE
Changes to fix xml tag used for SnapshotId in CnsSnapshotCreatedFault

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -612,7 +612,7 @@ type CnsSnapshotNotFoundFault struct {
 	CnsFault
 
 	VolumeId   CnsVolumeId   `xml:"volumeId,omitempty"`
-	SnapshotId CnsSnapshotId `xml:"snapshotId"`
+	SnapshotId CnsSnapshotId `xml:"SnapshotId"`
 }
 
 func init() {
@@ -623,7 +623,7 @@ type CnsSnapshotCreatedFault struct {
 	CnsFault
 
 	VolumeId   CnsVolumeId                  `xml:"volumeId"`
-	SnapshotId CnsSnapshotId                `xml:"snapshotId"`
+	SnapshotId CnsSnapshotId                `xml:"SnapshotId"`
 	Datastore  types.ManagedObjectReference `xml:"datastore"`
 }
 


### PR DESCRIPTION
## Description

Changes to fix xml tag used for SnapshotId in CnsSnapshotCreatedFault

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Simulated CnsSnapshotCreatedFault manually and verified CreateSnapshot API's response using client_test.go.
With tag "snapshotId", we are getting snapshotId as "" in the fault.
```
   client_test.go:372: Failed to create snapshots: fault=(*types.LocalizedMethodFault)(0xc0004ad300)({
         DynamicData: (types.DynamicData) {
         },
         Fault: (types.CnsSnapshotCreatedFault) {
          CnsFault: (types.CnsFault) {
           BaseMethodFault: (types.BaseMethodFault) <nil>,
           Reason: (string) (len=24) "Snapshot already created"
          },
          VolumeId: (types.CnsVolumeId) {
           DynamicData: (types.DynamicData) {
           },
           Id: (string) (len=36) "357c83c0-467a-4228-a736-81b2b24a7e40"
          },
          SnapshotId: (types.CnsSnapshotId) {
           DynamicData: (types.DynamicData) {
           },
           Id: (string) ""
          },
          Datastore: (types.ManagedObjectReference) Datastore:datastore-38
         },
         LocalizedMessage: (string) (len=141) "Volume 357c83c0-467a-4228-a736-81b2b24a7e40 has created snapshot 465af298-23de-4d0f-88ab-cd058a6a9c46 on datastore vim.Datastore:datastore-38"
        })
```

When tag is updated to "SnapshotId" (capital S), we are getting snapshotId in the fault as expected.

```
    client_test.go:372: Failed to create snapshots: fault=(*types.LocalizedMethodFault)(0xc0000ca800)({
         DynamicData: (types.DynamicData) {
         },
         Fault: (types.CnsSnapshotCreatedFault) {
          CnsFault: (types.CnsFault) {
           BaseMethodFault: (types.BaseMethodFault) <nil>,
           Reason: (string) (len=24) "Snapshot already created"
          },
          VolumeId: (types.CnsVolumeId) {
           DynamicData: (types.DynamicData) {
           },
           Id: (string) (len=36) "357c83c0-467a-4228-a736-81b2b24a7e40"
          },
          SnapshotId: (types.CnsSnapshotId) {
           DynamicData: (types.DynamicData) {
           },
           Id: (string) (len=36) "9e6a0dcc-b57e-4946-b4a1-cc9456f86d73"
          },
          Datastore: (types.ManagedObjectReference) Datastore:datastore-38
         },
         LocalizedMessage: (string) (len=141) "Volume 357c83c0-467a-4228-a736-81b2b24a7e40 has created snapshot 9e6a0dcc-b57e-4946-b4a1-cc9456f86d73 on datastore vim.Datastore:datastore-38"
        })
```

unit tests are passing:
% go test -v
```
=== RUN   TestNewClient
--- SKIP: TestNewClient (0.00s)
=== RUN   TestInvalidSdk
--- SKIP: TestInvalidSdk (0.00s)
=== RUN   TestPropertiesN
--- SKIP: TestPropertiesN (0.00s)
PASS
ok  	github.com/vmware/govmomi	0.553s
```

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
