### PR TITLE
api: ToString for vim types

### DIFF
--- a/vim25/types/helpers.go
+++ b/vim25/types/helpers.go
@@ -17,6 +17,9 @@ limitations under the License.
 package types
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -314,6 +317,78 @@ func (ci VirtualMachineConfigInfo) ToConfigSpec() VirtualMachineConfigSpec {
 	}
 
 	return cs
+}
+
+// ToString returns the string-ified version of the provided input value by
+// first attempting to encode the value to JSON using the vimtype JSON encoder,
+// and if that should fail, using the standard JSON encoder, and if that fails,
+// returning the value formatted with Sprintf("%v").
+//
+// Please note, this function is not intended to replace marshaling the data
+// to JSON using the normal workflows. This function is for when a string-ified
+// version of the data is needed for things like logging.
+func ToString(in AnyType) (s string) {
+	if in == nil {
+		return "null"
+	}
+
+	marshalWithSprintf := func() string {
+		return fmt.Sprintf("%v", in)
+	}
+
+	defer func() {
+		if err := recover(); err != nil {
+			s = marshalWithSprintf()
+		}
+	}()
+
+	rv := reflect.ValueOf(in)
+	switch rv.Kind() {
+
+	case reflect.Bool,
+		reflect.Complex64, reflect.Complex128,
+		reflect.Float32, reflect.Float64:
+
+		return fmt.Sprintf("%v", in)
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Uintptr:
+
+		return fmt.Sprintf("%d", in)
+
+	case reflect.String:
+		return in.(string)
+
+	case reflect.Interface, reflect.Pointer:
+		if rv.IsZero() {
+			return "null"
+		}
+		return ToString(rv.Elem().Interface())
+	}
+
+	marshalWithStdlibJSONEncoder := func() string {
+		data, err := json.Marshal(in)
+		if err != nil {
+			return marshalWithSprintf()
+		}
+		return string(data)
+	}
+
+	defer func() {
+		if err := recover(); err != nil {
+			s = marshalWithStdlibJSONEncoder()
+		}
+	}()
+
+	var w bytes.Buffer
+	enc := NewJSONEncoder(&w)
+	if err := enc.Encode(in); err != nil {
+		return marshalWithStdlibJSONEncoder()
+	}
+
+	// Do not include the newline character added by the vimtype JSON encoder.
+	return strings.TrimSuffix(w.String(), "\n")
 }
 
 func init() {


### PR DESCRIPTION
## Description

This patch adds a ToString helper function for invoking on any vim type. If the specified value is a primitive type, the returned string is generated using Sprintf. Otherwise the returned string is created first by attempting to marshal the data using the vimtype JSON encoder, and if that fails, the stdlib JSON encoder. If that fails, then `fmt.Sprintf("%v")` is used.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

```shell
go test -v -count 1 -run '^TestToString$' ./vim25/types
```

The following screenshot also demonstrates there is 100% code coverage for this new function:

<img width="552" alt="image" src="https://github.com/user-attachments/assets/cd4dbf6c-9985-4147-8bac-821e08e8aa4d">


## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
