### PR TITLE
nfc: Record the SSL thumbprint for the host the (device) URL refers to

### DIFF
--- a/nfc/lease.go
+++ b/nfc/lease.go
@@ -145,7 +145,11 @@ func (l *Lease) newLeaseInfo(li *types.HttpNfcLeaseInfo, items []types.OvfFileIt
 		// this is an import
 		for _, item := range items {
 			if device.ImportKey == item.DeviceId {
-				info.Items = append(info.Items, NewFileItem(u, item))
+				fi := NewFileItem(u, item)
+				fi.Thumbprint = device.SslThumbprint
+
+				info.Items = append(info.Items, fi)
+
 				break
 			}
 		}

--- a/nfc/lease_updater.go
+++ b/nfc/lease_updater.go
@@ -30,7 +30,9 @@ import (
 
 type FileItem struct {
 	types.OvfFileItem
-	URL *url.URL
+
+	URL        *url.URL
+	Thumbprint string
 
 	ch chan progress.Report
 }


### PR DESCRIPTION
## Description

With this change we are recording the SSL thumbprint for the host the device URL refers to. This is done so that clients of the nfc wrapper can perform their own SSL verification using the recorded thumbprint if necessary. The thumbprint is stored in the FileItem struct, but the New constructor is not modified so as not to introduce any breaking changes.

Please note that the thumbprint is recorded only for the import case (when deploying an OVF in my case) since that is the only necessary path for our internal usage.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

I have performed isolated testing against both a vCenter and a ESXi host. I have observed that the thumbprint is recorded and accessible through the `FileItem` struct as expected.

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
