### PR TITLE
bugfix: Exclude ServerGUID from MOR comparison in WaitEx

### DIFF
--- a/task/wait.go
+++ b/task/wait.go
@@ -141,7 +141,7 @@ func WaitEx(
 		func(updates []types.ObjectUpdate) bool {
 			for _, update := range updates {
 				// Only look at updates for the expected task object.
-				if update.Obj == ref {
+				if update.Obj.Value == ref.Value && update.Obj.Type == ref.Type {
 					if cb.fn(update.ChangeSet) {
 						return true
 					}


### PR DESCRIPTION
## Description

In rare cases it is possible for the ServerGUID field to be empty on managed objects.

One way to observe this is to run `queryVirtualDiskInfo` on the VC. The equivalent `govc` command is `datastore.disk.info`

WaitEx compares the entire ManagedObjectReference structure when filtering updates and if the ServerGUID is unset on the update object the data is dropped.

Since the property collector is scoped to a single VC the server GUID shouldn't even matte so we can safely ignore when filtering.

Closes: #3417

## Type of change

Please mark options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

I set up a VMDK as described in https://github.com/hashicorp/terraform-provider-vsphere/issues/2162
on a 7.0.3 vCenter

I observed that the ServerGUID is indeed empty and that I am unable to retrieve the data for the virtual disk.

After applying the code changes I was able to query the virtual disk.

Also ran `make test` and `make fix`

## Checklist:

- [X] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
