### PR TITLE
api: update eam bindings to include authentication schema with eam-vcenter build 24075398

### DIFF
--- a/eam/types/enum.go
+++ b/eam/types/enum.go
@@ -84,6 +84,28 @@ func init() {
 	types.Add("eam:AgencyVMPlacementPolicyVMDataAffinity", reflect.TypeOf((*AgencyVMPlacementPolicyVMDataAffinity)(nil)).Elem())
 }
 
+type AgentConfigInfoAuthenticationScheme string
+
+const (
+	AgentConfigInfoAuthenticationSchemeNONE              = AgentConfigInfoAuthenticationScheme("NONE")
+	AgentConfigInfoAuthenticationSchemeVMWARE_SESSION_ID = AgentConfigInfoAuthenticationScheme("VMWARE_SESSION_ID")
+)
+
+func (e AgentConfigInfoAuthenticationScheme) Values() []AgentConfigInfoAuthenticationScheme {
+	return []AgentConfigInfoAuthenticationScheme{
+		AgentConfigInfoAuthenticationSchemeNONE,
+		AgentConfigInfoAuthenticationSchemeVMWARE_SESSION_ID,
+	}
+}
+
+func (e AgentConfigInfoAuthenticationScheme) Strings() []string {
+	return types.EnumValuesAsStrings(e.Values())
+}
+
+func init() {
+	types.Add("eam:AgentConfigInfoAuthenticationScheme", reflect.TypeOf((*AgentConfigInfoAuthenticationScheme)(nil)).Elem())
+}
+
 // Defines the type of disk provisioning for the target Agent VMs.
 type AgentConfigInfoOvfDiskProvisioning string
 

--- a/gen/gen.sh
+++ b/gen/gen.sh
@@ -99,7 +99,7 @@ generate "../vslm" "vslm"
 generate "../sms" "sms"
 
 # ./sdk/ contains the files eam-messagetypes.xsd and eam-types.xsd from
-# eam-wsdl.zip, from eam-vcenter build 23699138.
+# eam-wsdl.zip, from eam-vcenter build 24075398.
 #
 # Please note the EAM files are also available at the following, public URL --
 # http://bit.ly/eam-sdk, therefore the WSDL resource for EAM are in fact


### PR DESCRIPTION
## Description

This patch updates the generated types for eam to include "authenticationSchema" in AgentConfigInfo.

An new parameter called "authenticationSchema" has been added to the
AgentConfigInfo in the EAM API. This parameter is used add an option for authentication scheme in agent config to access OVF urls.

Closes: #3521 

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

The HooksHookInfo struct is updated to SolutionsHookInfo. 
and ArrayOfHooksHookInfo struct is updated to ArrayOfSolutionsHookInfo.

This might break existing things.
@akutz @dougm 

## How Has This Been Tested?
Relied on GitHub actions for testing.

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
