### PR TITLE
Re-enable PC updates for indexed properties

### DIFF
--- a/vim25/mo/retrieve.go
+++ b/vim25/mo/retrieve.go
@@ -77,7 +77,11 @@ func ApplyPropertyChange(obj Reference, changes []types.PropertyChange) {
 	for _, p := range changes {
 		rv, ok := t.props[p.Name]
 		if !ok {
-			panic(p.Name + " not found")
+			// For now, skip unknown properties allowing PC updates to be triggered
+			// for partial updates (e.g. extensionList["my.extension"]).
+			// Ultimately we should support partial updates by assigning the value
+			// reflectively in assignValue.
+			continue
 		}
 
 		assignValue(v, rv, reflect.ValueOf(p.Val))


### PR DESCRIPTION
## Description

A previous change reverted behavior that ignored indexed property updates in favor of a panic. While we don't implement persistence for partial updates, some consumers rely on this behavior to test property collector updates on specific fields.

This change reverts a03f4735570027d2e6e2bc9cb7584a0af19f9353q to the previous behavior allowing downstream consumers to rely on this field for testing PC updates until full support for indexed fields is implemented.

Closes: #3349

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Verified indexed fields could trigger property collector updates.

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
