### PR TITLE
fix: vcsim: re-parent children in ResourcePool.Destroy

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -239,6 +239,17 @@ EOF
   wait $pid
 }
 
+@test "vcsim issue #3396" {
+  vcsim_env
+
+  govc pool.create /DC0/host/DC0_C0/Resources/foo
+  govc pool.create /DC0/host/DC0_C0/Resources/foo/bar
+  govc find -l /DC0/host/DC0_C0/Resources
+  govc pool.destroy /DC0/host/DC0_C0/Resources/foo
+  # prior to the fix, "bar"'s Parent was still "foo", causing the following to hang
+  govc find -l /DC0/host/DC0_C0/Resources
+}
+
 @test "vcsim run container" {
   require_docker
 

--- a/simulator/resource_pool.go
+++ b/simulator/resource_pool.go
@@ -483,7 +483,11 @@ func (p *ResourcePool) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.H
 			RemoveReference(&parent.ResourcePool, req.This)
 
 			// The grandchildren become children of the parent (rp)
-			parent.ResourcePool = append(parent.ResourcePool, p.ResourcePool.ResourcePool...)
+			for _, ref := range p.ResourcePool.ResourcePool {
+				child := ctx.Map.Get(ref).(*ResourcePool)
+				ctx.WithLock(child, func() { child.Parent = &parent.Self })
+				parent.ResourcePool = append(parent.ResourcePool, ref)
+			}
 		})
 
 		// And VMs move to the parent


### PR DESCRIPTION
Fixes #3396
