### PR TITLE
Re-enable TenantManager in vcsim

### DIFF
--- a/simulator/tenant_manager_test.go
+++ b/simulator/tenant_manager_test.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25"
-	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -43,69 +41,7 @@ func sortMoRefSlice(a []types.ManagedObjectReference) {
 	})
 }
 
-func TestTenantManagerForOldClients(t *testing.T) {
-	// ServiceContent TenantManager field is not present in older (<6.9.1) vmodl
-	// (e.g. response to RetrieveServiceConent() API or propery collector on
-	// ServiceInstance object), this field should be set only if the client is newer.
-	// Currently TenantManager is not set in vpx simulator's ServiceContent, and
-	// would be added once simulator supports client vmodl versioning properly.
-	t.Skip("needs vmodl versioning")
-
-	ctx := context.Background()
-	m := VPX()
-	defer m.Remove()
-
-	err := m.Create()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	s := m.Service.NewServer()
-	defer s.Close()
-
-	// Ensure non-nil moref being returned for ServiceContent.TenantManger for newer vim version clients.
-	newSoapClient := soap.NewClient(s.URL, true)
-	newSoapClient.Version = "6.9.1"
-	newVimClient, err := vim25.NewClient(ctx, newSoapClient)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if newVimClient.ServiceContent.TenantManager == nil {
-		t.Fatal("Expected retrieved ServiceContent.TenantManager to be non-nil")
-	}
-
-	// Ensure non-nil moref being returned for ServiceContent.TenantManger for default version used in vim25 client.
-	defaultSoapClient := soap.NewClient(s.URL, true)
-	// No version being set for soap client
-	defaultVimClient, err := vim25.NewClient(ctx, defaultSoapClient)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if defaultVimClient.ServiceContent.TenantManager == nil {
-		t.Fatal("Expected retrieved ServiceContent.TenantManager to be non-nil")
-	}
-
-	// Ensure nil being returned for ServiceContent.TenantManger for older vim version clients.
-	oldSoapClient := soap.NewClient(s.URL, true)
-	oldSoapClient.Version = "6.5"
-	oldVimClient, err := vim25.NewClient(ctx, oldSoapClient)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if oldVimClient.ServiceContent.TenantManager != nil {
-		t.Fatalf("Expected retrieved ServiceContent.TenantManager to be nil but found %v", oldVimClient.ServiceContent.TenantManager)
-	}
-
-}
-
 func TestTenantManagerVPX(t *testing.T) {
-	// ServiceContent TenantManager field is not present in older (<6.9.1) vmodl
-	// (e.g. response to RetrieveServiceConent() API or propery collector on
-	// ServiceInstance object), this field should be set only if the client is newer.
-	// Currently TenantManager is not set in vpx simulator's ServiceContent, and
-	// would be added once simulator supports client vmodl versioning properly.
-	t.Skip("needs vmodl versioning")
-
 	ctx := context.Background()
 	m := VPX()
 	defer m.Remove()

--- a/simulator/vpx/service_content.go
+++ b/simulator/vpx/service_content.go
@@ -87,4 +87,5 @@ var ServiceContent = types.ServiceContent{
 	HealthUpdateManager:         &types.ManagedObjectReference{Type: "HealthUpdateManager", Value: "HealthUpdateManager"},
 	FailoverClusterConfigurator: &types.ManagedObjectReference{Type: "FailoverClusterConfigurator", Value: "FailoverClusterConfigurator"},
 	FailoverClusterManager:      &types.ManagedObjectReference{Type: "FailoverClusterManager", Value: "FailoverClusterManager"},
+	TenantManager:               &types.ManagedObjectReference{Type: "TenantTenantManager", Value: "TenantManager"},
 }


### PR DESCRIPTION

## Description

* Tests were skipped to support older clients (<6.9).  Since supported clients have support for TenantManager, unskipped the test and removed the OldClients test.

## Type of change

Please mark options that are relevant:

- [ *] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [ x] Ran `go test -v -test.name=TestTenant` which passed.
- [ x] Ran `make test` which failed on `TestHostContainerBacking` because I don't have docker installed(?).
## Checklist:

- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
