### PR TITLE
fix: govc vm.disk.change should only modify CapacityInBytes

### DIFF
--- a/govc/vm/disk/change.go
+++ b/govc/vm/disk/change.go
@@ -154,7 +154,6 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	if int64(cmd.bytes) != 0 {
 		editdisk.CapacityInBytes = int64(cmd.bytes)
-		editdisk.CapacityInKB = int64(0) // zero deprecated field
 	}
 
 	if editdisk.StorageIOAllocation == nil {


### PR DESCRIPTION
PR #3424 switched from the deprecated CapacityInKB field to CapacityInBytes. That PR focus was to fix an issue with the simulator, but broke against real vCenter. Just leaving CapacityInKB as-is makes vCenter happy again.

Fixes #3464
