### PR TITLE
vcsim: Support PlaceVm with relocate placement type

### DIFF
--- a/simulator/cluster_compute_resource.go
+++ b/simulator/cluster_compute_resource.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator/esx"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -455,10 +456,9 @@ func (c *ClusterComputeResource) PlaceVm(ctx *Context, req *types.PlaceVm) soap.
 	case types.PlacementSpecPlacementTypeReconfigure:
 		// Validate input.
 		if req.PlacementSpec.ConfigSpec == nil {
-			invalidArg := &types.InvalidArgument{
+			body.Fault_ = Fault("", &types.InvalidArgument{
 				InvalidProperty: "PlacementSpec.configSpec",
-			}
-			body.Fault_ = Fault("", invalidArg)
+			})
 			return body
 		}
 
@@ -475,6 +475,24 @@ func (c *ClusterComputeResource) PlaceVm(ctx *Context, req *types.PlaceVm) soap.
 			TargetHost:   spec.Host,
 			RelocateSpec: spec,
 		})
+	case types.PlacementSpecPlacementTypeRelocate:
+		// Validate fields of req.PlacementSpec, if explicitly provided.
+		if !validatePlacementSpecForPlaceVmRelocate(ctx, req, body) {
+			return body
+		}
+
+		// After validating req.PlacementSpec, we must have a valid req.PlacementSpec.Vm.
+		vmObj := ctx.Map.Get(*req.PlacementSpec.Vm).(*VirtualMachine)
+
+		// Populate RelocateSpec's common fields, if not explicitly provided.
+		populateRelocateSpecForPlaceVmRelocate(&req.PlacementSpec.RelocateSpec, vmObj)
+
+		// Update PlacementResult.
+		res.Action = append(res.Action, &types.PlacementAction{
+			Vm:           req.PlacementSpec.Vm,
+			TargetHost:   req.PlacementSpec.RelocateSpec.Host,
+			RelocateSpec: req.PlacementSpec.RelocateSpec,
+		})
 	default:
 		log.Printf("unsupported placement type: %s", req.PlacementSpec.PlacementType)
 		body.Fault_ = Fault("", new(types.NotSupported))
@@ -488,6 +506,134 @@ func (c *ClusterComputeResource) PlaceVm(ctx *Context, req *types.PlaceVm) soap.
 	}
 
 	return body
