### PR TITLE
govc: add storage.policy.create zonal option

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -5478,11 +5478,13 @@ Create VM Storage Policy.
 
 Examples:
   govc storage.policy.create -category my_cat -tag my_tag MyStoragePolicy # Tag based placement
+  govc storage.policy.create -z MyZonalPolicy # Zonal topology
 
 Options:
   -category=             Category
   -d=                    Description
   -tag=                  Tag
+  -z=false               Enable Zonal topology for multi-zone Supervisor
 ```
 
 ## storage.policy.info

--- a/govc/test/storage.bats
+++ b/govc/test/storage.bats
@@ -26,3 +26,28 @@ load test_helper
     run govc storage.policy.info "vSAN Default Storage Policy"
     assert_success
 }
+
+@test "storage.policy.create" {
+  vcsim_env
+
+  run govc storage.policy.create MyStoragePolicy
+  assert_failure # at least one of -z or -tag required
+
+  run govc storage.policy.create -category my_cat -tag my_tag MyStoragePolicy
+  assert_success
+
+  run govc storage.policy.info MyStoragePolicy
+  assert_success
+
+  govc storage.policy.create -z MyZonalPolicy
+  assert_success
+
+  run govc storage.policy.info MyZonalPolicy
+  assert_success
+
+  run govc storage.policy.create -category my_cat -tag my_tag -z MyCombinedPolicy
+  assert_success
+
+  run govc storage.policy.info MyCombinedPolicy
+  assert_success
+}


### PR DESCRIPTION
New '-z' flag enables Zonal topology for multi-zone Supervisor

Uses the sub profile as created by the H5 UI, see for example:
```
govc storage.policy.info -json wcp-zonal | jq .policies[].profile.constraints.subProfiles
```
```json

[
  {
    "name": "Consumption domain",
    "capability": [
      {
        "id": {
          "namespace": "com.vmware.storage.consumptiondomain",
          "id": "StorageTopology"
        },
        "constraint": [
          {
            "propertyInstance": [
              {
                "id": "StorageTopologyType",
                "value": "Zonal"
              }
            ]
          }
        ]
      }
    ]
  }
]
```