### PR TITLE
fix: Use absolute path for reading manifest

### DIFF
--- a/ovf/importer/importer.go
+++ b/ovf/importer/importer.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -58,15 +57,16 @@ type Importer struct {
 	Manifest map[string]*library.Checksum
 }
 
-func (imp *Importer) ReadManifest(fpath string) error {
+func (imp *Importer) manifestPath(fpath string) string {
 	base := filepath.Base(fpath)
 	ext := filepath.Ext(base)
-	mfName := strings.Replace(base, ext, ".mf", 1)
+	return filepath.Join(filepath.Dir(fpath), strings.Replace(base, ext, ".mf", 1))
+}
 
-	mf, _, err := imp.Archive.Open(mfName)
+func (imp *Importer) ReadManifest(fpath string) error {
+	mf, _, err := imp.Archive.Open(imp.manifestPath(fpath))
 	if err != nil {
-		msg := fmt.Sprintf("manifest %q: %s", mf, err)
-		fmt.Fprintln(os.Stderr, msg)
+		msg := fmt.Sprintf("failed to read manifest %q: %s", mf, err)
 		return errors.New(msg)
 	}
 	imp.Manifest, err = library.ReadManifest(mf)

--- a/ovf/importer/importer_test.go
+++ b/ovf/importer/importer_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package importer
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestImporter_manifestPath(t *testing.T) {
+	// We can only test filepath operations on the target OS
+	manifestTests := []struct {
+		goos     string
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			goos:     "linux",
+			name:     "linux path",
+			path:     "/home/user/foo/bar/qux.ovf",
+			expected: "/home/user/foo/bar/qux.mf",
+		},
+		{
+			goos:     "darwin",
+			name:     "darwin path",
+			path:     "/home/user/foo/bar/qux.ovf",
+			expected: "/home/user/foo/bar/qux.mf",
+		},
+		{
+			goos:     "windows",
+			name:     "windows path",
+			path:     "C:\\ProgramData\\Foo\\Bar\\Qux.ovf",
+			expected: "C:\\ProgramData\\Foo\\Bar\\Qux.mf",
+		},
+	}
+
+	imp := Importer{}
+
+	for _, test := range manifestTests {
+		if test.goos == runtime.GOOS {
+			manifestPath := imp.manifestPath(test.path)
+			if manifestPath != test.expected {
+				t.Fatalf("'%s' failed: expected '%s', got '%s'", test.name, test.expected, manifestPath)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

Closes: #3550

Ensure the absolute path to the manifest is used.

Also stops any error from being printed on stderr.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Test case added.

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
