### PR TITLE
api: Expose vSphere API to evict subscribed content library

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -217,6 +217,7 @@ but appear via `govc $cmd -h`:
  - [library.cp](#librarycp)
  - [library.create](#librarycreate)
  - [library.deploy](#librarydeploy)
+ - [library.evict](#libraryevict)
  - [library.export](#libraryexport)
  - [library.import](#libraryimport)
  - [library.info](#libraryinfo)
@@ -3547,6 +3548,20 @@ Options:
   -options=              Options spec file path for VM deployment
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
   -profile=              Storage profile
+```
+
+## library.evict
+
+```
+Usage: govc library.evict [OPTIONS] LIBRARY NAME | ITEM NAME
+
+Evict library NAME or item NAME.
+
+Examples:
+  govc library.evict subscribed-library
+  govc library.evict subscribed-library/item
+
+Options:
 ```
 
 ## library.export

--- a/govc/library/evict.go
+++ b/govc/library/evict.go
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/library"
+)
+
+type evict struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("library.evict", &evict{})
+}
+
+func (cmd *evict) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *evict) Usage() string {
+	return "LIBRARY NAME | ITEM NAME"
+}
+
+func (cmd *evict) Description() string {
+	return `Evict library NAME or item NAME.
+
+Examples:
+  govc library.evict subscribed-library
+  govc library.evict subscribed-library/item`
+}
+
+func (cmd *evict) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
+
+	m := library.NewManager(c)
+
+	res, err := flags.ContentLibraryResult(ctx, c, "", f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	switch t := res.GetResult().(type) {
+	case library.Library:
+		return m.EvictSubscribedLibrary(ctx, &t)
+	case library.Item:
+		return m.EvictSubscribedLibraryItem(ctx, &t)
+	default:
+		return fmt.Errorf("%q is a %T", f.Arg(0), t)
+	}
+}

--- a/govc/library/evict.go
+++ b/govc/library/evict.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/govc/library/info.go
+++ b/govc/library/info.go
@@ -223,6 +223,7 @@ func (r infoResultsWriter) writeItem(
 	}
 	fmt.Fprintf(w, "  Type:\t%s\n", v.Type)
 	fmt.Fprintf(w, "  Size:\t%s\n", units.ByteSize(v.Size))
+	fmt.Fprintf(w, "  Cached:\t%t\n", v.Cached)
 	fmt.Fprintf(w, "  Created:\t%s\n", v.CreationTime.Format(time.ANSIC))
 	fmt.Fprintf(w, "  Modified:\t%s\n", v.LastModifiedTime.Format(time.ANSIC))
 	fmt.Fprintf(w, "  Version:\t%s\n", v.Version)

--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -608,7 +608,7 @@ EOF
   assert_matches INVALID_URL
 }
 
-@test "library.sublibevict" {
+@test "library.evict" {
   vcsim_env
 
   run govc library.create -pub published-content
@@ -640,14 +640,16 @@ EOF
   run govc library.sync subscribed-content/ttylinux-latest
   assert_success
 
-  result=$(govc library.info -l subscribed-content/ttylinux-latest)
-  echo "$result"
-  # assert cached is true
+  # assert cached is false after item sync
+  cached=$(govc library.info subscribed-content/ttylinux-latest | grep Cached: | awk '{print $2}')
+  assert_equal "true" "$cached"
 
-  run govc library.evict subscribed-content
+  run govc library.evict subscribed-content/ttylinux-latest
   assert_success
 
-  # assert cached is false
+  # assert cached is false after library item evict
+  cached=$(govc library.info subscribed-content/ttylinux-latest | grep Cached: | awk '{print $2}')
+  assert_equal "false" "$cached"
 }
 
 

--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -607,3 +607,47 @@ EOF
   assert_success
   assert_matches INVALID_URL
 }
+
+@test "library.sublibevict" {
+  vcsim_env
+
+  run govc library.create -pub published-content
+  assert_success
+  id="$output"
+
+  url="https://$(govc env GOVC_URL)/cls/vcsp/lib/$id"
+
+  run govc library.info published-content
+  assert_success
+  assert_matches "Publication:"
+  assert_matches "$url"
+
+  run govc library.import published-content "$GOVC_IMAGES/ttylinux-latest.ova"
+  assert_success
+
+  run govc library.create -sub "$url" -sub-ondemand=true subscribed-content
+  assert_success
+
+  run govc library.info subscribed-content
+  assert_success
+  assert_matches "Subscription:"
+  assert_matches "$url"
+
+  run govc library.ls subscribed-content/ttylinux-latest/
+  assert_success
+  assert_matches "/subscribed-content/ttylinux-latest/ttylinux-pc_i486-16.1.ovf"
+
+  run govc library.sync subscribed-content/ttylinux-latest
+  assert_success
+
+  result=$(govc library.info -l subscribed-content/ttylinux-latest)
+  echo "$result"
+  # assert cached is true
+
+  run govc library.evict subscribed-content
+  assert_success
+
+  # assert cached is false
+}
+
+

--- a/vapi/library/library.go
+++ b/vapi/library/library.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -321,4 +321,12 @@ func (c *Manager) DeleteSubscriber(ctx context.Context, library *Library, subscr
 	id := internal.SubscriptionDestination{ID: subscriber}
 	url := c.Resource(internal.Subscriptions).WithID(library.ID).WithAction("delete")
 	return c.Do(ctx, url.Request(http.MethodPost, &id), nil)
+}
+
+// EvictSubscribedLibrary evicts the cached content of an on-demand subscribed library.
+// This operation allows the cached content of a subscribed library to be removed to free up storage capacity.
+func (c *Manager) EvictSubscribedLibrary(ctx context.Context, library *Library) error {
+	path := internal.SubscribedLibraryPath
+	url := c.Resource(path).WithID(library.ID).WithAction("evict")
+	return c.Do(ctx, url.Request(http.MethodPost), nil)
 }

--- a/vapi/library/library_item.go
+++ b/vapi/library/library_item.go
@@ -206,3 +206,11 @@ func (c *Manager) FindLibraryItems(
 	var res []string
 	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
 }
+
+// EvictSubscribedLibraryItem evicts the cached content of a library item in an on-demand subscribed library.
+// This operation allows the cached content of a subscribed library item to be removed to free up storage capacity.
+func (c *Manager) EvictSubscribedLibraryItem(ctx context.Context, item *Item) error {
+	path := internal.SubscribedLibraryItem
+	url := c.Resource(path).WithID(item.ID).WithAction("evict")
+	return c.Do(ctx, url.Request(http.MethodPost), nil)
+}


### PR DESCRIPTION
Closes: #3400

## Description

This change exposes the vSphere API to evict the subscribed content library to free up storage capacity.
The vSphere API evicts the cached content of an on-demand subscribed library. This operation allows the cached content of a subscribed library to be removed to free up storage capacity. This operation will only work when a subscribed library is synchronized on-demand.

Closes: #3400

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?
Ran the govc tests locally

acharyasreej@acharyasreY5WYK test % ./library.bats
library.bats
 ✓ library
 ✓ library.import
 ✓ library.deploy
 ✓ library.clone ovf
 ✓ library.deploy vmtx
 ✓ library.vmtx.info
 ✓ library.pubsub
 ✓ library.subscriber example
 ✓ library.create.withpolicy
 ✓ library.findbyid
 ✓ library.trust
 ✓ library.session
 ✓ library.probe
 ✓ library.evict

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
