### PR TITLE
govc: Add '-size' flag to datastore.create

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1241,7 +1241,8 @@ Create datastore on HOST.
 
 Examples:
   govc datastore.create -type nfs -name nfsDatastore -remote-host 10.143.2.232 -remote-path /share cluster1
-  govc datastore.create -type vmfs -name vmfsDatastore -disk=mpx.vmhba0:C0:T0:L0 cluster1
+  govc datastore.create -type vmfs -name vmfsDatastore -disk=mpx.vmhba0:C0:T0:L0 cluster1 # use entire disk
+  govc datastore.create -type vmfs -name vmfsDatastore -disk=mpx.vmhba0:C0:T0:L0 -size 20G cluster1 # use 20G of disk
   govc datastore.create -type local -name localDatastore -path /var/datastore host1
 
 Options:
@@ -1254,6 +1255,7 @@ Options:
   -path=                 Local directory path for the datastore (local only)
   -remote-host=          Remote hostname of the NAS datastore
   -remote-path=          Remote path of the NFS mount point
+  -size=0B               Size of new disk. Default is to use entire disk
   -type=                 Datastore type (NFS|NFS41|CIFS|VMFS|local)
   -username=             Username to use when connecting (CIFS only)
   -version=<nil>         VMFS major version


### PR DESCRIPTION
Closes: #3519

## Description

govc: Add support for providing size while we create a VMFS datastore

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. If applicable, please also list any relevant
details for your test configuration.

- [ ] Test Description 1
         Tried to create a VMFS datastore without size argument in govc cli, so that it takes the entire size of disk into consideration(default case)
`go run main.go datastore.create -type VMFS -name vmfs61 -version 6 -disk eui.b8fa2f975ecc490ea090a46404568540 ocsqe-virt07.lab.eng.blr.redhat.com`
- [ ] Test Description 2
        Tried to create a VMFS datastore with some size in govc cli
`go run main.go datastore.create -type VMFS -name vmfs61 -version 6 -disk eui.b8fa2f975ecc490ea090a46404568540 -size 30 ocsqe-virt07.lab.eng.blr.redhat.com`

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
