### PR TITLE
vcsim: add ExtensionManager and TaskManager.CreateTask support

### DIFF
--- a/govc/task/create.go
+++ b/govc/task/create.go
@@ -1,0 +1,100 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package task
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/task"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type create struct {
+	*flags.ClientFlag
+
+	obj string
+}
+
+func init() {
+	cli.Register("task.create", &create{}, true)
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.obj, "o", "", "ManagedObject with which Task will be associated")
+}
+
+func (cmd *create) Description() string {
+	return `Create task of type ID.
+
+ID must be one of:
+  govc extension.info -json | jq -r '.extensions[].taskList | select(. != null) | .[].taskID'
+
+Examples:
+  govc task.create $ID`
+}
+
+func (cmd *create) Usage() string {
+	return "ID"
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	m := task.NewManager(c)
+
+	req := types.CreateTask{
+		This:       m.Reference(),
+		Obj:        c.ServiceContent.RootFolder,
+		TaskTypeId: f.Arg(0),
+		Cancelable: true,
+	}
+
+	if cmd.obj != "" {
+		req.Obj.FromString(cmd.obj)
+	}
+
+	s, err := session.NewManager(c).UserSession(ctx)
+	if err != nil {
+		return err
+	}
+	req.InitiatedBy = s.UserName
+
+	res, err := methods.CreateTask(ctx, c, &req)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(res.Returnval.Task)
+
+	return nil
+}

