### PR TITLE
vcsim: fix panic in CancelTask

### DIFF
--- a/govc/task/create.go
+++ b/govc/task/create.go
@@ -94,7 +94,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	fmt.Println(res.Returnval.Task)
+	fmt.Println(res.Returnval.Task.Value)
 
 	return nil
 }

--- a/govc/test/tasks.bats
+++ b/govc/test/tasks.bats
@@ -56,6 +56,15 @@ load test_helper
   assert_success
   task="$output"
 
+  run govc task.cancel "$task"
+  assert_success
+  cancelled=$(govc tasks -json | jq ".tasks[] | select(.key == \"$task\") | .cancelled")
+  assert_equal "true" "$cancelled"
+
+  run govc task.create "$id"
+  assert_success
+  task="$output"
+
   run govc task.set -s running "$task"
   assert_success
 

--- a/simulator/task.go
+++ b/simulator/task.go
@@ -257,7 +257,7 @@ func (t *Task) CancelTask(ctx *Context, req *types.CancelTask) soap.HasFault {
 	}
 
 	changes := []types.PropertyChange{
-		{Name: "info.canceled", Val: true},
+		{Name: "info.cancelled", Val: true},
 		{Name: "info.completeTime", Val: time.Now()},
 		{Name: "info.state", Val: types.TaskInfoStateError},
 		{Name: "info.error", Val: &types.LocalizedMethodFault{


### PR DESCRIPTION
PR #3451 changed mo.ApplyPropertyChange() to panic() on invalid property path. CancelTask had such a property for TaskInfo, 'canceled'. Fixed to 'cancelled' and adds test coverage for the CancelTask method.

Fixes #3506