### PR TITLE
api: Fix panic when encoding nil iface ptrs to JSON

### DIFF
--- a/vim25/json/discriminator.go
+++ b/vim25/json/discriminator.go
@@ -354,7 +354,11 @@ func discriminatorInterfaceEncode(e *encodeState, v reflect.Value, opts encOpts)
 		e.discriminatorEncodeTypeName = true
 		newStructEncoder(v.Type())(e, v, opts)
 	case reflect.Ptr:
-		discriminatorInterfaceEncode(e, v, opts)
+		if v.IsZero() {
+			newPtrEncoder(v.Type())(e, v, opts)
+		} else {
+			discriminatorInterfaceEncode(e, v, opts)
+		}
 	default:
 		discriminatorValue := opts.discriminatorValueFn(v.Type())
 		if discriminatorValue == "" {


### PR DESCRIPTION


## Description

This patch fixes a panic that occurred when encoding nil interface pointers to JSON using the vimtype JSON encoder.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

```
go test -v -count 1 -run '^TestSerialization$/^ConfigSpec$'  ./vim25/types
```

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
