### PR TITLE
Add service locator to CNS RelocateVolume spec

### DIFF
--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -40,6 +40,7 @@ import (
 )
 
 const VSphere70u3VersionInt = 703
+const VSphere80u3VersionInt = 803
 
 func TestClient(t *testing.T) {
 	// set CNS_DEBUG to true if you need to emit soap traces from these tests
@@ -62,9 +63,13 @@ func TestClient(t *testing.T) {
 	// example: export BACKING_DISK_URL_PATH='https://vc-ip/folder/vmdkfilePath.vmdk?dcPath=DataCenterPath&dsName=DataStoreName'
 	backingDiskURLPath := os.Getenv("BACKING_DISK_URL_PATH")
 
+	// set REMOTE_VC_URL, REMOTE_DATACENTER only if you want to test cross-VC CNS operations.
+	// For instance, testing cross-VC volume migration.
+	remoteVcUrl := os.Getenv("REMOTE_VC_URL")
+	remoteDatacenter := os.Getenv("REMOTE_DATACENTER")
+
 	// if datastoreForMigration is not set, test for CNS Relocate API of a volume to another datastore is skipped.
 	// input format is same as CNS_DATASTORE. Format eg. "vSANDirect_10.92.217.162_mpx.vmhba0:C0:T2:L0"/ "vsandatastore"
-	// make sure that migration datastore is accessible from host on which CNS_DATASTORE is mounted.
 	datastoreForMigration := os.Getenv("CNS_MIGRATION_DATASTORE")
 
 	// if spbmPolicyId4Reconfig is not set, test for CnsReconfigVolumePolicy API will be skipped
@@ -74,7 +79,7 @@ func TestClient(t *testing.T) {
 	if url == "" || datacenter == "" || datastore == "" {
 		t.Skip("CNS_VC_URL or CNS_DATACENTER or CNS_DATASTORE is not set")
 	}
-	resporcePoolPath := os.Getenv("CNS_RESOURCE_POOL_PATH") // example "/datacenter-name/host/host-ip/Resources" or  /datacenter-name/host/cluster-name/Resources
+	resourcePoolPath := os.Getenv("CNS_RESOURCE_POOL_PATH") // example "/datacenter-name/host/host-ip/Resources" or  /datacenter-name/host/cluster-name/Resources
 	u, err := soap.ParseURL(url)
 	if err != nil {
 		t.Fatal(err)
@@ -537,14 +542,72 @@ func TestClient(t *testing.T) {
 	// Test Relocate API
 	// Relocate API is not supported on ReleaseVSAN67u3 and ReleaseVSAN70
 	// This API is available on vSphere 7.0u1 onward
-	if cnsClient.Version != ReleaseVSAN67u3 && cnsClient.Version != ReleaseVSAN70 && datastoreForMigration != "" {
-		migrationDS, err := finder.Datastore(ctx, datastoreForMigration)
-		if err != nil {
-			t.Fatal(err)
+	if cnsClient.Version != ReleaseVSAN67u3 && cnsClient.Version != ReleaseVSAN70 &&
+		datastoreForMigration != "" {
+
+		var migrationDS *object.Datastore
+		var serviceLocatorInstance *vim25types.ServiceLocator = nil
+
+		// Cross-VC migration.
+		// This is only supported on 8.0u3 onwards.
+		if remoteVcUrl != "" && isvSphereVersion80U3orAbove(ctx, c.ServiceContent.About) {
+			remoteUrl, err := soap.ParseURL(remoteVcUrl)
+			if err != nil {
+				t.Fatal(err)
+			}
+			remoteVcClient, err := govmomi.NewClient(ctx, remoteUrl, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// UseServiceVersion sets soap.Client.Version to the current version of the service endpoint via /sdk/vsanServiceVersions.xml
+			remoteVcClient.UseServiceVersion("vsan")
+			remoteCnsClient, err := NewClient(ctx, remoteVcClient.Client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			remoteFinder := find.NewFinder(remoteCnsClient.vim25Client, false)
+			remoteDc, err := remoteFinder.Datacenter(ctx, remoteDatacenter)
+			if err != nil {
+				t.Fatal(err)
+			}
+			remoteFinder.SetDatacenter(remoteDc)
+
+			migrationDS, err = remoteFinder.Datastore(ctx, datastoreForMigration)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Get ServiceLocator instance for remote VC.
+			userName := remoteUrl.User.Username()
+			password, _ := remoteUrl.User.Password()
+			serviceLocatorInstance, err = GetServiceLocatorInstance(ctx, userName, password, remoteVcClient)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+		} else {
+			// Same VC migration
+			migrationDS, err = finder.Datastore(ctx, datastoreForMigration)
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
-		t.Logf("Relocating volume %v to datastore %+v", pretty.Sprint(volumeId), migrationDS.Reference())
-		relocateSpec := cnstypes.NewCnsBlockVolumeRelocateSpec(volumeId, migrationDS.Reference())
-		relocateTask, err := cnsClient.RelocateVolume(ctx, relocateSpec)
+
+		blockVolRelocateSpec := cnstypes.CnsBlockVolumeRelocateSpec{
+			CnsVolumeRelocateSpec: cnstypes.CnsVolumeRelocateSpec{
+				VolumeId: cnstypes.CnsVolumeId{
+					Id: volumeId,
+				},
+				Datastore: migrationDS.Reference(),
+			},
+		}
+		if serviceLocatorInstance != nil {
+			blockVolRelocateSpec.ServiceLocator = serviceLocatorInstance
+		}
+
+		t.Logf("Relocating volume using the spec: %+v", pretty.Sprint(blockVolRelocateSpec))
+
+		relocateTask, err := cnsClient.RelocateVolume(ctx, blockVolRelocateSpec)
 		if err != nil {
 			t.Errorf("Failed to migrate volume with Relocate API. Error: %+v \n", err)
 			t.Fatal(err)
@@ -778,10 +841,10 @@ func TestClient(t *testing.T) {
 		t.Fatal(err)
 	}
 	var resourcePool *object.ResourcePool
-	if resporcePoolPath == "" {
+	if resourcePoolPath == "" {
 		resourcePool, err = finder.DefaultResourcePool(ctx)
 	} else {
-		resourcePool, err = finder.ResourcePool(ctx, resporcePoolPath)
+		resourcePool, err = finder.ResourcePool(ctx, resourcePoolPath)
 	}
 	if err != nil {
 		t.Errorf("Error occurred while getting DefaultResourcePool. err: %+v", err)
@@ -930,6 +993,7 @@ func TestClient(t *testing.T) {
 			t.Logf("Successfully queried Volume using queryAsync API. queryVolumeAsyncTaskResult: %+v", pretty.Sprint(queryVolumeAsyncTaskResult))
 		}
 	}
+
 	// Test DeleteVolume API
 	t.Logf("Deleting volume: %+v", volumeIDList)
 	deleteTask, err := cnsClient.DeleteVolume(ctx, volumeIDList, true)
@@ -1408,6 +1472,29 @@ func isvSphereVersion70U3orAbove(ctx context.Context, aboutInfo vim25types.About
 		}
 		// Check if the current vSphere version is 7.0.3 or higher
 		if vSphereVersionInt >= VSphere70u3VersionInt {
+			return true
+		}
+	}
+	// For all other versions
+	return false
+}
+
+// isvSphereVersion80U3orAbove checks if specified version is 8.0 Update 3 or higher
+// The method takes aboutInfo{} as input which contains details about
+// VC version, build number and so on.
+// If the version is 8.0 Update 3 or higher, the method returns true, else returns false
+// along with appropriate errors during failure cases
+func isvSphereVersion80U3orAbove(ctx context.Context, aboutInfo vim25types.AboutInfo) bool {
+	items := strings.Split(aboutInfo.Version, ".")
+	version := strings.Join(items[:], "")
+	// Convert version string to string, Ex: "8.0.3" becomes 803, "8.0.3.1" becomes 703
+	if len(version) >= 3 {
+		vSphereVersionInt, err := strconv.Atoi(version[0:3])
+		if err != nil {
+			return false
+		}
+		// Check if the current vSphere version is 8.0.3 or higher
+		if vSphereVersionInt >= VSphere80u3VersionInt {
 			return true
 		}
 	}

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -535,9 +535,10 @@ type CnsRelocateVolumeResponse struct {
 type CnsVolumeRelocateSpec struct {
 	types.DynamicData
 
-	VolumeId  CnsVolumeId                           `xml:"volumeId"`
-	Datastore types.ManagedObjectReference          `xml:"datastore"`
-	Profile   []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
+	VolumeId       CnsVolumeId                           `xml:"volumeId"`
+	Datastore      types.ManagedObjectReference          `xml:"datastore"`
+	Profile        []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
+	ServiceLocator *types.ServiceLocator                 `xml:"serviceLocator,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

Add `ServiceLocator` type to `CnsVolumeRelocateSpec` to facilitate cross-vCenter volume migration

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

1. Deployed two vCenters and enabled vCenter FSS to support cross-vCenter volume migration.
2. Ran the tests for same vCenter migration and cross-vCenter migration after setting the appropriate environment variables.
3. Ran the unit tests for volume migrations and verified that both tests were successfully executed.

Environment variables set:
```
export CNS_VC_URL=https://<src-vc-user>:<src-vc-password>@<src-vc-ip>
export CNS_DATACENTER=VSAN-DC
export CNS_DATASTORE=vsanDatastore
export REMOTE_VC_URL=https://<dest-vc-user>:<dest-vc-password>@<dest-vc-ip>
export REMOTE_DATACENTER=VSAN-DC
export CNS_MIGRATION_DATASTORE=vsanDatastore
```

Cross-vCenter migration
--------------------

Test logs:
```
    client_test.go:569: Relocating volume using the spec: types.CnsBlockVolumeRelocateSpec{
            CnsVolumeRelocateSpec: types.CnsVolumeRelocateSpec{
                VolumeId: types.CnsVolumeId{
                    Id: "e7243753-3cdd-4f88-8e7e-fcc696606beb",
                },
                Datastore:      types.ManagedObjectReference{Type:"Datastore", Value:"datastore-47"},
                Profile:        nil,
                ServiceLocator: &types.ServiceLocator{
                    InstanceUuid: "de5ebad2-565e-4364-ab47-9c1ea849dabe",
                    Url:          "https://<redacted-vc-ip>/sdk",
                    Credential:   &types.ServiceLocatorNamePassword{
                        ServiceLocatorCredential: types.ServiceLocatorCredential{},
                        Username:                 "<redacted-user-name>",
                        Password:                 "<redacted-password>",
                    },
                    SslThumbprint: "B9:12:79:B9:36:1B:B5:C1:2F:20:4A:DD:BD:0C:3D:31:82:99:CB:5C",
                },
            },
        }
    client_test.go:587: Successfully Relocated volume. Relocate task info result: &types.CnsVolumeOperationResult{
            VolumeId: types.CnsVolumeId{
                Id: "e7243753-3cdd-4f88-8e7e-fcc696606beb",
            },
            Fault: (*types.LocalizedMethodFault)(nil),
        }
--- PASS: TestClient (28.37s)
PASS
ok  	github.com/vmware/govmomi/cns	28.784s
```

Same-vCenter migration
--------------------
For same VC migration, unset the `REMOTE_VC_URL` environment variable.
```
export REMOTE_VC_URL=
export CNS_MIGRATION_DATASTORE=nfs0-1
```

Test logs:
```
client_test.go:569: Relocating volume using the spec: types.CnsBlockVolumeRelocateSpec{
            CnsVolumeRelocateSpec: types.CnsVolumeRelocateSpec{
                VolumeId: types.CnsVolumeId{
                    Id: "13a673f5-20e6-4d64-9f79-2406d94cec5b",
                },
                Datastore:      types.ManagedObjectReference{Type:"Datastore", Value:"datastore-38"},
                Profile:        nil,
                ServiceLocator: (*types.ServiceLocator)(nil),
            },
        }
    client_test.go:587: Successfully Relocated volume. Relocate task info result: &types.CnsVolumeOperationResult{
            VolumeId: types.CnsVolumeId{
                Id: "13a673f5-20e6-4d64-9f79-2406d94cec5b",
            },
            Fault: (*types.LocalizedMethodFault)(nil),
        }
--- PASS: TestClient (10.86s)
PASS
ok  	github.com/vmware/govmomi/cns	11.332s
```


## Checklist:

- [X] My code follows the `CONTRIBUTION` [guidelines] of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
