### PR TITLE
Remove the code to change the Namespace to vim25 in NewClient function.

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -61,7 +61,6 @@ type Client struct {
 // NewClient creates a new CNS client
 func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
 	sc := c.Client.NewServiceClient(Path, Namespace)
-	sc.Namespace = c.Namespace
 	sc.Version = c.Version
 	return &Client{sc, sc, c}, nil
 }


### PR DESCRIPTION
## Description

This change is to remove code to change the Namespace to vim25 in NewClient function. This is not needed and other client does not have this logic.
Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Run the unit test for cns client, and it passed.
```
lipingx@lipingxNMD6R govmomi % pwd
/Users/lipingx/go/src/github.com/lipingxue/govmomi


lipingx@lipingxNMD6R cns %  go test -v
=== RUN   TestClient
    client_test.go:158: Creating volume using the spec: types.CnsVolumeCreateSpec{
            Name:       "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
            VolumeType: "BLOCK",
            Datastores: []types.ManagedObjectReference{
                {Type:"Datastore", Value:"datastore-48", ServerGUID:""},
            },
            Metadata: types.CnsVolumeMetadata{
                ContainerCluster: types.CnsContainerCluster{
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "OpenShift",
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    CapacityInMb: 5120,
                },
                BackingDiskId:                  "",
                BackingDiskUrlPath:             "",
                BackingDiskObjectId:            "",
                AggregatedSnapshotCapacityInMb: 0,
            },
            Profile:      nil,
            CreateSpec:   nil,
            VolumeSource: nil,
        }
    client_test.go:184: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:da92fb45-9308-43b7-84a4-2d5b44d2c0e0} Fault:<nil>} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0 PlacementResults:[{Datastore:Datastore:datastore-48 PlacementFaults:[]}]}
    client_test.go:185: Volume created sucessfully. volumeId: da92fb45-9308-43b7-84a4-2d5b44d2c0e0

...

--- PASS: TestClient (23.62s)
PASS
ok  	github.com/vmware/govmomi/cns	23.927s

```

## Checklist:

- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
