### PR TITLE
fix: Use absolute paths when uploading OVF files

### DIFF
--- a/ovf/importer/importer.go
+++ b/ovf/importer/importer.go
@@ -168,7 +168,7 @@ func (imp *Importer) Import(ctx context.Context, fpath string, opts Options) (*t
 	defer u.Done()
 
 	for _, i := range info.Items {
-		if err := imp.Upload(ctx, lease, i); err != nil {
+		if err := imp.Upload(ctx, lease, i, filepath.Dir(fpath)); err != nil {
 			return nil, err
 		}
 	}
@@ -281,10 +281,10 @@ func ValidateChecksum(ctx context.Context, lease *nfc.Lease, sum *library.Checks
 	return errors.New(msg)
 }
 
-func (imp *Importer) Upload(ctx context.Context, lease *nfc.Lease, item nfc.FileItem) error {
+func (imp *Importer) Upload(ctx context.Context, lease *nfc.Lease, item nfc.FileItem, srcDir string) error {
 	file := item.Path
 
-	f, size, err := imp.Archive.Open(file)
+	f, size, err := imp.Archive.Open(filepath.Join(srcDir, file))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Use absolute paths when opening files on disk for upload.

Closes #3555

## Type of change

Please mark options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
- [ ] Build related change

## How Has This Been Tested?

Tested internally.

## Checklist:

- [x] My code follows the `CONTRIBUTION` [guidelines] of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
