### PR TITLE
Exporting Unit field in MetricSeries struct for external use. Closes issue#3494.

### DIFF
--- a/performance/manager.go
+++ b/performance/manager.go
@@ -395,14 +395,14 @@ func (m *Manager) SampleByName(ctx context.Context, spec types.PerfQuerySpec, me
 
 // MetricSeries contains the same data as types.PerfMetricIntSeries, but with the CounterId converted to Name.
 type MetricSeries struct {
-	Name     string `json:"name"`
-	unit     string
+	Name     string  `json:"name"`
+	Unit     string  `json:"unit"`
 	Instance string  `json:"instance"`
 	Value    []int64 `json:"value"`
 }
 
 func (s *MetricSeries) Format(val int64) string {
-	switch types.PerformanceManagerUnit(s.unit) {
+	switch types.PerformanceManagerUnit(s.Unit) {
 	case types.PerformanceManagerUnitPercent:
 		return strconv.FormatFloat(float64(val)/100.0, 'f', 2, 64)
 	default:
@@ -470,7 +470,7 @@ func (m *Manager) ToMetricSeries(ctx context.Context, series []types.BasePerfEnt
 
 			values = append(values, MetricSeries{
 				Name:     info.Name(),
-				unit:     info.UnitInfo.GetElementDescription().Key,
+				Unit:     info.UnitInfo.GetElementDescription().Key,
 				Instance: v.Id.Instance,
 				Value:    v.Value,
 			})


### PR DESCRIPTION
## Description

This pull request exports the `Unit` field in the `MetricSeries` struct within the performance package and adds a corresponding JSON tag. This change allows for external access to the `Unit` field,

Closes: #3494

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] External Accessibility Test: This test confirms that the newly exported `Unit` field can be accessed and manipulated from 
outside the performance package

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
