### PR TITLE
api: use CheckTestType in compat and provisioning checkers

### DIFF
--- a/govc/vm/check/compat.go
+++ b/govc/vm/check/compat.go
@@ -35,7 +35,7 @@ func (cmd *compat) Description() string {
 	return `Check if VM can be placed on the given HOST in the given resource POOL.
 
 Examples:
-  govc vm.check.compat -vm my-vm -pool $pool`
+  govc vm.check.compat -vm my-vm -host $host -pool $pool`
 }
 
 func (cmd *compat) Run(ctx context.Context, f *flag.FlagSet) error {
@@ -53,7 +53,7 @@ func (cmd *compat) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	res, err := checker.CheckCompatibility(ctx, vm.Reference(), cmd.Host, cmd.Pool, cmd.Test...)
+	res, err := checker.CheckCompatibility(ctx, vm.Reference(), cmd.Host, cmd.Pool, cmd.testTypes...)
 	if err != nil {
 		return err
 	}

--- a/govc/vm/check/config.go
+++ b/govc/vm/check/config.go
@@ -51,7 +51,7 @@ func (cmd *config) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	res, err := checker.CheckVmConfig(ctx, spec, cmd.Machine, cmd.Host, cmd.Pool, cmd.Test...)
+	res, err := checker.CheckVmConfig(ctx, spec, cmd.Machine, cmd.Host, cmd.Pool, cmd.testTypes...)
 	if err != nil {
 		return err
 	}

--- a/govc/vm/check/flag.go
+++ b/govc/vm/check/flag.go
@@ -33,6 +33,28 @@ import (
 	"github.com/vmware/govmomi/vim25/xml"
 )
 
+var checkTestTypesList = []string{
+	string(types.CheckTestTypeDatastoreTests),
+	string(types.CheckTestTypeHostTests),
+	string(types.CheckTestTypeNetworkTests),
+	string(types.CheckTestTypeResourcePoolTests),
+	string(types.CheckTestTypeSourceTests),
+}
+
+type checkTestTypes []types.CheckTestType
+
+func (c *checkTestTypes) String() string {
+	return fmt.Sprint(*c)
+}
+
+func (c *checkTestTypes) Set(value string) error {
+	if !slices.Contains(checkTestTypesList, value) {
+		return fmt.Errorf("invalid CheckTestType value %q", value)
+	}
+	*c = append(*c, types.CheckTestType(value))
+	return nil
+}
+
 type checkFlag struct {
 	*flags.VirtualMachineFlag
 	*flags.HostSystemFlag
@@ -40,7 +62,7 @@ type checkFlag struct {
 
 	Machine, Host, Pool *types.ManagedObjectReference
 
-	Test []string
+	testTypes checkTestTypes
 }
 
 func (cmd *checkFlag) Register(ctx context.Context, f *flag.FlagSet) {
@@ -50,6 +72,8 @@ func (cmd *checkFlag) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.HostSystemFlag.Register(ctx, f)
 	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
 	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	f.Var(&cmd.testTypes, "test", fmt.Sprintf("The set of tests to run (%s)", strings.Join(checkTestTypesList, ",")))
 }
 
 func (cmd *checkFlag) Process(ctx context.Context) error {

--- a/govc/vm/check/relocate.go
+++ b/govc/vm/check/relocate.go
@@ -59,7 +59,7 @@ func (cmd *relocate) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	res, err := checker.CheckRelocate(ctx, vm.Reference(), spec, cmd.Test...)
+	res, err := checker.CheckRelocate(ctx, vm.Reference(), spec, cmd.testTypes...)
 	if err != nil {
 		return err
 	}

--- a/object/vm_compatability_checker.go
+++ b/object/vm_compatability_checker.go
@@ -45,14 +45,14 @@ func (c VmCompatibilityChecker) CheckCompatibility(
 	vm types.ManagedObjectReference,
 	host *types.ManagedObjectReference,
 	pool *types.ManagedObjectReference,
-	testTypes ...string) ([]types.CheckResult, error) {
+	testTypes ...types.CheckTestType) ([]types.CheckResult, error) {
 
 	req := types.CheckCompatibility_Task{
 		This:     c.Reference(),
 		Vm:       vm,
 		Host:     host,
 		Pool:     pool,
-		TestType: testTypes,
+		TestType: checkTestTypesToStrings(testTypes),
 	}
 
 	res, err := methods.CheckCompatibility_Task(ctx, c.c, &req)
@@ -74,7 +74,7 @@ func (c VmCompatibilityChecker) CheckVmConfig(
 	vm *types.ManagedObjectReference,
 	host *types.ManagedObjectReference,
 	pool *types.ManagedObjectReference,
-	testTypes ...string) ([]types.CheckResult, error) {
+	testTypes ...types.CheckTestType) ([]types.CheckResult, error) {
 
 	req := types.CheckVmConfig_Task{
 		This:     c.Reference(),
@@ -82,7 +82,7 @@ func (c VmCompatibilityChecker) CheckVmConfig(
 		Vm:       vm,
 		Host:     host,
 		Pool:     pool,
-		TestType: testTypes,
+		TestType: checkTestTypesToStrings(testTypes),
 	}
 
 	res, err := methods.CheckVmConfig_Task(ctx, c.c, &req)
@@ -96,4 +96,16 @@ func (c VmCompatibilityChecker) CheckVmConfig(
 	}
 
 	return ti.Result.(types.ArrayOfCheckResult).CheckResult, nil
+}
+
+func checkTestTypesToStrings(testTypes []types.CheckTestType) []string {
+	if len(testTypes) == 0 {
+		return nil
+	}
+
+	s := make([]string, len(testTypes))
+	for i := range testTypes {
+		s[i] = string(testTypes[i])
+	}
+	return s
 }

--- a/object/vm_provisioning_checker.go
+++ b/object/vm_provisioning_checker.go
@@ -44,13 +44,13 @@ func (c VmProvisioningChecker) CheckRelocate(
 	ctx context.Context,
 	vm types.ManagedObjectReference,
 	spec types.VirtualMachineRelocateSpec,
-	testTypes ...string) ([]types.CheckResult, error) {
+	testTypes ...types.CheckTestType) ([]types.CheckResult, error) {
 
 	req := types.CheckRelocate_Task{
 		This:     c.Reference(),
 		Vm:       vm,
 		Spec:     spec,
-		TestType: testTypes,
+		TestType: checkTestTypesToStrings(testTypes),
 	}
 
 	res, err := methods.CheckRelocate_Task(ctx, c.c, &req)


### PR DESCRIPTION
Use the CheckTestType enum as the testType arg type instead of a string in the VmCompatibilityChecker and VmProvisioningChecker functions.  The req task structs end up getting auto generated using the string type so we need to do a little unfortunate conversion.

Add check test type param to the govc commands

