### PR TITLE
chore: Better support for ESXi & HW versions

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -5818,7 +5818,7 @@ Options:
   -net.protocol=         Network device protocol. Applicable to vmxnet3vrdma. Default to 'rocev2'
   -on=true               Power on VM
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
-  -version=              ESXi hardware version [8.0.2|8.0|7.0.2|7.0.1|7.0.0|6.7.2|6.7|6.5|6.0|5.5|5.1|5.0|4.0|3|2]
+  -version=              ESXi hardware version [2|3|4|5.0|5.1|5.5|6.0|6.5|6.7|6.7.2|7.0|7.0.1|7.0.2|8.0|8.0.1|8.0.2]
 ```
 
 ## vm.customize

--- a/vim25/types/esxi_version.go
+++ b/vim25/types/esxi_version.go
@@ -1,0 +1,233 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// ESXiVersion is an ESXi version.
+type ESXiVersion uint8
+
+const (
+	esxiVersionBegin ESXiVersion = iota
+
+	ESXi2000
+	ESXi3000
+	ESXi4000
+	ESXi5000
+	ESXi5100
+	ESXi5500
+	ESXi6000
+	ESXi6500
+	ESXi6700
+	ESXi6720
+	ESXi7000
+	ESXi7010
+	ESXi7020
+	ESXi8000
+	ESXi8010
+	ESXi8020
+
+	esxiVersionEnd
+)
+
+// HardwareVersion returns the maximum hardware version supported by this
+// version of ESXi, per https://kb.vmware.com/s/article/1003746.
+func (ev ESXiVersion) HardwareVersion() HardwareVersion {
+	switch ev {
+	case ESXi2000:
+		return VMX3
+	case ESXi3000:
+		return VMX4
+	case ESXi4000:
+		return VMX7
+	case ESXi5000:
+		return VMX8
+	case ESXi5100:
+		return VMX9
+	case ESXi5500:
+		return VMX10
+	case ESXi6000:
+		return VMX11
+	case ESXi6500:
+		return VMX13
+	case ESXi6700:
+		return VMX14
+	case ESXi6720:
+		return VMX15
+	case ESXi7000:
+		return VMX17
+	case ESXi7010:
+		return VMX18
+	case ESXi7020:
+		return VMX19
+	case ESXi8000, ESXi8010:
+		return VMX20
+	case ESXi8020:
+		return VMX21
+	}
+	return 0
+}
+
+// IsHardwareVersionSupported returns true if the provided hardware version is
+// supported by the given version of ESXi.
+func (ev ESXiVersion) IsHardwareVersionSupported(hv HardwareVersion) bool {
+	return hv <= ev.HardwareVersion()
+}
+
+func (ev ESXiVersion) IsValid() bool {
+	return ev.String() != ""
+}
+
+func (ev ESXiVersion) String() string {
+	switch ev {
+	case ESXi2000:
+		return "2"
+	case ESXi3000:
+		return "3"
+	case ESXi4000:
+		return "4"
+	case ESXi5000:
+		return "5.0"
+	case ESXi5100:
+		return "5.1"
+	case ESXi5500:
+		return "5.5"
+	case ESXi6000:
+		return "6.0"
+	case ESXi6500:
+		return "6.5"
+	case ESXi6700:
+		return "6.7"
+	case ESXi6720:
+		return "6.7.2"
+	case ESXi7000:
+		return "7.0"
+	case ESXi7010:
+		return "7.0.1"
+	case ESXi7020:
+		return "7.0.2"
+	case ESXi8000:
+		return "8.0"
+	case ESXi8010:
+		return "8.0.1"
+	case ESXi8020:
+		return "8.0.2"
+	}
+	return ""
+}
+
+func (ev ESXiVersion) MarshalText() ([]byte, error) {
+	return []byte(ev.String()), nil
+}
+
+func (ev *ESXiVersion) UnmarshalText(text []byte) error {
+	v, err := ParseESXiVersion(string(text))
+	if err != nil {
+		return err
+	}
+	*ev = v
+	return nil
+}
+
+// MustParseESXiVersion parses the provided string into an ESXi version.
+func MustParseESXiVersion(s string) ESXiVersion {
+	v, err := ParseESXiVersion(s)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+var esxiRe = regexp.MustCompile(`(?i)^v?(\d)(?:\.(\d))?(?:\.(\d))?(?:\s*u(\d))?$`)
+
+// ParseESXiVersion parses the provided string into an ESXi version.
+func ParseESXiVersion(s string) (ESXiVersion, error) {
+	if m := esxiRe.FindStringSubmatch(s); len(m) > 0 {
+		var (
+			major  int64
+			minor  int64
+			patch  int64
+			update int64
+		)
+
+		major, _ = strconv.ParseInt(m[1], 0, 0)
+		if len(m) > 2 {
+			minor, _ = strconv.ParseInt(m[2], 0, 0)
+		}
+		if len(m) > 3 {
+			patch, _ = strconv.ParseInt(m[3], 0, 0)
+		}
+		if len(m) > 4 {
+			update, _ = strconv.ParseInt(m[4], 0, 0)
+		}
+
+		switch {
+		case major == 2 && minor == 0 && patch == 0 && update == 0:
+			return ESXi2000, nil
+		case major == 3 && minor == 0 && patch == 0 && update == 0:
+			return ESXi3000, nil
+		case major == 4 && minor == 0 && patch == 0 && update == 0:
+			return ESXi4000, nil
+		case major == 5 && minor == 0 && patch == 0 && update == 0:
+			return ESXi5000, nil
+		case major == 5 && minor == 1 && patch == 0 && update == 0:
+			return ESXi5100, nil
+		case major == 5 && minor == 5 && patch == 0 && update == 0:
+			return ESXi5500, nil
+		case major == 6 && minor == 0 && patch == 0 && update == 0:
+			return ESXi6000, nil
+		case major == 6 && minor == 5 && patch == 0 && update == 0:
+			return ESXi6500, nil
+		case major == 6 && minor == 7 && patch == 0 && update == 0:
+			return ESXi6700, nil
+		case major == 6 && minor == 7 && patch == 2 && update == 0,
+			major == 6 && minor == 7 && patch == 0 && update == 2:
+			return ESXi6720, nil
+		case major == 7 && minor == 0 && patch == 0 && update == 0:
+			return ESXi7000, nil
+		case major == 7 && minor == 0 && patch == 1 && update == 0,
+			major == 7 && minor == 0 && patch == 0 && update == 1:
+			return ESXi7010, nil
+		case major == 7 && minor == 0 && patch == 2 && update == 0,
+			major == 7 && minor == 0 && patch == 0 && update == 2:
+			return ESXi7020, nil
+		case major == 8 && minor == 0 && patch == 0 && update == 0:
+			return ESXi8000, nil
+		case major == 8 && minor == 0 && patch == 1 && update == 0,
+			major == 8 && minor == 0 && patch == 0 && update == 1:
+			return ESXi8010, nil
+		case major == 8 && minor == 0 && patch == 2 && update == 0,
+			major == 8 && minor == 0 && patch == 0 && update == 2:
+			return ESXi8020, nil
+		}
+	}
+
+	return 0, fmt.Errorf("invalid version: %q", s)
+}
+
+// GetESXiVersions returns a list of ESXi versions.
+func GetESXiVersions() []ESXiVersion {
+	dst := make([]ESXiVersion, esxiVersionEnd-1)
+	for i := esxiVersionBegin + 1; i < esxiVersionEnd; i++ {
+		dst[i-1] = i
+	}
+	return dst
+}

--- a/vim25/types/esxi_version_test.go
+++ b/vim25/types/esxi_version_test.go
@@ -1,0 +1,286 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"testing"
+)
+
+func TestESXiVersion(t *testing.T) {
+
+	var uniqueExpectedVersions []ESXiVersion
+
+	type testCase struct {
+		name                    string
+		in                      string
+		expectedIsValid         bool
+		expectedVersion         ESXiVersion
+		expectedString          string
+		expectedHardwareVersion HardwareVersion
+	}
+
+	testCasesForMajorVersion := func(
+		major int,
+		expectedVersion ESXiVersion,
+		expectedString string,
+		expectedHardwareVersion HardwareVersion) []testCase {
+
+		uniqueExpectedVersions = append(uniqueExpectedVersions, MustParseESXiVersion(expectedString))
+
+		szMajor := strconv.Itoa(major)
+		return []testCase{
+			{
+				name:                    szMajor,
+				in:                      szMajor,
+				expectedIsValid:         true,
+				expectedVersion:         expectedVersion,
+				expectedString:          expectedString,
+				expectedHardwareVersion: expectedHardwareVersion,
+			},
+			{
+				name:                    szMajor + ".0",
+				in:                      szMajor + ".0",
+				expectedIsValid:         true,
+				expectedVersion:         expectedVersion,
+				expectedString:          expectedString,
+				expectedHardwareVersion: expectedHardwareVersion,
+			},
+			{
+				name:                    szMajor + ".0.0",
+				in:                      szMajor + ".0.0",
+				expectedIsValid:         true,
+				expectedVersion:         expectedVersion,
+				expectedString:          expectedString,
+				expectedHardwareVersion: expectedHardwareVersion,
+			},
+		}
+	}
+
+	testCasesForMajorMinorVersion := func(
+		major, minor int,
+		expectedVersion ESXiVersion,
+		expectedString string,
+		expectedHardwareVersion HardwareVersion) []testCase {
+
+		uniqueExpectedVersions = append(uniqueExpectedVersions, MustParseESXiVersion(expectedString))
+
+		szMajor := strconv.Itoa(major)
+		szMinor := strconv.Itoa(minor)
+
+		return []testCase{
+			{
+				name:                    szMajor + "." + szMinor,
+				in:                      szMajor + "." + szMinor,
+				expectedIsValid:         true,
+				expectedVersion:         expectedVersion,
+				expectedString:          expectedString,
+				expectedHardwareVersion: expectedHardwareVersion,
+			},
+			{
+				name:                    szMajor + "." + szMinor + ".0",
+				in:                      szMajor + "." + szMinor + ".0",
+				expectedIsValid:         true,
+				expectedVersion:         expectedVersion,
+				expectedString:          expectedString,
+				expectedHardwareVersion: expectedHardwareVersion,
+			},
+		}
+	}
+
+	testCasesForMajorMinorUpdateVersion := func(
+		major, minor, update int,
+		expectedVersion ESXiVersion,
+		expectedString string,
+		expectedHardwareVersion HardwareVersion) []testCase {
+
+		uniqueExpectedVersions = append(uniqueExpectedVersions, MustParseESXiVersion(expectedString))
+
+		szMajor := strconv.Itoa(major)
+		szMinor := strconv.Itoa(minor)
+		szUpdate := strconv.Itoa(update)
+
+		return []testCase{
+			{
+				name:                    szMajor + "." + szMinor + "." + szUpdate,
+				in:                      szMajor + "." + szMinor + "." + szUpdate,
+				expectedIsValid:         true,
+				expectedVersion:         expectedVersion,
+				expectedString:          expectedString,
+				expectedHardwareVersion: expectedHardwareVersion,
+			},
+			{
+				name:                    szMajor + "." + szMinor + "u" + szUpdate,
+				in:                      szMajor + "." + szMinor + "u" + szUpdate,
+				expectedIsValid:         true,
+				expectedVersion:         expectedVersion,
+				expectedString:          expectedString,
+				expectedHardwareVersion: expectedHardwareVersion,
+			},
+			{
+				name:                    szMajor + "." + szMinor + "U" + szUpdate,
+				in:                      szMajor + "." + szMinor + "U" + szUpdate,
+				expectedIsValid:         true,
+				expectedVersion:         expectedVersion,
+				expectedString:          expectedString,
+				expectedHardwareVersion: expectedHardwareVersion,
+			},
+			{
+				name:                    szMajor + "." + szMinor + " u" + szUpdate,
+				in:                      szMajor + "." + szMinor + " u" + szUpdate,
+				expectedIsValid:         true,
+				expectedVersion:         expectedVersion,
+				expectedString:          expectedString,
+				expectedHardwareVersion: expectedHardwareVersion,
+			},
+			{
+				name:                    szMajor + "." + szMinor + " U" + szUpdate,
+				in:                      szMajor + "." + szMinor + " U" + szUpdate,
+				expectedIsValid:         true,
+				expectedVersion:         expectedVersion,
+				expectedString:          expectedString,
+				expectedHardwareVersion: expectedHardwareVersion,
+			},
+		}
+	}
+
+	testCases := []testCase{
+		{
+			name: "EmptyString",
+			in:   "",
+		},
+		{
+			name: "InvalidMajorVersion",
+			in:   "1",
+		},
+		{
+			name: "ValidMajorInvalidMinorVersion",
+			in:   "2.1",
+		},
+		{
+			name: "ValidMajorValidMinorInvalidPatchVersion",
+			in:   "7.0.5",
+		},
+		{
+			name: "ValidMajorValidMinorInvalidUpdateVersion",
+			in:   "7.0U5",
+		},
+		{
+			name: "ValidMajorValidMinorValidPatchInvalidUpdateVersion",
+			in:   "7.0.0U5",
+		},
+	}
+
+	testCases = append(testCases, testCasesForMajorVersion(2, ESXi2000, "2", VMX3)...)
+	testCases = append(testCases, testCasesForMajorVersion(3, ESXi3000, "3", VMX4)...)
+	testCases = append(testCases, testCasesForMajorVersion(4, ESXi4000, "4", VMX7)...)
+	testCases = append(testCases, testCasesForMajorVersion(5, ESXi5000, "5.0", VMX8)...)
+	testCases = append(testCases, testCasesForMajorMinorVersion(5, 1, ESXi5100, "5.1", VMX9)...)
+	testCases = append(testCases, testCasesForMajorMinorVersion(5, 5, ESXi5500, "5.5", VMX10)...)
+	testCases = append(testCases, testCasesForMajorVersion(6, ESXi6000, "6.0", VMX11)...)
+	testCases = append(testCases, testCasesForMajorMinorVersion(6, 5, ESXi6500, "6.5", VMX13)...)
+	testCases = append(testCases, testCasesForMajorMinorVersion(6, 7, ESXi6700, "6.7", VMX14)...)
+	testCases = append(testCases, testCasesForMajorMinorUpdateVersion(6, 7, 2, ESXi6720, "6.7.2", VMX15)...)
+	testCases = append(testCases, testCasesForMajorVersion(7, ESXi7000, "7.0", VMX17)...)
+	testCases = append(testCases, testCasesForMajorMinorUpdateVersion(7, 0, 1, ESXi7010, "7.0.1", VMX18)...)
+	testCases = append(testCases, testCasesForMajorMinorUpdateVersion(7, 0, 2, ESXi7020, "7.0.2", VMX19)...)
+	testCases = append(testCases, testCasesForMajorVersion(8, ESXi8000, "8.0", VMX20)...)
+	testCases = append(testCases, testCasesForMajorMinorUpdateVersion(8, 0, 1, ESXi8010, "8.0.1", VMX20)...)
+	testCases = append(testCases, testCasesForMajorMinorUpdateVersion(8, 0, 2, ESXi8020, "8.0.2", VMX21)...)
+
+	t.Run("GetESXiVersions", func(t *testing.T) {
+		a, e := uniqueExpectedVersions, GetESXiVersions()
+		sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+		sort.Slice(e, func(i, j int) bool { return e[i] < e[j] })
+		if a, e := len(a), len(e); a != e {
+			t.Errorf("unexpected number of versions: a=%d, e=%d", a, e)
+		}
+		for i := range a {
+			if a[i] != e[i] {
+				t.Errorf("unexpected version: i=%d, a=%s, e=%s", i, a, e)
+			}
+		}
+	})
+
+	t.Run("ParseESXiVersion", func(t *testing.T) {
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.name, func(t *testing.T) {
+				v, err := ParseESXiVersion(tc.in)
+				if err != nil && tc.expectedIsValid {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if a, e := v.IsValid(), tc.expectedIsValid; a != e {
+					t.Errorf("unexpected invalid value: a=%v, e=%v", a, e)
+				}
+				if tc.expectedIsValid {
+					if a, e := v, tc.expectedVersion; a != e {
+						t.Errorf("unexpected value: a=%v, e=%v", a, e)
+					}
+					if a, e := v.String(), tc.expectedString; a != e {
+						t.Errorf("unexpected string: a=%v, e=%v", a, e)
+					}
+					if a, e := v.IsHardwareVersionSupported(tc.expectedHardwareVersion), true; a != e {
+						t.Errorf("is hardware version supported failed for %s", tc.expectedHardwareVersion)
+					}
+					if a, e := v.HardwareVersion(), tc.expectedHardwareVersion; a != e {
+						t.Errorf("unexpected hardware version: a=%s, e=%s", a, e)
+					}
+				}
+			})
+		}
+	})
+	t.Run("MarshalText", func(t *testing.T) {
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.name, func(t *testing.T) {
+				data, err := tc.expectedVersion.MarshalText()
+				if err != nil {
+					t.Fatalf("unexpected error marshaling text: %v", err)
+				}
+				if a, e := string(data), tc.expectedString; a != e {
+					t.Errorf("unexpected data marshaling text: %s", a)
+				}
+			})
+		}
+	})
+
+	t.Run("UnmarshalText", func(t *testing.T) {
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.name, func(t *testing.T) {
+				var (
+					data = []byte(tc.in)
+					v    ESXiVersion
+				)
+				if err := v.UnmarshalText(data); err != nil {
+					if !tc.expectedIsValid {
+						if a, e := err.Error(), fmt.Sprintf("invalid version: %q", tc.in); a != e {
+							t.Errorf("unexpected error unmarshaling text: %q", a)
+						}
+					} else {
+						t.Errorf("unexpected error unmarshaling text: %v", err)
+					}
+				} else if a, e := v, v; a != e {
+					t.Errorf("unexpected data unmarshaling text: %s", a)
+				}
+			})
+		}
+	})
+}

--- a/vim25/types/hardware_version.go
+++ b/vim25/types/hardware_version.go
@@ -20,57 +20,105 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
-
-	"golang.org/x/mod/semver"
 )
 
-// hardwareVersions is a list of supported hardware versions from
-// https://kb.vmware.com/s/article/1003746.
-var hardwareVersions = []HardwareVersion{
-	"vmx-3",
-	"vmx-4",
-	"vmx-6",
-	"vmx-7",
-	"vmx-8",
-	"vmx-9",
-	"vmx-10",
-	"vmx-11",
-	"vmx-12",
-	"vmx-13",
-	"vmx-14",
-	"vmx-15",
-	"vmx-16",
-	"vmx-17",
-	"vmx-18",
-	"vmx-19",
-	"vmx-20",
-	"vmx-21",
+// HardwareVersion is a VMX hardware version.
+type HardwareVersion uint8
+
+const (
+	VMX3 HardwareVersion = iota + 3
+	VMX4
+
+	vmx5 // invalid
+
+	VMX6
+	VMX7
+	VMX8
+	VMX9
+	VMX10
+	VMX11
+	VMX12
+	VMX13
+	VMX14
+	VMX15
+	VMX16
+	VMX17
+	VMX18
+	VMX19
+	VMX20
+	VMX21
+)
+
+const (
+	// MinValidHardwareVersion is the minimum, valid hardware version supported
+	// by VMware hypervisors in the wild.
+	MinValidHardwareVersion = VMX3
+
+	// MaxValidHardwareVersion is the maximum, valid hardware version supported
+	// by VMware hypervisors in the wild.
+	MaxValidHardwareVersion = VMX21
+)
+
+func (hv HardwareVersion) IsValid() bool {
+	return hv != vmx5 &&
+		hv >= MinValidHardwareVersion &&
+		hv <= MaxValidHardwareVersion
 }
 
-var esxiVersions = []string{
-	"8.0.2",
-	"8.0",
-	"7.0.2",
-	"7.0.1",
-	"7.0.0",
-	"6.7.2",
-	"6.7",
-	"6.5",
-	"6.0",
-	"5.5",
-	"5.1",
-	"5.0",
-	"4.0",
-	"3",
-	"2",
+func (hv HardwareVersion) String() string {
+	if hv.IsValid() {
+		return fmt.Sprintf("vmx-%d", hv)
+	}
+	return ""
 }
 
-// GetESXiVersions returns a list of ESXi versions.
-func GetESXiVersions() []string {
-	dst := make([]string, len(esxiVersions))
-	copy(dst, esxiVersions)
-	return dst
+func (hv HardwareVersion) MarshalText() ([]byte, error) {
+	return []byte(hv.String()), nil
+}
+
+func (hv *HardwareVersion) UnmarshalText(text []byte) error {
+	v, err := ParseHardwareVersion(string(text))
+	if err != nil {
+		return err
+	}
+	*hv = v
+	return nil
+}
+
+var vmxRe = regexp.MustCompile(`(?i)^vmx-(\d+)$`)
+
+// MustParseHardwareVersion parses the provided string into a hardware version.
+func MustParseHardwareVersion(s string) HardwareVersion {
+	v, err := ParseHardwareVersion(s)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// ParseHardwareVersion parses the provided string into a hardware version.
+func ParseHardwareVersion(s string) (HardwareVersion, error) {
+	var u uint64
+	if m := vmxRe.FindStringSubmatch(s); len(m) > 0 {
+		u, _ = strconv.ParseUint(m[1], 10, 8)
+	} else {
+		u, _ = strconv.ParseUint(s, 10, 8)
+	}
+	v := HardwareVersion(u)
+	if !v.IsValid() {
+		return 0, fmt.Errorf("invalid version: %q", s)
+	}
+	return v, nil
+}
+
+var hardwareVersions []HardwareVersion
+
+func init() {
+	for i := MinValidHardwareVersion; i <= MaxValidHardwareVersion; i++ {
+		if i.IsValid() {
+			hardwareVersions = append(hardwareVersions, i)
+		}
+	}
 }
 
 // GetHardwareVersions returns a list of hardware versions.
@@ -78,107 +126,4 @@ func GetHardwareVersions() []HardwareVersion {
 	dst := make([]HardwareVersion, len(hardwareVersions))
 	copy(dst, hardwareVersions)
 	return dst
-}
-
-// GetSupportedHardwareVersionsForESXi returns a list of the hardware versions
-// supported by the specified ESXi version.
-func GetSupportedHardwareVersionsForESXi(esxVersion string) []HardwareVersion {
-	mv, ok := GetHardwareVersionForESXi(esxVersion)
-	if !ok {
-		return nil
-	}
-	var hv []HardwareVersion
-	for i := range hardwareVersions {
-		if hardwareVersions[i].Int() <= mv.Int() {
-			hv = append(hv, hardwareVersions[i])
-		}
-	}
-	return hv
-}
-
-// GetHardwareVersionForESXi returns the maximum supported hardware
-// version for a given ESX version. Please note that ESX versions prior to 7.0
-// did not use semantic versioning to denote update releases, ex. 6.7U2 is
-// 6.7.0.BUILD instead of 6.7.2. For the purposes of this function, however,
-// please use 6.7.2 for 6.7U2.
-func GetHardwareVersionForESXi(esxVersion string) (HardwareVersion, bool) {
-	if !strings.HasPrefix(esxVersion, "v") {
-		esxVersion = "v" + esxVersion
-	}
-
-	if !semver.IsValid(esxVersion) {
-		return "", false
-	}
-
-	// From https://kb.vmware.com/s/article/1003746
-	switch {
-	case semver.Compare(esxVersion, "v8.0.2") >= 0:
-		return "vmx-21", true
-	case semver.Compare(esxVersion, "v8.0") >= 0:
-		return "vmx-20", true
-	case semver.Compare(esxVersion, "v7.0.2") >= 0:
-		return "vmx-19", true
-	case semver.Compare(esxVersion, "v7.0.1") >= 0:
-		return "vmx-18", true
-	case semver.Compare(esxVersion, "v7.0.0") >= 0:
-		return "vmx-17", true
-	case semver.Compare(esxVersion, "v6.7.2") >= 0:
-		return "vmx-15", true
-	case semver.Compare(esxVersion, "v6.7") >= 0:
-		return "vmx-14", true
-	case semver.Compare(esxVersion, "v6.5") >= 0:
-		return "vmx-13", true
-	case semver.Compare(esxVersion, "v6.0") >= 0:
-		return "vmx-11", true
-	case semver.Compare(esxVersion, "v5.5") >= 0:
-		return "vmx-10", true
-	case semver.Compare(esxVersion, "v5.1") >= 0:
-		return "vmx-9", true
-	case semver.Compare(esxVersion, "v5.0") >= 0:
-		return "vmx-8", true
-	case semver.Compare(esxVersion, "v4.0") >= 0:
-		return "vmx-7", true
-	case semver.Compare(esxVersion, "v3") >= 0:
-		return "vmx-4", true
-	case semver.Compare(esxVersion, "v2") >= 0:
-		return "vmx-3", true
-	}
-	return "", false
-}
-
-type HardwareVersion string
-
-func (hv HardwareVersion) IsValid() bool {
-	_, err := hv.int()
-	return err == nil
-}
-
-// String returns the string value of the hardware version when IsValid is true,
-// otherwise an empty string is returned.
-func (hv HardwareVersion) String() string {
-	i, err := hv.int()
-	if err != nil {
-		return ""
-	}
-	return fmt.Sprintf("vmx-%d", i)
-}
-
-// Int returns the numerical value of the hardware version when IsValid is true,
-// otherwise 0 is returned.
-func (hv HardwareVersion) Int() int {
-	i, _ := hv.int()
-	return i
-}
-
-var vmxRe = regexp.MustCompile(`(?i)^vmx-(\d+)$`)
-
-func (hv HardwareVersion) int() (int, error) {
-	if m := vmxRe.FindStringSubmatch(string(hv)); len(m) > 0 {
-		v, err := strconv.ParseInt(m[1], 10, 0)
-		if err != nil {
-			return 0, err
-		}
-		return int(v), nil
-	}
-	return 0, fmt.Errorf("invalid hardware version: %q", string(hv))
 }

--- a/vim25/types/hardware_version_test.go
+++ b/vim25/types/hardware_version_test.go
@@ -17,70 +17,230 @@ limitations under the License.
 package types
 
 import (
+	"fmt"
+	"sort"
+	"strconv"
 	"testing"
 )
 
-func TestHardwareVersion(t *testing.T) {
+func TestParseHardwareVersion(t *testing.T) {
 	testCases := []struct {
 		name            string
 		in              string
 		expectedIsValid bool
-		expectedInt     int
+		expectedVersion HardwareVersion
 		expectedString  string
 	}{
 		{
-			name:            "empty string",
-			in:              "",
-			expectedIsValid: false,
-			expectedInt:     0,
-			expectedString:  "",
+			name: "EmptyString",
+			in:   "",
 		},
 		{
-			name:            "vmx prefix sans number",
-			in:              "vmx-",
-			expectedIsValid: false,
-			expectedInt:     0,
-			expectedString:  "",
+			name: "PrefixSansNumber",
+			in:   "vmx-",
 		},
 		{
-			name:            "number sans vmx prefix",
+			name:            "NumberSansPrefix",
 			in:              "13",
-			expectedIsValid: false,
-			expectedInt:     0,
-			expectedString:  "",
+			expectedIsValid: true,
+			expectedVersion: VMX13,
+			expectedString:  "vmx-13",
 		},
 		{
 			name:            "vmx-13",
 			in:              "vmx-13",
 			expectedIsValid: true,
-			expectedInt:     13,
+			expectedVersion: VMX13,
 			expectedString:  "vmx-13",
 		},
 		{
 			name:            "VMX-18",
 			in:              "VMX-18",
 			expectedIsValid: true,
-			expectedInt:     18,
+			expectedVersion: VMX18,
 			expectedString:  "vmx-18",
 		},
 	}
 
-	for i := range testCases {
-		tc := testCases[i]
-		t.Run(tc.name, func(t *testing.T) {
-			hv := HardwareVersion(tc.in)
-			if a, e := string(hv), tc.in; a != e {
-				t.Errorf("unexpected type assert: a=%v, e=%v", a, e)
-			}
-			if a, e := hv.IsValid(), tc.expectedIsValid; a != e {
-				t.Errorf("unexpected IsValid: a=%v, e=%v", a, e)
-			}
-			if a, e := hv.Int(), tc.expectedInt; a != e {
-				t.Errorf("unexpected Int: a=%v, e=%v", a, e)
-			}
-			if a, e := hv.String(), tc.expectedString; a != e {
-				t.Errorf("unexpected String: a=%v, e=%v", a, e)
-			}
-		})
+	t.Run("ParseHardwareVersion", func(t *testing.T) {
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.name, func(t *testing.T) {
+				v, err := ParseHardwareVersion(tc.in)
+				if err != nil && tc.expectedIsValid {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if a, e := v.IsValid(), tc.expectedIsValid; a != e {
+					t.Errorf("unexpected invalid value: a=%v, e=%v", a, e)
+				}
+				if v.IsValid() {
+					if a, e := v, tc.expectedVersion; a != e {
+						t.Errorf("unexpected value: a=%v, e=%v", a, e)
+					}
+					if a, e := v.String(), tc.expectedString; a != e {
+						t.Errorf("unexpected string: a=%v, e=%v", a, e)
+					}
+				}
+			})
+		}
+	})
+
+}
+
+func TestHardwareVersion(t *testing.T) {
+
+	var uniqueExpectedVersions []HardwareVersion
+
+	type testCase struct {
+		name            string
+		in              string
+		expectedIsValid bool
+		expectedVersion HardwareVersion
+		expectedString  string
 	}
+
+	testCasesForVersion := func(
+		version int,
+		expectedVersion HardwareVersion,
+		expectedString string) []testCase {
+
+		uniqueExpectedVersions = append(uniqueExpectedVersions, MustParseHardwareVersion(expectedString))
+
+		szVersion := strconv.Itoa(version)
+		return []testCase{
+			{
+				name:            szVersion,
+				in:              szVersion,
+				expectedIsValid: true,
+				expectedVersion: expectedVersion,
+				expectedString:  expectedString,
+			},
+			{
+				name:            "vmx-" + szVersion,
+				in:              "vmx-" + szVersion,
+				expectedIsValid: true,
+				expectedVersion: expectedVersion,
+				expectedString:  expectedString,
+			},
+			{
+				name:            "VMX-" + szVersion,
+				in:              "VMX-" + szVersion,
+				expectedIsValid: true,
+				expectedVersion: expectedVersion,
+				expectedString:  expectedString,
+			},
+		}
+	}
+
+	testCases := []testCase{
+		{
+			name: "EmptyString",
+			in:   "",
+		},
+		{
+			name: "PrefixSansVersion",
+			in:   "vmx-",
+		},
+		{
+			name: "PrefixAndInvalidVersion",
+			in:   "vmx-0",
+		},
+		{
+			name: "InvalidVersion",
+			in:   "1",
+		},
+	}
+
+	testCases = append(testCases, testCasesForVersion(3, VMX3, "vmx-3")...)
+	testCases = append(testCases, testCasesForVersion(4, VMX4, "vmx-4")...)
+	testCases = append(testCases, testCasesForVersion(6, VMX6, "vmx-6")...)
+	testCases = append(testCases, testCasesForVersion(7, VMX7, "vmx-7")...)
+	testCases = append(testCases, testCasesForVersion(8, VMX8, "vmx-8")...)
+	testCases = append(testCases, testCasesForVersion(9, VMX9, "vmx-9")...)
+	testCases = append(testCases, testCasesForVersion(10, VMX10, "vmx-10")...)
+	testCases = append(testCases, testCasesForVersion(11, VMX11, "vmx-11")...)
+	testCases = append(testCases, testCasesForVersion(12, VMX12, "vmx-12")...)
+	testCases = append(testCases, testCasesForVersion(13, VMX13, "vmx-13")...)
+	testCases = append(testCases, testCasesForVersion(14, VMX14, "vmx-14")...)
+	testCases = append(testCases, testCasesForVersion(15, VMX15, "vmx-15")...)
+	testCases = append(testCases, testCasesForVersion(16, VMX16, "vmx-16")...)
+	testCases = append(testCases, testCasesForVersion(17, VMX17, "vmx-17")...)
+	testCases = append(testCases, testCasesForVersion(18, VMX18, "vmx-18")...)
+	testCases = append(testCases, testCasesForVersion(19, VMX19, "vmx-19")...)
+	testCases = append(testCases, testCasesForVersion(20, VMX20, "vmx-20")...)
+	testCases = append(testCases, testCasesForVersion(21, VMX21, "vmx-21")...)
+
+	t.Run("GetHardwareVersions", func(t *testing.T) {
+		a, e := uniqueExpectedVersions, GetHardwareVersions()
+		sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+		sort.Slice(e, func(i, j int) bool { return e[i] < e[j] })
+		if a, e := len(a), len(e); a != e {
+			t.Errorf("unexpected number of versions: a=%d, e=%d", a, e)
+		}
+		for i := range a {
+			if a[i] != e[i] {
+				t.Errorf("unexpected version: i=%d, a=%s, e=%s", i, a, e)
+			}
+		}
+	})
+
+	t.Run("ParseHardwareVersion", func(t *testing.T) {
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.name, func(t *testing.T) {
+				v, err := ParseHardwareVersion(tc.in)
+				if err != nil && tc.expectedIsValid {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if a, e := v.IsValid(), tc.expectedIsValid; a != e {
+					t.Errorf("unexpected invalid value: a=%v, e=%v", a, e)
+				}
+				if tc.expectedIsValid {
+					if a, e := v, tc.expectedVersion; a != e {
+						t.Errorf("unexpected value: a=%v, e=%v", a, e)
+					}
+					if a, e := v.String(), tc.expectedString; a != e {
+						t.Errorf("unexpected string: a=%v, e=%v", a, e)
+					}
+				}
+			})
+		}
+	})
+	t.Run("MarshalText", func(t *testing.T) {
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.name, func(t *testing.T) {
+				data, err := tc.expectedVersion.MarshalText()
+				if err != nil {
+					t.Fatalf("unexpected error marshaling text: %v", err)
+				}
+				if a, e := string(data), tc.expectedString; a != e {
+					t.Errorf("unexpected data marshaling text: %s", a)
+				}
+			})
+		}
+	})
+
+	t.Run("UnmarshalText", func(t *testing.T) {
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.name, func(t *testing.T) {
+				var (
+					data = []byte(tc.in)
+					v    HardwareVersion
+				)
+				if err := v.UnmarshalText(data); err != nil {
+					if !tc.expectedIsValid {
+						if a, e := err.Error(), fmt.Sprintf("invalid version: %q", tc.in); a != e {
+							t.Errorf("unexpected error unmarshaling text: %q", a)
+						}
+					} else {
+						t.Errorf("unexpected error unmarshaling text: %v", err)
+					}
+				} else if a, e := v, v; a != e {
+					t.Errorf("unexpected data unmarshaling text: %s", a)
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION

## Description

This patch introduces yet even more enhancements to ESXi and VM hardware versions, not to mention a ton of new code coverage for the improvements.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [x] `go test -v -count 1 -run TestESXiVersion ./vim25/types`

    ```shell
    === RUN   TestESXiVersion
    === RUN   TestESXiVersion/GetESXiVersions
    === RUN   TestESXiVersion/ParseESXiVersion
    === RUN   TestESXiVersion/ParseESXiVersion/EmptyString
    === RUN   TestESXiVersion/ParseESXiVersion/InvalidMajorVersion
    === RUN   TestESXiVersion/ParseESXiVersion/ValidMajorInvalidMinorVersion
    === RUN   TestESXiVersion/ParseESXiVersion/ValidMajorValidMinorInvalidPatchVersion
    === RUN   TestESXiVersion/ParseESXiVersion/ValidMajorValidMinorInvalidUpdateVersion
    === RUN   TestESXiVersion/ParseESXiVersion/ValidMajorValidMinorValidPatchInvalidUpdateVersion
    === RUN   TestESXiVersion/ParseESXiVersion/2
    === RUN   TestESXiVersion/ParseESXiVersion/2.0
    === RUN   TestESXiVersion/ParseESXiVersion/2.0.0
    === RUN   TestESXiVersion/ParseESXiVersion/3
    === RUN   TestESXiVersion/ParseESXiVersion/3.0
    === RUN   TestESXiVersion/ParseESXiVersion/3.0.0
    === RUN   TestESXiVersion/ParseESXiVersion/4
    === RUN   TestESXiVersion/ParseESXiVersion/4.0
    === RUN   TestESXiVersion/ParseESXiVersion/4.0.0
    === RUN   TestESXiVersion/ParseESXiVersion/5
    === RUN   TestESXiVersion/ParseESXiVersion/5.0
    === RUN   TestESXiVersion/ParseESXiVersion/5.0.0
    === RUN   TestESXiVersion/ParseESXiVersion/5.1
    === RUN   TestESXiVersion/ParseESXiVersion/5.1.0
    === RUN   TestESXiVersion/ParseESXiVersion/5.5
    === RUN   TestESXiVersion/ParseESXiVersion/5.5.0
    === RUN   TestESXiVersion/ParseESXiVersion/6
    === RUN   TestESXiVersion/ParseESXiVersion/6.0
    === RUN   TestESXiVersion/ParseESXiVersion/6.0.0
    === RUN   TestESXiVersion/ParseESXiVersion/6.5
    === RUN   TestESXiVersion/ParseESXiVersion/6.5.0
    === RUN   TestESXiVersion/ParseESXiVersion/6.7
    === RUN   TestESXiVersion/ParseESXiVersion/6.7.0
    === RUN   TestESXiVersion/ParseESXiVersion/6.7.2
    === RUN   TestESXiVersion/ParseESXiVersion/6.7u2
    === RUN   TestESXiVersion/ParseESXiVersion/6.7U2
    === RUN   TestESXiVersion/ParseESXiVersion/6.7_u2
    === RUN   TestESXiVersion/ParseESXiVersion/6.7_U2
    === RUN   TestESXiVersion/ParseESXiVersion/7
    === RUN   TestESXiVersion/ParseESXiVersion/7.0
    === RUN   TestESXiVersion/ParseESXiVersion/7.0.0
    === RUN   TestESXiVersion/ParseESXiVersion/7.0.1
    === RUN   TestESXiVersion/ParseESXiVersion/7.0u1
    === RUN   TestESXiVersion/ParseESXiVersion/7.0U1
    === RUN   TestESXiVersion/ParseESXiVersion/7.0_u1
    === RUN   TestESXiVersion/ParseESXiVersion/7.0_U1
    === RUN   TestESXiVersion/ParseESXiVersion/7.0.2
    === RUN   TestESXiVersion/ParseESXiVersion/7.0u2
    === RUN   TestESXiVersion/ParseESXiVersion/7.0U2
    === RUN   TestESXiVersion/ParseESXiVersion/7.0_u2
    === RUN   TestESXiVersion/ParseESXiVersion/7.0_U2
    === RUN   TestESXiVersion/ParseESXiVersion/8
    === RUN   TestESXiVersion/ParseESXiVersion/8.0
    === RUN   TestESXiVersion/ParseESXiVersion/8.0.0
    === RUN   TestESXiVersion/ParseESXiVersion/8.0.1
    === RUN   TestESXiVersion/ParseESXiVersion/8.0u1
    === RUN   TestESXiVersion/ParseESXiVersion/8.0U1
    === RUN   TestESXiVersion/ParseESXiVersion/8.0_u1
    === RUN   TestESXiVersion/ParseESXiVersion/8.0_U1
    === RUN   TestESXiVersion/ParseESXiVersion/8.0.2
    === RUN   TestESXiVersion/ParseESXiVersion/8.0u2
    === RUN   TestESXiVersion/ParseESXiVersion/8.0U2
    === RUN   TestESXiVersion/ParseESXiVersion/8.0_u2
    === RUN   TestESXiVersion/ParseESXiVersion/8.0_U2
    === RUN   TestESXiVersion/MarshalText
    === RUN   TestESXiVersion/MarshalText/EmptyString
    === RUN   TestESXiVersion/MarshalText/InvalidMajorVersion
    === RUN   TestESXiVersion/MarshalText/ValidMajorInvalidMinorVersion
    === RUN   TestESXiVersion/MarshalText/ValidMajorValidMinorInvalidPatchVersion
    === RUN   TestESXiVersion/MarshalText/ValidMajorValidMinorInvalidUpdateVersion
    === RUN   TestESXiVersion/MarshalText/ValidMajorValidMinorValidPatchInvalidUpdateVersion
    === RUN   TestESXiVersion/MarshalText/2
    === RUN   TestESXiVersion/MarshalText/2.0
    === RUN   TestESXiVersion/MarshalText/2.0.0
    === RUN   TestESXiVersion/MarshalText/3
    === RUN   TestESXiVersion/MarshalText/3.0
    === RUN   TestESXiVersion/MarshalText/3.0.0
    === RUN   TestESXiVersion/MarshalText/4
    === RUN   TestESXiVersion/MarshalText/4.0
    === RUN   TestESXiVersion/MarshalText/4.0.0
    === RUN   TestESXiVersion/MarshalText/5
    === RUN   TestESXiVersion/MarshalText/5.0
    === RUN   TestESXiVersion/MarshalText/5.0.0
    === RUN   TestESXiVersion/MarshalText/5.1
    === RUN   TestESXiVersion/MarshalText/5.1.0
    === RUN   TestESXiVersion/MarshalText/5.5
    === RUN   TestESXiVersion/MarshalText/5.5.0
    === RUN   TestESXiVersion/MarshalText/6
    === RUN   TestESXiVersion/MarshalText/6.0
    === RUN   TestESXiVersion/MarshalText/6.0.0
    === RUN   TestESXiVersion/MarshalText/6.5
    === RUN   TestESXiVersion/MarshalText/6.5.0
    === RUN   TestESXiVersion/MarshalText/6.7
    === RUN   TestESXiVersion/MarshalText/6.7.0
    === RUN   TestESXiVersion/MarshalText/6.7.2
    === RUN   TestESXiVersion/MarshalText/6.7u2
    === RUN   TestESXiVersion/MarshalText/6.7U2
    === RUN   TestESXiVersion/MarshalText/6.7_u2
    === RUN   TestESXiVersion/MarshalText/6.7_U2
    === RUN   TestESXiVersion/MarshalText/7
    === RUN   TestESXiVersion/MarshalText/7.0
    === RUN   TestESXiVersion/MarshalText/7.0.0
    === RUN   TestESXiVersion/MarshalText/7.0.1
    === RUN   TestESXiVersion/MarshalText/7.0u1
    === RUN   TestESXiVersion/MarshalText/7.0U1
    === RUN   TestESXiVersion/MarshalText/7.0_u1
    === RUN   TestESXiVersion/MarshalText/7.0_U1
    === RUN   TestESXiVersion/MarshalText/7.0.2
    === RUN   TestESXiVersion/MarshalText/7.0u2
    === RUN   TestESXiVersion/MarshalText/7.0U2
    === RUN   TestESXiVersion/MarshalText/7.0_u2
    === RUN   TestESXiVersion/MarshalText/7.0_U2
    === RUN   TestESXiVersion/MarshalText/8
    === RUN   TestESXiVersion/MarshalText/8.0
    === RUN   TestESXiVersion/MarshalText/8.0.0
    === RUN   TestESXiVersion/MarshalText/8.0.1
    === RUN   TestESXiVersion/MarshalText/8.0u1
    === RUN   TestESXiVersion/MarshalText/8.0U1
    === RUN   TestESXiVersion/MarshalText/8.0_u1
    === RUN   TestESXiVersion/MarshalText/8.0_U1
    === RUN   TestESXiVersion/MarshalText/8.0.2
    === RUN   TestESXiVersion/MarshalText/8.0u2
    === RUN   TestESXiVersion/MarshalText/8.0U2
    === RUN   TestESXiVersion/MarshalText/8.0_u2
    === RUN   TestESXiVersion/MarshalText/8.0_U2
    === RUN   TestESXiVersion/UnmarshalText
    === RUN   TestESXiVersion/UnmarshalText/EmptyString
    === RUN   TestESXiVersion/UnmarshalText/InvalidMajorVersion
    === RUN   TestESXiVersion/UnmarshalText/ValidMajorInvalidMinorVersion
    === RUN   TestESXiVersion/UnmarshalText/ValidMajorValidMinorInvalidPatchVersion
    === RUN   TestESXiVersion/UnmarshalText/ValidMajorValidMinorInvalidUpdateVersion
    === RUN   TestESXiVersion/UnmarshalText/ValidMajorValidMinorValidPatchInvalidUpdateVersion
    === RUN   TestESXiVersion/UnmarshalText/2
    === RUN   TestESXiVersion/UnmarshalText/2.0
    === RUN   TestESXiVersion/UnmarshalText/2.0.0
    === RUN   TestESXiVersion/UnmarshalText/3
    === RUN   TestESXiVersion/UnmarshalText/3.0
    === RUN   TestESXiVersion/UnmarshalText/3.0.0
    === RUN   TestESXiVersion/UnmarshalText/4
    === RUN   TestESXiVersion/UnmarshalText/4.0
    === RUN   TestESXiVersion/UnmarshalText/4.0.0
    === RUN   TestESXiVersion/UnmarshalText/5
    === RUN   TestESXiVersion/UnmarshalText/5.0
    === RUN   TestESXiVersion/UnmarshalText/5.0.0
    === RUN   TestESXiVersion/UnmarshalText/5.1
    === RUN   TestESXiVersion/UnmarshalText/5.1.0
    === RUN   TestESXiVersion/UnmarshalText/5.5
    === RUN   TestESXiVersion/UnmarshalText/5.5.0
    === RUN   TestESXiVersion/UnmarshalText/6
    === RUN   TestESXiVersion/UnmarshalText/6.0
    === RUN   TestESXiVersion/UnmarshalText/6.0.0
    === RUN   TestESXiVersion/UnmarshalText/6.5
    === RUN   TestESXiVersion/UnmarshalText/6.5.0
    === RUN   TestESXiVersion/UnmarshalText/6.7
    === RUN   TestESXiVersion/UnmarshalText/6.7.0
    === RUN   TestESXiVersion/UnmarshalText/6.7.2
    === RUN   TestESXiVersion/UnmarshalText/6.7u2
    === RUN   TestESXiVersion/UnmarshalText/6.7U2
    === RUN   TestESXiVersion/UnmarshalText/6.7_u2
    === RUN   TestESXiVersion/UnmarshalText/6.7_U2
    === RUN   TestESXiVersion/UnmarshalText/7
    === RUN   TestESXiVersion/UnmarshalText/7.0
    === RUN   TestESXiVersion/UnmarshalText/7.0.0
    === RUN   TestESXiVersion/UnmarshalText/7.0.1
    === RUN   TestESXiVersion/UnmarshalText/7.0u1
    === RUN   TestESXiVersion/UnmarshalText/7.0U1
    === RUN   TestESXiVersion/UnmarshalText/7.0_u1
    === RUN   TestESXiVersion/UnmarshalText/7.0_U1
    === RUN   TestESXiVersion/UnmarshalText/7.0.2
    === RUN   TestESXiVersion/UnmarshalText/7.0u2
    === RUN   TestESXiVersion/UnmarshalText/7.0U2
    === RUN   TestESXiVersion/UnmarshalText/7.0_u2
    === RUN   TestESXiVersion/UnmarshalText/7.0_U2
    === RUN   TestESXiVersion/UnmarshalText/8
    === RUN   TestESXiVersion/UnmarshalText/8.0
    === RUN   TestESXiVersion/UnmarshalText/8.0.0
    === RUN   TestESXiVersion/UnmarshalText/8.0.1
    === RUN   TestESXiVersion/UnmarshalText/8.0u1
    === RUN   TestESXiVersion/UnmarshalText/8.0U1
    === RUN   TestESXiVersion/UnmarshalText/8.0_u1
    === RUN   TestESXiVersion/UnmarshalText/8.0_U1
    === RUN   TestESXiVersion/UnmarshalText/8.0.2
    === RUN   TestESXiVersion/UnmarshalText/8.0u2
    === RUN   TestESXiVersion/UnmarshalText/8.0U2
    === RUN   TestESXiVersion/UnmarshalText/8.0_u2
    === RUN   TestESXiVersion/UnmarshalText/8.0_U2
    --- PASS: TestESXiVersion (0.00s)
        --- PASS: TestESXiVersion/GetESXiVersions (0.00s)
        --- PASS: TestESXiVersion/ParseESXiVersion (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/EmptyString (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/InvalidMajorVersion (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/ValidMajorInvalidMinorVersion (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/ValidMajorValidMinorInvalidPatchVersion (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/ValidMajorValidMinorInvalidUpdateVersion (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/ValidMajorValidMinorValidPatchInvalidUpdateVersion (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/2.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/2.0.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/3 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/3.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/3.0.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/4 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/4.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/4.0.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/5 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/5.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/5.0.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/5.1 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/5.1.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/5.5 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/5.5.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/6 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/6.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/6.0.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/6.5 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/6.5.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/6.7 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/6.7.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/6.7.2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/6.7u2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/6.7U2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/6.7_u2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/6.7_U2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7.0.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7.0.1 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7.0u1 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7.0U1 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7.0_u1 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7.0_U1 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7.0.2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7.0u2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7.0U2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7.0_u2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/7.0_U2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8.0.0 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8.0.1 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8.0u1 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8.0U1 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8.0_u1 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8.0_U1 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8.0.2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8.0u2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8.0U2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8.0_u2 (0.00s)
            --- PASS: TestESXiVersion/ParseESXiVersion/8.0_U2 (0.00s)
        --- PASS: TestESXiVersion/MarshalText (0.00s)
            --- PASS: TestESXiVersion/MarshalText/EmptyString (0.00s)
            --- PASS: TestESXiVersion/MarshalText/InvalidMajorVersion (0.00s)
            --- PASS: TestESXiVersion/MarshalText/ValidMajorInvalidMinorVersion (0.00s)
            --- PASS: TestESXiVersion/MarshalText/ValidMajorValidMinorInvalidPatchVersion (0.00s)
            --- PASS: TestESXiVersion/MarshalText/ValidMajorValidMinorInvalidUpdateVersion (0.00s)
            --- PASS: TestESXiVersion/MarshalText/ValidMajorValidMinorValidPatchInvalidUpdateVersion (0.00s)
            --- PASS: TestESXiVersion/MarshalText/2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/2.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/2.0.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/3 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/3.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/3.0.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/4 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/4.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/4.0.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/5 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/5.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/5.0.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/5.1 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/5.1.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/5.5 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/5.5.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/6 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/6.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/6.0.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/6.5 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/6.5.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/6.7 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/6.7.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/6.7.2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/6.7u2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/6.7U2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/6.7_u2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/6.7_U2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7.0.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7.0.1 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7.0u1 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7.0U1 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7.0_u1 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7.0_U1 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7.0.2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7.0u2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7.0U2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7.0_u2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/7.0_U2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8.0.0 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8.0.1 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8.0u1 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8.0U1 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8.0_u1 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8.0_U1 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8.0.2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8.0u2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8.0U2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8.0_u2 (0.00s)
            --- PASS: TestESXiVersion/MarshalText/8.0_U2 (0.00s)
        --- PASS: TestESXiVersion/UnmarshalText (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/EmptyString (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/InvalidMajorVersion (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/ValidMajorInvalidMinorVersion (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/ValidMajorValidMinorInvalidPatchVersion (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/ValidMajorValidMinorInvalidUpdateVersion (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/ValidMajorValidMinorValidPatchInvalidUpdateVersion (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/2.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/2.0.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/3 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/3.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/3.0.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/4 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/4.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/4.0.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/5 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/5.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/5.0.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/5.1 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/5.1.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/5.5 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/5.5.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/6 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/6.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/6.0.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/6.5 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/6.5.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/6.7 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/6.7.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/6.7.2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/6.7u2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/6.7U2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/6.7_u2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/6.7_U2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7.0.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7.0.1 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7.0u1 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7.0U1 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7.0_u1 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7.0_U1 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7.0.2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7.0u2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7.0U2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7.0_u2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/7.0_U2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8.0.0 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8.0.1 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8.0u1 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8.0U1 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8.0_u1 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8.0_U1 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8.0.2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8.0u2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8.0U2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8.0_u2 (0.00s)
            --- PASS: TestESXiVersion/UnmarshalText/8.0_U2 (0.00s)
    PASS
    ok  	github.com/vmware/govmomi/vim25/types	0.618s
    ```

- [x] `go test -v -count 1 -run TestHardwareVersion ./vim25/types`

    ```shell
    === RUN   TestHardwareVersion
    === RUN   TestHardwareVersion/GetHardwareVersions
    === RUN   TestHardwareVersion/ParseHardwareVersion
    === RUN   TestHardwareVersion/ParseHardwareVersion/EmptyString
    === RUN   TestHardwareVersion/ParseHardwareVersion/PrefixSansVersion
    === RUN   TestHardwareVersion/ParseHardwareVersion/PrefixAndInvalidVersion
    === RUN   TestHardwareVersion/ParseHardwareVersion/InvalidVersion
    === RUN   TestHardwareVersion/ParseHardwareVersion/3
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-3
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-3
    === RUN   TestHardwareVersion/ParseHardwareVersion/4
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-4
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-4
    === RUN   TestHardwareVersion/ParseHardwareVersion/6
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-6
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-6
    === RUN   TestHardwareVersion/ParseHardwareVersion/7
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-7
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-7
    === RUN   TestHardwareVersion/ParseHardwareVersion/8
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-8
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-8
    === RUN   TestHardwareVersion/ParseHardwareVersion/9
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-9
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-9
    === RUN   TestHardwareVersion/ParseHardwareVersion/10
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-10
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-10
    === RUN   TestHardwareVersion/ParseHardwareVersion/11
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-11
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-11
    === RUN   TestHardwareVersion/ParseHardwareVersion/12
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-12
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-12
    === RUN   TestHardwareVersion/ParseHardwareVersion/13
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-13
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-13
    === RUN   TestHardwareVersion/ParseHardwareVersion/14
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-14
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-14
    === RUN   TestHardwareVersion/ParseHardwareVersion/15
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-15
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-15
    === RUN   TestHardwareVersion/ParseHardwareVersion/16
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-16
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-16
    === RUN   TestHardwareVersion/ParseHardwareVersion/17
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-17
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-17
    === RUN   TestHardwareVersion/ParseHardwareVersion/18
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-18
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-18
    === RUN   TestHardwareVersion/ParseHardwareVersion/19
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-19
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-19
    === RUN   TestHardwareVersion/ParseHardwareVersion/20
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-20
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-20
    === RUN   TestHardwareVersion/ParseHardwareVersion/21
    === RUN   TestHardwareVersion/ParseHardwareVersion/vmx-21
    === RUN   TestHardwareVersion/ParseHardwareVersion/VMX-21
    === RUN   TestHardwareVersion/MarshalText
    === RUN   TestHardwareVersion/MarshalText/EmptyString
    === RUN   TestHardwareVersion/MarshalText/PrefixSansVersion
    === RUN   TestHardwareVersion/MarshalText/PrefixAndInvalidVersion
    === RUN   TestHardwareVersion/MarshalText/InvalidVersion
    === RUN   TestHardwareVersion/MarshalText/3
    === RUN   TestHardwareVersion/MarshalText/vmx-3
    === RUN   TestHardwareVersion/MarshalText/VMX-3
    === RUN   TestHardwareVersion/MarshalText/4
    === RUN   TestHardwareVersion/MarshalText/vmx-4
    === RUN   TestHardwareVersion/MarshalText/VMX-4
    === RUN   TestHardwareVersion/MarshalText/6
    === RUN   TestHardwareVersion/MarshalText/vmx-6
    === RUN   TestHardwareVersion/MarshalText/VMX-6
    === RUN   TestHardwareVersion/MarshalText/7
    === RUN   TestHardwareVersion/MarshalText/vmx-7
    === RUN   TestHardwareVersion/MarshalText/VMX-7
    === RUN   TestHardwareVersion/MarshalText/8
    === RUN   TestHardwareVersion/MarshalText/vmx-8
    === RUN   TestHardwareVersion/MarshalText/VMX-8
    === RUN   TestHardwareVersion/MarshalText/9
    === RUN   TestHardwareVersion/MarshalText/vmx-9
    === RUN   TestHardwareVersion/MarshalText/VMX-9
    === RUN   TestHardwareVersion/MarshalText/10
    === RUN   TestHardwareVersion/MarshalText/vmx-10
    === RUN   TestHardwareVersion/MarshalText/VMX-10
    === RUN   TestHardwareVersion/MarshalText/11
    === RUN   TestHardwareVersion/MarshalText/vmx-11
    === RUN   TestHardwareVersion/MarshalText/VMX-11
    === RUN   TestHardwareVersion/MarshalText/12
    === RUN   TestHardwareVersion/MarshalText/vmx-12
    === RUN   TestHardwareVersion/MarshalText/VMX-12
    === RUN   TestHardwareVersion/MarshalText/13
    === RUN   TestHardwareVersion/MarshalText/vmx-13
    === RUN   TestHardwareVersion/MarshalText/VMX-13
    === RUN   TestHardwareVersion/MarshalText/14
    === RUN   TestHardwareVersion/MarshalText/vmx-14
    === RUN   TestHardwareVersion/MarshalText/VMX-14
    === RUN   TestHardwareVersion/MarshalText/15
    === RUN   TestHardwareVersion/MarshalText/vmx-15
    === RUN   TestHardwareVersion/MarshalText/VMX-15
    === RUN   TestHardwareVersion/MarshalText/16
    === RUN   TestHardwareVersion/MarshalText/vmx-16
    === RUN   TestHardwareVersion/MarshalText/VMX-16
    === RUN   TestHardwareVersion/MarshalText/17
    === RUN   TestHardwareVersion/MarshalText/vmx-17
    === RUN   TestHardwareVersion/MarshalText/VMX-17
    === RUN   TestHardwareVersion/MarshalText/18
    === RUN   TestHardwareVersion/MarshalText/vmx-18
    === RUN   TestHardwareVersion/MarshalText/VMX-18
    === RUN   TestHardwareVersion/MarshalText/19
    === RUN   TestHardwareVersion/MarshalText/vmx-19
    === RUN   TestHardwareVersion/MarshalText/VMX-19
    === RUN   TestHardwareVersion/MarshalText/20
    === RUN   TestHardwareVersion/MarshalText/vmx-20
    === RUN   TestHardwareVersion/MarshalText/VMX-20
    === RUN   TestHardwareVersion/MarshalText/21
    === RUN   TestHardwareVersion/MarshalText/vmx-21
    === RUN   TestHardwareVersion/MarshalText/VMX-21
    === RUN   TestHardwareVersion/UnmarshalText
    === RUN   TestHardwareVersion/UnmarshalText/EmptyString
    === RUN   TestHardwareVersion/UnmarshalText/PrefixSansVersion
    === RUN   TestHardwareVersion/UnmarshalText/PrefixAndInvalidVersion
    === RUN   TestHardwareVersion/UnmarshalText/InvalidVersion
    === RUN   TestHardwareVersion/UnmarshalText/3
    === RUN   TestHardwareVersion/UnmarshalText/vmx-3
    === RUN   TestHardwareVersion/UnmarshalText/VMX-3
    === RUN   TestHardwareVersion/UnmarshalText/4
    === RUN   TestHardwareVersion/UnmarshalText/vmx-4
    === RUN   TestHardwareVersion/UnmarshalText/VMX-4
    === RUN   TestHardwareVersion/UnmarshalText/6
    === RUN   TestHardwareVersion/UnmarshalText/vmx-6
    === RUN   TestHardwareVersion/UnmarshalText/VMX-6
    === RUN   TestHardwareVersion/UnmarshalText/7
    === RUN   TestHardwareVersion/UnmarshalText/vmx-7
    === RUN   TestHardwareVersion/UnmarshalText/VMX-7
    === RUN   TestHardwareVersion/UnmarshalText/8
    === RUN   TestHardwareVersion/UnmarshalText/vmx-8
    === RUN   TestHardwareVersion/UnmarshalText/VMX-8
    === RUN   TestHardwareVersion/UnmarshalText/9
    === RUN   TestHardwareVersion/UnmarshalText/vmx-9
    === RUN   TestHardwareVersion/UnmarshalText/VMX-9
    === RUN   TestHardwareVersion/UnmarshalText/10
    === RUN   TestHardwareVersion/UnmarshalText/vmx-10
    === RUN   TestHardwareVersion/UnmarshalText/VMX-10
    === RUN   TestHardwareVersion/UnmarshalText/11
    === RUN   TestHardwareVersion/UnmarshalText/vmx-11
    === RUN   TestHardwareVersion/UnmarshalText/VMX-11
    === RUN   TestHardwareVersion/UnmarshalText/12
    === RUN   TestHardwareVersion/UnmarshalText/vmx-12
    === RUN   TestHardwareVersion/UnmarshalText/VMX-12
    === RUN   TestHardwareVersion/UnmarshalText/13
    === RUN   TestHardwareVersion/UnmarshalText/vmx-13
    === RUN   TestHardwareVersion/UnmarshalText/VMX-13
    === RUN   TestHardwareVersion/UnmarshalText/14
    === RUN   TestHardwareVersion/UnmarshalText/vmx-14
    === RUN   TestHardwareVersion/UnmarshalText/VMX-14
    === RUN   TestHardwareVersion/UnmarshalText/15
    === RUN   TestHardwareVersion/UnmarshalText/vmx-15
    === RUN   TestHardwareVersion/UnmarshalText/VMX-15
    === RUN   TestHardwareVersion/UnmarshalText/16
    === RUN   TestHardwareVersion/UnmarshalText/vmx-16
    === RUN   TestHardwareVersion/UnmarshalText/VMX-16
    === RUN   TestHardwareVersion/UnmarshalText/17
    === RUN   TestHardwareVersion/UnmarshalText/vmx-17
    === RUN   TestHardwareVersion/UnmarshalText/VMX-17
    === RUN   TestHardwareVersion/UnmarshalText/18
    === RUN   TestHardwareVersion/UnmarshalText/vmx-18
    === RUN   TestHardwareVersion/UnmarshalText/VMX-18
    === RUN   TestHardwareVersion/UnmarshalText/19
    === RUN   TestHardwareVersion/UnmarshalText/vmx-19
    === RUN   TestHardwareVersion/UnmarshalText/VMX-19
    === RUN   TestHardwareVersion/UnmarshalText/20
    === RUN   TestHardwareVersion/UnmarshalText/vmx-20
    === RUN   TestHardwareVersion/UnmarshalText/VMX-20
    === RUN   TestHardwareVersion/UnmarshalText/21
    === RUN   TestHardwareVersion/UnmarshalText/vmx-21
    === RUN   TestHardwareVersion/UnmarshalText/VMX-21
    --- PASS: TestHardwareVersion (0.00s)
        --- PASS: TestHardwareVersion/GetHardwareVersions (0.00s)
        --- PASS: TestHardwareVersion/ParseHardwareVersion (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/EmptyString (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/PrefixSansVersion (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/PrefixAndInvalidVersion (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/InvalidVersion (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/3 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-3 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-3 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/4 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-4 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-4 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/6 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-6 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-6 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/7 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-7 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-7 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/8 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-8 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-8 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/9 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-9 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-9 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/10 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-10 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-10 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/11 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-11 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-11 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/12 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-12 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-12 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/13 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-13 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-13 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/14 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-14 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-14 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/15 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-15 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-15 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/16 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-16 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-16 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/17 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-17 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-17 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/18 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-18 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-18 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/19 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-19 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-19 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/20 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-20 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-20 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/21 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/vmx-21 (0.00s)
            --- PASS: TestHardwareVersion/ParseHardwareVersion/VMX-21 (0.00s)
        --- PASS: TestHardwareVersion/MarshalText (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/EmptyString (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/PrefixSansVersion (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/PrefixAndInvalidVersion (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/InvalidVersion (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/3 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-3 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-3 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/4 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-4 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-4 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/6 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-6 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-6 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/7 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-7 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-7 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/8 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-8 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-8 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/9 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-9 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-9 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/10 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-10 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-10 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/11 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-11 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-11 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/12 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-12 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-12 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/13 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-13 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-13 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/14 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-14 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-14 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/15 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-15 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-15 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/16 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-16 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-16 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/17 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-17 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-17 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/18 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-18 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-18 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/19 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-19 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-19 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/20 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-20 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-20 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/21 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/vmx-21 (0.00s)
            --- PASS: TestHardwareVersion/MarshalText/VMX-21 (0.00s)
        --- PASS: TestHardwareVersion/UnmarshalText (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/EmptyString (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/PrefixSansVersion (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/PrefixAndInvalidVersion (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/InvalidVersion (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/3 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-3 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-3 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/4 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-4 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-4 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/6 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-6 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-6 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/7 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-7 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-7 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/8 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-8 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-8 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/9 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-9 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-9 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/10 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-10 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-10 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/11 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-11 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-11 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/12 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-12 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-12 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/13 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-13 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-13 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/14 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-14 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-14 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/15 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-15 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-15 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/16 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-16 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-16 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/17 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-17 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-17 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/18 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-18 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-18 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/19 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-19 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-19 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/20 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-20 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-20 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/21 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/vmx-21 (0.00s)
            --- PASS: TestHardwareVersion/UnmarshalText/VMX-21 (0.00s)
    PASS
    ok  	github.com/vmware/govmomi/vim25/types	0.323s
    ```

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
