### PR TITLE
vcsim: add TaskHistoryCollector support

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -5594,14 +5594,22 @@ By default, all recent tasks are included (via TaskManager), but can be limited 
 to a specific inventory object.
 
 Examples:
-  govc tasks
+  govc tasks        # tasks completed within the past 10 minutes
+  govc tasks -b 24h # tasks completed within the past 24 hours
+  govc tasks -s queued -s running # incomplete tasks
+  govc tasks -s error -s success  # completed tasks
+  govc tasks -r /dc1/vm/Namespaces # tasks for VMs in this Folder only
   govc tasks -f
   govc tasks -f /dc1/host/cluster1
 
 Options:
+  -b=0s                  Begin time of task history
+  -e=0s                  End time of task history
   -f=false               Follow recent task updates
   -l=false               Use long task description
   -n=25                  Output the last N tasks
+  -r=false               Include child entities when PATH is specified
+  -s=[]                  Task states
 ```
 
 ## tree

--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -615,7 +615,7 @@ EOF
 
   n=$(ls "$dir"/*.xml | wc -l)
   rm -rf "$dir"
-  assert_equal 6 "$n"
+  assert_equal 10 "$n"
 }
 
 @test "tree" {

--- a/govc/test/tasks.bats
+++ b/govc/test/tasks.bats
@@ -7,13 +7,38 @@ load test_helper
 
   run govc tasks
   assert_success
-}
 
-@test "tasks host" {
-  vcsim_env
+  run govc tasks vm/DC0_H0_VM0
+  assert_success
+  assert_matches PowerOn
+
+  run govc tasks vm/DC0_H0_VM0 vm/DC0_H0_VM1
+  assert_failure # > 1 arg
 
   run govc tasks 'host/*'
+  assert_failure # matches 2 objects
+
+  run govc tasks -b 1h
   assert_success
+  [ ${#lines[@]} -gt 10 ]
+
+  run govc tasks -r /DC0/vm
+  assert_success
+  assert_matches CreateVm
+  assert_matches PowerOn
+}
+
+@test "tasks esx" {
+  vcsim_env -esx
+
+  run govc tasks
+  assert_success
+
+  run govc tasks -b 1h
+  assert_failure # TaskHistoryCollector not supported on ESX
+
+  run govc tasks -r
+  assert_failure # TaskHistoryCollector not supported on ESX
 }
 
 @test "task.create" {

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -36,8 +36,8 @@ EOF
 
   # compile + run examples against vcsim
   for main in ../../examples/*/main.go ; do
-    # TODO: #2567 #2476
-    if [[ $main =~ task|alarm ]]; then
+    # TODO: #2476
+    if [[ $main =~ alarm ]]; then
       continue
     fi
     run go run "$main" -insecure -url "$GOVC_URL"

--- a/simulator/event_manager_test.go
+++ b/simulator/event_manager_test.go
@@ -156,7 +156,12 @@ func TestEventManagerRead(t *testing.T) {
 		}
 	}()
 
-	spec := types.EventFilterSpec{}
+	spec := types.EventFilterSpec{
+		Entity: &types.EventFilterSpecByEntity{
+			Entity:    vc.Client.ServiceContent.RootFolder,
+			Recursion: types.EventFilterSpecRecursionOptionChildren,
+		},
+	}
 	em := event.NewManager(vc.Client)
 	c, err := em.CreateCollectorForEvents(ctx, spec)
 	if err != nil {
@@ -168,6 +173,9 @@ func TestEventManagerRead(t *testing.T) {
 		t.Fatal(err)
 	}
 	nevents := len(page)
+	if nevents == 0 {
+		t.Fatal("no recent events")
+	}
 	tests := []struct {
 		max    int
 		rewind bool
@@ -241,7 +249,11 @@ func TestEventManagerRead(t *testing.T) {
 		t.Errorf("expected 0 events, got %d", len(events))
 	}
 
-	err = em.PostEvent(ctx, &types.GeneralEvent{Message: "vcsim"})
+	event := &types.GeneralEvent{Message: "vcsim"}
+	event.Datacenter = &types.DatacenterEventArgument{
+		Datacenter: Map.Any("Datacenter").Reference(),
+	}
+	err = em.PostEvent(ctx, event)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/simulator/history_collector.go
+++ b/simulator/history_collector.go
@@ -1,0 +1,181 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"container/list"
+	"sync"
+
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var (
+	maxPageSize           = 1000
+	maxCollectors   int32 = 32 // the VC default limit
+	defaultPageSize       = 10
+
+	errInvalidArgMaxCount = &types.InvalidArgument{InvalidProperty: "maxCount"}
+)
+
+type HistoryCollector struct {
+	parent *history
+	root   types.ManagedObjectReference
+	size   int
+
+	fill func(*Context)
+	page *list.List
+	pos  *list.Element
+}
+
+type history struct {
+	sync.Mutex
+
+	page       *list.List
+	collectors map[types.ManagedObjectReference]mo.Reference
+}
+
+func newHistory() *history {
+	return &history{
+		page:       list.New(),
+		collectors: make(map[types.ManagedObjectReference]mo.Reference),
+	}
+}
+
+func (c *history) add(ctx *Context, collector mo.Reference) types.ManagedObjectReference {
+	ref := ctx.Session.Put(collector).Reference()
+
+	c.Lock()
+	c.collectors[ref] = collector
+	c.Unlock()
+
+	return ref
+}
+
+func (c *history) remove(ctx *Context, ref types.ManagedObjectReference) {
+	ctx.Session.Remove(ctx, ref)
+
+	c.Lock()
+	delete(c.collectors, ref)
+	c.Unlock()
+}
+
+func newHistoryCollector(ctx *Context, h *history, size int) *HistoryCollector {
+	return &HistoryCollector{
+		parent: h,
+		root:   ctx.Map.content().RootFolder,
+		size:   size,
+		page:   list.New(),
+	}
+}
+
+func (c *HistoryCollector) SetCollectorPageSize(ctx *Context, req *types.SetCollectorPageSize) soap.HasFault {
+	body := new(methods.SetCollectorPageSizeBody)
+	size, err := validatePageSize(req.MaxCount)
+	if err != nil {
+		body.Fault_ = err
+		return body
+	}
+
+	c.size = size
+	c.page = list.New()
+	c.fill(ctx)
+
+	body.Res = new(types.SetCollectorPageSizeResponse)
+	return body
+}
+
+func (c *HistoryCollector) ResetCollector(ctx *Context, req *types.ResetCollector) soap.HasFault {
+	c.pos = c.page.Back()
+
+	return &methods.ResetCollectorBody{
+		Res: new(types.ResetCollectorResponse),
+	}
+}
+
+func (c *HistoryCollector) RewindCollector(ctx *Context, req *types.RewindCollector) soap.HasFault {
+	c.pos = c.page.Front()
+
+	return &methods.RewindCollectorBody{
+		Res: new(types.RewindCollectorResponse),
+	}
+}
+
+func (c *HistoryCollector) DestroyCollector(ctx *Context, req *types.DestroyCollector) soap.HasFault {
+	ctx.Session.Remove(ctx, req.This)
+
+	c.parent.remove(ctx, req.This)
+
+	return &methods.DestroyCollectorBody{
+		Res: new(types.DestroyCollectorResponse),
+	}
+}
+
+func (c *HistoryCollector) read(max int32, next func() *list.Element, take func(*list.Element)) {
+	for i := 0; i < int(max); i++ {
+		e := next()
+		if e == nil {
+			break
+		}
+
+		take(e)
+		c.pos = e
+	}
+}
+
+func (c *HistoryCollector) next(max int32, take func(*list.Element)) {
+	next := func() *list.Element {
+		if c.pos != nil {
+			return c.pos.Next()
+		}
+		return c.page.Front()
+	}
+
+	c.read(max, next, take)
+}
+
+func (c *HistoryCollector) prev(max int32, take func(*list.Element)) {
+	next := func() *list.Element {
+		if c.pos != nil {
+			return c.pos.Prev()
+		}
+		return c.page.Back()
+	}
+
+	c.read(max, next, take)
+}
+
+func pushHistory(l *list.List, item types.AnyType) {
+	if l.Len() > maxPageSize {
+		l.Remove(l.Front()) // Prune history
+	}
+	l.PushBack(item)
+}
+
+func validatePageSize(count int32) (int, *soap.Fault) {
+	size := int(count)
+
+	if size == 0 {
+		size = defaultPageSize
+	} else if size < 0 || size > maxPageSize {
+		return -1, Fault("", errInvalidArgMaxCount)
+	}
+
+	return size, nil
+}

--- a/simulator/property_collector.go
+++ b/simulator/property_collector.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -105,6 +105,10 @@ func getManagedObject(obj mo.Reference) reflect.Value {
 		}
 		rval = rval.Field(0)
 		rtype = rval.Type()
+		if rtype.Kind() == reflect.Pointer {
+			rval = rval.Elem()
+			rtype = rval.Type()
+		}
 	}
 
 	return rval

--- a/simulator/task_manager.go
+++ b/simulator/task_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"container/list"
 	"sync"
 	"time"
 
@@ -33,6 +34,8 @@ var recentTaskMax = 200 // the VC limit
 type TaskManager struct {
 	mo.TaskManager
 	sync.Mutex
+
+	history *history
 }
 
 func (m *TaskManager) init(r *Registry) {
@@ -43,28 +46,96 @@ func (m *TaskManager) init(r *Registry) {
 			m.Description = esx.Description
 		}
 	}
+
+	if m.MaxCollector == 0 {
+		// In real VC this default can be changed via OptionManager "task.maxCollectors"
+		m.MaxCollector = maxCollectors
+	}
+
+	m.history = newHistory()
+
 	r.AddHandler(m)
 }
 
+func recentTask(recent []types.ManagedObjectReference, ref types.ManagedObjectReference) []types.PropertyChange {
+	// TODO: tasks completed > 10m ago should be removed
+	recent = append(recent, ref)
+	if len(recent) > recentTaskMax {
+		recent = recent[1:]
+	}
+	return []types.PropertyChange{{Name: "recentTask", Val: recent}}
+}
+
 func (m *TaskManager) PutObject(obj mo.Reference) {
-	ref := obj.Reference()
-	if ref.Type != "Task" {
+	task, ok := obj.(*Task)
+	if !ok {
+		return
+	}
+
+	ctx := SpoofContext()
+
+	// propagate new Tasks to:
+	// - TaskManager.RecentTask
+	// - TaskHistoryCollector instances, if Filter matches
+	// - $MO.RecentTask
+	m.Lock()
+	ctx.Map.Update(m, recentTask(m.RecentTask, task.Self))
+
+	pushHistory(m.history.page, task)
+
+	for _, hc := range m.history.collectors {
+		c := hc.(*TaskHistoryCollector)
+		ctx.WithLock(c, func() {
+			if c.taskMatches(ctx, &task.Info) {
+				pushHistory(c.page, task)
+				ctx.Map.Update(c, []types.PropertyChange{{Name: "latestPage", Val: c.GetLatestPage()}})
+			}
+		})
+	}
+	m.Unlock()
+
+	entity := ctx.Map.Get(*task.Info.Entity)
+	if e, ok := entity.(mo.Entity); ok {
+		ctx.Map.Update(entity, recentTask(e.Entity().RecentTask, task.Self))
+	}
+}
+
+func taskStateChanged(pc []types.PropertyChange) bool {
+	for i := range pc {
+		if pc[i].Name == "info.state" {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *TaskManager) UpdateObject(obj mo.Reference, pc []types.PropertyChange) {
+	task, ok := obj.(*mo.Task)
+	if !ok {
+		return
+	}
+
+	if !taskStateChanged(pc) {
+		// real vCenter only updates latestPage when Tasks are created (see PutObject above) and
+		// if Task.Info.State changes.
+		// Changes to Task.Info.{Description,Progress} does not update lastestPage.
 		return
 	}
 
 	m.Lock()
-	recent := append(m.RecentTask, ref)
-	if len(recent) > recentTaskMax {
-		recent = recent[1:]
+	for _, hc := range m.history.collectors {
+		c := hc.(*TaskHistoryCollector)
+		ctx := SpoofContext()
+		ctx.WithLock(c, func() {
+			if c.hasTask(ctx, &task.Info) {
+				ctx.Map.Update(c, []types.PropertyChange{{Name: "latestPage", Val: c.GetLatestPage()}})
+			}
+		})
 	}
-
-	Map.Update(m, []types.PropertyChange{{Name: "recentTask", Val: recent}})
 	m.Unlock()
 }
 
 func (*TaskManager) RemoveObject(*Context, types.ManagedObjectReference) {}
-
-func (*TaskManager) UpdateObject(mo.Reference, []types.PropertyChange) {}
 
 func validTaskID(ctx *Context, taskID string) bool {
 	m := ctx.Map.ExtensionManager()
@@ -108,4 +179,221 @@ func (m *TaskManager) CreateTask(ctx *Context, req *types.CreateTask) soap.HasFa
 	go ctx.Map.Put(task)
 
 	return body
+}
+
+type TaskHistoryCollector struct {
+	mo.TaskHistoryCollector
+
+	*HistoryCollector
+}
+
+func (m *TaskManager) createCollector(ctx *Context, req *types.CreateCollectorForTasks) (*TaskHistoryCollector, *soap.Fault) {
+	if len(m.history.collectors) >= int(m.MaxCollector) {
+		return nil, Fault("Too many task collectors to create", new(types.InvalidState))
+	}
+
+	collector := &TaskHistoryCollector{
+		HistoryCollector: newHistoryCollector(ctx, m.history, defaultPageSize),
+	}
+	collector.Filter = req.Filter
+
+	return collector, nil
+}
+
+// taskFilterChildren returns true if a child of self is the task entity.
+func taskFilterChildren(ctx *Context, root types.ManagedObjectReference, task *types.TaskInfo) bool {
+	seen := false
+
+	var match func(types.ManagedObjectReference)
+
+	match = func(child types.ManagedObjectReference) {
+		if child == *task.Entity {
+			seen = true
+			return
+		}
+
+		walk(ctx.Map.Get(child), match)
+	}
+
+	walk(ctx.Map.Get(root), match)
+
+	return seen
+}
+
+// entityMatches returns true if the spec Entity filter matches the task entity.
+func (c *TaskHistoryCollector) entityMatches(ctx *Context, task *types.TaskInfo, spec types.TaskFilterSpec) bool {
+	e := spec.Entity
+	if e == nil {
+		return true
+	}
+
+	isSelf := *task.Entity == e.Entity
+
+	switch e.Recursion {
+	case types.TaskFilterSpecRecursionOptionSelf:
+		return isSelf
+	case types.TaskFilterSpecRecursionOptionChildren:
+		return taskFilterChildren(ctx, e.Entity, task)
+	case types.TaskFilterSpecRecursionOptionAll:
+		return isSelf || taskFilterChildren(ctx, e.Entity, task)
+	}
+
+	return false
+}
+
+func (c *TaskHistoryCollector) stateMatches(_ *Context, task *types.TaskInfo, spec types.TaskFilterSpec) bool {
+	if len(spec.State) == 0 {
+		return true
+	}
+
+	for _, state := range spec.State {
+		if task.State == state {
+			return true
+
+		}
+	}
+
+	return false
+}
+
+func (c *TaskHistoryCollector) timeMatches(_ *Context, task *types.TaskInfo, spec types.TaskFilterSpec) bool {
+	if spec.Time == nil {
+		return true
+	}
+
+	created := task.QueueTime
+
+	if begin := spec.Time.BeginTime; begin != nil {
+		if created.Before(*begin) {
+			return false
+		}
+	}
+
+	if end := spec.Time.EndTime; end != nil {
+		if created.After(*end) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// taskMatches returns true one of the filters matches the task.
+func (c *TaskHistoryCollector) taskMatches(ctx *Context, task *types.TaskInfo) bool {
+	spec := c.Filter.(types.TaskFilterSpec)
+
+	matchers := []func(*Context, *types.TaskInfo, types.TaskFilterSpec) bool{
+		c.stateMatches,
+		c.timeMatches,
+		c.entityMatches,
+		// TODO: spec.UserName, etc
+	}
+
+	for _, match := range matchers {
+		if !match(ctx, task, spec) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (c *TaskHistoryCollector) hasTask(_ *Context, task *types.TaskInfo) bool {
+	for e := c.page.Front(); e != nil; e = e.Next() {
+		if e.Value.(*Task).Info.Key == task.Key {
+			return true
+		}
+	}
+	return false
+}
+
+// fillPage copies the manager's latest tasks into the collector's page with Filter applied.
+func (m *TaskManager) fillPage(ctx *Context, c *TaskHistoryCollector) {
+	m.history.Lock()
+	defer m.history.Unlock()
+
+	for e := m.history.page.Front(); e != nil; e = e.Next() {
+		task := e.Value.(*Task)
+
+		if c.taskMatches(ctx, &task.Info) {
+			pushHistory(c.page, task)
+		}
+	}
+}
+
+func (m *TaskManager) CreateCollectorForTasks(ctx *Context, req *types.CreateCollectorForTasks) soap.HasFault {
+	body := new(methods.CreateCollectorForTasksBody)
+
+	if ctx.Map.IsESX() {
+		body.Fault_ = Fault("", new(types.NotSupported))
+		return body
+	}
+
+	collector, err := m.createCollector(ctx, req)
+	if err != nil {
+		body.Fault_ = err
+		return body
+	}
+
+	collector.fill = func(x *Context) { m.fillPage(x, collector) }
+	collector.fill(ctx)
+
+	body.Res = &types.CreateCollectorForTasksResponse{
+		Returnval: m.history.add(ctx, collector),
+	}
+
+	return body
+}
+
+func (c *TaskHistoryCollector) ReadNextTasks(ctx *Context, req *types.ReadNextTasks) soap.HasFault {
+	body := new(methods.ReadNextTasksBody)
+	if req.MaxCount <= 0 {
+		body.Fault_ = Fault("", errInvalidArgMaxCount)
+		return body
+	}
+	body.Res = new(types.ReadNextTasksResponse)
+
+	c.next(req.MaxCount, func(e *list.Element) {
+		body.Res.Returnval = append(body.Res.Returnval, e.Value.(*Task).Info)
+	})
+
+	return body
+}
+
+func (c *TaskHistoryCollector) ReadPreviousTasks(ctx *Context, req *types.ReadPreviousTasks) soap.HasFault {
+	body := new(methods.ReadPreviousTasksBody)
+	if req.MaxCount <= 0 {
+		body.Fault_ = Fault("", errInvalidArgMaxCount)
+		return body
+	}
+	body.Res = new(types.ReadPreviousTasksResponse)
+
+	c.prev(req.MaxCount, func(e *list.Element) {
+		body.Res.Returnval = append(body.Res.Returnval, e.Value.(*Task).Info)
+	})
+
+	return body
+}
+
+func (c *TaskHistoryCollector) GetLatestPage() []types.TaskInfo {
+	var latestPage []types.TaskInfo
+
+	e := c.page.Back()
+	for i := 0; i < c.size; i++ {
+		if e == nil {
+			break
+		}
+		latestPage = append(latestPage, e.Value.(*Task).Info)
+		e = e.Prev()
+	}
+
+	return latestPage
+}
+
+func (c *TaskHistoryCollector) Get() mo.Reference {
+	clone := *c
+
+	clone.LatestPage = clone.GetLatestPage()
+
+	return &clone
 }

--- a/simulator/task_manager_test.go
+++ b/simulator/task_manager_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,34 +14,167 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package simulator_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/vmware/govmomi/simulator/esx"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/task"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 func TestTaskManagerRecent(t *testing.T) {
-	m := ESX()
-	m.Datastore = 0
-	m.Machine = 0
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		ref := simulator.Map.Any("VirtualMachine").Reference()
+		vm := object.NewVirtualMachine(c, ref)
 
-	err := m.Create()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	recentTaskMax = 5
-
-	tm := Map.Get(*esx.ServiceContent.TaskManager).(*TaskManager)
-	tm.RecentTask = nil
-
-	for i := 0; i < recentTaskMax+2; i++ {
-		CreateTask(esx.RootFolder, "noop", nil)
-
-		if len(tm.RecentTask) > recentTaskMax {
-			t.Errorf("too many tasks %d > %d", len(tm.RecentTask), recentTaskMax)
+		tasks := func() int {
+			var m mo.TaskManager
+			pc := property.DefaultCollector(c)
+			err := pc.RetrieveOne(ctx, *c.ServiceContent.TaskManager, nil, &m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return len(m.RecentTask)
 		}
-	}
+
+		start := tasks()
+		if start == 0 {
+			t.Fatal("recentTask is empty")
+		}
+
+		task, err := vm.PowerOff(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = task.WaitEx(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		end := tasks()
+		if end == 0 {
+			t.Fatal("recentTask is empty")
+		}
+		if start == end {
+			t.Fatal("recentTask not updated")
+		}
+	})
+}
+
+func TestTaskManagerRead(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		spec := types.TaskFilterSpec{
+			Entity: &types.TaskFilterSpecByEntity{
+				Entity:    vc.ServiceContent.RootFolder,
+				Recursion: types.TaskFilterSpecRecursionOptionAll,
+			},
+		}
+		tm := task.NewManager(vc)
+		c, err := tm.CreateCollectorForTasks(ctx, spec)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		page, err := c.LatestPage(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ntasks := len(page)
+		if ntasks == 0 {
+			t.Fatal("no recent tasks")
+		}
+		tests := []struct {
+			max    int
+			rewind bool
+			order  bool
+			read   func(context.Context, int32) ([]types.TaskInfo, error)
+		}{
+			{ntasks, true, true, c.ReadNextTasks},
+			{ntasks / 3, true, true, c.ReadNextTasks},
+			{ntasks * 3, false, true, c.ReadNextTasks},
+			{3, false, false, c.ReadPreviousTasks},
+			{ntasks * 3, false, true, c.ReadNextTasks},
+		}
+
+		for _, test := range tests {
+			var all []types.TaskInfo
+			count := 0
+			for {
+				tasks, err := test.read(ctx, int32(test.max))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(tasks) == 0 {
+					// expecting 0 below as we've read all tasks in the page
+					ztasks, nerr := test.read(ctx, int32(test.max))
+					if nerr != nil {
+						t.Fatal(nerr)
+					}
+					if len(ztasks) != 0 {
+						t.Errorf("ztasks=%d", len(ztasks))
+					}
+					break
+				}
+				count += len(tasks)
+				all = append(all, tasks...)
+			}
+			if count < len(page) {
+				t.Errorf("expected at least %d tasks, got: %d", len(page), count)
+			}
+
+			if test.rewind {
+				if err = c.Rewind(ctx); err != nil {
+					t.Error(err)
+				}
+			}
+		}
+
+		// after Reset() we should only get tasks via ReadPreviousTasks
+		if err = c.Reset(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		tasks, err := c.ReadNextTasks(ctx, int32(ntasks))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(tasks) != 0 {
+			t.Errorf("expected 0 tasks, got %d", len(tasks))
+		}
+
+		ref := simulator.Map.Any("VirtualMachine").Reference()
+		vm := object.NewVirtualMachine(vc, ref)
+		if _, err = vm.PowerOff(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		tasks, err = c.ReadNextTasks(ctx, int32(ntasks))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(tasks) != 1 {
+			t.Errorf("expected 1 tasks, got %d", len(tasks))
+		}
+
+		count := 0
+		for {
+			tasks, err = c.ReadPreviousTasks(ctx, 3)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(tasks) == 0 {
+				break
+			}
+			count += len(tasks)
+		}
+		if count < ntasks {
+			t.Errorf("expected %d tasks, got %d", ntasks, count)
+		}
+	})
 }


### PR DESCRIPTION
refactor portions of 'EventHistoryCollector' to 'HistoryCollector' for use with 'TaskHistoryCollector'

TaskHistoryCollector provides a way to collect Task history beyond the 10 minute max of the 'RecentTask' property.
And unlike 'RecentTask', can filter based on Task state and collect tasks of child entities.

govc: add history flags to 'tasks' command

Closes #2567
