### PR TITLE
api: add SSLCertificate to TransferEndpoint in content library API

### DIFF
--- a/vapi/library/library_item_updatesession_file.go
+++ b/vapi/library/library_item_updatesession_file.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
+Copyright (c) 2019-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import (
 // TransferEndpoint provides information on the source of a library item file.
 type TransferEndpoint struct {
 	URI                      string `json:"uri,omitempty"`
+	SSLCertificate           string `json:"ssl_certificate,omitempty"`
 	SSLCertificateThumbprint string `json:"ssl_certificate_thumbprint,omitempty"`
 }
 
@@ -107,7 +108,11 @@ func (c *Manager) AddLibraryItemFileFromURI(ctx context.Context, sessionID, name
 		if err != nil {
 			return nil, err
 		}
-		source.SSLCertificateThumbprint = res.SSLThumbprint
+		if res.SSLCertificate != "" {
+			source.SSLCertificate = res.SSLCertificate
+		} else {
+			source.SSLCertificateThumbprint = res.SSLThumbprint
+		}
 	}
 
 	return c.AddLibraryItemFile(ctx, sessionID, file)


### PR DESCRIPTION
## Description

Add the optional SSLCertificate field to TransferEndpoint in content library API so it can be specified to probe remote transfer endpoint or upload file from remote endpoint by pull. The field is already in the ProbeResult as an optional field.

Closes: #3420

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
