### PR TITLE
build(deps): add vcsim to rpm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,6 +37,7 @@ nfpms:
   - package_name: govmomi
     builds:
       - govc
+      - vcsim
     homepage: https://github.com/vmware/govmomi
     maintainer: Doug MacEachern <dougm@vmware.com>
     description: |-


### PR DESCRIPTION
## Description
Previously, we enabled rpm builds. However, only 'govc' was added. Let's add 'vcsim', too, as the package name 'govmomi' implies it.

Closes: #3413

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [x] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x]  Execute goreleaser goreleaser release --clean --snapshot --rm-dist --verbose --skip docker,homebrew; install rpm on x86_64; call govc --help; call vcsim -h

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
