### PR TITLE
Self identify the executable making calls to vCenter

### DIFF
--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -59,9 +59,10 @@ const (
 )
 
 // defaultUserAgent is the default user agent string, e.g.
-// "govmomi/0.28.0 (go1.18.3;linux;amd64)"
+// "govc govmomi/0.28.0 (go1.18.3;linux;amd64)"
 var defaultUserAgent = fmt.Sprintf(
-	"%s/%s (%s)",
+	"%s %s/%s (%s)",
+	execName(),
 	version.ClientName,
 	version.ClientVersion,
 	strings.Join([]string{runtime.Version(), runtime.GOOS, runtime.GOARCH}, ";"),
@@ -926,4 +927,13 @@ func (c *Client) DownloadFile(ctx context.Context, file string, u *url.URL, para
 	}
 
 	return c.WriteFile(ctx, file, rc, contentLength, param.Progress, param.Writer)
+}
+
+// execName gets the name of the executable for the current process
+func execName() string {
+	name, err := os.Executable()
+	if err != nil {
+		return "N/A"
+	}
+	return strings.TrimSuffix(filepath.Base(name), ".exe")
 }


### PR DESCRIPTION
When reviewing data from vCenter for troubleshooting and analysis it is hard to distinguish where the request comes from. Having the govmomi and golang version is helpful. As we now have increasing number of go clients we need more data.

The go debug value produce din tests is like
"__debug_bin2861234748 govmomi/0.31.0 (go1.20.5;darwin;arm64)"

## Description

Add the executable name to the default user agent 

Closes: #3339 

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [X] Unit tests for the user-agent

## Checklist:

- [X] My code follows the `CONTRIBUTION` [guidelines] of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