+}
+
+// validatePlacementSpecForPlaceVmRelocate validates the fields of req.PlacementSpec for a relocate placement type.
+// Returns true if the fields are valid, false otherwise.
+func validatePlacementSpecForPlaceVmRelocate(ctx *Context, req *types.PlaceVm, body *methods.PlaceVmBody) bool {
+	if req.PlacementSpec.Vm == nil {
+		body.Fault_ = Fault("", &types.InvalidArgument{
+			InvalidProperty: "PlacementSpec",
+		})
+		return false
+	}
+
+	// Oddly when the VM is not found, PlaceVm complains about configSpec being invalid, despite this being
+	// a relocate placement type. Possibly due to treating the missing VM as a create placement type
+	// internally, which requires the configSpec to be present.
+	vmObj, exist := ctx.Map.Get(*req.PlacementSpec.Vm).(*VirtualMachine)
+	if !exist {
+		body.Fault_ = Fault("", &types.InvalidArgument{
+			InvalidProperty: "PlacementSpec.configSpec",
+		})
+		return false
+	}
+
+	return validateRelocateSpecForPlaceVmRelocate(ctx, req.PlacementSpec.RelocateSpec, body, vmObj)
+}
+
+// validateRelocateSpecForPlaceVmRelocate validates the fields of req.PlacementSpec.RelocateSpec for a relocate
+// placement type. Returns true if the fields are valid, false otherwise.
+func validateRelocateSpecForPlaceVmRelocate(ctx *Context, spec *types.VirtualMachineRelocateSpec, body *methods.PlaceVmBody, vmObj *VirtualMachine) bool {
+	if spec == nil {
+		// An empty relocate spec is valid, as it will be populated with default values.
+		return true
+	}
+
+	if spec.Host != nil {
+		if _, exist := ctx.Map.Get(*spec.Host).(*HostSystem); !exist {
+			body.Fault_ = Fault("", &types.ManagedObjectNotFound{
+				Obj: *spec.Host,
+			})
+			return false
+		}
+	}
+
+	if spec.Datastore != nil {
+		if _, exist := ctx.Map.Get(*spec.Datastore).(*Datastore); !exist {
+			body.Fault_ = Fault("", &types.ManagedObjectNotFound{
+				Obj: *spec.Datastore,
+			})
+			return false
+		}
+	}
+
+	if spec.Pool != nil {
+		if _, exist := ctx.Map.Get(*spec.Pool).(*ResourcePool); !exist {
+			body.Fault_ = Fault("", &types.ManagedObjectNotFound{
+				Obj: *spec.Pool,
+			})
+			return false
+		}
+	}
+
+	if spec.Disk != nil {
+		deviceList := object.VirtualDeviceList(vmObj.Config.Hardware.Device)
+		vdiskList := deviceList.SelectByType(&types.VirtualDisk{})
+		for _, disk := range spec.Disk {
+			var diskFound bool
+			for _, vdisk := range vdiskList {
+				if disk.DiskId == vdisk.GetVirtualDevice().Key {
+					diskFound = true
+					break
+				}
+			}
+			if !diskFound {
+				body.Fault_ = Fault("", &types.InvalidArgument{
+					InvalidProperty: "PlacementSpec.vm",
+				})
+				return false
+			}
+
+			// Unlike a non-existing spec.Datastore that throws ManagedObjectNotFound, a non-existing disk.Datastore
+			// throws InvalidArgument.
+			if _, exist := ctx.Map.Get(disk.Datastore).(*Datastore); !exist {
+				body.Fault_ = Fault("", &types.InvalidArgument{
+					InvalidProperty: "RelocateSpec",
+				})
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// populateRelocateSpecForPlaceVmRelocate populates the fields of req.PlacementSpec.RelocateSpec for a relocate
+// placement type, if not explicitly provided.
+func populateRelocateSpecForPlaceVmRelocate(specPtr **types.VirtualMachineRelocateSpec, vmObj *VirtualMachine) {
+	if *specPtr == nil {
+		*specPtr = &types.VirtualMachineRelocateSpec{}
+	}
+
+	spec := *specPtr
+
+	if spec.DiskMoveType == "" {
+		spec.DiskMoveType = string(types.VirtualMachineRelocateDiskMoveOptionsMoveAllDiskBackingsAndDisallowSharing)
+	}
+
+	if spec.Datastore == nil {
+		spec.Datastore = &vmObj.Datastore[0]
+	}
+
+	if spec.Host == nil {
+		spec.Host = vmObj.Runtime.Host
+	}
+
+	if spec.Pool == nil {
+		spec.Pool = vmObj.ResourcePool
+	}
+
+	if spec.Disk == nil {
+		deviceList := object.VirtualDeviceList(vmObj.Config.Hardware.Device)
+		for _, vdisk := range deviceList.SelectByType(&types.VirtualDisk{}) {
+			spec.Disk = append(spec.Disk, types.VirtualMachineRelocateSpecDiskLocator{
+				DiskId:       vdisk.GetVirtualDevice().Key,
+				Datastore:    *spec.Datastore,
+				DiskMoveType: spec.DiskMoveType,
+			})
+		}
+	}
 }
 
 func CreateClusterComputeResource(ctx *Context, f *Folder, name string, spec types.ClusterConfigSpecEx) (*ClusterComputeResource, types.BaseMethodFault) {


### PR DESCRIPTION
## Description

This patch introduces basic support for `ClusterComputeResource.PlaceVm` with the `relocate` placement type in vcsim. Since relocate is a supported placement type in real vSphere environments, it is essential to ensure that our simulator environment reflects this capability for accurate and comprehensive testing.

Closes: #3540 

## Type of change

Please mark options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

All of the added unit tests simulate behavior (i.e., expected Faults/Recommendations) when testing the same `PlacementSpec` against a real vSphere environment.
```
% go test -v -count 1 -run 'TestPlaceVm' -coverprofile cover.out ./simulator

=== RUN   TestPlaceVmReconfigure
2024/09/06 14:56:08 unsupported placement type: unsupported
--- PASS: TestPlaceVmReconfigure (1.76s)
=== RUN   TestPlaceVmRelocate
--- PASS: TestPlaceVmRelocate (0.39s)
=== RUN   TestPlaceVmsXCluster
--- PASS: TestPlaceVmsXCluster (0.87s)
PASS
coverage: 27.4% of statements
ok      github.com/vmware/govmomi/simulator     3.455s  coverage: 27.4% of statements
```

```
go tool cover -html=cover.out -o=coverage.html 
```
100% code coverage on new code:
![Screenshot 2024-09-06 at 2 59 18 PM](https://github.com/user-attachments/assets/244ca43a-fb8f-42c9-8649-c18718adddec)
![Screenshot 2024-09-06 at 2 59 30 PM](https://github.com/user-attachments/assets/0adc9291-0bdb-42e1-9016-0358b6f2c53e)
![Screenshot 2024-09-06 at 2 59 41 PM](https://github.com/user-attachments/assets/3da01fbc-d500-43e9-a302-0e4e5f09bab4)
![Screenshot 2024-09-06 at 2 59 56 PM](https://github.com/user-attachments/assets/793fa942-ad30-478e-97a2-3633764fbf4b)

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
