### PR TITLE
Add storage profile related api and govc helpers

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -4311,20 +4311,21 @@ Usage: govc namespace.create [OPTIONS] NAME
 
 Creates a new vSphere Namespace on a Supervisor.
 
-The '-library' and '-vm-class' flags can each be specified multiple times.
+The '-library', '-vmclass' and '-storage' flags can each be specified multiple times.
 
 Examples:
-  govc namespace.create -supervisor=domain-c1 test-namespace
-  govc namespace.create -supervisor=domain-c1 -library=dca9cc16-9460-4da0-802c-4aa148ac6cf7 test-namespace
-  govc namespace.create -supervisor=domain-c1 -library=dca9cc16-9460-4da0-802c-4aa148ac6cf7 -library=dca9cc16-9460-4da0-802c-4aa148ac6cf7 test-namespace
-  govc namespace.create -supervisor=domain-c1 -vm-class=best-effort-2xlarge test-namespace
-  govc namespace.create -supervisor=domain-c1 -vm-class=best-effort-2xlarge -vm-class best-effort-4xlarge test-namespace
-  govc namespace.create -supervisor=domain-c1 -library=dca9cc16-9460-4da0-802c-4aa148ac6cf7 -library=dca9cc16-9460-4da0-802c-4aa148ac6cf7 -vm-class=best-effort-2xlarge -vm-class=best-effort-4xlarge test-namespace
+  govc namespace.create -cluster C1 test-namespace
+  govc namespace.create -cluster C1 -library vmsvc test-namespace
+  govc namespace.create -cluster C1 -library vmsvc -library tkgs test-namespace -storage wcp-policy
+  govc namespace.create -cluster C1 -vmclass best-effort-2xlarge test-namespace
+  govc namespace.create -cluster C1 -vmclass best-effort-2xlarge -vmclass best-effort-4xlarge test-namespace
+  govc namespace.create -cluster C1 -library vmsvc -library tkgs -vmclass best-effort-2xlarge -vmclass best-effort-4xlarge test-namespace
 
 Options:
+  -cluster=              Cluster [GOVC_CLUSTER]
   -library=[]            Content library IDs to associate with the vSphere Namespace.
-  -supervisor=           The identifier of the Supervisor.
-  -vm-class=[]           Virtual machine class IDs to associate with the vSphere Namespace.
+  -storage=[]            Storage profile IDs to associate with the vSphere Namespace.
+  -vmclass=[]            Virtual machine class IDs to associate with the vSphere Namespace.
 ```
 
 ## namespace.info
@@ -4476,15 +4477,16 @@ Usage: govc namespace.update [OPTIONS] NAME
 Modifies an existing vSphere Namespace on a Supervisor.
 
 Examples:
-  govc namespace.update -library=dca9cc16-9460-4da0-802c-4aa148ac6cf7 test-namespace
-  govc namespace.update -library=dca9cc16-9460-4da0-802c-4aa148ac6cf7 -library=617a3ee3-a2ff-4311-9a7c-0016ccf958bd test-namespace
-  govc namespace.update -vm-class=best-effort-2xlarge test-namespace
-  govc namespace.update -vm-class=best-effort-2xlarge -vm-class=best-effort-4xlarge test-namespace
-  govc namespace.update -library=dca9cc16-9460-4da0-802c-4aa148ac6cf7 -library=617a3ee3-a2ff-4311-9a7c-0016ccf958bd -vm-class=best-effort-2xlarge -vm-class=best-effort-4xlarge test-namespace
+  govc namespace.update -library vmsvc test-namespace
+  govc namespace.update -library vmsvc -library tkgs -storage wcp-policy test-namespace
+  govc namespace.update -vmclass best-effort-2xlarge test-namespace
+  govc namespace.update -vmclass best-effort-2xlarge -vmclass best-effort-4xlarge test-namespace
+  govc namespace.update -library vmsvc -library tkgs -vmclass best-effort-2xlarge -vmclass best-effort-4xlarge test-namespace
 
 Options:
   -library=[]            Content library IDs to associate with the vSphere Namespace.
-  -vm-class=[]           Virtual machine class IDs to associate with the vSphere Namespace.
+  -storage=[]            Storage profile IDs to associate with the vSphere Namespace.
+  -vmclass=[]            Virtual machine class IDs to associate with the vSphere Namespace.
 ```
 
 ## namespace.vmclass.create
