### PR TITLE
fix: Update summary.config.hwVersion in simulator

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -232,6 +232,7 @@ func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 		{spec.InstanceUuid, &vm.Config.InstanceUuid},
 		{spec.InstanceUuid, &vm.Summary.Config.InstanceUuid},
 		{spec.Version, &vm.Config.Version},
+		{spec.Version, &vm.Summary.Config.HwVersion},
 		{spec.Files.VmPathName, &vm.Config.Files.VmPathName},
 		{spec.Files.VmPathName, &vm.Summary.Config.VmPathName},
 		{spec.Files.SnapshotDirectory, &vm.Config.Files.SnapshotDirectory},
@@ -1883,10 +1884,18 @@ func (vm *VirtualMachine) UpgradeVMTask(ctx *Context, req *types.UpgradeVM_Task)
 	body := &methods.UpgradeVM_TaskBody{}
 
 	task := CreateTask(vm, "upgradeVm", func(t *Task) (types.AnyType, types.BaseMethodFault) {
-		if vm.Config.Version != esx.HardwareVersion {
-			ctx.Map.Update(vm, []types.PropertyChange{{
-				Name: "config.version", Val: esx.HardwareVersion,
-			}})
+		if req.Version == "" {
+			req.Version = esx.HardwareVersion
+		}
+		if req.Version != vm.Config.Version {
+			ctx.Map.Update(vm, []types.PropertyChange{
+				{
+					Name: "config.version", Val: req.Version,
+				},
+				{
+					Name: "summary.config.hwVersion", Val: req.Version,
+				},
+			})
 		}
 		return nil, nil
 	})


### PR DESCRIPTION

## Description

This patch updates the simulator to correctly handle VM hardware upgrades so the property `summary.config.hwVersion` is updated when the hardware is upgraded.


Closes: NA

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] `go test -v -count 1 -run TestUpgradeVm ./simulator`

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
