### PR TITLE
vcsim: add library item storage API support

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1553,6 +1553,7 @@ If device is not specified, the first CD-ROM device is used.
 
 Examples:
   govc device.cdrom.insert -vm vm-1 -device cdrom-3000 images/boot.iso
+  govc device.cdrom.insert -vm vm-1 library:/boot/linux/ubuntu.iso # Content Library ISO
 
 Options:
   -device=               CD-ROM device name
@@ -3631,6 +3632,8 @@ Usage: govc library.info [OPTIONS]
 
 Display library information.
 
+Note: the '-s' flag only applies to files, not items or the library itself.
+
 Examples:
   govc library.info
   govc library.info /lib1
@@ -3638,7 +3641,8 @@ Examples:
   govc library.info /lib1/item1
   govc library.info /lib1/item1/
   govc library.info */
-  govc device.cdrom.insert -vm $vm -device cdrom-3000 $(govc library.info -L /lib1/item1/file1)
+  govc library.info -L /lib1/item1/file1 # file path relative to Datastore
+  govc library.info -L -l /lib1/item1/file1 # file path including Datastore
   govc library.info -json | jq .
   govc library.info -json /lib1/item1 | jq .
 
@@ -3646,6 +3650,7 @@ Options:
   -L=false               List Datastore path only
   -U=false               List pub/sub URL(s) only
   -l=false               Long listing format
+  -s=false               Include file specific storage details
 ```
 
 ## library.ls
@@ -6284,6 +6289,7 @@ https://code.vmware.com/apis/358/vsphere/doc/vim.vm.GuestOsDescriptor.GuestOsIde
 
 Examples:
   govc vm.create -on=false vm-name
+  govc vm.create -iso library:/boot/linux/ubuntu.iso vm-name # Content Library ISO
   govc vm.create -cluster cluster1 vm-name # use compute cluster placement
   govc vm.create -datastore-cluster dscluster vm-name # use datastore cluster placement
   govc vm.create -m 2048 -c 2 -g freebsd64Guest -net.adapter vmxnet3 -disk.controller pvscsi vm-name

--- a/govc/device/cdrom/insert.go
+++ b/govc/device/cdrom/insert.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -64,7 +64,8 @@ func (cmd *insert) Description() string {
 If device is not specified, the first CD-ROM device is used.
 
 Examples:
-  govc device.cdrom.insert -vm vm-1 -device cdrom-3000 images/boot.iso`
+  govc device.cdrom.insert -vm vm-1 -device cdrom-3000 images/boot.iso
+  govc device.cdrom.insert -vm vm-1 library:/boot/linux/ubuntu.iso # Content Library ISO`
 }
 
 func (cmd *insert) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -87,7 +88,7 @@ func (cmd *insert) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	iso, err := cmd.DatastorePath(f.Arg(0))
+	iso, err := cmd.FileBacking(ctx, f.Arg(0), false)
 	if err != nil {
 		return err
 	}

