### PR TITLE
vcsim: add ExtensionManager.FindExtension method

### DIFF
--- a/govc/test/extension.bats
+++ b/govc/test/extension.bats
@@ -8,10 +8,10 @@ load test_helper
   run govc extension.info enoent
   assert_failure
 
-  id=$(new_id)
+  run govc extension.info
+  assert_success
 
-  result=$(govc extension.info | grep $id | wc -l)
-  [ $result -eq 0 ]
+  id=$(new_id)
 
   # register extension
   run govc extension.register $id <<EOS
@@ -54,9 +54,12 @@ EOS
   # remove generated cert and key
   rm ${id}.{crt,key}
 
+  run govc extension.info $(govc extension.info -json | jq -r .extensions[].key)
+  assert_success
+
   run govc extension.unregister $id
   assert_success
 
-  result=$(govc extension.info | grep $id | wc -l)
-  [ $result -eq 0 ]
+  run govc extension.info $id
+  assert_failure
 }

--- a/simulator/extension_manager.go
+++ b/simulator/extension_manager.go
@@ -67,6 +67,21 @@ func (m *ExtensionManager) init(r *Registry) {
 	}
 }
 
+func (m *ExtensionManager) FindExtension(ctx *Context, req *types.FindExtension) soap.HasFault {
+	body := &methods.FindExtensionBody{
+		Res: new(types.FindExtensionResponse),
+	}
+
+	for _, x := range m.ExtensionList {
+		if x.Key == req.ExtensionKey {
+			body.Res.Returnval = &x
+			break
+		}
+	}
+
+	return body
+}
+
 func (m *ExtensionManager) RegisterExtension(ctx *Context, req *types.RegisterExtension) soap.HasFault {
 	body := &methods.RegisterExtensionBody{}
 


### PR DESCRIPTION
d9af2a2 added simulator.ExtensionManager but did not included this method.

govc: use ExtensionManager.FindExtension when given a single KEY arg, rather than fetch the entire list.

Closes #2644
