### PR TITLE
Add BackingDiskPath to BackingObjectDetails

### DIFF
--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -308,6 +308,27 @@ func TestClient(t *testing.T) {
 		}
 	}
 
+	// Test BackingDiskPath field
+	var queryFilterBackingDiskPathTest cnstypes.CnsQueryFilter
+	var volumeIDListBackingDiskPathTest []cnstypes.CnsVolumeId
+	volumeIDListBackingDiskPathTest = append(volumeIDListBackingDiskPathTest, cnstypes.CnsVolumeId{Id: volumeId})
+	queryFilterBackingDiskPathTest.VolumeIds = volumeIDListBackingDiskPathTest
+	t.Logf("Calling QueryVolume using queryFilter: %+v", pretty.Sprint(queryFilterBackingDiskPathTest))
+	queryResultBackingDiskPathTest, err := cnsClient.QueryVolume(ctx, queryFilterBackingDiskPathTest)
+	if err != nil {
+		t.Errorf("Failed to query all volumes. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	t.Logf("Successfully Queried Volumes. queryResultBackingDiskPathTest: %+v", pretty.Sprint(queryResultBackingDiskPathTest))
+	t.Log("Checking backingDiskPath retrieved")
+	for _, vol := range queryResultBackingDiskPathTest.Volumes {
+		backingDiskPath := vol.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).BackingDiskPath
+		if backingDiskPath == "" {
+			t.Errorf("Failed to get BackingDiskPath")
+			t.FailNow()
+		}
+	}
+
 	// Test QuerySnapshots API on 7.0 U3 or above
 	var snapshotQueryFilter cnstypes.CnsSnapshotQueryFilter
 	var querySnapshotsTaskResult *cnstypes.CnsSnapshotQueryResult

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -396,6 +396,7 @@ type CnsBlockBackingDetails struct {
 	BackingDiskUrlPath             string `xml:"backingDiskUrlPath,omitempty"`
 	BackingDiskObjectId            string `xml:"backingDiskObjectId,omitempty"`
 	AggregatedSnapshotCapacityInMb int64  `xml:"aggregatedSnapshotCapacityInMb,omitempty"`
+	BackingDiskPath                string `xml:"backingDiskPath,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

Add BackingDiskPath to BackingObjectDetails

Closes: #(issue-number)

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Added a unit test and it is passing.

Unit testing logs:
```
   client_test.go:316: Calling QueryVolume using queryFilter: types.CnsQueryFilter{
            VolumeIds: []types.CnsVolumeId{
                {
                    Id: "2cb3e6b7-3275-411f-9eaa-7b508572ea5f",
                },
            },  
            Names:                        nil,
            ContainerClusterIds:          nil,
            StoragePolicyId:              "",
            Datastores:                   nil,
            Labels:                       nil,
            ComplianceStatus:             "",
            DatastoreAccessibilityStatus: "",
            Cursor:                       (*types.CnsCursor)(nil),
            HealthStatus:                 "",
        }       
    client_test.go:322: Successfully Queried Volumes. queryResultBackingDiskPathTest: &types.CnsQueryResult{
            Volumes: []types.CnsVolume{
                {
                    VolumeId: types.CnsVolumeId{
                        Id: "2cb3e6b7-3275-411f-9eaa-7b508572ea5f",
                    },
                    DatastoreUrl:    "ds:///vmfs/volumes/vsan:528f0821be4c5b06-5a4fa1d24249bbf5/",
                    Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                    VolumeType:      "BLOCK",
                    StoragePolicyId: "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                    Metadata:        types.CnsVolumeMetadata{
                        ContainerCluster: types.CnsContainerCluster{
                            ClusterType:         "KUBERNETES",
                            ClusterId:           "demo-cluster-id",
                            VSphereUser:         "Administrator@vsphere.local",
                            ClusterFlavor:       "VANILLA",
                            ClusterDistribution: "OpenShift",
                        },
                        EntityMetadata:        nil,
                        ContainerClusterArray: []types.CnsContainerCluster{
                            {
                                ClusterType:         "KUBERNETES",
                                ClusterId:           "demo-cluster-id",
                                VSphereUser:         "Administrator@vsphere.local",
                                ClusterFlavor:       "VANILLA",
                                ClusterDistribution: "OpenShift",
                            },
                        },
                    },
                    BackingObjectDetails: &types.CnsBlockBackingDetails{
                        CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                            CapacityInMb: 5120,
                        },
                        BackingDiskId:                  "2cb3e6b7-3275-411f-9eaa-7b508572ea5f",
                        BackingDiskUrlPath:             "",
                        BackingDiskObjectId:            "71d2d166-b0a3-3932-013b-0050568b6f1c",
                        AggregatedSnapshotCapacityInMb: 0,
                        BackingDiskPath:                "[vsanDatastore] 851ebe66-7b9a-cb04-2b12-0050568b2529/4e334336cdee4bbcaa9749d95f7e818d.vmdk",
                    },
                    ComplianceStatus:             "compliant",
                    DatastoreAccessibilityStatus: "accessible",
                    HealthStatus:                 "green",
                },
          },
            Cursor: types.CnsCursor{
                Offset:       1,
                Limit:        100,
                TotalRecords: 1,
            },
        }
    client_test.go:323: Checking backingDiskPath retieved
```

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
