### PR TITLE
Update library state info to content library API

### DIFF
--- a/vapi/library/library.go
+++ b/vapi/library/library.go
@@ -50,6 +50,13 @@ type Library struct {
 	Publication           *Publication     `json:"publish_info,omitempty"`
 	SecurityPolicyID      string           `json:"security_policy_id,omitempty"`
 	UnsetSecurityPolicyID bool             `json:"unset_security_policy_id,omitempty"`
+	ServerGUID            string           `json:"server_guid,omitempty"`
+	StateInfo             *StateInfo       `json:"state_info,omitempty"`
+}
+
+// StateInfo provides the state info of a content library.
+type StateInfo struct {
+	State string `json:"state"`
 }
 
 // Subscription info

--- a/vapi/library/library_test.go
+++ b/vapi/library/library_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25"
+
+	_ "github.com/vmware/govmomi/vapi/simulator"
+)
+
+func TestManagerCreateLibrary(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		c := rest.NewClient(vc)
+
+		err := c.Login(ctx, simulator.DefaultLogin)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ds, err := find.NewFinder(vc).DefaultDatastore(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		m := library.NewManager(c)
+
+		libName := "example"
+		libType := "LOCAL"
+		id, err := m.CreateLibrary(ctx, library.Library{
+			Name: libName,
+			Type: libType,
+			Storage: []library.StorageBacking{{
+				DatastoreID: ds.Reference().Value,
+				Type:        "DATASTORE",
+			}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		l, err := m.GetLibraryByID(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if l.ID == "" {
+			t.Fatal("library ID should be generated")
+		}
+		if l.ServerGUID == "" {
+			t.Fatal("library server GUID should be generated")
+		}
+		if l.Name != libName {
+			t.Fatalf("expected library name %s, got %s", libName, l.Name)
+		}
+		if l.Type != libType {
+			t.Fatalf("expected library type %s, got %s", libType, l.Type)
+		}
+		if len(l.Storage) == 0 {
+			t.Fatal("library should have a storage backing")
+		}
+		if l.Storage[0].Type != "DATASTORE" {
+			t.Fatalf("expected library storage type DATASTORE, got %s", l.Storage[0].Type)
+		}
+		if l.Storage[0].DatastoreID != ds.Reference().Value {
+			t.Fatalf("expected library datastore ref %s, got %s", ds.Reference().Value, l.Storage[0].DatastoreID)
+		}
+		if l.StateInfo == nil || l.StateInfo.State != "ACTIVE" {
+			t.Fatal("library should have state ACTIVE")
+		}
+	})
+}

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -919,6 +919,7 @@ func (s *handler) library(w http.ResponseWriter, r *http.Request) {
 
 			id := uuid.New().String()
 			spec.Library.ID = id
+			spec.Library.ServerGUID = uuid.New().String()
 			spec.Library.CreationTime = types.NewTime(time.Now())
 			spec.Library.LastModifiedTime = types.NewTime(time.Now())
 			spec.Library.UnsetSecurityPolicyID = spec.Library.SecurityPolicyID == ""
@@ -952,6 +953,8 @@ func (s *handler) library(w http.ResponseWriter, r *http.Request) {
 					s.Library[id].Item = p.Item
 				}
 			}
+
+			spec.Library.StateInfo = &library.StateInfo{State: "ACTIVE"}
 
 			OK(w, id)
 		}


### PR DESCRIPTION
## Description

Add the optional state info and server guid to Library type, both fields are the info for read only (get API), also update the fields to the library simulator and example test accordingly.

Closes: #3542

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Unit tests via simulator

=== RUN   TestManagerCreateLibrary
created library example
--- PASS: TestManagerCreateLibrary (0.36s)
PASS

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
