### PR TITLE
vcsim: Add support for DRS automation levels

### DIFF
--- a/simulator/cluster_compute_resource.go
+++ b/simulator/cluster_compute_resource.go
@@ -104,6 +104,9 @@ func (c *ClusterComputeResource) update(cfg *types.ClusterConfigInfoEx, cspec *t
 		if val := cspec.DrsConfig.Enabled; val != nil {
 			cfg.DrsConfig.Enabled = val
 		}
+		if val := cspec.DrsConfig.DefaultVmBehavior; val != "" {
+			cfg.DrsConfig.DefaultVmBehavior = val
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Closes: #3485

## Description

We are using vcsim for some workflows, and we need to simulate checking the DRS automation cluster attribute.

We need the following to be supported / reflected on VCSim:

```
clusterSpec1 := types.ClusterConfigSpecEx{
			DrsConfig: &types.ClusterDrsConfigInfo{
				Enabled:           types.NewBool(true),
				DefaultVmBehavior: types.DrsBehaviorFullyAutomated, // Set DRS to fully automated
			},
			DasConfig: &types.ClusterDasConfigInfo{
				Enabled: types.NewBool(true),
			},
		}

		task1, err := cl1.Reconfigure(ctx, &clusterSpec1, false)

```

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Unit tests

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
