### PR TITLE
vcsim: Support VM crypto spec in vC Sim

### DIFF
--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -961,3 +961,19 @@ func UnmarshalBody(typeFunc func(string) (reflect.Type, bool), data []byte) (*Me
 
 	return method, nil
 }
+
+func newInvalidStateFault(format string, args ...any) *types.InvalidState {
+	msg := fmt.Sprintf(format, args...)
+	return &types.InvalidState{
+		VimFault: types.VimFault{
+			MethodFault: types.MethodFault{
+				FaultCause: &types.LocalizedMethodFault{
+					Fault: &types.SystemErrorFault{
+						Reason: msg,
+					},
+					LocalizedMessage: msg,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION


## Description

This patch adds support for "encrypting", "recrypting", and "decrypting" VMs in vC Sim. Please note, no encryption is actually used, and this change only impacts the state machine semantics. For example, if a VM is reconfigured to be encrypted, then retrieving the VM's "config.keyId" property will return the ID of the key and provider used to encrypt the VM.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

```
$ go test -v -count 1 -run 'TestEncryptDecryptVM' -coverprofile cover.out ./simulator
=== RUN   TestEncryptDecryptVM
=== RUN   TestEncryptDecryptVM/encrypt
=== RUN   TestEncryptDecryptVM/encrypt_w_already_encrypted
=== RUN   TestEncryptDecryptVM/encrypt_w_powered_on
=== RUN   TestEncryptDecryptVM/encrypt_w_snapshots
=== RUN   TestEncryptDecryptVM/decrypt
=== RUN   TestEncryptDecryptVM/decrypt_w_not_encrypted
=== RUN   TestEncryptDecryptVM/decrypt_w_powered_on
=== RUN   TestEncryptDecryptVM/decrypt_w_snapshots
=== RUN   TestEncryptDecryptVM/deep_recrypt
=== RUN   TestEncryptDecryptVM/deep_recrypt_w_same_provider_id
=== RUN   TestEncryptDecryptVM/deep_recrypt_w_not_encrypted
=== RUN   TestEncryptDecryptVM/deep_recrypt_w_powered_on
=== RUN   TestEncryptDecryptVM/deep_recrypt_w_snapshots
=== RUN   TestEncryptDecryptVM/shallow_recrypt
=== RUN   TestEncryptDecryptVM/shallow_recrypt_w_same_provider_id
=== RUN   TestEncryptDecryptVM/shallow_recrypt_w_not_encrypted
=== RUN   TestEncryptDecryptVM/shallow_recrypt_w_single_snapshot_chain
=== RUN   TestEncryptDecryptVM/shallow_recrypt_w_snapshot_tree
2024/08/30 12:14:08 *types.FileAlreadyExists: /var/folders/j4/r0gh7dx10fv4j0jwdfb6hz980000gq/T/govcsim-DC0-LocalDS_0-342415882/DC0_C0_RP0_VM0/DC0_C0_RP0_VM0-Snapshot1.vmsn
2024/08/30 12:14:08 *types.FileAlreadyExists: /var/folders/j4/r0gh7dx10fv4j0jwdfb6hz980000gq/T/govcsim-DC0-LocalDS_0-342415882/DC0_C0_RP0_VM0/DC0_C0_RP0_VM0-Snapshot1.vmsn
2024/08/30 12:14:08 *types.FileAlreadyExists: /var/folders/j4/r0gh7dx10fv4j0jwdfb6hz980000gq/T/govcsim-DC0-LocalDS_0-342415882/DC0_C0_RP0_VM0/DC0_C0_RP0_VM0-Snapshot2.vmsn
=== RUN   TestEncryptDecryptVM/noop
=== RUN   TestEncryptDecryptVM/register
--- PASS: TestEncryptDecryptVM (4.99s)
    --- PASS: TestEncryptDecryptVM/encrypt (0.24s)
    --- PASS: TestEncryptDecryptVM/encrypt_w_already_encrypted (0.25s)
    --- PASS: TestEncryptDecryptVM/encrypt_w_powered_on (0.27s)
    --- PASS: TestEncryptDecryptVM/encrypt_w_snapshots (0.27s)
    --- PASS: TestEncryptDecryptVM/decrypt (0.27s)
    --- PASS: TestEncryptDecryptVM/decrypt_w_not_encrypted (0.21s)
    --- PASS: TestEncryptDecryptVM/decrypt_w_powered_on (0.26s)
    --- PASS: TestEncryptDecryptVM/decrypt_w_snapshots (0.29s)
    --- PASS: TestEncryptDecryptVM/deep_recrypt (0.23s)
    --- PASS: TestEncryptDecryptVM/deep_recrypt_w_same_provider_id (0.24s)
    --- PASS: TestEncryptDecryptVM/deep_recrypt_w_not_encrypted (0.23s)
    --- PASS: TestEncryptDecryptVM/deep_recrypt_w_powered_on (0.23s)
    --- PASS: TestEncryptDecryptVM/deep_recrypt_w_snapshots (0.27s)
    --- PASS: TestEncryptDecryptVM/shallow_recrypt (0.23s)
    --- PASS: TestEncryptDecryptVM/shallow_recrypt_w_same_provider_id (0.24s)
    --- PASS: TestEncryptDecryptVM/shallow_recrypt_w_not_encrypted (0.24s)
    --- PASS: TestEncryptDecryptVM/shallow_recrypt_w_single_snapshot_chain (0.22s)
    --- PASS: TestEncryptDecryptVM/shallow_recrypt_w_snapshot_tree (0.32s)
    --- PASS: TestEncryptDecryptVM/noop (0.22s)
    --- PASS: TestEncryptDecryptVM/register (0.26s)
PASS
coverage: 27.6% of statements
ok  	github.com/vmware/govmomi/simulator	5.425s	coverage: 27.6% of statements
```

```
go tool cover -html=cover.out
```

The new function has 100% coverage:

<img width="905" alt="image" src="https://github.com/user-attachments/assets/67a353b5-5377-4d9a-8fa6-e87ffddbbb53">
<img width="905" alt="image" src="https://github.com/user-attachments/assets/62631ff5-2edb-4294-a634-06c16c1a22a8">


## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
