### PR TITLE
govc: Add support for providing size while we create a VMFS datastore

### DIFF
--- a/govc/datastore/create.go
+++ b/govc/datastore/create.go
@@ -28,8 +28,14 @@ import (
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/units"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	sectorSize  = 512  // Sector size in bytes
+	startSector = 2048 // Start sector (typically fixed)
 )
 
 type create struct {
@@ -50,6 +56,7 @@ type create struct {
 	// Options for VMFS
 	DiskCanonicalName string
 	Version           *int32
+	Size              units.ByteSize
 
 	// Options for local
 	Path string
@@ -144,6 +151,7 @@ func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 	// Options for VMFS
 	f.StringVar(&cmd.DiskCanonicalName, "disk", "", "Canonical name of disk (VMFS only)")
 	f.Var(flags.NewOptionalInt32(&cmd.Version), "version", "VMFS major version")
+	f.Var(&cmd.Size, "size", "Size of new disk")
 
 	// Options for Local
 	f.StringVar(&cmd.Path, "path", "", "Local directory path for the datastore (local only)")
@@ -165,7 +173,7 @@ func (cmd *create) Description() string {
 
 Examples:
   govc datastore.create -type nfs -name nfsDatastore -remote-host 10.143.2.232 -remote-path /share cluster1
-  govc datastore.create -type vmfs -name vmfsDatastore -disk=mpx.vmhba0:C0:T0:L0 cluster1
+  govc datastore.create -type vmfs -name vmfsDatastore -disk=mpx.vmhba0:C0:T0:L0 -size 20G cluster1
   govc datastore.create -type local -name localDatastore -path /var/datastore host1`
 }
 
@@ -268,7 +276,6 @@ func (cmd *create) CreateVmfsDatastore(ctx context.Context, hosts []*object.Host
 		if disk == nil {
 			return fmt.Errorf("no eligible disk found for name %#v", cmd.DiskCanonicalName)
 		}
-
 		// Query for creation options and pick the right one
 		options, err := ds.QueryVmfsDatastoreCreateOptions(ctx, disk.DevicePath)
 		if err != nil {
@@ -289,6 +296,12 @@ func (cmd *create) CreateVmfsDatastore(ctx context.Context, hosts []*object.Host
 
 		spec := *option.Spec.(*types.VmfsDatastoreCreateSpec)
 		spec.Vmfs.VolumeName = cmd.Name
+		if cmd.Size > 0 {
+			endSector := CalculateSectors(int64(cmd.Size))
+			// set values for Sectors
+			spec.Partition.Partition[0].StartSector = startSector
+			spec.Partition.Partition[0].EndSector = endSector
+		}
 		if cmd.Version != nil {
 			spec.Vmfs.MajorVersion = *cmd.Version
 		}
@@ -299,6 +312,14 @@ func (cmd *create) CreateVmfsDatastore(ctx context.Context, hosts []*object.Host
 	}
 
 	return nil
+}
+
+// CalculateSectors calculates the start and end sectors based on the given size.
+func CalculateSectors(sizeInBytes int64) (endSector int64) {
+	totalSectors := sizeInBytes / sectorSize
+	endSector = startSector + totalSectors - 1
+
+	return endSector
 }
 
 func (cmd *create) CreateLocalDatastore(ctx context.Context, hosts []*object.HostSystem) error {


### PR DESCRIPTION
## Description
govc: Add support for providing size while we create a VMFS datastore

Closes: #(issue-number)
https://github.com/vmware/govmomi/issues/3519

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [x] Test Description 1
    Tried to create a VMFS datastore with some size in govc cli
    `go run main.go datastore.create -type VMFS -name vmfs61 -version 6 -disk eui.b8fa2f975ecc490ea090a46404568540 -size 30 ocsqe-virt07.lab.eng.blr.redhat.com`
- [x] Test Description 2
    Tried to create a VMFS datastore without size argument in govc cli, so that it takes the entire size of disk into consideration(default case)
    `go run main.go datastore.create -type VMFS -name vmfs61 -version 6 -disk eui.b8fa2f975ecc490ea090a46404568540 ocsqe-virt07.lab.eng.blr.redhat.com`

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
