### PR TITLE
fix: Abort lease on upload failure

### DIFF
--- a/ovf/importer/importer.go
+++ b/ovf/importer/importer.go
@@ -161,6 +161,7 @@ func (imp *Importer) Import(ctx context.Context, fpath string, opts Options) (*t
 
 	info, err := lease.Wait(ctx, spec.FileItem)
 	if err != nil {
+		_ = lease.Abort(ctx, nil)
 		return nil, err
 	}
 
@@ -169,6 +170,11 @@ func (imp *Importer) Import(ctx context.Context, fpath string, opts Options) (*t
 
 	for _, i := range info.Items {
 		if err := imp.Upload(ctx, lease, i); err != nil {
+			_ = lease.Abort(ctx, &types.LocalizedMethodFault{
+				Fault: &types.FileFault{
+					File: i.Path,
+				},
+			})
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Description

Aborts the lease on OVF upload failure.

Closes #3554.

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Tested internally.

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
