### PR TITLE
[WIP]Add new "UsedCapacityInMb" in struct "CnsBlockBackingDetails"

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -395,6 +395,7 @@ type CnsBlockBackingDetails struct {
 	BackingDiskId       string `xml:"backingDiskId,omitempty"`
 	BackingDiskUrlPath  string `xml:"backingDiskUrlPath,omitempty"`
 	BackingDiskObjectId string `xml:"backingDiskObjectId,omitempty"`
+	UsedCapacityInMb    int64  `xml:"usedCapacityInMb"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

This change add new field "UsedCapacityInMb" in struct "CnsBlockBackingDetails". This field is s the rolled up used capacity of the FCD and its snapshots.
Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] run cns unit test

unit test passed and in the QueryVolume API output. Field "UsedCapacityInMb" exists in struct "CnsBlockBackingDetails".
```
bash-3.2$ pwd                       
/Users/lipingx/go/src/github.com/lipingxue/govmomi/cns
bash-3.2$ go test -v      
...

client_test.go:244: Successfully Queried Volumes. queryResult: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "2c4d86f3-3f6c-406f-8a5b-45e9ba37dcca",
                    },
                    DatastoreUrl:    "ds:///vmfs/volumes/vsan:52680136b8cf925d-47750bb646138963/",
                    Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:      "BLOCK",
                    StoragePolicyId: "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:        types.CnsVolumeMetadata{
                        ContainerCluster: types.CnsContainerCluster{
                            ClusterType:         "KUBERNETES",
                            ClusterId:           "demo-cluster-id",
                            VSphereUser:         "Administrator@vsphere.local",
                            ClusterFlavor:       "VANILLA",
                            ClusterDistribution: "OpenShift",
                        },
                        EntityMetadata:        nil,
                        ContainerClusterArray: []types.CnsContainerCluster{
                            {
                                ClusterType:         "KUBERNETES",
                                ClusterId:           "demo-cluster-id",
                                VSphereUser:         "Administrator@vsphere.local",
                                ClusterFlavor:       "VANILLA",
                                ClusterDistribution: "OpenShift",
                            },
                        },
                    },
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 5120,
                        },
                        BackingDiskId:       "2c4d86f3-3f6c-406f-8a5b-45e9ba37dcca",
                        BackingDiskUrlPath:  "",
                        BackingDiskObjectId: "46a2b165-b28f-220a-a17d-02007609a56a",
                        UsedCapacityInMb:    -1,
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "green",
                },
            },

```

## Checklist:

- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
