### PR TITLE
Add support for using storage profiles when creating and attaching VirtualDisks

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -122,7 +122,9 @@ but appear via `govc $cmd -h`:
  - [device.serial.connect](#deviceserialconnect)
  - [device.serial.disconnect](#deviceserialdisconnect)
  - [device.usb.add](#deviceusbadd)
+ - [disk.attach](#diskattach)
  - [disk.create](#diskcreate)
+ - [disk.detach](#diskdetach)
  - [disk.ls](#diskls)
  - [disk.register](#diskregister)
  - [disk.rm](#diskrm)
@@ -2008,6 +2010,24 @@ Options:
   -vm=                   Virtual machine [GOVC_VM]
 ```
 
+## disk.attach
+
+```
+Usage: govc disk.attach [OPTIONS] ID
+
+Attach disk ID on VM.
+
+See also: govc vm.disk.attach
+
+Examples:
+  govc disk.attach -vm $vm ID
+  govc disk.attach -vm $vm -ds $ds ID
+
+Options:
+  -ds=                   Datastore [GOVC_DATASTORE]
+  -vm=                   Virtual machine [GOVC_VM]
+```
+
 ## disk.create
 
 ```
@@ -2023,7 +2043,24 @@ Options:
   -ds=                   Datastore [GOVC_DATASTORE]
   -keep=<nil>            Keep disk after VM is deleted
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
+  -profile=[]            Storage profile name or ID
   -size=10.0GB           Size of new disk
+```
+
+## disk.detach
+
+```
+Usage: govc disk.detach [OPTIONS] ID
+
+Detach disk ID from VM.
+
+See also: govc device.remove
+
+Examples:
+  govc disk.detach -vm $vm ID
+
+Options:
+  -vm=                   Virtual machine [GOVC_VM]
 ```
 
 ## disk.ls
@@ -3602,7 +3639,7 @@ Options:
   -m=false               Preserve MAC-addresses on network adapters
   -ovf=false             Clone as OVF (default is VM Template)
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
-  -profile=              Storage profile
+  -profile=[]            Storage profile name or ID
   -vm=                   Virtual machine [GOVC_VM]
 ```
 
@@ -3667,7 +3704,7 @@ Options:
   -host=                 Host system [GOVC_HOST]
   -options=              Options spec file path for VM deployment
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
-  -profile=              Storage profile
+  -profile=[]            Storage profile name or ID
 ```
 
 ## library.evict
@@ -4434,7 +4471,7 @@ Examples:
 Options:
   -cluster=              Cluster [GOVC_CLUSTER]
   -library=[]            Content library IDs to associate with the vSphere Namespace.
-  -storage=[]            Storage profile IDs to associate with the vSphere Namespace.
+  -storage=[]            Storage profile name or ID
   -vmclass=[]            Virtual machine class IDs to associate with the vSphere Namespace.
 ```
 
@@ -4609,7 +4646,7 @@ Examples:
 
 Options:
   -library=[]            Content library IDs to associate with the vSphere Namespace.
-  -storage=[]            Storage profile IDs to associate with the vSphere Namespace.
+  -storage=[]            Storage profile name or ID
   -vmclass=[]            Virtual machine class IDs to associate with the vSphere Namespace.
 ```
 
@@ -6449,7 +6486,7 @@ Options:
   -net.protocol=         Network device protocol. Applicable to vmxnet3vrdma. Default to 'rocev2'
   -on=true               Power on VM
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
-  -profile=              Storage profile name or ID
+  -profile=[]            Storage profile name or ID
   -version=              ESXi hardware version [2|3|4|5.0|5.1|5.5|6.0|6.5|6.7|6.7.2|7.0|7.0.1|7.0.2|8.0|8.0.1|8.0.2]
 ```
 
@@ -6693,6 +6730,7 @@ Options:
   -link=true             Link specified disk
   -mode=                 Disk mode (persistent|nonpersistent|undoable|independent_persistent|independent_nonpersistent|append)
   -persist=true          Persist attached disk
+  -profile=[]            Storage profile name or ID
   -sharing=              Sharing (sharingNone|sharingMultiWriter)
   -vm=                   Virtual machine [GOVC_VM]
 ```
@@ -6741,6 +6779,7 @@ Options:
   -eager=false           Eagerly scrub new disk
   -mode=persistent       Disk mode (persistent|nonpersistent|undoable|independent_persistent|independent_nonpersistent|append)
   -name=                 Name for new disk
+  -profile=[]            Storage profile name or ID
   -sharing=              Sharing (sharingNone|sharingMultiWriter)
   -size=10.0GB           Size of new disk
   -thick=false           Thick provision new disk

--- a/govc/disk/attach.go
+++ b/govc/disk/attach.go
@@ -1,0 +1,97 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type attach struct {
+	*flags.VirtualMachineFlag
+	*flags.DatastoreFlag
+}
+
+func init() {
+	cli.Register("disk.attach", &attach{})
+}
+
+func (cmd *attach) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+}
+
+func (cmd *attach) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.DatastoreFlag.Process(ctx)
+}
+
+func (cmd *attach) Usage() string {
+	return "ID"
+}
+
+func (cmd *attach) Description() string {
+	return `Attach disk ID on VM.
+
+See also: govc vm.disk.attach
+
+Examples:
+  govc disk.attach -vm $vm ID
+  govc disk.attach -vm $vm -ds $ds ID`
+}
+
+func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	ds, err := cmd.DatastoreIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if ds == nil {
+		var props mo.VirtualMachine
+		err = vm.Properties(ctx, vm.Reference(), []string{"datastore"}, &props)
+		if err != nil {
+			return err
+		}
+		if len(props.Datastore) != 1 {
+			ds, err = cmd.Datastore() // likely results in MultipleFoundError
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	id := f.Arg(0)
+
+	return vm.AttachDisk(ctx, id, ds, 0, nil)
+}

--- a/govc/disk/detach.go
+++ b/govc/disk/detach.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+)
+
+type detach struct {
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("disk.detach", &detach{})
+}
+
+func (cmd *detach) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *detach) Usage() string {
+	return "ID"
+}
+
+func (cmd *detach) Description() string {
+	return `Detach disk ID from VM.
+
+See also: govc device.remove
+
+Examples:
+  govc disk.detach -vm $vm ID`
+}
+
+func (cmd *detach) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	id := f.Arg(0)
+
+	return vm.DetachDisk(ctx, id)
+}

--- a/govc/flags/storage_profile.go
+++ b/govc/flags/storage_profile.go
@@ -1,0 +1,124 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type StorageProfileFlag struct {
+	*ClientFlag
+
+	Name []string
+
+	option string
+}
+
+func NewStorageProfileFlag(ctx context.Context, option ...string) (*StorageProfileFlag, context.Context) {
+	v := &StorageProfileFlag{}
+	if len(option) == 1 {
+		v.option = option[0]
+	} else {
+		v.option = "profile"
+	}
+	v.ClientFlag, ctx = NewClientFlag(ctx)
+	return v, ctx
+}
+
+func (e *StorageProfileFlag) String() string {
+	return fmt.Sprint(e.Name)
+}
+
+func (e *StorageProfileFlag) Set(value string) error {
+	e.Name = append(e.Name, value)
+	return nil
+}
+
+func (flag *StorageProfileFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.ClientFlag.Register(ctx, f)
+
+	f.Var(flag, flag.option, "Storage profile name or ID")
+}
+
+func (flag *StorageProfileFlag) StorageProfileList(ctx context.Context) ([]string, error) {
+	if len(flag.Name) == 0 {
+		return nil, nil
+	}
+
+	c, err := flag.PbmClient()
+	if err != nil {
+		return nil, err
+	}
+	m, err := c.ProfileMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	list := make([]string, len(flag.Name))
+
+	for i, name := range flag.Name {
+		p, ok := m.Name[name]
+		if !ok {
+			return nil, fmt.Errorf("storage profile %q not found", name)
+		}
+
+		list[i] = p.GetPbmProfile().ProfileId.UniqueId
+	}
+
+	return list, nil
+}
+
+func (flag *StorageProfileFlag) StorageProfile(ctx context.Context) (string, error) {
+	switch len(flag.Name) {
+	case 0:
+		return "", nil
+	case 1:
+	default:
+		return "", errors.New("only 1 '-profile' can be specified")
+	}
+
+	list, err := flag.StorageProfileList(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return list[0], nil
+}
+
+func (flag *StorageProfileFlag) StorageProfileSpec(ctx context.Context) ([]types.BaseVirtualMachineProfileSpec, error) {
+	if len(flag.Name) == 0 {
+		return nil, nil
+	}
+
+	list, err := flag.StorageProfileList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	spec := make([]types.BaseVirtualMachineProfileSpec, len(list))
+	for i, name := range list {
+		spec[i] = &types.VirtualMachineDefinedProfileSpec{
+			ProfileId: name,
+		}
+	}
+	return spec, nil
+}

--- a/govc/namespace/create.go
+++ b/govc/namespace/create.go
@@ -88,7 +88,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		return flag.ErrHelp
 	}
 
-	rc, err := cmd.RestClient()
+	rc, err := cmd.namespaceFlag.RestClient()
 	if err != nil {
 		return err
 	}

--- a/govc/test/disk.bats
+++ b/govc/test/disk.bats
@@ -26,6 +26,14 @@ load test_helper
 
   govc disk.ls -json "$id" | jq .
 
+  vm=DC0_H0_VM0
+
+  run govc disk.attach -vm $vm "$id"
+  assert_success
+
+  run govc disk.detach -vm $vm "$id"
+  assert_success
+
   run govc disk.rm "$id"
   assert_success
 

--- a/govc/test/disk.bats
+++ b/govc/test/disk.bats
@@ -39,6 +39,13 @@ load test_helper
 
   run govc disk.rm "$id"
   assert_failure
+
+  name=$(new_id)
+  run govc disk.create -profile enoent "$name"
+  assert_failure # profile does not exist
+
+  run govc disk.create -profile "vSAN Default Storage Policy" "$name"
+  assert_success
 }
 
 @test "disk.create -datastore-cluster" {

--- a/govc/test/namespace.bats
+++ b/govc/test/namespace.bats
@@ -130,6 +130,15 @@ load test_helper
 
     ns=$(govc namespace.info -json test-namespace-2 | jq)
     assert_equal "2" $(echo $ns | jq -r '."vm_service_spec"."content_libraries"' | jq length)
+
+    run govc namespace.create -cluster DC0_C0 -storage MyStoragePolicy test-namespace-2
+    assert_failure # storage policy does not exist
+
+    run govc storage.policy.create -category my_cat -tag my_tag MyStoragePolicy
+    assert_success
+
+    run govc namespace.create -cluster DC0_C0 -storage MyStoragePolicy test-namespace-2
+    assert_success
 }
 
 @test "namespace.update" {

--- a/govc/test/vm.bats
+++ b/govc/test/vm.bats
@@ -695,6 +695,13 @@ load test_helper
 
   run govc vm.disk.change -vm "$vm" -disk.name "$disk" -size 1M
   assert_failure # cannot shrink disk
+
+  name=$(new_id)
+  run govc vm.disk.create -vm "$vm" -name "$vm/$name" -profile enoent
+  assert_failure # profile does not exist
+
+  run govc vm.disk.create -vm "$vm" -name "$vm/$name" -profile "vSAN Default Storage Policy"
+  assert_success
 }
 
 @test "vm.disk.attach" {

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015-2023 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -500,7 +500,7 @@ func diskFileOperation(op types.VirtualDeviceConfigSpecOperation, fop types.Virt
 	return ""
 }
 
-func (v VirtualMachine) configureDevice(ctx context.Context, op types.VirtualDeviceConfigSpecOperation, fop types.VirtualDeviceConfigSpecFileOperation, devices ...types.BaseVirtualDevice) error {
+func (v VirtualMachine) configureDevice(ctx context.Context, profile []types.BaseVirtualMachineProfileSpec, op types.VirtualDeviceConfigSpecOperation, fop types.VirtualDeviceConfigSpecFileOperation, devices ...types.BaseVirtualDevice) error {
 	spec := types.VirtualMachineConfigSpec{}
 
 	for _, device := range devices {
@@ -508,6 +508,7 @@ func (v VirtualMachine) configureDevice(ctx context.Context, op types.VirtualDev
 			Device:        device,
 			Operation:     op,
 			FileOperation: diskFileOperation(op, fop, device),
+			Profile:       profile,
 		}
 
 		spec.DeviceChange = append(spec.DeviceChange, config)
@@ -523,12 +524,22 @@ func (v VirtualMachine) configureDevice(ctx context.Context, op types.VirtualDev
 
 // AddDevice adds the given devices to the VirtualMachine
 func (v VirtualMachine) AddDevice(ctx context.Context, device ...types.BaseVirtualDevice) error {
-	return v.configureDevice(ctx, types.VirtualDeviceConfigSpecOperationAdd, types.VirtualDeviceConfigSpecFileOperationCreate, device...)
+	return v.AddDeviceWithProfile(ctx, nil, device...)
+}
+
+// AddDeviceWithProfile adds the given devices to the VirtualMachine with the given profile
+func (v VirtualMachine) AddDeviceWithProfile(ctx context.Context, profile []types.BaseVirtualMachineProfileSpec, device ...types.BaseVirtualDevice) error {
+	return v.configureDevice(ctx, profile, types.VirtualDeviceConfigSpecOperationAdd, types.VirtualDeviceConfigSpecFileOperationCreate, device...)
 }
 
 // EditDevice edits the given (existing) devices on the VirtualMachine
 func (v VirtualMachine) EditDevice(ctx context.Context, device ...types.BaseVirtualDevice) error {
-	return v.configureDevice(ctx, types.VirtualDeviceConfigSpecOperationEdit, types.VirtualDeviceConfigSpecFileOperationReplace, device...)
+	return v.EditDeviceWithProfile(ctx, nil, device...)
+}
+
+// EditDeviceWithProfile edits the given (existing) devices on the VirtualMachine with the given profile
+func (v VirtualMachine) EditDeviceWithProfile(ctx context.Context, profile []types.BaseVirtualMachineProfileSpec, device ...types.BaseVirtualDevice) error {
+	return v.configureDevice(ctx, profile, types.VirtualDeviceConfigSpecOperationEdit, types.VirtualDeviceConfigSpecFileOperationReplace, device...)
 }
 
 // RemoveDevice removes the given devices on the VirtualMachine
@@ -537,7 +548,7 @@ func (v VirtualMachine) RemoveDevice(ctx context.Context, keepFiles bool, device
 	if keepFiles {
 		fop = ""
 	}
-	return v.configureDevice(ctx, types.VirtualDeviceConfigSpecOperationRemove, fop, device...)
+	return v.configureDevice(ctx, nil, types.VirtualDeviceConfigSpecOperationRemove, fop, device...)
 }
 
 // AttachDisk attaches the given disk to the VirtualMachine

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -541,13 +541,13 @@ func (v VirtualMachine) RemoveDevice(ctx context.Context, keepFiles bool, device
 }
 
 // AttachDisk attaches the given disk to the VirtualMachine
-func (v VirtualMachine) AttachDisk(ctx context.Context, id string, datastore *Datastore, controllerKey int32, unitNumber int32) error {
+func (v VirtualMachine) AttachDisk(ctx context.Context, id string, datastore *Datastore, controllerKey int32, unitNumber *int32) error {
 	req := types.AttachDisk_Task{
 		This:          v.Reference(),
 		DiskId:        types.ID{Id: id},
 		Datastore:     datastore.Reference(),
 		ControllerKey: controllerKey,
-		UnitNumber:    &unitNumber,
+		UnitNumber:    unitNumber,
 	}
 
 	res, err := methods.AttachDisk_Task(ctx, v.c, &req)

--- a/simulator/vstorage_object_manager.go
+++ b/simulator/vstorage_object_manager.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -285,6 +285,10 @@ func (m *VcenterVStorageObjectManager) DeleteVStorageObjectTask(ctx *Context, re
 		obj := m.object(req.Datastore, req.Id)
 		if obj == nil {
 			return nil, &types.InvalidArgument{}
+		}
+
+		if len(obj.Config.ConsumerId) != 0 {
+			return nil, &types.InvalidState{}
 		}
 
 		backing := obj.Config.Backing.(*types.BaseConfigInfoDiskFileBackingInfo)


### PR DESCRIPTION
This includes support both First Class Disks and "classic" VM Disks.

govc: add disk.create '-profile' flag
govc: add vm.disk.create '-profile' flag
govc: add vm.disk.attach '-profile' flag
chore: govc: add common StorageProfileFlag
api: add VirtualMachine.AddDeviceWithProfile method
vcsim: add VirtualMachine AttachDisk and DetachDisk methods
govc add disk.attach and disk.detach commands
api: VirtualMachine.AttachDisk unitNumber param is optional