### PR TITLE
api: add session.Manager.ImpersonateUser method

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -5137,6 +5137,7 @@ The session.login command can be used to:
 - Issue a SAML token
 - Renew a SAML token
 - Login using a SAML token
+- Impersonate a user
 - Avoid passing credentials to other govc commands
 - Send an authenticated raw HTTP request
 
@@ -5149,6 +5150,7 @@ Examples:
   govc session.ls -u root@host # Use the cached session with another command
   ticket=$(govc session.login -u root@host -clone)
   govc session.login -u root@host -ticket $ticket
+  govc session.login -u Administrator@vsphere.local:password@host -as other@vsphere.local
   govc session.login -u host -extension com.vmware.vsan.health -cert rui.crt -key rui.key
   token=$(govc session.login -u host -cert user.crt -key user.key -issue) # HoK token
   bearer=$(govc session.login -u user:pass@host -issue) # Bearer token
@@ -5161,6 +5163,7 @@ Examples:
 
 Options:
   -X=                    HTTP method
+  -as=                   Impersonate user
   -clone=false           Acquire clone ticket
   -cookie=               Set HTTP cookie for an existing session
   -extension=            Extension name

--- a/govc/test/session.bats
+++ b/govc/test/session.bats
@@ -130,6 +130,17 @@ load test_helper
     run govc tags.ls -u "$user@$host"
     assert_failure # logged out of persisted session
 
+    # ImpersonateUser
+
+    run govc session.login -as vcsim
+    assert_failure # user must have an existing session
+
+    run govc session.login -u vcsim:pass@"$host"
+    assert_success
+
+    run govc session.login -as vcsim
+    assert_success
+
     rm -rf "$dir"
 }
 

--- a/session/manager.go
+++ b/session/manager.go
@@ -291,3 +291,19 @@ func (sm *Manager) UpdateServiceMessage(ctx context.Context, message string) err
 
 	return err
 }
+
+func (sm *Manager) ImpersonateUser(ctx context.Context, name string) error {
+	req := types.ImpersonateUser{
+		This:     sm.Reference(),
+		UserName: name,
+		Locale:   Locale,
+	}
+
+	res, err := methods.ImpersonateUser(ctx, sm.client, &req)
+	if err != nil {
+		return err
+	}
+
+	sm.userSession = &res.Returnval
+	return nil
+}


### PR DESCRIPTION
Helper method for calling [vim.SessionManager.impersonateUser](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.SessionManager.html#impersonateUser)

govc: add session.login '-as' flag to impersonate user
vcsim: add SessionManager.ImpersonateUser method

Closes #3507