@@ -6318,6 +6320,7 @@ Options:
   -net.protocol=         Network device protocol. Applicable to vmxnet3vrdma. Default to 'rocev2'
   -on=true               Power on VM
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
+  -profile=              Storage profile name or ID
   -version=              ESXi hardware version [2|3|4|5.0|5.1|5.5|6.0|6.5|6.7|6.7.2|7.0|7.0.1|7.0.2|8.0|8.0.1|8.0.2]
 ```
 

--- a/govc/namespace/flag.go
+++ b/govc/namespace/flag.go
@@ -1,0 +1,93 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vapi/namespace"
+)
+
+type namespaceFlag struct {
+	*flags.ClientFlag
+
+	library flags.StringList
+	vmclass flags.StringList
+	storage flags.StringList
+}
+
+func (ns *namespaceFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	ns.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	ns.ClientFlag.Register(ctx, f)
+
+	f.Var(&ns.library, "library", "Content library IDs to associate with the vSphere Namespace.")
+	f.Var(&ns.vmclass, "vmclass", "Virtual machine class IDs to associate with the vSphere Namespace.")
+	f.Var(&ns.storage, "storage", "Storage profile IDs to associate with the vSphere Namespace.")
+}
+
+func (ns *namespaceFlag) Process(ctx context.Context) error {
+	if err := ns.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	rc, err := ns.RestClient()
+	if err != nil {
+		return err
+	}
+
+	for i, name := range ns.library {
+		l, err := flags.ContentLibrary(ctx, rc, name)
+		if err == nil {
+			ns.library[i] = l.ID
+		}
+	}
+
+	pc, err := ns.PbmClient()
+	if err != nil {
+		return err
+	}
+
+	m, err := pc.ProfileMap(ctx)
+	if err != nil {
+		return err
+	}
+
+	for i, name := range ns.storage {
+		if n, ok := m.Name[name]; ok {
+			ns.storage[i] = n.GetPbmProfile().ProfileId.UniqueId
+		}
+	}
+
+	return nil
+}
+
+func (ns *namespaceFlag) storageSpec() []namespace.StorageSpec {
+	s := make([]namespace.StorageSpec, len(ns.storage))
+	for i := range ns.storage {
+		s[i].Policy = ns.storage[i]
+	}
+	return s
+}
+
+func (ns *namespaceFlag) vmServiceSpec() namespace.VmServiceSpec {
+	return namespace.VmServiceSpec{
+		ContentLibraries: ns.library,
+		VmClasses:        ns.vmclass,
+	}
+}

--- a/govc/storage/policy/ls.go
+++ b/govc/storage/policy/ls.go
@@ -74,33 +74,17 @@ Examples:
 }
 
 func ListProfiles(ctx context.Context, c *pbm.Client, name string) ([]types.BasePbmProfile, error) {
-	rtype := types.PbmProfileResourceType{
-		ResourceType: string(types.PbmProfileResourceTypeEnumSTORAGE),
-	}
-
-	category := types.PbmProfileCategoryEnumREQUIREMENT
-
-	ids, err := c.QueryProfile(ctx, rtype, string(category))
+	m, err := c.ProfileMap(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	profiles, err := c.RetrieveContent(ctx, ids)
-	if err != nil {
-		return nil, err
-	}
-
 	if name == "" {
-		return profiles, nil
+		return m.Profile, nil
 	}
-
-	for _, p := range profiles {
-		if p.GetPbmProfile().Name == name {
-			return []types.BasePbmProfile{p}, nil
-		}
+	if p, ok := m.Name[name]; ok {
+		return []types.BasePbmProfile{p}, nil
 	}
-
-	return c.RetrieveContent(ctx, []types.PbmProfileId{{UniqueId: name}})
+	return nil, fmt.Errorf("profile %q not found", name)
 }
 
 type lsResult struct {

--- a/vapi/namespace/namespace.go
+++ b/vapi/namespace/namespace.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020-2022 VMware, Inc. All Rights Reserved.
+Copyright (c) 2020-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -680,6 +680,7 @@ type NamespacesInstanceInfo struct {
 	SelfServiceNamespace bool                    `json:"self_service_namespace,omitempty"`
 	Messages             []LocalizableMessage    `json:"message"`
 	VmServiceSpec        VmServiceSpec           `json:"vm_service_spec,omitempty"`
+	StorageSpecs         []StorageSpec           `json:"storage_specs,omitempty"`
 }
 
 // NamespacesInstanceCreateSpec https://developer.vmware.com/apis/vsphere-automation/v7.0U3/vcenter/data-structures/Namespaces/Instances/CreateSpec/
@@ -687,6 +688,7 @@ type NamespacesInstanceCreateSpec struct {
 	Cluster       string        `json:"cluster"`
 	Namespace     string        `json:"namespace"`
 	VmServiceSpec VmServiceSpec `json:"vm_service_spec,omitempty"`
+	StorageSpecs  []StorageSpec `json:"storage_specs,omitempty"`
 }
 
 // VmServiceSpec https://developer.vmware.com/apis/vsphere-automation/v7.0U3/vcenter/data-structures/Namespaces/Instances/VMServiceSpec/
@@ -695,9 +697,16 @@ type VmServiceSpec struct {
 	VmClasses        []string `json:"vm_classes,omitempty"`
 }
 
+// StorageSpec https://developer.broadcom.com/apis/vsphere-automation-api/v7.0U3/vcenter/data-structures/Namespaces_Instances_StorageSpec/
+type StorageSpec struct {
+	Policy string `json:"policy"`
+	Limit  int64  `json:"limit,omitempty"`
+}
+
 // NamespacesInstanceUpdateSpec https://developer.vmware.com/apis/vsphere-automation/v7.0U3/vcenter/data-structures/Namespaces/Instances/UpdateSpec/
 type NamespacesInstanceUpdateSpec struct {
 	VmServiceSpec VmServiceSpec `json:"vm_service_spec,omitempty"`
+	StorageSpecs  []StorageSpec `json:"storage_specs,omitempty"`
 }
 
 // ListNamespaces https://developer.vmware.com/apis/vsphere-automation/v7.0U3/vcenter/api/vcenter/namespaces/instances/get/


### PR DESCRIPTION
api: add pbm.DatastoreMap for finding compatible Datastores
- add pbm.ProfileMap for finding storage profiles by name

govc: add vm.create '-profile' and '-place' flags

api: add storage_specs field to Namespace related structures

govc: add '-storage' flag to namespace.create and namespace.update commands
- The '-cluster', '-library' and '-storage' flags can be specified by name, rather than ID
- The namespace.info command outputs cluster, library and storage by name, rather than ID
