### PR TITLE
fix: endpoint url to bypass lookup service if envoy sidecar enabled

### DIFF
--- a/lookup/client.go
+++ b/lookup/client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/base64"
+	"fmt"
 	"log"
 	"net/url"
 
@@ -119,6 +120,10 @@ func (c *Client) SiteID(ctx context.Context) (string, error) {
 // If the endpoint is found, its TLS certificate is also added to the vim25.Client's trusted host thumbprints.
 // If the Lookup Service is not available, the given path is returned as the default.
 func EndpointURL(ctx context.Context, c *vim25.Client, path string, filter *types.LookupServiceRegistrationFilter) string {
+	// Services running on vCenter can bypass lookup service.
+	if useSidecar := internal.UsingEnvoySidecar(c); useSidecar {
+		return fmt.Sprintf("http://%s%s", c.URL().Host, path)
+	}
 	if lu, err := NewClient(ctx, c); err == nil {
 		info, _ := lu.List(ctx, filter)
 		if len(info) != 0 && len(info[0].ServiceEndpoints) != 0 {


### PR DESCRIPTION
EndpointURL returns FQDN:443 as endpoint url even if envoy sidecar enabled. This MR updates to bypass lookup service if envoy sidecar enabled.

## Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] Test Description 1
- [ ] Test Description 2

## Checklist:

- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
