### PR TITLE
vcsim: Fix:#3423 - mandated to pass the new disk size in Bytes and KB…

### DIFF
--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -686,8 +686,15 @@ load test_helper
 
   run govc vm.disk.create -vm "$vm" -name "$vm/$name" -size 1M
   assert_success
-  result=$(govc device.ls -vm "$vm" | grep -c disk-)
+  disk=$(govc device.ls -vm "$vm" disk-* | awk '{print $1}')
+  result=$(grep -c disk- <<<"$disk")
   [ "$result" -eq 1 ]
+
+  run govc vm.disk.change -vm "$vm" -disk.name "$disk" -size 2M
+  assert_success
+
+  run govc vm.disk.change -vm "$vm" -disk.name "$disk" -size 1M
+  assert_failure # cannot shrink disk
 }
 
 @test "vm.disk.attach" {

--- a/govc/vm/disk/change.go
+++ b/govc/vm/disk/change.go
@@ -153,9 +153,13 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
 	}
 
 	if int64(cmd.bytes) != 0 {
-		editdisk.CapacityInKB = int64(cmd.bytes) / 1024
+		editdisk.CapacityInBytes = int64(cmd.bytes)
+		editdisk.CapacityInKB = int64(0) // zero deprecated field
 	}
 
+	if editdisk.StorageIOAllocation == nil {
+		editdisk.StorageIOAllocation = new(types.StorageIOAllocationInfo)
+	}
 	editdisk.StorageIOAllocation.Limit = cmd.limit
 
 	switch backing := editdisk.Backing.(type) {

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1184,7 +1184,10 @@ func getDiskSize(disk *types.VirtualDisk) int64 {
 
 func changedDiskSize(oldDisk *types.VirtualDisk, newDiskSpec *types.VirtualDisk) (int64, bool) {
 	// capacity cannot be decreased
-	if newDiskSpec.CapacityInBytes < oldDisk.CapacityInBytes || newDiskSpec.CapacityInKB < oldDisk.CapacityInKB {
+	if newDiskSpec.CapacityInBytes > 0 && newDiskSpec.CapacityInBytes < oldDisk.CapacityInBytes {
+		return 0, false
+	}
+	if newDiskSpec.CapacityInKB > 0 && newDiskSpec.CapacityInKB < oldDisk.CapacityInKB {
 		return 0, false
 	}
 
@@ -1196,10 +1199,13 @@ func changedDiskSize(oldDisk *types.VirtualDisk, newDiskSpec *types.VirtualDisk)
 		return newDiskSpec.CapacityInBytes, true
 	}
 
-	// CapacityInBytes and CapacityInKB indicate different values
-	if newDiskSpec.CapacityInBytes != newDiskSpec.CapacityInKB*1024 {
-		return 0, false
+	// if both set, CapacityInBytes and CapacityInKB must be the same
+	if newDiskSpec.CapacityInBytes > 0 && newDiskSpec.CapacityInKB > 0 {
+		if newDiskSpec.CapacityInBytes != newDiskSpec.CapacityInKB*1024 {
+			return 0, false
+		}
 	}
+
 	return newDiskSpec.CapacityInBytes, true
 }
 


### PR DESCRIPTION
…. If either of value is 0, ReconfigVM_Task is throwing *types.InvalidDeviceOperation

Closes: #3423

## Description

Fix the new disk size check. 

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [X] Deployed VM using vRA using vCSIM.  And Vm provisioning was successful. ReconfigureVM_task successful.


## Checklist:

- [X] My code follows the `CONTRIBUTION` [guidelines] of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
