### PR TITLE
api: Add library item storage APIs

### DIFF
--- a/govc/library/create.go
+++ b/govc/library/create.go
@@ -82,7 +82,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	cmd.library.Name = f.Arg(0)
 	cmd.library.Type = "LOCAL"
-	cmd.library.Storage = []library.StorageBackings{
+	cmd.library.Storage = []library.StorageBacking{
 		{
 			DatastoreID: ds.Reference().Value,
 			Type:        "DATASTORE",

--- a/vapi/internal/internal.go
+++ b/vapi/internal/internal.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ const (
 	LibraryItemFileData            = "/com/vmware/cis/data"
 	LibraryItemPath                = "/com/vmware/content/library/item"
 	LibraryItemFilePath            = "/com/vmware/content/library/item/file"
+	LibraryItemStoragePath         = "/com/vmware/content/library/item/storage"
 	LibraryItemUpdateSession       = "/com/vmware/content/library/item/update-session"
 	LibraryItemUpdateSessionFile   = "/com/vmware/content/library/item/updatesession/file"
 	LibraryItemDownloadSession     = "/com/vmware/content/library/item/download-session"

--- a/vapi/library/example_test.go
+++ b/vapi/library/example_test.go
@@ -48,7 +48,7 @@ func ExampleManager_CreateLibrary() {
 		id, err := m.CreateLibrary(ctx, library.Library{
 			Name: "example",
 			Type: "LOCAL",
-			Storage: []library.StorageBackings{{
+			Storage: []library.StorageBacking{{
 				DatastoreID: ds.Reference().Value,
 				Type:        "DATASTORE",
 			}},

--- a/vapi/library/library.go
+++ b/vapi/library/library.go
@@ -28,27 +28,28 @@ import (
 	"github.com/vmware/govmomi/vapi/rest"
 )
 
-// StorageBackings for Content Libraries
-type StorageBackings struct {
+// StorageBacking defines a storage location where content in a library will be stored.
+type StorageBacking struct {
 	DatastoreID string `json:"datastore_id,omitempty"`
 	Type        string `json:"type,omitempty"`
+	StorageURI  string `json:"storage_uri,omitempty"`
 }
 
 // Library  provides methods to create, read, update, delete, and enumerate libraries.
 type Library struct {
-	CreationTime          *time.Time        `json:"creation_time,omitempty"`
-	Description           *string           `json:"description,omitempty"`
-	ID                    string            `json:"id,omitempty"`
-	LastModifiedTime      *time.Time        `json:"last_modified_time,omitempty"`
-	LastSyncTime          *time.Time        `json:"last_sync_time,omitempty"`
-	Name                  string            `json:"name,omitempty"`
-	Storage               []StorageBackings `json:"storage_backings,omitempty"`
-	Type                  string            `json:"type,omitempty"`
-	Version               string            `json:"version,omitempty"`
-	Subscription          *Subscription     `json:"subscription_info,omitempty"`
-	Publication           *Publication      `json:"publish_info,omitempty"`
-	SecurityPolicyID      string            `json:"security_policy_id,omitempty"`
-	UnsetSecurityPolicyID bool              `json:"unset_security_policy_id,omitempty"`
+	CreationTime          *time.Time       `json:"creation_time,omitempty"`
+	Description           *string          `json:"description,omitempty"`
+	ID                    string           `json:"id,omitempty"`
+	LastModifiedTime      *time.Time       `json:"last_modified_time,omitempty"`
+	LastSyncTime          *time.Time       `json:"last_sync_time,omitempty"`
+	Name                  string           `json:"name,omitempty"`
+	Storage               []StorageBacking `json:"storage_backings,omitempty"`
+	Type                  string           `json:"type,omitempty"`
+	Version               string           `json:"version,omitempty"`
+	Subscription          *Subscription    `json:"subscription_info,omitempty"`
+	Publication           *Publication     `json:"publish_info,omitempty"`
+	SecurityPolicyID      string           `json:"security_policy_id,omitempty"`
+	UnsetSecurityPolicyID bool             `json:"unset_security_policy_id,omitempty"`
 }
 
 // Subscription info

--- a/vapi/library/library_item_storage.go
+++ b/vapi/library/library_item_storage.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/internal"
+)
+
+// Storage is an expanded form of library.File that includes details about the
+// storage backing for a file in a library item
+type Storage struct {
+	Checksum       Checksum       `json:"checksum_info,omitempty"`
+	StorageBacking StorageBacking `json:"storage_backing"`
+	StorageURIs    []string       `json:"storage_uris"`
+	Name           string         `json:"name"`
+	Size           int64          `json:"size"`
+	Cached         bool           `json:"cached"`
+	Version        string         `json:"version"`
+}
+
+// ListLibraryItemStorage returns a list of all the storage for a library item.
+func (c *Manager) ListLibraryItemStorage(ctx context.Context, id string) ([]Storage, error) {
+	url := c.Resource(internal.LibraryItemStoragePath).WithParam("library_item_id", id)
+	var res []Storage
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// GetLibraryItemStorage returns the storage for a specific file in a library item.
+func (c *Manager) GetLibraryItemStorage(ctx context.Context, id, fileName string) (*Storage, error) {
+	url := c.Resource(internal.LibraryItemStoragePath).WithID(id).WithAction("get")
+	spec := struct {
+		Name string `json:"name"`
+	}{fileName}
+	var res Storage
+	return &res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}


### PR DESCRIPTION
## Description

This PR adds a new set of APIs to retrieve library item storage, as defined in https://developer.broadcom.com/xapis/vsphere-automation-api/v8.0U1/content/library/item-storage/

Closes: N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Consumed this API in an operator running in the internal Supervisor cluster and verified the expected Storage URI retrieved for each file available in a content library item:

```
fileInfo:
  - cached: true
    name: ubuntu-20.04-vmservice-v1alpha1.20210528.ovf
    sizeInBytes: "10552"
    storageURI: ds:///vmfs/volumes/... <redacted>
    version: "1"
  - cached: true
    name: ubuntu-20.04-vmservice-v1alpha1.20210528-disk1.vmdk
    sizeInBytes: "1426063360"
    storageURI: ds:///vmfs/volumes/... <redacted>
    version: "1"
```

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] (N/A) I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
