### PR TITLE
api: add sata controller

### DIFF
--- a/govc/vm/create.go
+++ b/govc/vm/create.go
@@ -519,6 +519,14 @@ func (cmd *create) addStorage(devices object.VirtualDeviceList) (object.VirtualD
 
 			devices = append(devices, nvme)
 			cmd.controller = devices.Name(nvme)
+		} else if cmd.controller == "sata" {
+			sata, err := devices.CreateSATAController()
+			if err != nil {
+				return nil, err
+			}
+
+			devices = append(devices, sata)
+			cmd.controller = devices.Name(sata)
 		} else {
 			scsi, err := devices.CreateSCSIController(cmd.controller)
 			if err != nil {


### PR DESCRIPTION

## Description

Adds support for creating SATA controllers.

Closes: #1219

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [x] Local test: `TestCreateSATAController`

```sh
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestCreateSATAController$ github.com/vmware/govmomi/object

ok  	github.com/vmware/govmomi/object	(cached)
```

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
