### PR TITLE
fix: govc object.collect truncation

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -70,6 +70,21 @@ EOF
   assert_matches "govmomi simulator"
 }
 
+@test "truncated WaitForUpdatesEx" {
+  total=142 # 100 is the default MaxObjectUpdates
+  vcsim_env -standalone-host 0 -vm $total
+
+  url="https://$(govc env GOVC_URL)"
+
+  model=$(curl -sfk "$url/debug/vars" | jq .vcsim.model)
+  vms=$(jq .machine <<<"$model")
+  assert_equal $total "$vms" # sanity check
+
+  run govc object.collect -type m / name
+  assert_success
+  [ ${#lines[@]} -eq "$total" ]
+}
+
 @test "vcsim host placement" {
   vcsim_start -dc 0
 

--- a/property/collector.go
+++ b/property/collector.go
@@ -276,7 +276,7 @@ func (p *Collector) RetrieveOne(ctx context.Context, obj types.ManagedObjectRefe
 // propagation.
 func (p *Collector) WaitForUpdatesEx(
 	ctx context.Context,
-	opts WaitOptions,
+	opts *WaitOptions,
 	onUpdatesFn func([]types.ObjectUpdate) bool) error {
 
 	if !p.mu.TryLock() {

--- a/property/example_test.go
+++ b/property/example_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -310,4 +311,67 @@ func ExampleCollector_WaitForUpdatesEx_errConcurrentCollector() {
 	// WaitForUpdatesEx call succeeded
 	// WaitForUpdatesEx call returned ErrConcurrentCollector
 	// WaitForUpdatesEx call succeeded
+}
+
+func ExampleCollector_WaitForUpdatesEx_pagination() {
+	model := simulator.VPX()
+	model.Cluster = 3
+	model.Machine = 42
+
+	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
+		pc := property.DefaultCollector(c)
+		m := view.NewManager(c)
+
+		// Note: both types can be collected with 1 ContainerView and 1 PropertyFilter,
+		// but we are creating 2 PropertyFilter for example purposes.
+		kinds := []string{"HostSystem", "VirtualMachine"}
+		for _, kind := range kinds {
+			v, err := m.CreateContainerView(ctx, c.ServiceContent.RootFolder, []string{kind}, true)
+			if err != nil {
+				return err
+			}
+
+			defer v.Destroy(ctx)
+
+			filter := new(property.WaitFilter).Add(v.Reference(), kind, []string{"name"}, v.TraversalSpec())
+
+			f, err := pc.CreateFilter(ctx, filter.CreateFilter)
+			if err != nil {
+				return err
+			}
+
+			defer f.Destroy(ctx)
+		}
+
+		options := &property.WaitOptions{
+			Options: &types.WaitOptions{MaxObjectUpdates: 50},
+		}
+
+		// Callback is invoked once for each FilterSet:
+		// 1st WaitForUpdatesEx call returns 2 FilterSet, 10 hosts + 40 vms
+		// Next 4 calls are 1 FilterSet of 50, 50 and 28 vms
+		callbacks := 0
+		objects := make(map[string]int)
+
+		err := pc.WaitForUpdatesEx(ctx, options, func(updates []types.ObjectUpdate) bool {
+			for _, update := range updates {
+				objects[update.Obj.Type]++
+			}
+			callbacks++
+			return options.Truncated == false
+		})
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("%d Callbacks\n", callbacks)
+		for _, kind := range kinds {
+			fmt.Printf("%d %s\n", objects[kind], kind)
+		}
+		return nil
+	}, model)
+	// Output:
+	// 5 Callbacks
+	// 10 HostSystem
+	// 168 VirtualMachine
 }

--- a/property/example_test.go
+++ b/property/example_test.go
@@ -153,7 +153,7 @@ func ExampleCollector_WaitForUpdatesEx_addingRemovingPropertyFilters() {
 		go func() {
 			if err := pc.WaitForUpdatesEx(
 				cancelCtx,
-				property.WaitOptions{},
+				&property.WaitOptions{},
 				func(updates []types.ObjectUpdate) bool {
 					return waitForPowerStateChanges(
 						cancelCtx,
@@ -265,7 +265,7 @@ func ExampleCollector_WaitForUpdatesEx_errConcurrentCollector() {
 
 		waitForChanges := func(chanErr chan error) {
 			defer close(chanErr)
-			chanErr <- pc.WaitForUpdatesEx(ctx, waitOptions, onUpdatesFn)
+			chanErr <- pc.WaitForUpdatesEx(ctx, &waitOptions, onUpdatesFn)
 		}
 
 		// Start two goroutines that wait for changes, but only one will begin
@@ -296,7 +296,7 @@ func ExampleCollector_WaitForUpdatesEx_errConcurrentCollector() {
 
 		// The third WaitForUpdatesEx call should be able to successfully obtain
 		// the lock since the other two calls are completed.
-		if err := pc.WaitForUpdatesEx(ctx, waitOptions, onUpdatesFn); err != nil {
+		if err := pc.WaitForUpdatesEx(ctx, &waitOptions, onUpdatesFn); err != nil {
 			return fmt.Errorf(
 				"unexpected error from third call to WaitForUpdatesEx: %s", err)
 		}

--- a/property/wait.go
+++ b/property/wait.go
@@ -123,7 +123,7 @@ func WaitForUpdates(
 		return err
 	}
 
-	return pc.WaitForUpdatesEx(ctx, filter.WaitOptions, onUpdatesFn)
+	return pc.WaitForUpdatesEx(ctx, &filter.WaitOptions, onUpdatesFn)
 }
 
 // WaitForUpdates waits for any of the specified properties of the specified
@@ -166,5 +166,5 @@ func WaitForUpdatesEx(
 
 	}()
 
-	return pc.WaitForUpdatesEx(ctx, filter.WaitOptions, onUpdatesFn)
+	return pc.WaitForUpdatesEx(ctx, &filter.WaitOptions, onUpdatesFn)
 }


### PR DESCRIPTION
In the PR #3331 refactor WaitOptions was changed to pass by value, rather than reference.
The Truncated value needs to be propagated from WaitForUpdatesEx response to the caller.

Fixes #3501

vcsim: implement WaitForUpdatesEx pagination support

Default [WaitOptions.MaxObjectUpdates](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vmodl.query.PropertyCollector.WaitOptions.html) default to 100 as real vCenter does.