### PR TITLE
api: Add simulator test for GetVirtualDiskInfoByUUID

### DIFF
--- a/vmdk/disk_info.go
+++ b/vmdk/disk_info.go
@@ -43,7 +43,7 @@ type VirtualDiskInfo struct {
 // - VirtualDiskSparseVer2BackingInfo
 // - VirtualDiskRawDiskVer2BackingInfo
 //
-// These are the only backing types that have a Uuid property for comparing the
+// These are the only backing types that have a UUID property for comparing the
 // provided value.
 func GetVirtualDiskInfoByUUID(
 	ctx context.Context,
@@ -80,7 +80,7 @@ func GetVirtualDiskInfoByUUID(
 			&mo); err != nil {
 
 			return VirtualDiskInfo{},
-				fmt.Errorf("failed to retrieve properties %w", err)
+				fmt.Errorf("failed to retrieve properties: %w", err)
 		}
 	}
 


### PR DESCRIPTION

## Description

This patch adds a simulator test for GetVirtualDiskInfoByUUID. I merged https://github.com/vmware/govmomi/pull/3482 without adding these changes, but they _were_ part of my local testing recorded in that PR description, so please refer to https://github.com/vmware/govmomi/pull/3482 for a full description.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

See https://github.com/vmware/govmomi/pull/3482

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
