### PR TITLE
ISSUE-3337: Fix bug in vcsim - vim.VirtualMachine.snapshot property c…

### DIFF
--- a/simulator/internal/types.go
+++ b/simulator/internal/types.go
@@ -41,6 +41,7 @@ type FetchResponse struct {
 }
 
 type FetchBody struct {
+	Req    *Fetch         `xml:"Fetch,omitempty"`
 	Res    *FetchResponse `xml:"FetchResponse,omitempty"`
 	Fault_ *soap.Fault    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
 }

--- a/simulator/property_collector.go
+++ b/simulator/property_collector.go
@@ -855,9 +855,12 @@ func (pc *PropertyCollector) Fetch(ctx *Context, req *internal.Fetch) soap.HasFa
 
 	obj := res.(*methods.RetrievePropertiesExBody).Res.Returnval.Objects[0]
 	if len(obj.PropSet) == 0 {
-		fault := obj.MissingSet[0].Fault
-		body.Fault_ = Fault(fault.LocalizedMessage, fault.Fault)
-		return body
+		if len(obj.MissingSet) > 0 {
+			fault := obj.MissingSet[0].Fault
+			body.Fault_ = Fault(fault.LocalizedMessage, fault.Fault)
+			return body
+		}
+		return res
 	}
 
 	body.Res = &internal.FetchResponse{

--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/simulator/esx"
+	"github.com/vmware/govmomi/simulator/internal"
 	"github.com/vmware/govmomi/simulator/vpx"
 	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25"
@@ -680,6 +681,20 @@ func TestPropertyCollectorWithUnsetValues(t *testing.T) {
 		err = property.Wait(ctx, pc, vmRef, propSet, f(true))
 		if err != nil {
 			t.Error(err)
+		}
+
+		// internal Fetch() method used by ovftool and pyvmomi
+		for _, prop := range propSet {
+			body := &internal.FetchBody{
+				Req: &internal.Fetch{
+					This: vm.Reference(),
+					Prop: prop,
+				},
+			}
+
+			if err := client.RoundTrip(ctx, body, body); err != nil {
+				t.Error(err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
…auses runtime error when not set

## Description

This is a hotfix that solving the issue [3337](https://github.com/vmware/govmomi/issues/3337)
vcsim: vim.VirtualMachine.snapshot property causes runtime error when not set

Closes: #(3337)

## Type of change
I saw that if VirtualMachine.snapshot wasn't set I'm getting the error 
`runtime error: index out of range [0] with length 0`

That due to `obj.MissingSet` is empty 

Please mark options that are relevant:

- [ V] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?
Running a create VM request without snapshot against vcsim 


## Checklist:

- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ V] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ V] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
