### PR TITLE
Add "AggregatedSnapshotCapacityInMb" to cnstype

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -395,6 +395,7 @@ type CnsBlockBackingDetails struct {
 	BackingDiskId       string `xml:"backingDiskId,omitempty"`
 	BackingDiskUrlPath  string `xml:"backingDiskUrlPath,omitempty"`
 	BackingDiskObjectId string `xml:"backingDiskObjectId,omitempty"`
+	UsedCapacityInMb    int64  `xml:"usedCapacityInMb"`
 }
 
 func init() {

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -392,10 +392,10 @@ func init() {
 type CnsBlockBackingDetails struct {
 	CnsBackingObjectDetails
 
-	BackingDiskId       string `xml:"backingDiskId,omitempty"`
-	BackingDiskUrlPath  string `xml:"backingDiskUrlPath,omitempty"`
-	BackingDiskObjectId string `xml:"backingDiskObjectId,omitempty"`
-	UsedCapacityInMb    int64  `xml:"usedCapacityInMb"`
+	BackingDiskId                  string `xml:"backingDiskId,omitempty"`
+	BackingDiskUrlPath             string `xml:"backingDiskUrlPath,omitempty"`
+	BackingDiskObjectId            string `xml:"backingDiskObjectId,omitempty"`
+	AggregatedSnapshotCapacityInMb int64  `xml:"aggregatedSnapshotCapacityInMb,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

Add "AggregatedSnapshotCapacityInMb" in  "CnsBlockBackingDetails" struct.

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

Run unit test, and can see this new field is available in the QueryVolume result.

 client_test.go:244: Successfully Queried Volumes. queryResult: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "1aea2f18-d51c-4c67-a793-3c03d587100a",
                    },
                    DatastoreUrl:    "ds:///vmfs/volumes/65b980ec-15046ef0-c7e0-0200aec77050/",
                    Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:      "BLOCK",   
                    StoragePolicyId: "",
                    Metadata:        types.CnsVolumeMetadata{
                        ContainerCluster: types.CnsContainerCluster{
                            ClusterType:         "KUBERNETES",
                            ClusterId:           "demo-cluster-id",
                            VSphereUser:         "Administrator@vsphere.local",
                            ClusterFlavor:       "VANILLA",
                            ClusterDistribution: "OpenShift",
                        },
                        EntityMetadata:        nil,
                        ContainerClusterArray: []types.CnsContainerCluster{
                            {
                                ClusterType:         "KUBERNETES",
                                ClusterId:           "demo-cluster-id",
                                VSphereUser:         "Administrator@vsphere.local",
                                ClusterFlavor:       "VANILLA",
                                ClusterDistribution: "OpenShift",
                            },
                        },
                    },
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 5120,
                        },
                        BackingDiskId:                  "1aea2f18-d51c-4c67-a793-3c03d587100a",
                        BackingDiskUrlPath:             "",
                        BackingDiskObjectId:            "",
                        AggregatedSnapshotCapacityInMb: 0,
                    },
                    ComplianceStatus:             "",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "green",
                },
            },


## Checklist:

- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
