### PR TITLE
govc: snapshot.tree json output to stdout

### DIFF
--- a/govc/vm/snapshot/tree.go
+++ b/govc/vm/snapshot/tree.go
@@ -151,7 +151,7 @@ func (cmd *tree) writeJson(vm mo.VirtualMachine) {
 		SnapshotRecords = append(SnapshotRecords, cmd.makeSnapshotRecord(vm, rootSnapshot, nil))
 	}
 	b, _ := json.MarshalIndent(SnapshotRecords, "", "  ")
-	println(string(b))
+	fmt.Println(string(b))
 
 }
 func (cmd *tree) write(level int, parent string, pref *types.ManagedObjectReference, st []types.VirtualMachineSnapshotTree) {


### PR DESCRIPTION
golang builtin println is meant for debugging only and prints always to stderr

## Description

Print json to stdout instead of stderr.

Closes: https://github.com/vmware/govmomi/issues/3392

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Run command:
`govc snapshot.tree -json -vm $vm 2> /dev/null`

Obverve json appearing in the terminal.

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