--- a/vapi/library/finder/path.go
+++ b/vapi/library/finder/path.go
@@ -1,0 +1,132 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package finder
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// PathFinder is used to find the Datastore path of a library.Library, library.Item or library.File.
+type PathFinder struct {
+	m     *library.Manager
+	c     *vim25.Client
+	cache map[string]string
+}
+
+// NewPathFinder creates a new PathFinder instance.
+func NewPathFinder(m *library.Manager, c *vim25.Client) *PathFinder {
+	return &PathFinder{
+		m:     m,
+		c:     c,
+		cache: make(map[string]string),
+	}
+}
+
+// Path returns the absolute datastore path for a Library, Item or File.
+// The cache is used by DatastoreName().
+func (f *PathFinder) Path(ctx context.Context, r FindResult) (string, error) {
+	switch l := r.GetResult().(type) {
+	case library.Library:
+		id := ""
+		if len(l.Storage) != 0 {
+			var err error
+			id, err = f.datastoreName(ctx, l.Storage[0].DatastoreID)
+			if err != nil {
+				return "", err
+			}
+		}
+		return fmt.Sprintf("[%s] contentlib-%s", id, l.ID), nil
+	case library.Item:
+		p, err := f.Path(ctx, r.GetParent())
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s/%s", p, l.ID), nil
+	case library.File:
+		return f.getFileItemPath(ctx, r)
+	default:
+		return "", fmt.Errorf("unsupported type=%T", l)
+	}
+}
+
+// getFileItemPath returns the absolute datastore path for a library.File
+func (f *PathFinder) getFileItemPath(ctx context.Context, r FindResult) (string, error) {
+	name := r.GetName()
+
+	dir, err := f.Path(ctx, r.GetParent())
+	if err != nil {
+		return "", err
+	}
+
+	p := path.Join(dir, name)
+
+	lib := r.GetParent().GetParent().GetResult().(library.Library)
+	if len(lib.Storage) == 0 {
+		return p, nil
+	}
+
+	// storage file name includes a uuid, for example:
+	//  "ubuntu-14.04.6-server-amd64.iso" -> "ubuntu-14.04.6-server-amd64_0653e3f3-b4f4-41fb-9b72-c4102450e3dc.iso"
+	s, err := f.m.GetLibraryItemStorage(ctx, r.GetParent().GetID(), name)
+	if err != nil {
+		return p, err
+	}
+	// Currently there can only be 1 storage URI
+	if len(s) == 0 {
+		return p, nil
+	}
+
+	uris := s[0].StorageURIs
+	if len(uris) == 0 {
+		return p, nil
+	}
+	u, err := url.Parse(uris[0])
+	if err != nil {
+		return p, err
+	}
+
+	return path.Join(dir, path.Base(u.Path)), nil
+}
+
+// datastoreName returns the Datastore.Name for the given id.
+func (f *PathFinder) datastoreName(ctx context.Context, id string) (string, error) {
+	if name, ok := f.cache[id]; ok {
+		return name, nil
+	}
+
+	obj := types.ManagedObjectReference{
+		Type:  "Datastore",
+		Value: id,
+	}
+
+	ds := object.NewDatastore(f.c, obj)
+	name, err := ds.ObjectName(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	f.cache[id] = name
+	return name, nil
+}

--- a/vapi/library/library_item_storage.go
+++ b/vapi/library/library_item_storage.go
@@ -43,11 +43,11 @@ func (c *Manager) ListLibraryItemStorage(ctx context.Context, id string) ([]Stor
 }
 
 // GetLibraryItemStorage returns the storage for a specific file in a library item.
-func (c *Manager) GetLibraryItemStorage(ctx context.Context, id, fileName string) (*Storage, error) {
+func (c *Manager) GetLibraryItemStorage(ctx context.Context, id, fileName string) ([]Storage, error) {
 	url := c.Resource(internal.LibraryItemStoragePath).WithID(id).WithAction("get")
 	spec := struct {
-		Name string `json:"name"`
+		Name string `json:"file_name"`
 	}{fileName}
-	var res Storage
-	return &res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+	var res []Storage
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
 }

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,10 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -27,6 +31,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"log"
 	"net/http"
@@ -75,6 +80,7 @@ type content struct {
 }
 
 type update struct {
+	*sync.WaitGroup
 	*library.Session
 	Library *library.Library
 	File    map[string]*library.UpdateFile
@@ -152,6 +158,8 @@ func New(u *url.URL, r *simulator.Registry) ([]string, http.Handler) {
 		{internal.Subscriptions + "/", s.subscriptionsID},
 		{internal.LibraryItemPath, s.libraryItem},
 		{internal.LibraryItemPath + "/", s.libraryItemID},
+		{internal.LibraryItemStoragePath, s.libraryItemStorage},
+		{internal.LibraryItemStoragePath + "/", s.libraryItemStorageID},
 		{internal.SubscribedLibraryItem + "/", s.libraryItemID},
 		{internal.LibraryItemUpdateSession, s.libraryItemUpdateSession},
 		{internal.LibraryItemUpdateSession + "/", s.libraryItemUpdateSessionID},
@@ -1282,6 +1290,93 @@ func (s *handler) libraryItemID(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (s *handler) libraryItemByID(id string) (*content, *item) {
+	for _, l := range s.Library {
+		if item, ok := l.Item[id]; ok {
+			return l, item
+		}
+	}
+
+	log.Printf("library for item %q not found", id)
+
+	return nil, nil
+}
+
+func (s *handler) libraryItemStorageByID(id string) ([]library.Storage, bool) {
+	lib, item := s.libraryItemByID(id)
+	if item == nil {
+		return nil, false
+	}
+
+	storage := make([]library.Storage, len(item.File))
+
+	for i, file := range item.File {
+		storage[i] = library.Storage{
+			StorageBacking: lib.Storage[0],
+			StorageURIs: []string{
+				path.Join(libraryPath(lib.Library, id), file.Name),
+			},
+			Name:    file.Name,
+			Version: file.Version,
+		}
+		if file.Checksum != nil {
+			storage[i].Checksum = *file.Checksum
+		}
+		if file.Size != nil {
+			storage[i].Size = *file.Size
+		}
+		if file.Cached != nil {
+			storage[i].Cached = *file.Cached
+		}
+	}
+
+	return storage, true
+}
+
+func (s *handler) libraryItemStorage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := r.URL.Query().Get("library_item_id")
+	storage, ok := s.libraryItemStorageByID(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	OK(w, storage)
+}
+
+func (s *handler) libraryItemStorageID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := s.id(r)
+	storage, ok := s.libraryItemStorageByID(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	var spec struct {
+		Name string `json:"file_name"`
+	}
+
+	if s.decode(r, w, &spec) {
+		for _, file := range storage {
+			if file.Name == spec.Name {
+				OK(w, []library.Storage{file})
+				return
+			}
+		}
+		http.NotFound(w, r)
+	}
+}
+
 func (s *handler) libraryItemUpdateSession(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
@@ -1315,9 +1410,10 @@ func (s *handler) libraryItemUpdateSession(w http.ResponseWriter, r *http.Reques
 				ExpirationTime:            types.NewTime(time.Now().Add(time.Hour)),
 			}
 			s.Update[session.ID] = update{
-				Session: session,
-				Library: lib,
-				File:    make(map[string]*library.UpdateFile),
+				WaitGroup: new(sync.WaitGroup),
+				Session:   session,
+				Library:   lib,
+				File:      make(map[string]*library.UpdateFile),
 			}
 			OK(w, session.ID)
 		}
@@ -1335,7 +1431,9 @@ func (s *handler) libraryItemUpdateSessionID(w http.ResponseWriter, r *http.Requ
 
 	session := up.Session
 	done := func(state string) {
-		up.State = state
+		if up.State != "ERROR" {
+			up.State = state
+		}
 		go time.AfterFunc(session.ExpirationTime.Sub(time.Now()), func() {
 			s.Lock()
 			delete(s.Update, id)
@@ -1351,7 +1449,10 @@ func (s *handler) libraryItemUpdateSessionID(w http.ResponseWriter, r *http.Requ
 		case "cancel":
 			done("CANCELED")
 		case "complete":
-			done("DONE")
+			go func() {
+				up.Wait() // wait for any PULL sources to complete
+				done("DONE")
+			}()
 		case "fail":
 			done("ERROR")
 		case "keep-alive":
@@ -1466,14 +1567,16 @@ func (s *handler) libraryItemUpdateSessionFile(w http.ResponseWriter, r *http.Re
 }
 
 func (s *handler) pullSource(up update, info *library.UpdateFile) {
+	defer up.Done()
 	done := func(err error) {
 		s.Lock()
 		info.Status = "READY"
 		if err != nil {
 			log.Printf("PULL %s: %s", info.SourceEndpoint.URI, err)
 			info.Status = "ERROR"
-			up.State = "ERROR"
-			up.ErrorMessage = &rest.LocalizableMessage{DefaultMessage: err.Error()}
+			info.ErrorMessage = &rest.LocalizableMessage{DefaultMessage: err.Error()}
+			up.State = info.Status
+			up.ErrorMessage = info.ErrorMessage
 		}
 		s.Unlock()
 	}
@@ -1490,8 +1593,19 @@ func (s *handler) pullSource(up update, info *library.UpdateFile) {
 		return
 	}
 
-	err = s.libraryItemFileCreate(&up, info.Name, res.Body)
+	err = s.libraryItemFileCreate(&up, info.Name, res.Body, info.Checksum)
 	done(err)
+}
+
+func hasChecksum(c *library.Checksum) bool {
+	return c != nil && c.Checksum != ""
+}
+
+var checksum = map[string]func() hash.Hash{
+	"MD5":    md5.New,
+	"SHA1":   sha1.New,
+	"SHA256": sha256.New,
+	"SHA512": sha512.New,
 }
 
 func (s *handler) libraryItemUpdateSessionFileID(w http.ResponseWriter, r *http.Request) {
@@ -1517,6 +1631,7 @@ func (s *handler) libraryItemUpdateSessionFileID(w http.ResponseWriter, r *http.
 			id = uuid.New().String()
 			info := &library.UpdateFile{
 				Name:             spec.File.Name,
+				Checksum:         spec.File.Checksum,
 				SourceType:       spec.File.SourceType,
 				Status:           "WAITING_FOR_TRANSFER",
 				BytesTransferred: 0,
@@ -1530,20 +1645,30 @@ func (s *handler) libraryItemUpdateSessionFileID(w http.ResponseWriter, r *http.
 				}
 				info.UploadEndpoint = &library.TransferEndpoint{URI: u.String()}
 			case "PULL":
+				if hasChecksum(info.Checksum) && checksum[info.Checksum.Algorithm] == nil {
+					BadRequest(w, "com.vmware.vapi.std.errors.invalid_argument")
+					return
+				}
 				info.SourceEndpoint = spec.File.SourceEndpoint
+				info.Status = "TRANSFERRING"
+				up.Add(1)
 				go s.pullSource(up, info)
 			}
 			up.File[id] = info
 			OK(w, info)
 		}
 	case "get":
-		OK(w, up.Session)
-	case "list":
-		var ids []string
-		for id := range up.File {
-			ids = append(ids, id)
+		var spec struct {
+			File string `json:"file_name"`
 		}
-		OK(w, ids)
+		if s.decode(r, w, &spec) {
+			for _, f := range up.File {
+				if f.Name == spec.File {
+					OK(w, f)
+					return
+				}
+			}
+		}
 	case "remove":
 		if up.State != "ACTIVE" {
 			s.error(w, fmt.Errorf("removeFile not allowed in state %s", up.State))
@@ -1580,20 +1705,12 @@ func (s *handler) libraryItemDownloadSession(w http.ResponseWriter, r *http.Requ
 
 		switch s.action(r) {
 		case "create", "":
-			var lib *library.Library
-			var files []library.File
-			for _, l := range s.Library {
-				if item, ok := l.Item[spec.Session.LibraryItemID]; ok {
-					lib = l.Library
-					files = item.File
-					break
-				}
-			}
-			if lib == nil {
-				log.Printf("library for item %q not found", spec.Session.LibraryItemID)
+			lib, item := s.libraryItemByID(spec.Session.LibraryItemID)
+			if item == nil {
 				http.NotFound(w, r)
 				return
 			}
+
 			session := &library.Session{
 				ID:                        uuid.New().String(),
 				LibraryItemID:             spec.Session.LibraryItemID,
@@ -1604,10 +1721,10 @@ func (s *handler) libraryItemDownloadSession(w http.ResponseWriter, r *http.Requ
 			}
 			s.Download[session.ID] = download{
 				Session: session,
-				Library: lib,
+				Library: lib.Library,
 				File:    make(map[string]*library.DownloadFile),
 			}
-			for _, file := range files {
+			for _, file := range item.File {
 				s.Download[session.ID].File[file.Name] = &library.DownloadFile{
 					Name:   file.Name,
 					Status: "UNPREPARED",
@@ -1741,7 +1858,7 @@ func libraryPath(l *library.Library, id string) string {
 	return path.Join(append([]string{ds.Info.GetDatastoreInfo().Url, "contentlib-" + l.ID}, id)...)
 }
 
-func (s *handler) libraryItemFileCreate(up *update, name string, body io.ReadCloser) error {
+func (s *handler) libraryItemFileCreate(up *update, name string, body io.ReadCloser, cs *library.Checksum) error {
 	var in io.Reader = body
 	dir := libraryPath(up.Library, up.Session.LibraryItemID)
 	if err := os.MkdirAll(dir, 0750); err != nil {
@@ -1770,6 +1887,12 @@ func (s *handler) libraryItemFileCreate(up *update, name string, body io.ReadClo
 		return err
 	}
 
+	var h hash.Hash
+	if hasChecksum(cs) {
+		h = checksum[cs.Algorithm]()
+		in = io.TeeReader(in, h)
+	}
+
 	n, err := io.Copy(file, in)
 	_ = body.Close()
 	if err != nil {
@@ -1778,6 +1901,13 @@ func (s *handler) libraryItemFileCreate(up *update, name string, body io.ReadClo
 	err = file.Close()
 	if err != nil {
 		return err
+	}
+
+	if h != nil {
+		sum := fmt.Sprintf("%x", h.Sum(nil))
+		if sum != cs.Checksum {
+			return fmt.Errorf("checksum mismatch: actual=%s, expected=%s", sum, cs.Checksum)
+		}
 	}
 
 	i := s.Library[up.Library.ID].Item[up.Session.LibraryItemID]
@@ -1828,7 +1958,7 @@ func (s *handler) libraryItemFileData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.libraryItemFileCreate(up, name, r.Body)
+	err := s.libraryItemFileCreate(up, name, r.Body, nil)
 	if err != nil {
 		s.error(w, err)
 	}


### PR DESCRIPTION
govc: support Content Library iso files for cdrom backing

The 'device.cdrom.insert' and 'vm.create -iso' commands can now a URL with 'library' scheme to back a cdrom device from a Content Library.

api: refactor 'library.info -L' functionality into library PathFinder helper.

Fixes #3213
