### PR TITLE
fix: restore govc import.spec DiskProvisioning default value

### DIFF
--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -212,6 +212,25 @@ load test_helper
   grep "invalid NetworkMapping.Name" <<<"$output"
 }
 
+@test "import invalid disk provisioning" {
+  vcsim_env
+
+  ovf="$GOVC_IMAGES/$TTYLINUX_NAME.ovf"
+
+  spec=$(govc import.spec "$GOVC_IMAGES/$TTYLINUX_NAME.ovf")
+
+  options=$(jq ".DiskProvisioning = \"enoent\"" <<<"$spec")
+
+  run govc import.ovf -options - "$ovf" <<<"$options"
+  assert_failure "govc: Disk provisioning type not supported: enoent"
+
+  options=$(jq ".DiskProvisioning = \"monolithicSparse\"" <<<"$spec")
+
+  run govc import.ovf -options - "$ovf" <<<"$options"
+  assert_failure
+  assert_matches DeviceUnsupportedForVmPlatform
+}
+
 @test "import properties" {
   vcsim_env
 

--- a/ovf/importer/spec.go
+++ b/ovf/importer/spec.go
@@ -99,9 +99,9 @@ func Spec(fpath string, a Archive, hidden, verbose bool) (*Options, error) {
 	}
 
 	o := Options{
-		DiskProvisioning:   allDiskProvisioningOptions[0],
-		IPAllocationPolicy: allIPAllocationPolicyOptions[0],
-		IPProtocol:         allIPProtocolOptions[0],
+		DiskProvisioning:   string(types.OvfCreateImportSpecParamsDiskProvisioningTypeFlat),
+		IPAllocationPolicy: string(types.VAppIPAssignmentInfoIpAllocationPolicyDhcpPolicy),
+		IPProtocol:         string(types.VAppIPAssignmentInfoProtocolsIPv4),
 		MarkAsTemplate:     false,
 		PowerOn:            false,
 		WaitForIP:          false,

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1359,6 +1359,13 @@ func (vm *VirtualMachine) configureDevice(
 
 		summary = fmt.Sprintf("%s KB", numberToString(x.CapacityInKB, ','))
 		switch b := d.Backing.(type) {
+		case *types.VirtualDiskSparseVer2BackingInfo:
+			// Sparse disk creation not supported in ESX
+			return &types.DeviceUnsupportedForVmPlatform{
+				InvalidDeviceSpec: types.InvalidDeviceSpec{
+					InvalidVmConfig: types.InvalidVmConfig{Property: "VirtualDeviceSpec.device.backing"},
+				},
+			}
 		case types.BaseVirtualDeviceFileBackingInfo:
 			info := b.GetVirtualDeviceFileBackingInfo()
 			var path object.DatastorePath


### PR DESCRIPTION
PR #3427 changed to using generated enum lists in various govc commands.
This also changed the default DiskProvisioning value from "flat" to "monolithicSparse",
which results in a DeviceUnsupportedForVmPlatform fault when importing.

This change restores the default to "flat".
The default values for IPProtocol and IPAllocationPolicy had not changed,
but this commit explicitly sets their values rather than using first element of the generated list.

Fixes #3483

vcsim: add ovf DiskProvisioning validation