### PR TITLE
api: Fault helpers

### DIFF
--- a/fault/fault.go
+++ b/fault/fault.go
@@ -1,0 +1,315 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fault
+
+import (
+	"reflect"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// As finds the first fault in the error's tree that matches target, and if one
+// is found, sets the target to that fault value and returns the fault's
+// localized message and true. Otherwise, false is returned.
+//
+// The tree is inspected according to the object type. If the object implements
+// Golang's error interface, the Unwrap() error or Unwrap() []error methods are
+// repeatedly checked for additional errors. If the object implements GoVmomi's
+// BaseMethodFault or HasLocalizedMethodFault interfaces, the object is checked
+// for an underlying FaultCause. When err wraps multiple errors or faults, err
+// is examined followed by a depth-first traversal of its children.
+//
+// An error matches target if the error's concrete value is assignable to the
+// value pointed to by target, or if the error has a method
+// AsFault(BaseMethodFault) (string, bool) such that AsFault(BaseMethodFault)
+// returns true. In the latter case, the AsFault method is responsible for
+// setting target.
+//
+// An error type might provide an AsFault method so it can be treated as if it
+// were a different error type.
+//
+// This function panics if err does not implement error, types.BaseMethodFault,
+// types.HasLocalizedMethodFault, Fault() types.BaseMethodFault, or if target is
+// not a pointer.
+func As(err, target any) (localizedMessage string, okay bool) {
+	if err == nil {
+		return
+	}
+	if target == nil {
+		panic("fault: target cannot be nil")
+	}
+	val := reflect.ValueOf(target)
+	typ := val.Type()
+	if typ.Kind() != reflect.Ptr || val.IsNil() {
+		panic("fault: target must be a non-nil pointer")
+	}
+	targetType := typ.Elem()
+	if targetType.Kind() != reflect.Interface &&
+		!targetType.Implements(baseMethodFaultType) {
+		panic("fault: *target must be interface or implement BaseMethodFault")
+	}
+	if !as(err, target, val, targetType, &localizedMessage) {
+		return "", false
+	}
+	return localizedMessage, true
+}
+
+func as(
+	err,
+	target any,
+	targetVal reflect.Value,
+	targetType reflect.Type,
+	localizedMsg *string) bool {
+
+	for {
+		if reflect.TypeOf(err).AssignableTo(targetType) {
+			targetVal.Elem().Set(reflect.ValueOf(err))
+			return true
+		}
+		if tErr, ok := err.(hasAsFault); ok {
+			if msg, ok := tErr.AsFault(target); ok {
+				*localizedMsg = msg
+				return true
+			}
+			return false
+		}
+		switch tErr := err.(type) {
+		case types.HasLocalizedMethodFault:
+			if fault := tErr.GetLocalizedMethodFault(); fault != nil {
+				*localizedMsg = fault.LocalizedMessage
+				if fault.Fault != nil {
+					return as(
+						fault.Fault,
+						target,
+						targetVal,
+						targetType,
+						localizedMsg)
+				}
+			}
+			return false
+		case types.BaseMethodFault:
+			if fault := tErr.GetMethodFault(); fault != nil {
+				if fault.FaultCause != nil {
+					*localizedMsg = fault.FaultCause.LocalizedMessage
+					return as(
+						fault.FaultCause,
+						target,
+						targetVal,
+						targetType,
+						localizedMsg)
+				}
+			}
+			return false
+		case hasFault:
+			if fault := tErr.Fault(); fault != nil {
+				return as(fault, target, targetVal, targetType, localizedMsg)
+			}
+			return false
+		case unwrappableError:
+			if err = tErr.Unwrap(); err == nil {
+				return false
+			}
+		case unwrappableErrorSlice:
+			for _, err := range tErr.Unwrap() {
+				if err == nil {
+					continue
+				}
+				return as(err, target, targetVal, targetType, localizedMsg)
+			}
+			return false
+		default:
+			return false
+		}
+	}
+}
+
+// Is reports whether any fault in err's tree matches target.
+//
+// The tree is inspected according to the object type. If the object implements
+// Golang's error interface, the Unwrap() error or Unwrap() []error methods are
+// repeatedly checked for additional errors. If the object implements GoVmomi's
+// BaseMethodFault or HasLocalizedMethodFault interfaces, the object is checked
+// for an underlying FaultCause. When err wraps multiple errors or faults, err
+// is examined followed by a depth-first traversal of its children.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method IsFault(BaseMethodFault) bool such that
+// IsFault(BaseMethodFault) returns true.
+//
+// An error type might provide an IsFault method so it can be treated as
+// equivalent to an existing fault. For example, if MyFault defines:
+//
+//	func (m MyFault) IsFault(target BaseMethodFault) bool {
+//		return target == &types.NotSupported{}
+//	}
+//
+// then IsFault(MyError{}, &types.NotSupported{}) returns true. An IsFault
+// method should only shallowly compare err and the target and not unwrap
+// either.
+func Is(err any, target types.BaseMethodFault) bool {
+	if target == nil {
+		return err == target
+	}
+	isComparable := reflect.TypeOf(target).Comparable()
+	return is(err, target, isComparable)
+}
+
+func is(err any, target types.BaseMethodFault, targetComparable bool) bool {
+	for {
+		if targetComparable && err == target {
+			return true
+		}
+		if tErr, ok := err.(hasIsFault); ok && tErr.IsFault(target) {
+			return true
+		}
+		switch tErr := err.(type) {
+		case types.HasLocalizedMethodFault:
+			fault := tErr.GetLocalizedMethodFault()
+			if fault == nil {
+				return false
+			}
+			err = fault.Fault
+		case types.BaseMethodFault:
+			if reflect.ValueOf(err).Type() == reflect.ValueOf(target).Type() {
+				return true
+			}
+			fault := tErr.GetMethodFault()
+			if fault == nil {
+				return false
+			}
+			err = fault.FaultCause
+		case hasFault:
+			if err = tErr.Fault(); err == nil {
+				return false
+			}
+		case unwrappableError:
+			if err = tErr.Unwrap(); err == nil {
+				return false
+			}
+		case unwrappableErrorSlice:
+			for _, err := range tErr.Unwrap() {
+				if is(err, target, targetComparable) {
+					return true
+				}
+			}
+			return false
+		default:
+			return false
+		}
+	}
+}
+
+// OnFaultFn is called for every fault encountered when inspecting an error
+// or fault for a fault tree. The In function returns when the entire tree is
+// inspected or the OnFaultFn returns true.
+type OnFaultFn func(
+	fault types.BaseMethodFault,
+	localizedMessage string,
+	localizableMessages []types.LocalizableMessage) bool
+
+// In invokes onFaultFn for each fault in err's tree.
+//
+// The tree is inspected according to the object type. If the object implements
+// Golang's error interface, the Unwrap() error or Unwrap() []error methods are
+// repeatedly checked for additional errors. If the object implements GoVmomi's
+// BaseMethodFault or HasLocalizedMethodFault interfaces, the object is checked
+// for an underlying FaultCause. When err wraps multiple errors or faults, err
+// is examined followed by a depth-first traversal of its children.
+//
+// This function panics if err does not implement error, types.BaseMethodFault,
+// types.HasLocalizedMethodFault, Fault() types.BaseMethodFault, or if onFaultFn
+// is nil.
+func In(err any, onFaultFn OnFaultFn) {
+	if onFaultFn == nil {
+		panic("fault: onFaultFn must not be nil")
+	}
+	switch tErr := err.(type) {
+	case types.HasLocalizedMethodFault:
+		inFault(tErr.GetLocalizedMethodFault(), onFaultFn)
+	case types.BaseMethodFault:
+		inFault(&types.LocalizedMethodFault{Fault: tErr}, onFaultFn)
+	case hasFault:
+		if fault := tErr.Fault(); fault != nil {
+			inFault(&types.LocalizedMethodFault{Fault: fault}, onFaultFn)
+		}
+	case unwrappableError:
+		In(tErr.Unwrap(), onFaultFn)
+	case unwrappableErrorSlice:
+		for _, uErr := range tErr.Unwrap() {
+			if uErr == nil {
+				continue
+			}
+			In(uErr, onFaultFn)
+		}
+	default:
+		panic("fault: err must implement error, types.BaseMethodFault, or " +
+			"types.HasLocalizedMethodFault")
+	}
+}
+
+func inFault(
+	localizedMethodFault *types.LocalizedMethodFault,
+	onFaultFn OnFaultFn) {
+
+	if localizedMethodFault == nil {
+		return
+	}
+
+	fault := localizedMethodFault.Fault
+	if fault == nil {
+		return
+	}
+
+	var (
+		faultCause    *types.LocalizedMethodFault
+		faultMessages []types.LocalizableMessage
+	)
+
+	if methodFault := fault.GetMethodFault(); methodFault != nil {
+		faultCause = methodFault.FaultCause
+		faultMessages = methodFault.FaultMessage
+	}
+
+	if onFaultFn(fault, localizedMethodFault.LocalizedMessage, faultMessages) {
+		return
+	}
+
+	// Check the fault's children.
+	inFault(faultCause, onFaultFn)
+}
+
+type hasFault interface {
+	Fault() types.BaseMethodFault
+}
+
+type hasAsFault interface {
+	AsFault(target any) (string, bool)
+}
+
+type hasIsFault interface {
+	IsFault(target types.BaseMethodFault) bool
+}
+
+type unwrappableError interface {
+	Unwrap() error
+}
+
+type unwrappableErrorSlice interface {
+	Unwrap() []error
+}
+
+var baseMethodFaultType = reflect.TypeOf((*types.BaseMethodFault)(nil)).Elem()

--- a/fault/fault_example_test.go
+++ b/fault/fault_example_test.go
@@ -1,0 +1,260 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fault_test
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/vmware/govmomi/fault"
+	"github.com/vmware/govmomi/task"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func ExampleAs_faultByAddress() {
+	var (
+		err    any
+		target *types.InvalidPowerState
+	)
+
+	err = task.Error{
+		LocalizedMethodFault: &types.LocalizedMethodFault{
+			Fault: &types.InvalidPowerState{
+				ExistingState:  types.VirtualMachinePowerStatePoweredOn,
+				RequestedState: types.VirtualMachinePowerStatePoweredOff,
+			},
+			LocalizedMessage: "vm must be powered off to encrypt",
+		},
+	}
+
+	localizedMessage, ok := fault.As(err, &target)
+
+	fmt.Printf("result              = %v\n", ok)
+	fmt.Printf("localizedMessage    = %v\n", localizedMessage)
+	fmt.Printf("existingPowerState  = %v\n", target.ExistingState)
+	fmt.Printf("requestedPowerState = %v\n", target.RequestedState)
+
+	// Output:
+	// result              = true
+	// localizedMessage    = vm must be powered off to encrypt
+	// existingPowerState  = poweredOn
+	// requestedPowerState = poweredOff
+}
+
+type valueFault uint8
+
+func (f valueFault) GetMethodFault() *types.MethodFault {
+	return nil
+}
+
+func ExampleAs_faultByValue() {
+	var (
+		err    any
+		target valueFault
+	)
+
+	err = &types.SystemError{
+		RuntimeFault: types.RuntimeFault{
+			MethodFault: types.MethodFault{
+				FaultCause: &types.LocalizedMethodFault{
+					Fault:            valueFault(1),
+					LocalizedMessage: "fault by value",
+				},
+			},
+		},
+	}
+
+	localizedMessage, ok := fault.As(err, &target)
+
+	fmt.Printf("result              = %v\n", ok)
+	fmt.Printf("localizedMessage    = %v\n", localizedMessage)
+	fmt.Printf("value               = %d\n", target)
+
+	// Output:
+	// result              = true
+	// localizedMessage    = fault by value
+	// value               = 1
+}
+
+func ExampleIs_baseMethodFault() {
+	var (
+		err    any
+		target types.BaseMethodFault
+	)
+
+	err = &types.SystemError{}
+	target = &types.SystemError{}
+
+	fmt.Printf("result = %v\n", fault.Is(err, target))
+
+	// Output:
+	// result = true
+}
+
+func ExampleIs_nestedFault() {
+	var (
+		err    any
+		target types.BaseMethodFault
+	)
+
+	err = task.Error{
+		LocalizedMethodFault: &types.LocalizedMethodFault{
+			Fault: &types.RuntimeFault{
+				MethodFault: types.MethodFault{
+					FaultCause: &types.LocalizedMethodFault{
+						Fault: &types.SystemError{},
+					},
+				},
+			},
+		},
+	}
+	target = &types.SystemError{}
+
+	fmt.Printf("result = %v\n", fault.Is(err, target))
+
+	// Output:
+	// result = true
+}
+
+func ExampleIs_soapFault() {
+	var (
+		err    any
+		target types.BaseMethodFault
+	)
+
+	err = soap.WrapSoapFault(&soap.Fault{
+		Detail: struct {
+			Fault types.AnyType "xml:\",any,typeattr\""
+		}{
+			Fault: &types.RuntimeFault{
+				MethodFault: types.MethodFault{
+					FaultCause: &types.LocalizedMethodFault{
+						Fault: &types.SystemError{},
+					},
+				},
+			},
+		},
+	})
+	target = &types.SystemError{}
+
+	fmt.Printf("result = %v\n", fault.Is(err, target))
+
+	// Output:
+	// result = true
+}
+
+func ExampleIs_vimFault() {
+	var (
+		err    any
+		target types.BaseMethodFault
+	)
+
+	err = soap.WrapVimFault(&types.RuntimeFault{
+		MethodFault: types.MethodFault{
+			FaultCause: &types.LocalizedMethodFault{
+				Fault: &types.SystemError{},
+			},
+		},
+	})
+	target = &types.SystemError{}
+
+	fmt.Printf("result = %v\n", fault.Is(err, target))
+
+	// Output:
+	// result = true
+}
+
+func ExampleIn_printAllTypeNamesAndMessages() {
+	var (
+		err     any
+		onFault fault.OnFaultFn
+	)
+
+	err = task.Error{
+		LocalizedMethodFault: &types.LocalizedMethodFault{
+			Fault: &types.RuntimeFault{
+				MethodFault: types.MethodFault{
+					FaultCause: &types.LocalizedMethodFault{
+						Fault:            &types.SystemError{},
+						LocalizedMessage: "inner message",
+					},
+				},
+			},
+			LocalizedMessage: "outer message",
+		},
+	}
+
+	onFault = func(
+		fault types.BaseMethodFault,
+		localizedMessage string,
+		localizableMessages []types.LocalizableMessage) bool {
+
+		fmt.Printf("type             = %s\n", reflect.ValueOf(fault).Elem().Type().Name())
+		fmt.Printf("localizedMessage = %s\n", localizedMessage)
+
+		// Return false to continue discovering faults.
+		return false
+	}
+
+	fault.In(err, onFault)
+
+	// Output:
+	// type             = RuntimeFault
+	// localizedMessage = outer message
+	// type             = SystemError
+	// localizedMessage = inner message
+}
+
+func ExampleIn_printFirstDiscoveredTypeNameAndMessage() {
+	var (
+		err     any
+		onFault fault.OnFaultFn
+	)
+
+	err = task.Error{
+		LocalizedMethodFault: &types.LocalizedMethodFault{
+			Fault: &types.RuntimeFault{
+				MethodFault: types.MethodFault{
+					FaultCause: &types.LocalizedMethodFault{
+						Fault:            &types.SystemError{},
+						LocalizedMessage: "inner message",
+					},
+				},
+			},
+			LocalizedMessage: "outer message",
+		},
+	}
+
+	onFault = func(
+		fault types.BaseMethodFault,
+		localizedMessage string,
+		localizableMessages []types.LocalizableMessage) bool {
+
+		fmt.Printf("type             = %s\n", reflect.ValueOf(fault).Elem().Type().Name())
+		fmt.Printf("localizedMessage = %s\n", localizedMessage)
+
+		// Return true to force discovery to halt.
+		return true
+	}
+
+	fault.In(err, onFault)
+
+	// Output:
+	// type             = RuntimeFault
+	// localizedMessage = outer message
+}

--- a/fault/fault_test.go
+++ b/fault/fault_test.go
@@ -1,0 +1,968 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fault_test
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/govmomi/fault"
+	"github.com/vmware/govmomi/task"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func asPtr[T any](args ...T) *T {
+	if len(args) == 0 {
+		var t T
+		return &t
+	}
+	return &args[0]
+}
+
+var (
+	nilSystemErr       = asPtr[*types.SystemError]()
+	nilInvalidVmConfig = asPtr[*types.InvalidVmConfig]()
+)
+
+type nilErrWrapper struct{}
+
+func (e nilErrWrapper) Unwrap() error {
+	return nil
+}
+
+type unwrappableErrSlice []error
+
+func (e unwrappableErrSlice) Unwrap() []error {
+	return e
+}
+
+type nilBaseMethodFault struct{}
+
+func (f nilBaseMethodFault) GetMethodFault() *types.MethodFault {
+	return nil
+}
+
+type asFaulter struct {
+	val  any
+	okay bool
+	msg  string
+}
+
+func (f asFaulter) AsFault(target any) (string, bool) {
+	if !f.okay {
+		return "", false
+	}
+	targetVal := reflect.ValueOf(target)
+	targetVal.Elem().Set(reflect.ValueOf(f.val))
+	return f.msg, true
+}
+
+type isFaulter bool
+
+func (f isFaulter) GetMethodFault() *types.MethodFault {
+	return nil
+}
+
+func (f isFaulter) IsFault(target types.BaseMethodFault) bool {
+	return bool(f)
+}
+
+func TestAs(t *testing.T) {
+
+	testCases := []struct {
+		name                     string
+		err                      any
+		target                   any
+		expectedLocalizedMessage string
+		expectedOkay             bool
+		expectedPanic            any
+		expectedTarget           any
+	}{
+
+		{
+			name:           "err is nil",
+			err:            nil,
+			target:         asPtr[*types.SystemError](),
+			expectedTarget: asPtr[*types.SystemError](),
+		},
+		{
+			name:           "err is not supported",
+			err:            struct{}{},
+			target:         asPtr[*types.SystemError](),
+			expectedTarget: asPtr[*types.SystemError](),
+		},
+		{
+			name:           "target is nil",
+			err:            errors.New("error"),
+			target:         nil,
+			expectedTarget: nil,
+			expectedPanic:  "fault: target cannot be nil",
+		},
+		{
+			name:           "target is not pointer",
+			err:            errors.New("error"),
+			target:         types.SystemError{},
+			expectedTarget: types.SystemError{},
+			expectedPanic:  "fault: target must be a non-nil pointer",
+		},
+		{
+			name:           "target is not pointer to expected type",
+			err:            errors.New("error"),
+			target:         &types.SystemError{},
+			expectedTarget: &types.SystemError{},
+			expectedPanic:  "fault: *target must be interface or implement BaseMethodFault",
+		},
+		{
+			name: "err is task.Error with fault",
+			err: task.Error{
+				LocalizedMethodFault: &types.LocalizedMethodFault{
+					Fault: &types.SystemError{},
+				},
+			},
+			target:                   asPtr[*types.SystemError](),
+			expectedTarget:           asPtr(&types.SystemError{}),
+			expectedOkay:             true,
+			expectedLocalizedMessage: "",
+		},
+		{
+			name:           "err unwraps to nil error",
+			err:            nilErrWrapper{},
+			target:         asPtr[*types.SystemError](),
+			expectedTarget: asPtr[*types.SystemError](),
+		},
+		{
+			name:           "err unwraps to nil error slice",
+			err:            unwrappableErrSlice{},
+			target:         asPtr[*types.SystemError](),
+			expectedTarget: asPtr[*types.SystemError](),
+		},
+		{
+			name: "err is wrapped task.Error with fault",
+			err: fmt.Errorf("my error: %w", task.Error{
+				LocalizedMethodFault: &types.LocalizedMethodFault{
+					Fault: &types.SystemError{},
+				},
+			}),
+			target:                   asPtr[*types.SystemError](),
+			expectedTarget:           asPtr(&types.SystemError{}),
+			expectedOkay:             true,
+			expectedLocalizedMessage: "",
+		},
+		{
+			name: "err is wrapped nil error and task.Error with fault",
+			err: unwrappableErrSlice{
+				nil,
+				task.Error{
+					LocalizedMethodFault: &types.LocalizedMethodFault{
+						Fault: &types.SystemError{},
+					},
+				},
+			},
+			target:                   asPtr[*types.SystemError](),
+			expectedTarget:           asPtr(&types.SystemError{}),
+			expectedOkay:             true,
+			expectedLocalizedMessage: "",
+		},
+		{
+			name:                     "err is types.BaseMethodFault",
+			err:                      &types.SystemError{},
+			target:                   asPtr[*types.SystemError](),
+			expectedTarget:           asPtr(&types.SystemError{}),
+			expectedOkay:             true,
+			expectedLocalizedMessage: "",
+		},
+		{
+			name:                     "err is types.BaseMethodFault that returns nil",
+			err:                      nilBaseMethodFault{},
+			target:                   asPtr[*types.SystemError](),
+			expectedTarget:           asPtr[*types.SystemError](),
+			expectedLocalizedMessage: "",
+		},
+		{
+			name:                     "err is asFaulter that returns true and fault",
+			err:                      asFaulter{okay: true, msg: "Hello, world.", val: &types.SystemError{}},
+			target:                   asPtr[*types.SystemError](),
+			expectedTarget:           asPtr(&types.SystemError{}),
+			expectedOkay:             true,
+			expectedLocalizedMessage: "Hello, world.",
+		},
+		{
+			name:                     "err is asFaulter that returns false",
+			err:                      asFaulter{okay: false, msg: "Hello, world."},
+			target:                   asPtr[*types.SystemError](),
+			expectedTarget:           asPtr[*types.SystemError](),
+			expectedLocalizedMessage: "",
+		},
+		{
+			name: "err is *types.LocalizedMethodFault",
+			err: &types.LocalizedMethodFault{
+				LocalizedMessage: "fake",
+				Fault:            &types.SystemError{},
+			},
+			target:                   asPtr[*types.SystemError](),
+			expectedTarget:           asPtr(&types.SystemError{}),
+			expectedOkay:             true,
+			expectedLocalizedMessage: "fake",
+		},
+		{
+			name: "err is *types.LocalizedMethodFault w nil fault",
+			err: &types.LocalizedMethodFault{
+				LocalizedMessage: "fake",
+				Fault:            nil,
+			},
+			target:         asPtr[*types.SystemError](),
+			expectedTarget: asPtr[*types.SystemError](),
+			expectedOkay:   false,
+		},
+		{
+			name: "err is task.Error with nested fault",
+			err: &types.LocalizedMethodFault{
+				LocalizedMessage: "fake1",
+				Fault: &types.SystemError{
+					RuntimeFault: types.RuntimeFault{
+						MethodFault: types.MethodFault{
+							FaultCause: &types.LocalizedMethodFault{
+								LocalizedMessage: "fake2",
+								Fault:            &types.InvalidVmConfig{},
+							},
+						},
+					},
+				},
+			},
+			target:                   asPtr[*types.InvalidVmConfig](),
+			expectedTarget:           asPtr(&types.InvalidVmConfig{}),
+			expectedOkay:             true,
+			expectedLocalizedMessage: "fake2",
+		},
+		{
+			name: "err is soap fault",
+			err: soap.WrapSoapFault(&soap.Fault{
+				Detail: struct {
+					Fault types.AnyType "xml:\",any,typeattr\""
+				}{
+					Fault: &types.SystemError{
+						RuntimeFault: types.RuntimeFault{
+							MethodFault: types.MethodFault{
+								FaultCause: &types.LocalizedMethodFault{
+									Fault: &types.InvalidVmConfig{},
+								},
+							},
+						},
+					},
+				},
+			}),
+			target:         asPtr[*types.InvalidVmConfig](),
+			expectedTarget: asPtr(&types.InvalidVmConfig{}),
+			expectedOkay:   true,
+		},
+		{
+			name: "err is soap fault with nil vim fault",
+			err: soap.WrapSoapFault(&soap.Fault{
+				Detail: struct {
+					Fault types.AnyType "xml:\",any,typeattr\""
+				}{
+					Fault: nil,
+				},
+			}),
+			target:         asPtr[*types.InvalidVmConfig](),
+			expectedTarget: asPtr[*types.InvalidVmConfig](),
+			expectedOkay:   false,
+		},
+		{
+			name: "err is vim fault",
+			err: soap.WrapVimFault(&types.SystemError{
+				RuntimeFault: types.RuntimeFault{
+					MethodFault: types.MethodFault{
+						FaultCause: &types.LocalizedMethodFault{
+							Fault: &types.InvalidVmConfig{},
+						},
+					},
+				},
+			}),
+			target:         asPtr[*types.InvalidVmConfig](),
+			expectedTarget: asPtr(&types.InvalidVmConfig{}),
+			expectedOkay:   true,
+		},
+		{
+			name: "err is vim fault with nil vim fault",
+			err: soap.WrapVimFault(&types.SystemError{
+				RuntimeFault: types.RuntimeFault{
+					MethodFault: types.MethodFault{
+						FaultCause: &types.LocalizedMethodFault{
+							Fault: nil,
+						},
+					},
+				},
+			}),
+			target:         asPtr[*types.InvalidVmConfig](),
+			expectedTarget: asPtr[*types.InvalidVmConfig](),
+			expectedOkay:   false,
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				okay             bool
+				localizedMessage string
+			)
+
+			if tc.expectedPanic != nil {
+				assert.PanicsWithValue(
+					t,
+					tc.expectedPanic,
+					func() {
+						localizedMessage, okay = fault.As(tc.err, tc.target)
+					})
+			} else {
+				localizedMessage, okay = fault.As(tc.err, tc.target)
+			}
+
+			assert.Equal(t, tc.expectedOkay, okay)
+			assert.Equal(t, tc.expectedLocalizedMessage, localizedMessage)
+			assert.Equal(t, tc.expectedTarget, tc.target)
+		})
+	}
+}
+
+type faultResult struct {
+	fault               types.BaseMethodFault
+	localizedMessage    string
+	localizableMessages []types.LocalizableMessage
+}
+
+type testHarness struct {
+	isNil                bool
+	numCalls             int
+	numCallsToReturnTrue int
+	results              []faultResult
+}
+
+func (h *testHarness) Callback(
+	fault types.BaseMethodFault,
+	localizedMessage string,
+	localizableMessages []types.LocalizableMessage) bool {
+
+	h.numCalls++
+
+	rvFault := reflect.ValueOf(fault)
+	if rvFault.Kind() == reflect.Pointer {
+		rvFault = rvFault.Elem()
+	}
+	emptyFault := reflect.New(rvFault.Type())
+
+	h.results = append(h.results, faultResult{
+		fault:               emptyFault.Interface().(types.BaseMethodFault),
+		localizedMessage:    localizedMessage,
+		localizableMessages: localizableMessages,
+	})
+	return h.numCallsToReturnTrue == h.numCalls
+}
+
+func TestIn(t *testing.T) {
+	const unsupported = "fault: err must implement error, types.BaseMethodFault, or types.HasLocalizedMethodFault"
+
+	testCases := []struct {
+		name             string
+		err              any
+		callback         *testHarness
+		expectedNumCalls int
+		expectedResults  []faultResult
+		expectedPanic    any
+	}{
+		{
+			name:             "err is nil",
+			err:              nil,
+			callback:         &testHarness{},
+			expectedNumCalls: 0,
+			expectedPanic:    unsupported,
+		},
+		{
+			name:             "callback is nil",
+			err:              errors.New("error"),
+			callback:         &testHarness{isNil: true},
+			expectedNumCalls: 0,
+			expectedPanic:    "fault: onFaultFn must not be nil",
+		},
+		{
+			name:             "err is unsupported",
+			err:              struct{}{},
+			callback:         &testHarness{},
+			expectedNumCalls: 0,
+			expectedPanic:    unsupported,
+		},
+		{
+			name:             "error is task.Error",
+			err:              task.Error{},
+			callback:         &testHarness{},
+			expectedNumCalls: 0,
+		},
+		{
+			name: "error is task.Error with localized message and fault",
+			err: task.Error{
+				LocalizedMethodFault: &types.LocalizedMethodFault{
+					LocalizedMessage: "fake",
+					Fault:            &types.SystemError{},
+				},
+			},
+			callback:         &testHarness{},
+			expectedNumCalls: 1,
+			expectedResults: []faultResult{
+				{
+					localizedMessage: "fake",
+					fault:            &types.SystemError{},
+				},
+			},
+		},
+		{
+			name:             "error is types.SystemError",
+			err:              &types.SystemError{},
+			callback:         &testHarness{},
+			expectedNumCalls: 1,
+			expectedResults: []faultResult{
+				{
+					fault: &types.SystemError{},
+				},
+			},
+		},
+		{
+			name: "error is task.Error with a localized message but no fault",
+			err: task.Error{
+				LocalizedMethodFault: &types.LocalizedMethodFault{
+					LocalizedMessage: "fake",
+				},
+			},
+			callback:         &testHarness{},
+			expectedNumCalls: 0,
+		},
+		{
+			name: "error is multiple, wrapped errors",
+			err: unwrappableErrSlice{
+				nil,
+				task.Error{
+					LocalizedMethodFault: &types.LocalizedMethodFault{
+						LocalizedMessage: "fake",
+						Fault:            &types.SystemError{},
+					},
+				},
+			},
+			callback:         &testHarness{},
+			expectedNumCalls: 1,
+			expectedResults: []faultResult{
+				{
+					localizedMessage: "fake",
+					fault:            &types.SystemError{},
+				},
+			},
+		},
+		{
+			name: "error has nested task.Error with localized message and fault",
+			err: fmt.Errorf(
+				"error 1: %w",
+				fmt.Errorf(
+					"error 2: %w",
+					task.Error{
+						LocalizedMethodFault: &types.LocalizedMethodFault{
+							LocalizedMessage: "fake",
+							Fault:            &types.SystemError{},
+						},
+					},
+				),
+			),
+			callback:         &testHarness{},
+			expectedNumCalls: 1,
+			expectedResults: []faultResult{
+				{
+					localizedMessage: "fake",
+					fault:            &types.SystemError{},
+				},
+			},
+		},
+		{
+			name: "error is task.Error with localized message and fault with localizable messages",
+			err: task.Error{
+				LocalizedMethodFault: &types.LocalizedMethodFault{
+					LocalizedMessage: "fake",
+					Fault: &types.SystemError{
+						RuntimeFault: types.RuntimeFault{
+							MethodFault: types.MethodFault{
+								FaultMessage: []types.LocalizableMessage{
+									{
+										Key:     "fake.id",
+										Message: "fake",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			callback:         &testHarness{},
+			expectedNumCalls: 1,
+			expectedResults: []faultResult{
+				{
+					fault:            &types.SystemError{},
+					localizedMessage: "fake",
+					localizableMessages: []types.LocalizableMessage{
+						{
+							Key:     "fake.id",
+							Message: "fake",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "error is task.Error with nested faults",
+			err: task.Error{
+				LocalizedMethodFault: &types.LocalizedMethodFault{
+					LocalizedMessage: "fake1",
+					Fault: &types.SystemError{
+						RuntimeFault: types.RuntimeFault{
+							MethodFault: types.MethodFault{
+								FaultMessage: []types.LocalizableMessage{
+									{
+										Key:     "fake1.id",
+										Message: "fake1",
+									},
+								},
+								FaultCause: &types.LocalizedMethodFault{
+									LocalizedMessage: "fake2",
+									Fault: &types.NotSupported{
+										RuntimeFault: types.RuntimeFault{
+											MethodFault: types.MethodFault{
+												FaultMessage: []types.LocalizableMessage{
+													{
+														Key:     "fake2.id",
+														Message: "fake2",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			callback:         &testHarness{},
+			expectedNumCalls: 2,
+			expectedResults: []faultResult{
+				{
+					fault:            &types.SystemError{},
+					localizedMessage: "fake1",
+					localizableMessages: []types.LocalizableMessage{
+						{
+							Key:     "fake1.id",
+							Message: "fake1",
+						},
+					},
+				},
+				{
+					fault:            &types.NotSupported{},
+					localizedMessage: "fake2",
+					localizableMessages: []types.LocalizableMessage{
+						{
+							Key:     "fake2.id",
+							Message: "fake2",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "error is task.Error with nested faults but returns after single fault",
+			err: task.Error{
+				LocalizedMethodFault: &types.LocalizedMethodFault{
+					LocalizedMessage: "fake1",
+					Fault: &types.SystemError{
+						RuntimeFault: types.RuntimeFault{
+							MethodFault: types.MethodFault{
+								FaultMessage: []types.LocalizableMessage{
+									{
+										Key:     "fake1.id",
+										Message: "fake1",
+									},
+								},
+								FaultCause: &types.LocalizedMethodFault{
+									LocalizedMessage: "fake2",
+									Fault: &types.NotSupported{
+										RuntimeFault: types.RuntimeFault{
+											MethodFault: types.MethodFault{
+												FaultMessage: []types.LocalizableMessage{
+													{
+														Key:     "fake2.id",
+														Message: "fake2",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			callback:         &testHarness{numCallsToReturnTrue: 1},
+			expectedNumCalls: 1,
+			expectedResults: []faultResult{
+				{
+					fault:            &types.SystemError{},
+					localizedMessage: "fake1",
+					localizableMessages: []types.LocalizableMessage{
+						{
+							Key:     "fake1.id",
+							Message: "fake1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "err is soap fault",
+			err: soap.WrapSoapFault(&soap.Fault{
+				Detail: struct {
+					Fault types.AnyType "xml:\",any,typeattr\""
+				}{
+					Fault: &types.SystemError{},
+				},
+			}),
+			callback:         &testHarness{numCallsToReturnTrue: 1},
+			expectedNumCalls: 1,
+			expectedResults: []faultResult{
+				{
+					fault: &types.SystemError{},
+				},
+			},
+		},
+		{
+			name:             "err is vim fault",
+			err:              soap.WrapVimFault(&types.SystemError{}),
+			callback:         &testHarness{numCallsToReturnTrue: 1},
+			expectedNumCalls: 1,
+			expectedResults: []faultResult{
+				{
+					fault: &types.SystemError{},
+				},
+			},
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var callback fault.OnFaultFn
+
+			if !tc.callback.isNil {
+				callback = tc.callback.Callback
+			}
+
+			if tc.expectedPanic != nil {
+				assert.PanicsWithValue(
+					t,
+					tc.expectedPanic,
+					func() {
+						fault.In(tc.err, callback)
+					})
+			} else {
+				fault.In(tc.err, callback)
+			}
+
+			assert.Equal(t, tc.expectedNumCalls, tc.callback.numCalls)
+			assert.Equal(t, tc.expectedResults, tc.callback.results)
+		})
+	}
+}
+
+func TestIs(t *testing.T) {
+
+	testCases := []struct {
+		name          string
+		err           any
+		target        types.BaseMethodFault
+		expectedOkay  bool
+		expectedPanic any
+	}{
+		{
+			name:         "err is nil",
+			err:          nil,
+			target:       &types.SystemError{},
+			expectedOkay: false,
+		},
+		{
+			name:         "target is nil",
+			err:          &types.SystemError{},
+			target:       nil,
+			expectedOkay: false,
+		},
+		{
+			name:         "target and error are nil",
+			err:          nil,
+			target:       nil,
+			expectedOkay: true,
+		},
+		{
+			name:         "err is not supported",
+			err:          struct{}{},
+			expectedOkay: false,
+		},
+		{
+			name:         "err and target are same value type",
+			err:          nilBaseMethodFault{},
+			target:       nilBaseMethodFault{},
+			expectedOkay: true,
+		},
+		{
+			name:         "target implements IsFault",
+			err:          isFaulter(true),
+			target:       &types.SystemError{},
+			expectedOkay: true,
+		},
+		{
+			name:         "err is *LocalizedMethodFault with nil fault",
+			err:          &types.LocalizedMethodFault{},
+			target:       &types.SystemError{},
+			expectedOkay: false,
+		},
+		{
+			name: "err is *LocalizedMethodFault with SystemError fault",
+			err: &types.LocalizedMethodFault{
+				Fault: &types.SystemError{},
+			},
+			target:       &types.SystemError{},
+			expectedOkay: true,
+		},
+		{
+			name: "err is *LocalizedMethodFault with InvalidVmConfig fault",
+			err: &types.LocalizedMethodFault{
+				Fault: &types.SystemError{},
+			},
+			target:       &types.InvalidVmConfig{},
+			expectedOkay: false,
+		},
+		{
+			name: "err is task.Error with nested InvalidVmConfig fault",
+			err: task.Error{
+				LocalizedMethodFault: &types.LocalizedMethodFault{
+					Fault: &types.SystemError{
+						RuntimeFault: types.RuntimeFault{
+							MethodFault: types.MethodFault{
+								FaultCause: &types.LocalizedMethodFault{
+									Fault: &types.InvalidVmConfig{},
+								},
+							},
+						},
+					},
+				},
+			},
+			target:       &types.InvalidVmConfig{},
+			expectedOkay: true,
+		},
+		{
+			name: "err is *LocalizedMethodFault with nested InvalidVmConfig fault",
+			err: &types.LocalizedMethodFault{
+				Fault: &types.SystemError{
+					RuntimeFault: types.RuntimeFault{
+						MethodFault: types.MethodFault{
+							FaultCause: &types.LocalizedMethodFault{
+								Fault: &types.InvalidVmConfig{},
+							},
+						},
+					},
+				},
+			},
+			target:       &types.InvalidVmConfig{},
+			expectedOkay: true,
+		},
+		{
+			name: "err is *LocalizedMethodFault with nested nil fault",
+			err: &types.LocalizedMethodFault{
+				Fault: &types.SystemError{
+					RuntimeFault: types.RuntimeFault{
+						MethodFault: types.MethodFault{
+							FaultCause: &types.LocalizedMethodFault{
+								Fault: nilBaseMethodFault{},
+							},
+						},
+					},
+				},
+			},
+			target:       &types.InvalidVmConfig{},
+			expectedOkay: false,
+		},
+		{
+			name: "err is wrapped task.Error with nested InvalidVmConfig fault",
+			err: fmt.Errorf("my error: %w", task.Error{
+				LocalizedMethodFault: &types.LocalizedMethodFault{
+					Fault: &types.SystemError{
+						RuntimeFault: types.RuntimeFault{
+							MethodFault: types.MethodFault{
+								FaultCause: &types.LocalizedMethodFault{
+									Fault: &types.InvalidVmConfig{},
+								},
+							},
+						},
+					},
+				},
+			}),
+			target:       &types.InvalidVmConfig{},
+			expectedOkay: true,
+		},
+		{
+			name:         "err is wrapped nil error",
+			err:          nilErrWrapper{},
+			target:       &types.InvalidVmConfig{},
+			expectedOkay: false,
+		},
+		{
+			name: "err is wrapped error slice with expected value",
+			err: unwrappableErrSlice{
+				nil,
+				task.Error{
+					LocalizedMethodFault: &types.LocalizedMethodFault{
+						Fault: &types.SystemError{
+							RuntimeFault: types.RuntimeFault{
+								MethodFault: types.MethodFault{
+									FaultCause: &types.LocalizedMethodFault{
+										Fault: &types.InvalidVmConfig{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			target:       &types.InvalidVmConfig{},
+			expectedOkay: true,
+		},
+		{
+			name: "err is wrapped error slice sans expected value",
+			err: unwrappableErrSlice{
+				nil,
+				task.Error{
+					LocalizedMethodFault: &types.LocalizedMethodFault{
+						Fault: &types.SystemError{
+							RuntimeFault: types.RuntimeFault{
+								MethodFault: types.MethodFault{
+									FaultCause: &types.LocalizedMethodFault{
+										Fault: &types.SystemError{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			target:       &types.InvalidVmConfig{},
+			expectedOkay: false,
+		},
+		{
+			name: "err is soap fault",
+			err: soap.WrapSoapFault(&soap.Fault{
+				Detail: struct {
+					Fault types.AnyType "xml:\",any,typeattr\""
+				}{
+					Fault: &types.SystemError{
+						RuntimeFault: types.RuntimeFault{
+							MethodFault: types.MethodFault{
+								FaultCause: &types.LocalizedMethodFault{
+									Fault: &types.InvalidVmConfig{},
+								},
+							},
+						},
+					},
+				},
+			}),
+			target:       &types.InvalidVmConfig{},
+			expectedOkay: true,
+		},
+		{
+			name: "err is soap fault with nil vim fault",
+			err: soap.WrapSoapFault(&soap.Fault{
+				Detail: struct {
+					Fault types.AnyType "xml:\",any,typeattr\""
+				}{
+					Fault: nil,
+				},
+			}),
+			target:       &types.InvalidVmConfig{},
+			expectedOkay: false,
+		},
+		{
+			name: "err is vim fault",
+			err: soap.WrapVimFault(&types.SystemError{
+				RuntimeFault: types.RuntimeFault{
+					MethodFault: types.MethodFault{
+						FaultCause: &types.LocalizedMethodFault{
+							Fault: &types.InvalidVmConfig{},
+						},
+					},
+				},
+			}),
+			target:       &types.InvalidVmConfig{},
+			expectedOkay: true,
+		},
+		{
+			name: "err is vim fault with nil vim fault",
+			err: soap.WrapVimFault(&types.SystemError{
+				RuntimeFault: types.RuntimeFault{
+					MethodFault: types.MethodFault{
+						FaultCause: &types.LocalizedMethodFault{
+							Fault: nil,
+						},
+					},
+				},
+			}),
+			target:       &types.InvalidVmConfig{},
+			expectedOkay: false,
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var okay bool
+
+			if tc.expectedPanic != nil {
+				assert.PanicsWithValue(
+					t,
+					tc.expectedPanic,
+					func() {
+						okay = fault.Is(tc.err, tc.target)
+					})
+			} else {
+				okay = fault.Is(tc.err, tc.target)
+			}
+
+			assert.Equal(t, tc.expectedOkay, okay)
+		})
+	}
+}

--- a/vim25/soap/error.go
+++ b/vim25/soap/error.go
@@ -62,6 +62,26 @@ func (s soapFaultError) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
+func (s soapFaultError) Fault() types.BaseMethodFault {
+	if s.fault != nil {
+		fault := s.fault.Detail.Fault
+		if fault == nil {
+			return nil
+		}
+		if f, ok := fault.(types.BaseMethodFault); ok {
+			return f
+		}
+		if val := reflect.ValueOf(fault); val.Kind() != reflect.Pointer {
+			ptrVal := reflect.New(val.Type())
+			ptrVal.Elem().Set(val)
+			if f, ok := ptrVal.Interface().(types.BaseMethodFault); ok {
+				return f
+			}
+		}
+	}
+	return nil
+}
+
 type vimFaultError struct {
 	fault types.BaseMethodFault
 }

--- a/vim25/types/fault.go
+++ b/vim25/types/fault.go
@@ -41,3 +41,15 @@ func IsAlreadyExists(err error) bool {
 
 	return false
 }
+
+// HasLocalizedMethodFault is any type that has a LocalizedMethodFault.
+type HasLocalizedMethodFault interface {
+
+	// GetLocalizedMethodFault returns the LocalizedMethodFault instance.
+	GetLocalizedMethodFault() *LocalizedMethodFault
+}
+
+// GetLocalizedMethodFault returns this LocalizedMethodFault.
+func (f *LocalizedMethodFault) GetLocalizedMethodFault() *LocalizedMethodFault {
+	return f
+}


### PR DESCRIPTION
## Description

This patch adds support for the new, top-level `fault` package with helper functions such as `As`, `In`, and `Is` for testing and traversing Golang `error` types and VMware `fault` types.

Closes: `NA`

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

With the command:

```shell
go test -v -count 1 -cover ./fault
```

The results shows there is 100% code coverage:

```shell
=== RUN   TestAs
=== RUN   TestAs/err_is_nil
=== PAUSE TestAs/err_is_nil
=== RUN   TestAs/err_is_not_supported
=== PAUSE TestAs/err_is_not_supported
=== RUN   TestAs/target_is_nil
=== PAUSE TestAs/target_is_nil
=== RUN   TestAs/target_is_not_pointer
=== PAUSE TestAs/target_is_not_pointer
=== RUN   TestAs/target_is_not_pointer_to_expected_type
=== PAUSE TestAs/target_is_not_pointer_to_expected_type
=== RUN   TestAs/err_is_task.Error_with_fault
=== PAUSE TestAs/err_is_task.Error_with_fault
=== RUN   TestAs/err_unwraps_to_nil_error
=== PAUSE TestAs/err_unwraps_to_nil_error
=== RUN   TestAs/err_unwraps_to_nil_error_slice
=== PAUSE TestAs/err_unwraps_to_nil_error_slice
=== RUN   TestAs/err_is_wrapped_task.Error_with_fault
=== PAUSE TestAs/err_is_wrapped_task.Error_with_fault
=== RUN   TestAs/err_is_wrapped_nil_error_and_task.Error_with_fault
=== PAUSE TestAs/err_is_wrapped_nil_error_and_task.Error_with_fault
=== RUN   TestAs/err_is_types.BaseMethodFault
=== PAUSE TestAs/err_is_types.BaseMethodFault
=== RUN   TestAs/err_is_types.BaseMethodFault_that_returns_nil
=== PAUSE TestAs/err_is_types.BaseMethodFault_that_returns_nil
=== RUN   TestAs/err_is_asFaulter_that_returns_true_and_fault
=== PAUSE TestAs/err_is_asFaulter_that_returns_true_and_fault
=== RUN   TestAs/err_is_asFaulter_that_returns_false
=== PAUSE TestAs/err_is_asFaulter_that_returns_false
=== RUN   TestAs/err_is_*types.LocalizedMethodFault
=== PAUSE TestAs/err_is_*types.LocalizedMethodFault
=== RUN   TestAs/err_is_*types.LocalizedMethodFault_w_nil_fault
=== PAUSE TestAs/err_is_*types.LocalizedMethodFault_w_nil_fault
=== RUN   TestAs/err_is_task.Error_with_nested_fault
=== PAUSE TestAs/err_is_task.Error_with_nested_fault
=== CONT  TestAs/err_is_nil
=== CONT  TestAs/err_is_task.Error_with_nested_fault
=== CONT  TestAs/err_unwraps_to_nil_error_slice
=== CONT  TestAs/err_unwraps_to_nil_error
=== CONT  TestAs/err_is_wrapped_task.Error_with_fault
=== CONT  TestAs/err_is_task.Error_with_fault
=== CONT  TestAs/err_is_asFaulter_that_returns_false
=== CONT  TestAs/err_is_types.BaseMethodFault_that_returns_nil
=== CONT  TestAs/err_is_wrapped_nil_error_and_task.Error_with_fault
=== CONT  TestAs/err_is_types.BaseMethodFault
=== CONT  TestAs/target_is_not_pointer_to_expected_type
=== CONT  TestAs/target_is_not_pointer
=== CONT  TestAs/target_is_nil
=== CONT  TestAs/err_is_not_supported
=== CONT  TestAs/err_is_*types.LocalizedMethodFault_w_nil_fault
=== CONT  TestAs/err_is_*types.LocalizedMethodFault
=== CONT  TestAs/err_is_asFaulter_that_returns_true_and_fault
--- PASS: TestAs (0.00s)
    --- PASS: TestAs/err_is_nil (0.00s)
    --- PASS: TestAs/err_unwraps_to_nil_error_slice (0.00s)
    --- PASS: TestAs/err_unwraps_to_nil_error (0.00s)
    --- PASS: TestAs/err_is_task.Error_with_nested_fault (0.00s)
    --- PASS: TestAs/err_is_asFaulter_that_returns_false (0.00s)
    --- PASS: TestAs/err_is_types.BaseMethodFault (0.00s)
    --- PASS: TestAs/err_is_wrapped_task.Error_with_fault (0.00s)
    --- PASS: TestAs/err_is_task.Error_with_fault (0.00s)
    --- PASS: TestAs/err_is_types.BaseMethodFault_that_returns_nil (0.00s)
    --- PASS: TestAs/err_is_wrapped_nil_error_and_task.Error_with_fault (0.00s)
    --- PASS: TestAs/err_is_not_supported (0.00s)
    --- PASS: TestAs/err_is_*types.LocalizedMethodFault_w_nil_fault (0.00s)
    --- PASS: TestAs/err_is_*types.LocalizedMethodFault (0.00s)
    --- PASS: TestAs/err_is_asFaulter_that_returns_true_and_fault (0.00s)
    --- PASS: TestAs/target_is_not_pointer_to_expected_type (0.00s)
    --- PASS: TestAs/target_is_nil (0.00s)
    --- PASS: TestAs/target_is_not_pointer (0.00s)
=== RUN   TestIn
=== RUN   TestIn/err_is_nil
=== PAUSE TestIn/err_is_nil
=== RUN   TestIn/callback_is_nil
=== PAUSE TestIn/callback_is_nil
=== RUN   TestIn/err_is_unsupported
=== PAUSE TestIn/err_is_unsupported
=== RUN   TestIn/error_is_task.Error
=== PAUSE TestIn/error_is_task.Error
=== RUN   TestIn/error_is_task.Error_with_localized_message_and_fault
=== PAUSE TestIn/error_is_task.Error_with_localized_message_and_fault
=== RUN   TestIn/error_is_types.SystemError
=== PAUSE TestIn/error_is_types.SystemError
=== RUN   TestIn/error_is_task.Error_with_a_localized_message_but_no_fault
=== PAUSE TestIn/error_is_task.Error_with_a_localized_message_but_no_fault
=== RUN   TestIn/error_is_multiple,_wrapped_errors
=== PAUSE TestIn/error_is_multiple,_wrapped_errors
=== RUN   TestIn/error_has_nested_task.Error_with_localized_message_and_fault
=== PAUSE TestIn/error_has_nested_task.Error_with_localized_message_and_fault
=== RUN   TestIn/error_is_task.Error_with_localized_message_and_fault_with_localizable_messages
=== PAUSE TestIn/error_is_task.Error_with_localized_message_and_fault_with_localizable_messages
=== RUN   TestIn/error_is_task.Error_with_nested_faults
=== PAUSE TestIn/error_is_task.Error_with_nested_faults
=== RUN   TestIn/error_is_task.Error_with_nested_faults_but_returns_after_single_fault
=== PAUSE TestIn/error_is_task.Error_with_nested_faults_but_returns_after_single_fault
=== CONT  TestIn/err_is_nil
=== CONT  TestIn/error_is_task.Error_with_a_localized_message_but_no_fault
=== CONT  TestIn/error_has_nested_task.Error_with_localized_message_and_fault
=== CONT  TestIn/error_is_task.Error_with_localized_message_and_fault_with_localizable_messages
=== CONT  TestIn/error_is_types.SystemError
=== CONT  TestIn/error_is_task.Error_with_localized_message_and_fault
=== CONT  TestIn/error_is_task.Error
=== CONT  TestIn/err_is_unsupported
=== CONT  TestIn/callback_is_nil
=== CONT  TestIn/error_is_task.Error_with_nested_faults
=== CONT  TestIn/error_is_multiple,_wrapped_errors
=== CONT  TestIn/error_is_task.Error_with_nested_faults_but_returns_after_single_fault
--- PASS: TestIn (0.00s)
    --- PASS: TestIn/error_is_task.Error_with_a_localized_message_but_no_fault (0.00s)
    --- PASS: TestIn/err_is_nil (0.00s)
    --- PASS: TestIn/error_has_nested_task.Error_with_localized_message_and_fault (0.00s)
    --- PASS: TestIn/error_is_types.SystemError (0.00s)
    --- PASS: TestIn/error_is_task.Error_with_localized_message_and_fault_with_localizable_messages (0.00s)
    --- PASS: TestIn/error_is_task.Error_with_localized_message_and_fault (0.00s)
    --- PASS: TestIn/error_is_task.Error (0.00s)
    --- PASS: TestIn/err_is_unsupported (0.00s)
    --- PASS: TestIn/callback_is_nil (0.00s)
    --- PASS: TestIn/error_is_task.Error_with_nested_faults (0.00s)
    --- PASS: TestIn/error_is_multiple,_wrapped_errors (0.00s)
    --- PASS: TestIn/error_is_task.Error_with_nested_faults_but_returns_after_single_fault (0.00s)
=== RUN   TestIs
=== RUN   TestIs/err_is_nil
=== PAUSE TestIs/err_is_nil
=== RUN   TestIs/target_is_nil
=== PAUSE TestIs/target_is_nil
=== RUN   TestIs/target_and_error_are_nil
=== PAUSE TestIs/target_and_error_are_nil
=== RUN   TestIs/err_is_not_supported
=== PAUSE TestIs/err_is_not_supported
=== RUN   TestIs/err_and_target_are_same_value_type
=== PAUSE TestIs/err_and_target_are_same_value_type
=== RUN   TestIs/target_implements_IsFault
=== PAUSE TestIs/target_implements_IsFault
=== RUN   TestIs/err_is_*LocalizedMethodFault_with_nil_fault
=== PAUSE TestIs/err_is_*LocalizedMethodFault_with_nil_fault
=== RUN   TestIs/err_is_*LocalizedMethodFault_with_SystemError_fault
=== PAUSE TestIs/err_is_*LocalizedMethodFault_with_SystemError_fault
=== RUN   TestIs/err_is_*LocalizedMethodFault_with_InvalidVmConfig_fault
=== PAUSE TestIs/err_is_*LocalizedMethodFault_with_InvalidVmConfig_fault
=== RUN   TestIs/err_is_task.Error_with_nested_InvalidVmConfig_fault
=== PAUSE TestIs/err_is_task.Error_with_nested_InvalidVmConfig_fault
=== RUN   TestIs/err_is_*LocalizedMethodFault_with_nested_InvalidVmConfig_fault
=== PAUSE TestIs/err_is_*LocalizedMethodFault_with_nested_InvalidVmConfig_fault
=== RUN   TestIs/err_is_*LocalizedMethodFault_with_nested_nil_fault
=== PAUSE TestIs/err_is_*LocalizedMethodFault_with_nested_nil_fault
=== RUN   TestIs/err_is_wrapped_task.Error_with_nested_InvalidVmConfig_fault
=== PAUSE TestIs/err_is_wrapped_task.Error_with_nested_InvalidVmConfig_fault
=== RUN   TestIs/err_is_wrapped_nil_error
=== PAUSE TestIs/err_is_wrapped_nil_error
=== RUN   TestIs/err_is_wrapped_error_slice_with_expected_value
=== PAUSE TestIs/err_is_wrapped_error_slice_with_expected_value
=== RUN   TestIs/err_is_wrapped_error_slice_sans_expected_value
=== PAUSE TestIs/err_is_wrapped_error_slice_sans_expected_value
=== CONT  TestIs/err_is_nil
=== CONT  TestIs/err_is_*LocalizedMethodFault_with_InvalidVmConfig_fault
=== CONT  TestIs/err_is_wrapped_task.Error_with_nested_InvalidVmConfig_fault
=== CONT  TestIs/err_is_*LocalizedMethodFault_with_nested_InvalidVmConfig_fault
=== CONT  TestIs/err_is_*LocalizedMethodFault_with_SystemError_fault
=== CONT  TestIs/err_is_task.Error_with_nested_InvalidVmConfig_fault
=== CONT  TestIs/err_is_*LocalizedMethodFault_with_nested_nil_fault
=== CONT  TestIs/err_is_wrapped_error_slice_sans_expected_value
=== CONT  TestIs/err_is_wrapped_error_slice_with_expected_value
=== CONT  TestIs/err_is_*LocalizedMethodFault_with_nil_fault
=== CONT  TestIs/target_implements_IsFault
=== CONT  TestIs/err_is_not_supported
=== CONT  TestIs/target_and_error_are_nil
=== CONT  TestIs/target_is_nil
=== CONT  TestIs/err_is_wrapped_nil_error
=== CONT  TestIs/err_and_target_are_same_value_type
--- PASS: TestIs (0.00s)
    --- PASS: TestIs/err_is_nil (0.00s)
    --- PASS: TestIs/err_is_*LocalizedMethodFault_with_InvalidVmConfig_fault (0.00s)
    --- PASS: TestIs/err_is_*LocalizedMethodFault_with_SystemError_fault (0.00s)
    --- PASS: TestIs/err_is_*LocalizedMethodFault_with_nested_InvalidVmConfig_fault (0.00s)
    --- PASS: TestIs/err_is_*LocalizedMethodFault_with_nested_nil_fault (0.00s)
    --- PASS: TestIs/err_is_wrapped_task.Error_with_nested_InvalidVmConfig_fault (0.00s)
    --- PASS: TestIs/err_is_task.Error_with_nested_InvalidVmConfig_fault (0.00s)
    --- PASS: TestIs/err_is_wrapped_error_slice_sans_expected_value (0.00s)
    --- PASS: TestIs/err_is_wrapped_error_slice_with_expected_value (0.00s)
    --- PASS: TestIs/err_is_*LocalizedMethodFault_with_nil_fault (0.00s)
    --- PASS: TestIs/target_implements_IsFault (0.00s)
    --- PASS: TestIs/err_is_not_supported (0.00s)
    --- PASS: TestIs/target_and_error_are_nil (0.00s)
    --- PASS: TestIs/target_is_nil (0.00s)
    --- PASS: TestIs/err_is_wrapped_nil_error (0.00s)
    --- PASS: TestIs/err_and_target_are_same_value_type (0.00s)
=== RUN   ExampleAs_faultByAddress
--- PASS: ExampleAs_faultByAddress (0.00s)
=== RUN   ExampleAs_faultByValue
--- PASS: ExampleAs_faultByValue (0.00s)
=== RUN   ExampleIs_baseMethodFault
--- PASS: ExampleIs_baseMethodFault (0.00s)
=== RUN   ExampleIs_nestedFault
--- PASS: ExampleIs_nestedFault (0.00s)
=== RUN   ExampleIn_printAllTypeNamesAndMessages
--- PASS: ExampleIn_printAllTypeNamesAndMessages (0.00s)
=== RUN   ExampleIn_printFirstDiscoveredTypeNameAndMessage
--- PASS: ExampleIn_printFirstDiscoveredTypeNameAndMessage (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/vmware/govmomi/fault	0.303s	coverage: 100.0% of statements
```

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
