### PR TITLE
Remove deprecation for task.Wait and task.WaitForResult

### DIFF
--- a/object/task.go
+++ b/object/task.go
@@ -44,13 +44,17 @@ func NewTask(c *vim25.Client, ref types.ManagedObjectReference) *Task {
 	return &t
 }
 
-// Deprecated: Please use WaitEx instead.
+// Wait waits for a task to complete.
+// NOTE: This method create a thread-safe PropertyCollector instance per-call, so it is thread safe.
+// The downside of this approach is the additional resource usage on the vCenter side for each call.
 func (t *Task) Wait(ctx context.Context) error {
 	_, err := t.WaitForResult(ctx, nil)
 	return err
 }
 
-// Deprecated: Please use WaitForResultEx instead.
+// WaitForResult wait for a task to complete.
+// NOTE: This method create a thread-safe PropertyCollector instance per-call, so it is thread safe.
+// The downside of this approach is the additional resource usage on the vCenter side for each call.
 func (t *Task) WaitForResult(ctx context.Context, s ...progress.Sinker) (taskInfo *types.TaskInfo, result error) {
 	var pr progress.Sinker
 	if len(s) == 1 {
@@ -79,11 +83,17 @@ func (t *Task) WaitForResult(ctx context.Context, s ...progress.Sinker) (taskInf
 	return task.WaitEx(ctx, t.Reference(), p, pr)
 }
 
+// WaitEx waits for a task to complete.
+// NOTE: This method use the same PropertyCollector instance in each call, thus reducing resource usage on the vCenter side.
+// The downside of this approach is that this method is not thread safe.
 func (t *Task) WaitEx(ctx context.Context) error {
 	_, err := t.WaitForResultEx(ctx, nil)
 	return err
 }
 
+// WaitForResultEx waits for a task to complete.
+// NOTE: This method use the same PropertyCollector instance in each call, thus reducing resource usage on the vCenter side.
+// The downside of this approach is that this method is not thread safe.
 func (t *Task) WaitForResultEx(ctx context.Context, s ...progress.Sinker) (*types.TaskInfo, error) {
 	var pr progress.Sinker
 	if len(s) == 1 {

--- a/property/wait.go
+++ b/property/wait.go
@@ -92,10 +92,6 @@ func Wait(ctx context.Context, c *Collector, obj types.ManagedObjectReference, p
 // By default, ObjectUpdate.MissingSet faults are not propagated to the returned
 // error, set WaitFilter.PropagateMissing=true to enable MissingSet fault
 // propagation.
-//
-// Deprecated: Please consider using WaitForUpdatesEx instead, as it does not
-// create a new property collector, instead it destroys the property filter
-// after the expected update is received.
 func WaitForUpdates(
 	ctx context.Context,
 	c *Collector,


### PR DESCRIPTION
## Description

Remove deprecation for task.Wait and task.WaitForResult as per discussion in https://github.com/vmware/govmomi/issues/3394

Closes: #3394

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Not test, it is only a godoc change

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
