### PR TITLE
api: move vim25.Client.UseServiceVersion to soap.Client

### DIFF
--- a/vim25/client.go
+++ b/vim25/client.go
@@ -19,15 +19,11 @@ package vim25
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"net/http"
-	"path"
 	"strings"
 
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/govmomi/vim25/xml"
 )
 
 const (
@@ -86,42 +82,6 @@ func NewClient(ctx context.Context, rt soap.RoundTripper) (*Client, error) {
 	}
 
 	return &c, nil
-}
-
-// UseServiceVersion sets soap.Client.Version to the current version of the service endpoint via /sdk/vimServiceVersions.xml
-func (c *Client) UseServiceVersion(kind ...string) error {
-	ns := "vim"
-	if len(kind) != 0 {
-		ns = kind[0]
-	}
-
-	u := c.URL()
-	u.Path = path.Join(Path, ns+"ServiceVersions.xml")
-
-	res, err := c.Get(u.String())
-	if err != nil {
-		return err
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("http.Get(%s): %s", u.Path, err)
-	}
-
-	v := struct {
-		Namespace *string `xml:"namespace>name"`
-		Version   *string `xml:"namespace>version"`
-	}{
-		&c.Namespace,
-		&c.Version,
-	}
-
-	err = xml.NewDecoder(res.Body).Decode(&v)
-	_ = res.Body.Close()
-	if err != nil {
-		return fmt.Errorf("xml.Decode(%s): %s", u.Path, err)
-	}
-
-	return nil
 }
 
 // RoundTrip dispatches to the RoundTripper field.


### PR DESCRIPTION
This method only changes fields in soap.Client
Moving it allows UseServiceVersion to be called after NewServiceVersion.