--- a/govc/task/set.go
+++ b/govc/task/set.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package task
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type set struct {
+	*flags.ClientFlag
+
+	desc     types.LocalizableMessage
+	state    string
+	err      string
+	progress int
+}
+
+func init() {
+	cli.Register("task.set", &set{}, true)
+}
+
+func (cmd *set) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.desc.Key, "d", "", "Task description key")
+	f.StringVar(&cmd.desc.Message, "m", "", "Task description message")
+	f.StringVar(&cmd.state, "s", "", "Task state")
+	f.StringVar(&cmd.err, "e", "", "Task error")
+	f.IntVar(&cmd.progress, "p", 0, "Task progress")
+}
+
+func (cmd *set) Description() string {
+	return `Set task state.
+
+Examples:
+  id=$(govc task.create com.vmware.govmomi.simulator.test)
+  govc task.set $id -s error`
+}
+
+func (cmd *set) Usage() string {
+	return "ID"
+}
+
+func (cmd *set) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	ref := types.ManagedObjectReference{Type: "Task"}
+	if !ref.FromString(f.Arg(0)) {
+		ref.Value = f.Arg(0)
+	}
+
+	task := object.NewTask(c, ref)
+
+	var fault *types.LocalizedMethodFault
+
+	if cmd.err != "" {
+		fault = &types.LocalizedMethodFault{
+			Fault:            &types.SystemError{Reason: cmd.err},
+			LocalizedMessage: cmd.err,
+		}
+		cmd.state = string(types.TaskInfoStateError)
+	}
+
+	if cmd.state != "" {
+		err := task.SetState(ctx, types.TaskInfoState(cmd.state), nil, fault)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.progress != 0 {
+		err := task.UpdateProgress(ctx, cmd.progress)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.desc.Key != "" {
+		err := task.SetDescription(ctx, cmd.desc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/govc/test/extension.bats
+++ b/govc/test/extension.bats
@@ -3,9 +3,7 @@
 load test_helper
 
 @test "extension" {
-  vcsim_env_todo
-
-  govc extension.info | grep Name: | grep govc-test | awk '{print $2}' | $xargs -r govc extension.unregister
+  vcsim_env
 
   run govc extension.info enoent
   assert_failure
@@ -51,16 +49,7 @@ EOS
   run govc extension.setcert -cert-pem '+' $id
   assert_success
 
-  # test client certificate authentication
-  (
-    # remove password from env, set user to extension id and turn of session cache
-    govc_url_to_vars
-    unset GOVC_PASSWORD
-    GOVC_USERNAME=$id
-    export GOVC_PERSIST_SESSION=false
-    run govc about -cert "${id}.crt" -key "${id}.key"
-    assert_success
-  )
+  # client certificate authentication is tested in session.bats
 
   # remove generated cert and key
   rm ${id}.{crt,key}

--- a/govc/test/tasks.bats
+++ b/govc/test/tasks.bats
@@ -15,3 +15,36 @@ load test_helper
   run govc tasks 'host/*'
   assert_success
 }
+
+@test "task.create" {
+  vcsim_env
+
+  export GOVC_SHOW_UNRELEASED=true
+
+  run govc task.create enoent
+  assert_failure
+
+  id=$(govc extension.info -json | jq -r '.extensions[].taskList | select(. != null) | .[].taskID' | head -1)
+  assert_equal com.vmware.govmomi.simulator.test "$id"
+
+  run govc task.create "$id"
+  assert_success
+  task="$output"
+
+  run govc task.set -s running "$task"
+  assert_success
+
+  govc tasks | grep "$id"
+
+  run govc task.set -d "$id.init" -m "task init" "$task"
+  assert_success
+
+  run govc task.set -p 42 "$task"
+  assert_success
+
+  run govc task.set -s success "$task"
+  assert_success
+
+  run govc task.set -s running "$task"
+  assert_failure
+}

--- a/simulator/extension_manager.go
+++ b/simulator/extension_manager.go
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"time"
+
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var ExtensionList = []types.Extension{
+	{
+		Description: &types.Description{
+			Label:   "vcsim",
+			Summary: "Go vCenter simulator",
+		},
+		Key:         "com.vmware.govmomi.simulator",
+		Company:     "VMware, Inc.",
+		Type:        "",
+		Version:     "0.37.0",
+		SubjectName: "",
+		Server:      nil,
+		Client:      nil,
+		TaskList: []types.ExtensionTaskTypeInfo{
+			{
+				TaskID: "com.vmware.govmomi.simulator.test",
+			},
+		},
+		EventList:              nil,
+		FaultList:              nil,
+		PrivilegeList:          nil,
+		ResourceList:           nil,
+		LastHeartbeatTime:      time.Now(),
+		HealthInfo:             (*types.ExtensionHealthInfo)(nil),
+		OvfConsumerInfo:        (*types.ExtensionOvfConsumerInfo)(nil),
+		ExtendedProductInfo:    (*types.ExtExtendedProductInfo)(nil),
+		ManagedEntityInfo:      nil,
+		ShownInSolutionManager: types.NewBool(false),
+		SolutionManagerInfo:    (*types.ExtSolutionManagerInfo)(nil),
+	},
+}
+
+type ExtensionManager struct {
+	mo.ExtensionManager
+}
+
+func (m *ExtensionManager) init(r *Registry) {
+	if r.IsVPX() && len(m.ExtensionList) == 0 {
+		m.ExtensionList = ExtensionList
+	}
+}
+
+func (m *ExtensionManager) RegisterExtension(ctx *Context, req *types.RegisterExtension) soap.HasFault {
+	body := &methods.RegisterExtensionBody{}
+
+	for _, x := range m.ExtensionList {
+		if x.Key == req.Extension.Key {
+			body.Fault_ = Fault("", &types.InvalidArgument{
+				InvalidProperty: "extension.key",
+			})
+			return body
+		}
+	}
+
+	body.Res = new(types.RegisterExtensionResponse)
+	m.ExtensionList = append(m.ExtensionList, req.Extension)
+
+	return body
+}
+
+func (m *ExtensionManager) UnregisterExtension(ctx *Context, req *types.UnregisterExtension) soap.HasFault {
+	body := &methods.UnregisterExtensionBody{}
+
+	for i, x := range m.ExtensionList {
+		if x.Key == req.ExtensionKey {
+			m.ExtensionList = append(m.ExtensionList[:i], m.ExtensionList[i+1:]...)
+
+			body.Res = new(types.UnregisterExtensionResponse)
+			return body
+		}
+	}
+
+	body.Fault_ = Fault("", new(types.NotFound))
+
+	return body
+}
+
+func (m *ExtensionManager) UpdateExtension(ctx *Context, req *types.UpdateExtension) soap.HasFault {
+	body := &methods.UpdateExtensionBody{}
+
+	for i, x := range m.ExtensionList {
+		if x.Key == req.Extension.Key {
+			m.ExtensionList[i] = req.Extension
+
+			body.Res = new(types.UpdateExtensionResponse)
+			return body
+		}
+	}
+
+	body.Fault_ = Fault("", new(types.NotFound))
+
+	return body
+}
+
+func (m *ExtensionManager) SetExtensionCertificate(ctx *Context, req *types.SetExtensionCertificate) soap.HasFault {
+	body := &methods.SetExtensionCertificateBody{}
+
+	for _, x := range m.ExtensionList {
+		if x.Key == req.ExtensionKey {
+			// TODO: save req.CertificatePem for use with SessionManager.LoginExtensionByCertificate()
+
+			body.Res = new(types.SetExtensionCertificateResponse)
+			return body
+		}
+	}
+
+	body.Fault_ = Fault("", new(types.NotFound))
+
+	return body
+}

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -243,6 +243,7 @@ var kinds = map[string]reflect.Type{
 	"DistributedVirtualSwitchManager": reflect.TypeOf((*DistributedVirtualSwitchManager)(nil)).Elem(),
 	"EnvironmentBrowser":              reflect.TypeOf((*EnvironmentBrowser)(nil)).Elem(),
 	"EventManager":                    reflect.TypeOf((*EventManager)(nil)).Elem(),
+	"ExtensionManager":                reflect.TypeOf((*ExtensionManager)(nil)).Elem(),
 	"FileManager":                     reflect.TypeOf((*FileManager)(nil)).Elem(),
 	"Folder":                          reflect.TypeOf((*Folder)(nil)).Elem(),
 	"GuestOperationsManager":          reflect.TypeOf((*GuestOperationsManager)(nil)).Elem(),

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -570,6 +570,11 @@ func (r *Registry) CustomFieldsManager() *CustomFieldsManager {
 // TenantManager returns TenantManager singleton
 func (r *Registry) TenantManager() *TenantManager {
 	return r.Get(r.content().TenantManager.Reference()).(*TenantManager)
+}
+
+// ExtensionManager returns the ExtensionManager singleton
+func (r *Registry) ExtensionManager() *ExtensionManager {
+	return r.Get(r.content().ExtensionManager.Reference()).(*ExtensionManager)
 }
 
 func (r *Registry) MarshalJSON() ([]byte, error) {

--- a/simulator/task_manager.go
+++ b/simulator/task_manager.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,10 +18,13 @@ package simulator
 
 import (
 	"sync"
+	"time"
 
 	"github.com/vmware/govmomi/simulator/esx"
 	"github.com/vmware/govmomi/simulator/vpx"
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -62,3 +65,47 @@ func (m *TaskManager) PutObject(obj mo.Reference) {
 func (*TaskManager) RemoveObject(*Context, types.ManagedObjectReference) {}
 
 func (*TaskManager) UpdateObject(mo.Reference, []types.PropertyChange) {}
+
+func validTaskID(ctx *Context, taskID string) bool {
+	m := ctx.Map.ExtensionManager()
+
+	for _, x := range m.ExtensionList {
+		for _, task := range x.TaskList {
+			if task.TaskID == taskID {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (m *TaskManager) CreateTask(ctx *Context, req *types.CreateTask) soap.HasFault {
+	body := &methods.CreateTaskBody{}
+
+	if !validTaskID(ctx, req.TaskTypeId) {
+		body.Fault_ = Fault("", &types.InvalidArgument{
+			InvalidProperty: "taskType",
+		})
+		return body
+	}
+
+	task := &Task{}
+
+	task.Self = ctx.Map.newReference(task)
+	task.Info.Key = task.Self.Value
+	task.Info.Task = task.Self
+	task.Info.DescriptionId = req.TaskTypeId
+	task.Info.Cancelable = req.Cancelable
+	task.Info.Entity = &req.Obj
+	task.Info.EntityName = req.Obj.Value
+	task.Info.Reason = &types.TaskReasonUser{UserName: ctx.Session.UserName}
+	task.Info.QueueTime = time.Now()
+	task.Info.State = types.TaskInfoStateQueued
+
+	body.Res = &types.CreateTaskResponse{Returnval: task.Info}
+
+	go ctx.Map.Put(task)
+
+	return body
+}


### PR DESCRIPTION
- needed an easier way to control Task state when testing, so added TaskManager.CreateTask and Task methods for updating state (wcpsvc also uses these methods)
- in real VC, CreateTask requires a taskID from an Extension, so went ahead and added basic ExtensionManager support too (and with this enabled govc extension bats)