### PR TITLE
govc: Support thick/eager disk opts on vm.create

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -6418,6 +6418,8 @@ Options:
   -disk=                 Disk path (to use existing) OR size (to create new, e.g. 20GB)
   -disk-datastore=       Datastore for disk file
   -disk.controller=scsi  Disk controller type
+  -disk.eager=false      Eagerly scrub new disk
+  -disk.thick=false      Thick provision new disk
   -ds=                   Datastore [GOVC_DATASTORE]
   -firmware=bios         Firmware type [bios|efi]
   -folder=               Inventory folder [GOVC_FOLDER]

--- a/govc/vm/create.go
+++ b/govc/vm/create.go
@@ -60,6 +60,8 @@ type create struct {
 	on         bool
 	force      bool
 	controller string
+	eager      bool
+	thick      bool
 	annotation string
 	firmware   string
 	version    string
@@ -126,6 +128,8 @@ func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 	f.BoolVar(&cmd.on, "on", true, "Power on VM")
 	f.BoolVar(&cmd.force, "force", false, "Create VM if vmx already exists")
 	f.StringVar(&cmd.controller, "disk.controller", "scsi", "Disk controller type")
+	f.BoolVar(&cmd.eager, "disk.eager", false, "Eagerly scrub new disk")
+	f.BoolVar(&cmd.thick, "disk.thick", false, "Thick provision new disk")
 	f.StringVar(&cmd.annotation, "annotation", "", "VM description")
 	f.StringVar(&cmd.firmware, "firmware", FirmwareTypes[0], FirmwareUsage)
 	f.StringVar(&cmd.profile, "profile", "", "Storage profile name or ID")
@@ -558,13 +562,17 @@ func (cmd *create) addStorage(devices object.VirtualDeviceList) (object.VirtualD
 			return nil, err
 		}
 
+		backing := &types.VirtualDiskFlatVer2BackingInfo{
+			DiskMode:        string(types.VirtualDiskModePersistent),
+			ThinProvisioned: types.NewBool(!cmd.thick),
+		}
+		if cmd.thick {
+			backing.EagerlyScrub = &cmd.eager
+		}
 		disk := &types.VirtualDisk{
 			VirtualDevice: types.VirtualDevice{
-				Key: devices.NewKey(),
-				Backing: &types.VirtualDiskFlatVer2BackingInfo{
-					DiskMode:        string(types.VirtualDiskModePersistent),
-					ThinProvisioned: types.NewBool(true),
-				},
+				Key:     devices.NewKey(),
+				Backing: backing,
 			},
 			CapacityInKB: cmd.diskByteSize / 1024,
 		}


### PR DESCRIPTION
## Description

Add support to create vms with thick provisioned disks to govc.
This adds the following config options:
```
  -disk.eager=false      Eagerly scrub new disk
  -disk.thick=false      Thick provision new disk
```
Closes: #3526

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [X] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

- [X] setup thick provisioned VM

```govc vm.create -cluster 'clustername' -folder foldername -pool=poolname -disk-datastore=datastorename -disk.eager=false -disk.thick=true -disk=100GB -c=10 -m=16384 -g=debian10_64Guest '-net=netname' -net.adapter=vmxnet3 -disk.controller=pvscsi -on=false vmname```


## Checklist:

- [X] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
  - its a trivial change
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
  - I was not able to find an existing test that checks for disk creation on vm.create, nothing to add there.
- [ ] New and existing unit tests pass locally with my changes
  - was not able to find a relevant existing test.
- [X] Any dependent changes have been merged (none)

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
