### PR TITLE
Various Docs and GitHub chores

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,38 +1,15 @@
 ## Description
 
-Please include a summary of the change and which issue is fixed. Please also
-include relevant motivation and context. List any dependencies that are required
-for this change.
+Please include a summary of the change.
 
 Closes: #(issue-number)
 
-## Type of change
-
-Please mark options that are relevant:
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to
-  not work as expected)
-- [ ] This change requires a documentation update
-- [ ] Build related change
-
 ## How Has This Been Tested?
 
-Please describe the tests that you ran to verify your changes. Provide
-instructions so we can reproduce. If applicable, please also list any relevant
-details for your test configuration.
+Please describe any manual tests done to verify your changes.
 
-- [ ] Test Description 1
-- [ ] Test Description 2
+## Guidelines
 
-## Checklist:
-
-- [ ] My code follows the `CONTRIBUTION` [guidelines] of this project
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged
+Please read and follow the `CONTRIBUTION` [guidelines] of this project.
 
 [guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md

--- a/.github/workflows/govmomi-build.yaml
+++ b/.github/workflows/govmomi-build.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.22
 
       - name: Restore Go cache
         uses: actions/cache@v4
@@ -54,9 +54,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.21-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.22-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.21-
+            ${{ runner.os }}-go-1.22-
 
       - name: Create CHANGELOG
         env:

--- a/.github/workflows/govmomi-go-lint.yaml
+++ b/.github/workflows/govmomi-go-lint.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.22
         id: go
 
       - name: Go Lint
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.22
         id: go
 
       - name: Install Tools

--- a/.github/workflows/govmomi-go-tests.yaml
+++ b/.github/workflows/govmomi-go-tests.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Run Unit Tests
     strategy:
       matrix:
-        go-version: ["1.21", "1.22"]
+        go-version: ["1.22", "1.23"]
         platform: ["ubuntu-20.04"]
       fail-fast: false
 

--- a/.github/workflows/govmomi-govc-tests.yaml
+++ b/.github/workflows/govmomi-govc-tests.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.21"]
+        go-version: ["1.22"]
         platform: ["ubuntu-20.04"]
         cmd: ["govc-test"]
         experimental: [false]
@@ -73,7 +73,7 @@ jobs:
     name: Verify govc docs are up2date
     strategy:
       matrix:
-        go-version: ["1.21"]
+        go-version: ["1.22"]
         platform: ["ubuntu-20.04"]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 3

--- a/.github/workflows/govmomi-release.yaml
+++ b/.github/workflows/govmomi-release.yaml
@@ -23,7 +23,7 @@ on:
         type: string
         default: 'v0.99.0'
       dryrun:
-        description: 'Verify release workflow without pushing any changes (catches most but not all errors)'
+        description: 'Dry Run (verify workflow without pushing a release)'
         type: boolean
         required: false
         default: true
@@ -102,9 +102,9 @@ jobs:
 
           # check whether the new tag is also the latest
           if [[ $LATEST == $TAG ]]; then
-            echo "islatest::true >> $GITHUB_OUTPUT"
+            echo "islatest=true >> $GITHUB_OUTPUT"
           else
-            echo "islatest::false >> $GITHUB_OUTPUT"
+            echo "islatest=false >> $GITHUB_OUTPUT"
           fi
 
       - name: Push changes and tag to release branch

--- a/.github/workflows/govmomi-release.yaml
+++ b/.github/workflows/govmomi-release.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
 
       - name: Update version.go
         run: |

--- a/.mailmap
+++ b/.mailmap
@@ -57,3 +57,9 @@ Yun Zhou <yunz@vmware.com> <41678287+gh05tn0va@users.noreply.github.com>
 Zach G <zguan@vmware.com> zach96guan <zach96guan@users.noreply.github.com>
 Zach Tucker <ztucker@vmware.com> <jzt@users.noreply.github.com>
 Zee Yang <zeey@vmware.com> <zee.yang@gmail.com>
+Arunesh Pandey <parunesh@vmware.com> Arunesh Pandey <aruneshpa@gmail.com>
+Eric Cao <ecao@vmware.com> Eric Cao <32748317+ericvmw@users.noreply.github.com>
+Eric Cao <ecao@vmware.com> Eric Cao <eric.cao@broadcom.com>
+Ryan Johnson <johnsonryan@vmware.com> Ryan Johnson <ryan.johnson@broadcom.com>
+Stoyan Zhelyazkov <stoyan.zhelyazkov@broadcom.com> Stoyan Zhelyazkov <156204153+spacegospod@users.noreply.github.com>
+Yanlei Zhao <yanleizhao@vmware.com> Yanlei Zhao <136122252+yanleizhao-vmware@users.noreply.github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,559 @@
 
+<a name="v0.43.0"></a>
+## [Release v0.43.0](https://github.com/vmware/govmomi/compare/v0.42.0...v0.43.0)
+
+> Release Date: 2024-09-10
+
+### 🐞 Fix
+
+- [97aa7214]	vcsim: avoid possible race when encoding PropertyCollector response
+- [ad2d3573]	use complete InventoryPath in Datacenter.Folders
+
+### 💫 API Changes
+
+- [476704a3]	Fault helpers
+- [caad54aa]	add VirtualMachine.AddDeviceWithProfile method
+- [a316da5c]	VirtualMachine.AttachDisk unitNumber param is optional
+- [8491321a]	ToString for vim types
+- [64610213]	add namespace.RegisterVM binding
+- [e602029e]	Fix panic when encoding nil iface ptrs to JSON
+
+### 💫 `govc` (CLI)
+
+- [8fd86912]	add disk.create '-profile' flag
+- [ea3cf257]	add vm.disk.create '-profile' flag
+- [e73c34fa]	add vm.disk.attach '-profile' flag
+- [06dcf31a]	Add '-size' flag to datastore.create
+- [23390c23]	add namespace.registervm command
+- [1892eecd]	Support thick/eager disk opts on vm.create
+
+### 💫 `vcsim` (Simulator)
+
+- [8421b678]	Support PlaceVm with relocate placement type
+- [9234233e]	Support PlaceVm with reconfigure placement type
+- [f06d0834]	add VirtualMachine AttachDisk and DetachDisk methods
+- [35dc193f]	Support VM crypto spec in vC Sim
+- [0517b87e]	add namespace/registervm implementation
+
+### 🧹 Chore
+
+- [b17abb20]	Update version.go for v0.43.0
+- [93da4a20]	sync generated govc/USAGE.md
+- [51105db8]	govc: add common StorageProfileFlag
+
+### ⚠️ BREAKING
+
+VirtualMachine.AttachDisk unitNumber param is optional [a316da5c]:
+switching from int32 to *int32, otherwise the client must choose a valid unitNumber.
+vCenter will choose a unitNumber when not provided.
+
+### 📖 Commits
+
+- [b17abb20]	chore: Update version.go for v0.43.0
+- [476704a3]	api: Fault helpers
+- [8421b678]	vcsim: Support PlaceVm with relocate placement type
+- [93b97e18]	Update library state info to content library API
+- [9234233e]	vcsim: Support PlaceVm with reconfigure placement type
+- [a2cbe108]	build(deps): bump golang.org/x/text from 0.17.0 to 0.18.0
+- [93da4a20]	chore: sync generated govc/USAGE.md
+- [8fd86912]	govc: add disk.create '-profile' flag
+- [ea3cf257]	govc: add vm.disk.create '-profile' flag
+- [e73c34fa]	govc: add vm.disk.attach '-profile' flag
+- [51105db8]	chore: govc: add common StorageProfileFlag
+- [caad54aa]	api: add VirtualMachine.AddDeviceWithProfile method
+- [f06d0834]	vcsim: add VirtualMachine AttachDisk and DetachDisk methods
+- [97aa7214]	fix: vcsim: avoid possible race when encoding PropertyCollector response
+- [014a150b]	build(deps): bump peter-evans/create-pull-request from 6 to 7
+- [35dc193f]	vcsim: Support VM crypto spec in vC Sim
+- [a56e33d3]	Add BackingDiskPath to BackingObjectDetails
+- [06dcf31a]	govc: Add '-size' flag to datastore.create
+- [f881d9b6]	govc add disk.attach and disk.detach commands
+- [a316da5c]	api: VirtualMachine.AttachDisk unitNumber param is optional
+- [8491321a]	api: ToString for vim types
+- [0517b87e]	vcsim: add namespace/registervm implementation
+- [23390c23]	govc: add namespace.registervm command
+- [64610213]	api: add namespace.RegisterVM binding
+- [e602029e]	api: Fix panic when encoding nil iface ptrs to JSON
+- [1892eecd]	govc: Support thick/eager disk opts on vm.create
+- [ad2d3573]	fix: use complete InventoryPath in Datacenter.Folders
+
+<a name="v0.42.0"></a>
+## [Release v0.42.0](https://github.com/vmware/govmomi/compare/v0.41.0...v0.42.0)
+
+> Release Date: 2024-08-16
+
+### 💫 API Changes
+
+- [3fd16f78]	update eam bindings to include authentication schema with eam-vcenter build 24075398 Closes: 3521
+
+### 🧹 Chore
+
+- [7a7c0646]	Update version.go for v0.42.0
+
+### ⚠️ BREAKING
+
+### 📖 Commits
+
+- [7a7c0646]	chore: Update version.go for v0.42.0
+- [3fd16f78]	api: update eam bindings to include authentication schema with eam-vcenter build 24075398 Closes: 3521
+
+<a name="v0.41.0"></a>
+## [Release v0.41.0](https://github.com/vmware/govmomi/compare/v0.40.0...v0.41.0)
+
+> Release Date: 2024-08-16
+
+### 💫 API Changes
+
+- [5a036494]	OptionValues IsTrue|IsFalse
+
+### 🧹 Chore
+
+- [a6cdbd4c]	Update version.go for v0.41.0
+
+### ⚠️ BREAKING
+
+### 📖 Commits
+
+- [a6cdbd4c]	chore: Update version.go for v0.41.0
+- [5a036494]	api: OptionValues IsTrue|IsFalse
+
+<a name="v0.40.0"></a>
+## [Release v0.40.0](https://github.com/vmware/govmomi/compare/v0.39.0...v0.40.0)
+
+> Release Date: 2024-08-12
+
+### 🐞 Fix
+
+- [15d5ffdb]	govc object.collect truncation
+- [18e43541]	govc: output Message field for 'EventEx' types
+- [11dc5a39]	restore govc import.spec DiskProvisioning default value
+
+### 💡 Examples
+
+- [eea1d299]	add ExampleCollector_WaitForUpdatesEx_pagination
+
+### 💫 API Changes
+
+- [d035dc72]	add session.Manager.ImpersonateUser method
+- [ea3e806f]	add alarm package with helpers for AlarmManager and Alarms
+- [208d532c]	convert vSAN directory name to uuid in ResolveLibraryItemStorage
+
+### 💫 `govc` (CLI)
+
+- [0917e718]	add session.login '-as' flag to impersonate user
+- [d6a3b614]	add alarm commands
+- [2975ade1]	add event.post command
+- [db6e9623]	add library.sync '-f' flag to force sync file content
+- [cc02310c]	add library.info -S flag
+
+### 💫 `vcsim` (Simulator)
+
+- [ee966a69]	add SessionManager.ImpersonateUser method
+- [5a501b50]	implement WaitForUpdatesEx pagination support
+- [9c282108]	add AlarmManager
+- [db40be6b]	fix panic in CancelTask
+- [e63f1272]	add ovf DiskProvisioning validation
+- [0633de5c]	add DatastoreNamespaceManager
+
+### 🧹 Chore
+
+- [6e27ff34]	Update version.go for v0.40.0
+
+### ⚠️ BREAKING
+
+### 📖 Commits
+
+- [6e27ff34]	chore: Update version.go for v0.40.0
+- [eea1d299]	examples: add ExampleCollector_WaitForUpdatesEx_pagination
+- [ee966a69]	vcsim: add SessionManager.ImpersonateUser method
+- [0917e718]	govc: add session.login '-as' flag to impersonate user
+- [d035dc72]	api: add session.Manager.ImpersonateUser method
+- [15d5ffdb]	fix: govc object.collect truncation
+- [5a501b50]	vcsim: implement WaitForUpdatesEx pagination support
+- [9c282108]	vcsim: add AlarmManager
+- [d6a3b614]	govc: add alarm commands
+- [ea3e806f]	api: add alarm package with helpers for AlarmManager and Alarms
+- [2975ade1]	govc: add event.post command
+- [18e43541]	fix: govc: output Message field for 'EventEx' types
+- [6f998780]	build(deps): bump golang.org/x/text from 0.16.0 to 0.17.0
+- [db40be6b]	vcsim: fix panic in CancelTask
+- [db6e9623]	govc: add library.sync '-f' flag to force sync file content
+- [11dc5a39]	fix: restore govc import.spec DiskProvisioning default value
+- [e63f1272]	vcsim: add ovf DiskProvisioning validation
+- [208d532c]	api: convert vSAN directory name to uuid in ResolveLibraryItemStorage
+- [0633de5c]	vcsim: add DatastoreNamespaceManager
+- [cc02310c]	govc: add library.info -S flag
+- [0d6a605c]	review feedback
+- [2957bedf]	review feedback
+- [8e509dfb]	implement capacityAllocationUnits parser
+
+<a name="v0.39.0"></a>
+## [Release v0.39.0](https://github.com/vmware/govmomi/compare/v0.38.0...v0.39.0)
+
+> Release Date: 2024-07-22
+
+### 🐞 Fix
+
+- [1bc3a4a4]	handle base types by default in mo.LoadObjectContent
+
+### 💫 API Changes
+
+- [5c0af375]	use CheckTestType in compat and provisioning checkers
+- [2e77836c]	add sata controller
+- [bdb034ee]	Exporting Unit field in MetricSeries struct for external use
+- [78f07c63]	Add simulator test for GetVirtualDiskInfoByUUID
+- [2d16e19f]	GetVirtualDiskInfoByUUID for getting capacity/size info
+- [29b1bce9]	change CoresPerNumaNode to a pointer type
+- [3139de32]	Add a method for extending VMDK
+- [6096c0d4]	add ResolveLibraryItemStorage
+
+### 💫 `govc` (CLI)
+
+- [04fe4c26]	add vm.check commands
+- [976bca3b]	add '-spec' flag to vm clone, migrate and create commands
+- [d92015c4]	add vm.migrate -net flag
+
+### 💫 `vcsim` (Simulator)
+
+- [eb2e1ea1]	add VmCompatibilityChecker and VmProvisioningChecker
+- [a463e543]	Add support for DRS automation levels
+- [f7a85a81]	Re-enable TenantManager
+
+### 🧹 Chore
+
+- [590c92b1]	Update version.go for v0.39.0
+- [4434e26b]	bump go version
+- [d7e27099]	fix codeql ([#3492](https://github.com/vmware/govmomi/issues/3492))
+- [fb6e5977]	fix codeql
+
+### ⚠️ BREAKING
+
+### 📖 Commits
+
+- [590c92b1]	chore: Update version.go for v0.39.0
+- [5c0af375]	api: use CheckTestType in compat and provisioning checkers
+- [2e77836c]	api: add sata controller
+- [bdb034ee]	api: Exporting Unit field in MetricSeries struct for external use
+- [4434e26b]	chore: bump go version
+- [04fe4c26]	govc: add vm.check commands
+- [976bca3b]	govc: add '-spec' flag to vm clone, migrate and create commands
+- [d92015c4]	govc: add vm.migrate -net flag
+- [eb2e1ea1]	vcsim: add VmCompatibilityChecker and VmProvisioningChecker
+- [12467b00]	refactor: make importing templates available as a lib
+- [d7e27099]	chore: fix codeql ([#3492](https://github.com/vmware/govmomi/issues/3492))
+- [fb6e5977]	chore: fix codeql
+- [a463e543]	vcsim: Add support for DRS automation levels
+- [78f07c63]	api: Add simulator test for GetVirtualDiskInfoByUUID
+- [2d16e19f]	api: GetVirtualDiskInfoByUUID for getting capacity/size info
+- [29b1bce9]	api: change CoresPerNumaNode to a pointer type
+- [3139de32]	api: Add a method for extending VMDK
+- [6096c0d4]	api: add ResolveLibraryItemStorage
+- [1bc3a4a4]	fix: handle base types by default in mo.LoadObjectContent
+- [f7a85a81]	vcsim: Re-enable TenantManager
+
+<a name="v0.38.0"></a>
+## [Release v0.38.0](https://github.com/vmware/govmomi/compare/v0.37.3...v0.38.0)
+
+> Release Date: 2024-06-24
+
+### 🐞 Fix
+
+- [22607cd8]	xml marshal byte array fields as vCenter does
+- [298cfbf3]	govc vm.disk.change should only modify CapacityInBytes
+
+### 💫 API Changes
+
+- [0de9553a]	EnsureDisksHaveControllers helper
+- [3d70ab5c]	OptionValueList helper
+- [d80136a5]	add storage_specs field to Namespace related structures
+- [748043cd]	add pbm.DatastoreMap for finding compatible Datastores
+- [fc2a6b12]	HardwareVersion.IsSupported vs IsValid
+- [a68c21f2]	Add library item storage APIs
+- [7d1be3e7]	Update ConfigInfoToConfigSpec
+- [12ab4099]	Update generated types
+- [45aa2e92]	add checksum validation in Content Library update session file API
+- [7a00a0b4]	Generate enum consts with Values funcs
+- [f2852e39]	add SSLCertificate to TransferEndpoint in content library API
+
+### 💫 `govc` (CLI)
+
+- [c3c5ffba]	add vsan.info -file-service-enabled flag
+- [a916df4e]	add host.tpm.info and host.tpm.report commands
+- [7f0c9f0c]	add host.cert.info -show flag
+- [ae316d65]	add storage.policy.create zonal option
+- [3e648db2]	add '-storage' flag to namespace.create and namespace.update commands
+- [e7d54f90]	add vm.create '-profile' and '-place' flags
+- [5677b0e5]	Add feature to pass fullname and org for windows vm customization
+
+### 💫 `vcsim` (Simulator)
+
+- [e9f4cb73]	add vSAN FileServiceConfig support
+- [072011c6]	add HostCertificateManager
+- [a0bbbf3f]	add library item storage API support
+- [3b7ff25f]	add PropertyCollector index support
+- [651f7d27]	fix: ignore unknown refs in Datacenter.PowerOnMultiVM
+- [7251db75]	Add PbmCheckCompatibility method in pbm simulator
+- [542398a2]	add HostVirtualNicManager
+- [0be5fec8]	fix ReconfigVM validation when changing disk size
+
+### 🧹 Chore
+
+- [51648874]	Update version.go for v0.38.0
+- [43510fbc]	make doc
+- [36631314]	govc: use generated enum lists
+
+### ⚠️ BREAKING
+
+HardwareVersion.IsSupported vs IsValid [fc2a6b12]:
+HardwareVersion.IsValid is more relaxed, consider IsSupported
+* HardwareVersion.IsValid returns true if the specified value
+  matches a VMX version format.
+* HardwareVersion.IsSupported behaves how IsValid used to behave.
+
+### 📖 Commits
+
+- [51648874]	chore: Update version.go for v0.38.0
+- [c3c5ffba]	govc: add vsan.info -file-service-enabled flag
+- [e9f4cb73]	vcsim: add vSAN FileServiceConfig support
+- [43510fbc]	chore: make doc
+- [a916df4e]	govc: add host.tpm.info and host.tpm.report commands
+- [072011c6]	vcsim: add HostCertificateManager
+- [7f0c9f0c]	govc: add host.cert.info -show flag
+- [22607cd8]	fix: xml marshal byte array fields as vCenter does
+- [ae316d65]	govc: add storage.policy.create zonal option
+- [0de9553a]	api: EnsureDisksHaveControllers helper
+- [3d70ab5c]	api: OptionValueList helper
+- [3e648db2]	govc: add '-storage' flag to namespace.create and namespace.update commands
+- [d80136a5]	api: add storage_specs field to Namespace related structures
+- [e7d54f90]	govc: add vm.create '-profile' and '-place' flags
+- [748043cd]	api: add pbm.DatastoreMap for finding compatible Datastores
+- [5677b0e5]	govc: Add feature to pass fullname and org for windows vm customization
+- [298cfbf3]	fix: govc vm.disk.change should only modify CapacityInBytes
+- [ee49793c]	build(deps): bump goreleaser/goreleaser-action from 5 to 6
+- [a0bbbf3f]	vcsim: add library item storage API support
+- [1ec975ca]	nfc: Record the SSL thumbprint for the host the (device) URL refers to
+- [3b7ff25f]	vcsim: add PropertyCollector index support
+- [651f7d27]	vcsim: fix: ignore unknown refs in Datacenter.PowerOnMultiVM
+- [fc2a6b12]	api: HardwareVersion.IsSupported vs IsValid
+- [1edfbe3b]	feat: vSphere Zones API bindings
+- [a68c21f2]	api: Add library item storage APIs
+- [b20c733e]	build(deps): bump nokogiri from 1.16.2 to 1.16.5 in /gen
+- [7d1be3e7]	api: Update ConfigInfoToConfigSpec
+- [12ab4099]	api: Update generated types
+- [7251db75]	vcsim: Add PbmCheckCompatibility method in pbm simulator
+- [45aa2e92]	api: add checksum validation in Content Library update session file API
+- [542398a2]	vcsim: add HostVirtualNicManager
+- [36631314]	chore: govc: use generated enum lists
+- [7a00a0b4]	api: Generate enum consts with Values funcs
+- [0be5fec8]	vcsim: fix ReconfigVM validation when changing disk size
+- [f2852e39]	api: add SSLCertificate to TransferEndpoint in content library API
+- [12f8babe]	build(deps): bump chuhlomin/render-template from 1.9 to 1.10
+- [0893552e]	bugfix: Exclude ServerGUID from MOR comparison in WaitEx
+
+<a name="v0.37.3"></a>
+## [Release v0.37.3](https://github.com/vmware/govmomi/compare/v0.37.2...v0.37.3)
+
+> Release Date: 2024-06-05
+
+### 🧹 Chore
+
+- [6b391d35]	Update version.go for v0.37.3
+
+### ⚠️ BREAKING
+
+### 📖 Commits
+
+- [6b391d35]	chore: Update version.go for v0.37.3
+- [a554e040]	nfc: Record the SSL thumbprint for the host the (device) URL refers to
+
+<a name="v0.37.2"></a>
+## [Release v0.37.2](https://github.com/vmware/govmomi/compare/v0.37.1...v0.37.2)
+
+> Release Date: 2024-05-09
+
+### 💫 API Changes
+
+- [37269b6a]	add checksum validation in Content Library update session file API
+- [ce7ef70a]	add SSLCertificate to TransferEndpoint in content library API
+
+### 💫 `vcsim` (Simulator)
+
+- [6a0d7e7d]	Add PbmCheckCompatibility method in pbm simulator
+- [e6fe159b]	fix ReconfigVM validation when changing disk size
+
+### 🧹 Chore
+
+- [9a1b3c8f]	Update version.go for v0.37.2
+
+### ⚠️ BREAKING
+
+### 📖 Commits
+
+- [9a1b3c8f]	chore: Update version.go for v0.37.2
+- [6a0d7e7d]	vcsim: Add PbmCheckCompatibility method in pbm simulator
+- [37269b6a]	api: add checksum validation in Content Library update session file API
+- [e6fe159b]	vcsim: fix ReconfigVM validation when changing disk size
+- [ce7ef70a]	api: add SSLCertificate to TransferEndpoint in content library API
+
+<a name="v0.37.1"></a>
+## [Release v0.37.1](https://github.com/vmware/govmomi/compare/v0.37.0...v0.37.1)
+
+> Release Date: 2024-04-18
+
+### 🧹 Chore
+
+- [bf28314d]	Update version.go for v0.37.1
+
+### ⚠️ BREAKING
+
+### 📖 Commits
+
+- [bf28314d]	chore: Update version.go for v0.37.1
+- [8c99cb85]	bugfix: Exclude ServerGUID from MOR comparison in WaitEx
+
+<a name="v0.37.0"></a>
+## [Release v0.37.0](https://github.com/vmware/govmomi/compare/v0.36.3...v0.37.0)
+
+> Release Date: 2024-04-12
+
+### 🐞 Fix
+
+- [095f926b]	make cns.Client independent of vim25.Client
+- [dcf063cd]	vcsim: re-parent children in ResourcePool.Destroy
+- [7455935a]	endpoint url to bypass lookup service if envoy sidecar enabled
+- [83754772]	lookup client to use envoy sidecar url if enabled
+
+### 💫 API Changes
+
+- [f5080d3e]	use RetrievePropertiesEx in mo package functions
+- [a0a8257a]	change RetrieveProperties to collect results in batches
+- [367c55fe]	move vim25.Client.UseServiceVersion to soap.Client
+- [f6710489]	Expose vSphere API to evict subscribed content library
+- [3784b2f2]	Add Downloadendpoint field in the library item file struct
+
+### 💫 `govc` (CLI)
+
+- [9285e441]	Add library.evict command
+- [fc20e24d]	add default output formatting for namespace commands
+- [27824cf5]	snapshot.tree json output to stdout
+
+### 💫 `vcsim` (Simulator)
+
+- [70a7617d]	toggle Content Library cached fields in sync and evict calls
+- [cf719441]	add ExtensionManager.FindExtension method
+- [4348bd9f]	RetrievePropertiesEx & ContinueRetrievePropertiesEx
+- [4cec0597]	add TaskHistoryCollector support
+- [9c59e9c5]	add TaskManager.CreateTask support
+- [d9af2a26]	add ExtensionManager support
+
+### 📃 Documentation
+
+- [368d194a]	update CHANGELOG
+- [2bbe81af]	update CONTRIBUTORS
+
+### 🧹 Chore
+
+- [134152d4]	Update version.go for v0.37.0
+
+### ⚠️ BREAKING
+
+### 📖 Commits
+
+- [134152d4]	chore: Update version.go for v0.37.0
+- [70a7617d]	vcsim: toggle Content Library cached fields in sync and evict calls
+- [9285e441]	govc: Add library.evict command
+- [cf719441]	vcsim: add ExtensionManager.FindExtension method
+- [92a29ebf]	build(deps): add vcsim to rpm
+- [fc20e24d]	govc: add default output formatting for namespace commands
+- [095f926b]	fix: make cns.Client independent of vim25.Client
+- [f5080d3e]	api: use RetrievePropertiesEx in mo package functions
+- [4348bd9f]	vcsim: RetrievePropertiesEx & ContinueRetrievePropertiesEx
+- [a0a8257a]	api: change RetrieveProperties to collect results in batches
+- [8a618f77]	feat: Add VAPI bindings for guest namespaces and virtual machine classes
+- [e66065ab]	build(deps): enable rpm builds and add archs
+- [367c55fe]	api: move vim25.Client.UseServiceVersion to soap.Client
+- [f6710489]	api: Expose vSphere API to evict subscribed content library
+- [dcf063cd]	fix: vcsim: re-parent children in ResourcePool.Destroy
+- [4cec0597]	vcsim: add TaskHistoryCollector support
+- [041fd59a]	Remove deprecation for task.Wait and task.WaitForResult
+- [27824cf5]	govc: snapshot.tree json output to stdout
+- [7455935a]	fix: endpoint url to bypass lookup service if envoy sidecar enabled
+- [3784b2f2]	api: Add Downloadendpoint field in the library item file struct
+- [9c59e9c5]	vcsim: add TaskManager.CreateTask support
+- [d9af2a26]	vcsim: add ExtensionManager support
+- [e0ab2da2]	build(deps): bump google.golang.org/protobuf in /hack/tools
+- [8bfb252c]	Add support for SHA256 thumbprint based vCenter authentication
+- [83754772]	fix: lookup client to use envoy sidecar url if enabled
+- [368d194a]	docs: update CHANGELOG
+- [2bbe81af]	docs: update CONTRIBUTORS
+
+<a name="v0.36.3"></a>
+## [Release v0.36.3](https://github.com/vmware/govmomi/compare/v0.36.2...v0.36.3)
+
+> Release Date: 2024-04-02
+
+### 🧹 Chore
+
+- [35df9f35]	Update version.go for v0.36.3
+
+### ⚠️ BREAKING
+
+### 📖 Commits
+
+- [35df9f35]	chore: Update version.go for v0.36.3
+- [47c5ff94]	Remove deprecation for task.Wait and task.WaitForResult
+
+<a name="v0.36.2"></a>
+## [Release v0.36.2](https://github.com/vmware/govmomi/compare/v0.36.1...v0.36.2)
+
+> Release Date: 2024-03-27
+
+### 🐞 Fix
+
+- [9c5fca64]	endpoint url to bypass lookup service if envoy sidecar enabled
+
+### 💫 API Changes
+
+- [f9e1a48e]	Add Downloadendpoint field in the library item file struct
+
+### 💫 `govc` (CLI)
+
+- [cd9ce0ae]	snapshot.tree json output to stdout
+
+### 🧹 Chore
+
+- [f2a87d75]	Update version.go for v0.36.2
+
+### ⚠️ BREAKING
+
+### 📖 Commits
+
+- [f2a87d75]	chore: Update version.go for v0.36.2
+- [cd9ce0ae]	govc: snapshot.tree json output to stdout
+- [9c5fca64]	fix: endpoint url to bypass lookup service if envoy sidecar enabled
+- [f9e1a48e]	api: Add Downloadendpoint field in the library item file struct
+
+<a name="v0.36.1"></a>
+## [Release v0.36.1](https://github.com/vmware/govmomi/compare/v0.36.0...v0.36.1)
+
+> Release Date: 2024-03-12
+
+### 🐞 Fix
+
+- [edf70dc3]	lookup client to use envoy sidecar url if enabled
+
+### 🧹 Chore
+
+- [cc533e4b]	Update version.go for v0.36.1
+
+### ⚠️ BREAKING
+
+### 📖 Commits
+
+- [cc533e4b]	chore: Update version.go for v0.36.1
+- [27996347]	Add support for SHA256 thumbprint based vCenter authentication
+- [edf70dc3]	fix: lookup client to use envoy sidecar url if enabled
+
 <a name="v0.36.0"></a>
 ## [Release v0.36.0](https://github.com/vmware/govmomi/compare/v0.35.0...v0.36.0)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing to `govmomi`
 
+tl;dr
+
+- Sign your commits, unless you've signed the CLA
+- Include a component `prefix:` in your commit message, if applicable
+- Squash fixup commits and force push to your branch
+
 ## Getting started
 
 First, fork the repository on GitHub to your personal account.
@@ -27,6 +33,7 @@ This is a rough outline of what a contributor's workflow looks like:
 - Create an issue describing the feature/fix
 - Create a topic branch from where you want to base your work.
 - Make commits of logical units.
+- [Sign](#sign-off-your-work) your commits.
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to a topic branch in your fork of the repository.
 - Submit a pull request to `vmware/govmomi`.
@@ -38,12 +45,30 @@ and **supported prefixes**, e.g. `govc: <message>`.
 > my!](https://www.mgasch.com/2021/05/git-basics/) for more details on how to
 > successfully contribute to an open source project.
 
+### Sign-off Your Work
+
+Use the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) on all Pull Requests.
+By adding this line to their commit messages, contributors *sign-off* that they adhere to the requirements of the DCO.
+
+Git provides the `-s` command-line option to append the required line
+automatically to the commit message:
+
+```bash
+git commit -s -m 'This is my commit message'
+```
+
+For an existing commit, you can also use this option with `--amend`:
+
+```bash
+git commit -s --amend
+```
+
 ### Example 1 - Fix a Bug in `govmomi`
 
 ```bash
 git checkout -b issue-<number> main
 git add <files>
-git commit -m "fix: ..." -m "Closes: #<issue-number>"
+git commit -s -m "fix: ..." -m "Closes: #<issue-number>"
 git push $USER issue-<number>
 ```
 
@@ -52,7 +77,7 @@ git push $USER issue-<number>
 ```bash
 git checkout -b issue-<number> main
 git add <files>
-git commit -m "Add API ..." -m "Closes: #<issue-number>"
+git commit -s -m "Add API ..." -m "Closes: #<issue-number>"
 git push $USER issue-<number>
 ```
 
@@ -61,10 +86,10 @@ git push $USER issue-<number>
 ```bash
 git checkout -b issue-<number> main
 git add <files>
-git commit -m "govc: Add feature ..." -m "Closes: #<issue-number>"
+git commit -s -m "govc: Add feature ..." -m "Closes: #<issue-number>"
 git push $USER issue-<number>
 ```
-**Note**:  
+**Note**:
 To register the new `govc` command package, add a blank `_` import to `govmomi/govc/main.go`.
 
 ### Example 4 - Fix a Bug in `vcsim`
@@ -72,7 +97,7 @@ To register the new `govc` command package, add a blank `_` import to `govmomi/g
 ```bash
 git checkout -b issue-<number> main
 git add <files>
-git commit -m "vcsim: Fix ..." -m "Closes: #<issue-number>"
+git commit -s -m "vcsim: Fix ..." -m "Closes: #<issue-number>"
 git push $USER issue-<number>
 ```
 
@@ -80,7 +105,7 @@ git push $USER issue-<number>
 
 Breaking changes, e.g. to the `govmomi` APIs, are highlighted in the `CHANGELOG`
 and release notes when the keyword `BREAKING:` is used in the commit message
-body. 
+body.
 
 The text after `BREAKING:` is used in the corresponding highlighted section.
 Thus these details should be stated at the body of the commit message.
@@ -89,7 +114,7 @@ Multi-line strings are supported.
 ```bash
 git checkout -b issue-<number> main
 git add <files>
-cat << EOF | git commit -F -
+cat << EOF | git commit -s -F -
 Add ctx to funcXYZ
 
 This commit introduces context.Context to function XYZ
@@ -127,7 +152,7 @@ directly instead.
 git add .
 
 # create a fixup commit which will be merged into your (original) <commit>
-git commit --fixup <commit>
+git commit -s --fixup <commit>
 git push $USER issue-<number>
 ```
 
@@ -162,7 +187,7 @@ e.g. `Closes: #<number>`.
 The [`CHANGELOG.md`](./CHANGELOG.md) and release page uses **commit message
 prefixes** for grouping and highlighting. A commit message that
 starts with `[prefix:] ` will place this commit under the respective
-section in the `CHANGELOG`. 
+section in the `CHANGELOG`.
 
 The following example creates a commit referencing the `issue: 1234` and puts
 the commit message in the `govc` `CHANGELOG` section:
@@ -186,7 +211,7 @@ is recommended to break up your commits using distinct prefixes.
 
 ### Running CI Checks and Tests
 You can run both `make check` and `make test` from the top level of the
-repository. 
+repository.
 
 While `make check` will catch formatting and import errors, it will not apply
 any fixes. The developer is expected to do that.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,6 +8,7 @@ abrarshivani <abrarshivani@users.noreply.github.com>
 Adam Chalkley <atc0005@users.noreply.github.com>
 Adam Fowler <adam@adamfowler.org>
 Adam Shannon <adamkshannon@gmail.com>
+Adnan Baruni <badnan@vmware.com>
 Akanksha Panse <pansea@vmware.com>
 Al Biheiri <abiheiri@apple.com>
 Alessandro Cortiana <alessandro.cortiana@gmail.com>
@@ -24,6 +25,7 @@ Andrew <AndrewDi@users.noreply.github.com>
 Andrew Chin <andrew@andrewtchin.com>
 Andrew Kutz <akutz@vmware.com>
 Andrey Klimentyev <andrey.klimentyev@flant.com>
+aneesurrehman001 <55150455+aneesurrehman001@users.noreply.github.com>
 Anfernee Yongkun Gui <agui@vmware.com>
 angystardust <angystardust@users.noreply.github.com>
 aniketGslab <aniket.shinde@gslab.com>
@@ -32,6 +34,7 @@ Ankit Vaidya <vaidyaa@vmware.com>
 Ankur Huralikoppi <huralikoppia@vmware.com>
 Anna Carrigan <anna.carrigan@hpe.com>
 Antony Saba <awsaba@gmail.com>
+Anusha Ramineni <raminenia@vmware.com>
 Ariel Chinn <arielchinn@gmail.com>
 Arran Walker <arran.walker@zopa.com>
 Artem Anisimov <aanisimov@inbox.ru>
@@ -46,6 +49,7 @@ Ben Vickers <bvickers@pivotal.io>
 Benjamin Davini <davinib@vmware.com>
 Benjamin Peterson <benjamin@python.org>
 Benjamin Vickers <bvickers@vmware.com>
+Bernd Zeimetz <bernd@bzed.de>
 Bhavya Choudhary <bhavyac@vmware.com>
 Bob Killen <killen.bob@gmail.com>
 Brad Fitzpatrick <bradfitz@golang.org>
@@ -57,6 +61,7 @@ Bruno Meneguello <1322552+bkmeneguello@users.noreply.github.com>
 Bryan Venteicher <bryanventeicher@gmail.com>
 C S P Nanda <cspn@google.com>
 Carsten Grohmann <mail@carstengrohmann.de>
+Chebrolu <hchebrol@redhat.com>
 Cheng Cheng <chengch@vmware.com>
 Chethan Venkatesh <chethanv@vmware.com>
 Choudhury Sarada Prasanna Nanda <cspn@google.com>
@@ -82,6 +87,7 @@ Davide Agnello <dagnello@hp.com>
 Davinder Kumar <davinderk@vmware.com>
 Defa <zhoudefa666@163.com>
 demarey <christophe.demarey@inria.fr>
+Derek Beard <derek.beard@gmail.com>
 Deric Crago <deric.crago@gmail.com>
 Deyan Popov <deyan.popov@gmail.com>
 Dinesh Bhat <35480850+dbhat-arkin@users.noreply.github.com>
@@ -92,12 +98,14 @@ Doug MacEachern <dougm@vmware.com>
 East <60801291+houfangdong@users.noreply.github.com>
 Eloy Coto <eloy.coto@gmail.com>
 Eng Zer Jun <engzerjun@gmail.com>
+Eric Cao <ecao@vmware.com>
 Eric Edens <ericedens@google.com>
 Eric Graham <16710890+Pheric@users.noreply.github.com>
 Eric Gray <egray@vmware.com>
 Eric Yutao <eric.yutao@gmail.com>
 Erik Hollensbe <github@hollensbe.org>
 Erik Lund <info@erikjensen.it>
+Erim Erdal <erim.erdal@broadcom.com>
 Essodjolo KAHANAM <essodjolo@kahanam.com>
 Ethan Kaley <ethan.kaley@emc.com>
 Evan Chu <echu@vmware.com>
@@ -121,6 +129,7 @@ Hasan Mahmood <mahmoodh@vmware.com>
 Haydon Ryan <haydon.ryan@gmail.com>
 Heiko Reese <hreese@users.noreply.github.com>
 Henrik Hodne <henrik@travis-ci.com>
+Himanshu Ranjan <rhimanshu@vmware.com>
 hkumar <hkumar@vmware.com>
 Hrabur Stoyanov <hstoyanov@vmware.com>
 hui luo <luoh@vmware.com>
@@ -135,10 +144,12 @@ Jeremy Canady <jcanady@jackhenry.com>
 jeremy-clerc <jeremy@clerc.io>
 Jiatong Wang <wjiatong@vmware.com>
 jingyizPensando <jingyiz@pensando.io>
+jitinkumar94 <jitinkumar94@github.com>
 Jonas Ausevicius <jonas.ausevicius@virtustream.com>
 Jorge Sevilla <jorge.sevilla@rstor.io>
 Joseph LeBlanc <jsleblanc@users.noreply.github.com>
 João Pereira <joaodrp@gmail.com>
+Jukka Lehtniemi <ext-jukka.lehtniemi@vaisala.com>
 Julien PILLON <jpillon@lesalternatives.org>
 Justin J. Novack <jnovack@users.noreply.github.com>
 kayrus <kay.diam@gmail.com>
@@ -155,6 +166,7 @@ Liping Xue <lipingx@vmware.com>
 liron.levin <liron.levin@wiz.io>
 Louie Jiang <jiangl@vmware.com>
 Lubron Zhan <lzhan@vmware.com>
+Luis Davim <dluis@vmware.com>
 Luther Monson <luther.monson@gmail.com>
 Madanagopal Arunachalam <marunachalam@vmware.com>
 makelarisjr <8687447+makelarisjr@users.noreply.github.com>
@@ -209,16 +221,19 @@ Robin Watkins <robwatkins@gmail.com>
 Rowan Jacobs <rojacobs@pivotal.io>
 Roy Ling <royling0024@gmail.com>
 rsikdar <rsikdar@berkeley.edu>
+rubinthomasdev <rubinthomasdev@gmail.com>
 runner.mei <runner.mei@gmail.com>
 Ryan Johnson <johnsonryan@vmware.com>
 S R Ashrith <sashrith@vmware.com>
 S.Çağlar Onur <conur@vmware.com>
 Saad Malik <saad@spectrocloud.com>
+Sai Diliyaer <sai.diliyaer@gmail.com>
 Sam Zhu <zhusa@zhusa-a02.vmware.com>
 samzhu333 <45263849+samzhu333@users.noreply.github.com>
 Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>
 schmikei <keith.schmitt@bluemedora.com>
 Scott Holden <scott@nullops.io>
+Sebastian Mitterle <smitterl@redhat.com>
 Sergey Ignatov <sergey.ignatov@jetbrains.com>
 serokles <timbo.alexander@gmail.com>
 shahra <shahra@vmware.com>
@@ -229,6 +244,7 @@ shylasrinivas <sshyla@vmware.com>
 sky-joker <sky.jokerxx@gmail.com>
 smaftoul <samuel.maftoul@gmail.com>
 smahadik <smahadik@vmware.com>
+Sreeja Acharya <acharyasreej@vmware.com>
 Sten Feldman <exile@chamber.ee>
 Stepan Mazurov <smazurov@gmail.com>
 Steve Purcell <steve@sanityinc.com>
@@ -264,6 +280,7 @@ xing-yang <xingyang105@gmail.com>
 xinyanw409 <wxinyan@vmware.com>
 Yang Yang <yangy@vmware.com>
 yangxi <yangxi@vmware.com>
+Yanlei Zhao <yanleizhao@vmware.com>
 Yann Hodique <yhodique@google.com>
 Yash Nitin Desai <desaiy@vmware.com>
 Yassine TIJANI <ytijani@vmware.com>

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ In addition to the vSphere API client, this repository includes:
 
 ## Compatibility
 
-This library supports vCenter Server and ESXi versions following the [VMware Product Lifecycle Matrix][reference-lifecycle].
-
-Product versions that are end of support may work, but are not officially supported.
+vSphere 7.0 and higher.
 
 ## Documentation
 
@@ -37,10 +35,7 @@ Installation instructions, released binaries, and Docker images are documented i
 
 ## Discussion
 
-The project encourages the community to collaborate using GitHub [issues][govmomi-github-issues], GitHub [discussions][govmomi-github-discussions], and [Slack][slack-channel].
-
-> **Note**
-> Access to Slack requires a free [VMware {code}][slack-join] developer program membership.
+Collaborate with the community using GitHub [discussions][govmomi-github-discussions] and GitHub [issues][govmomi-github-issues].
 
 ## Status
 
@@ -48,29 +43,8 @@ Changes to the API are subject to [semantic versioning][reference-semver].
 
 Refer to the [CHANGELOG][govmomi-changelog] for version to version changes.
 
-## Notable Projects Using govmomi
-
-* [collectd-vsphere][project-travisci-collectd-vsphere]
-* [Docker LinuxKit][project-docker-linuxKit]
-* [Elastic Agent VMware vSphere integration][project-elastic-agent]
-* [Gru][project-gru]
-* [Juju][project-juju]
-* [Jupiter Brain][project-travisci-jupiter-brain]
-* [Kubernetes vSphere Cloud Provider][project-k8s-cloud-provider]
-* [Kubernetes Cluster API][project-k8s-cluster-api]
-* [OPS][project-nanovms-ops]
-* [OpenTelemetry Collector Contrib][opentelemetry-collector-contrib]
-* [Packer Plugin for VMware vSphere][project-hashicorp-packer-plugin-vsphere]
-* [Rancher][project-rancher]
-* [Terraform Provider for VMware vSphere][project-hashicorp-terraform-provider-vsphere]
-* [Telegraf][project-influxdata-telegraf]
-* [VMware Event Broker Appliance][project-vmware-veba]
-* [VMware vSphere Integrated Containers Engine][project-vmware-vic]
-* [VMware vSphere 7.0][project-vmware-vsphere]
-
 ## Related Projects
 
-* [go-vmware-nsxt][reference-go-vmware-nsxt]
 * [pyvmomi][reference-pyvmomi]
 * [rbvmomi][reference-rbvmomi]
 
@@ -80,7 +54,7 @@ govmomi is available under the [Apache 2 License][govmomi-license].
 
 ## Name
 
-Pronounced: _go·​v·​mom·​ie_
+Pronounced: _go·​v·​mom·​e_
 
 Follows pyvmomi and rbvmomi: language prefix + the vSphere acronym "VM Object Management Infrastructure".
 
@@ -97,31 +71,10 @@ Follows pyvmomi and rbvmomi: language prefix + the vSphere acronym "VM Object Ma
 [go-reference]: https://pkg.go.dev/github.com/vmware/govmomi
 [go-report-card]: https://goreportcard.com/report/github.com/vmware/govmomi
 [go-version]: https://github.com/vmware/govmomi
-[opentelemetry-collector-contrib]: https://github.com/open-telemetry/opentelemetry-collector-contrib
-[project-docker-linuxKit]: https://github.com/linuxkit/linuxkit/tree/master/src/cmd/linuxkit
-[project-elastic-agent]: https://github.com/elastic/integrations/tree/main/packages/vsphere
-[project-gru]: https://github.com/dnaeon/gru
-[project-hashicorp-packer-plugin-vsphere]: https://github.com/hashicorp/packer-plugin-vsphere
-[project-hashicorp-terraform-provider-vsphere]: https://github.com/hashicorp/terraform-provider-vsphere
-[project-influxdata-telegraf]: https://github.com/influxdata/telegraf/tree/master/plugins/inputs/vsphere
-[project-juju]: https://github.com/juju/juju
-[project-k8s-cloud-provider]: https://github.com/kubernetes/cloud-provider-vsphere
-[project-k8s-cluster-api]: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere
-[project-nanovms-ops]: https://github.com/nanovms/ops
-[project-rancher]: https://github.com/rancher/rancher/blob/master/pkg/api/norman/customization/vsphere/listers.go
-[project-travisci-collectd-vsphere]: https://github.com/travis-ci/collectd-vsphere
-[project-travisci-jupiter-brain]: https://github.com/travis-ci/jupiter-brain
-[project-vmware-veba]: https://github.com/vmware-samples/vcenter-event-broker-appliance/tree/development/vmware-event-router
-[project-vmware-vic]: https://github.com/vmware/vic
-[project-vmware-vsphere]: https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-7-vsphere-with-kubernetes-release-notes.html
-[reference-api]: https://developer.vmware.com/apis/968/vsphere
-[reference-godoc]: http://godoc.org/github.com/vmware/govmomi
-[reference-go-vmware-nsxt]: https://github.com/vmware/go-vmware-nsxt
-[reference-lifecycle]: https://lifecycle.vmware.com
+[reference-api]: https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/
+[reference-godoc]: https://pkg.go.dev/github.com/vmware/govmomi
 [reference-pyvmomi]: https://github.com/vmware/pyvmomi
 [reference-rbvmomi]: https://github.com/vmware/rbvmomi
 [reference-semver]: http://semver.org
-[slack-join]: https://developer.vmware.com/join/
-[slack-channel]: https://vmwarecode.slack.com/messages/govmomi
 [toolbox]: toolbox/README.md
 [vcsim]: vcsim/README.md

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/govmomi
 
-go 1.21
+go 1.22
 
 require (
 	github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d

--- a/govc/README.md
+++ b/govc/README.md
@@ -34,9 +34,7 @@ Github using:
 go install github.com/vmware/govmomi/govc@latest
 ```
 
-**Note:** `govmomi` and its binaries use [Go
-modules](https://golang.org/ref/mod), i.e. explicitly setting `GOPATH` is not
-required anymore. To inject build variables (see details
+**Note:** To inject build variables (see details
 [below](#install-via-goreleaser)) used by `govc version [-l]`, `GOFLAGS` can be
 defined and are honored by `go get`.
 
@@ -250,40 +248,6 @@ Test connection using `curl`:
 curl --verbose -k -X POST https://x.x.x.x/sdk
 ```
 
-### MSYS2 (Windows)
-
-Inventory path arguments with a leading '/' are subject
-to [Posix path conversion](http://www.mingw.org/wiki/Posix_path_conversion).
-
-### NotAuthenticated
-
-When connecting to a non-TLS endpoint, Go's http.Client will not send Secure
-cookies, resulting in a `NotAuthenticated` error. For example, running `govc`
-directly against the vCenter vpxd endpoint at `http://127.0.0.1:8085`. Set the
-environment variable `GOVMOMI_INSECURE_COOKIES=true` to workaround this:
-
-```bash
-GOVMOMI_INSECURE_COOKIES=true govc ls -u http://user:pass@127.0.0.1:8085
-```
-
-## Examples
-
-Several examples are embedded in the govc command [help](USAGE.md)
-
-* [Upload ssh public key to a VM](examples/lib/ssh.sh)
-
-* [Create a CoreOS VM](https://github.com/vmware/govmomi/blob/main/toolbox/toolbox-test.sh)
-
-* [Create a Debian VM](https://github.com/kubernetes/kubernetes/tree/master/cluster/vsphere)
-
-* [Create a Windows VM](https://github.com/dougm/govc-windows-box/blob/master/provision-esx.sh)
-
-* [Create an ESX VM](../scripts/vcsa/create-esxi-vm.sh)
-
-* [Create a vCenter VM](../scripts/vcsa/create-vcsa-vm.sh)
-
-* [Create a Cluster](../scripts/vcsa/create-cluster.sh)
-
 ## Status
 
 Changes to the CLI are subject to [semantic versioning](http://semver.org).
@@ -297,22 +261,6 @@ script, for example:
 ```bash
 govc version -require 0.24
 ```
-
-## Projects using `govc`
-
-* [Emacs govc package](./emacs)
-
-* [Kubernetes vSphere Cloud Provider](https://github.com/kubernetes/cloud-provider-vsphere)
-
-* [VMware VIC Engine](https://github.com/vmware/vic)
-
-* [vSphere Docker Volume Service](https://github.com/vmware/docker-volume-vsphere)
-
-* [golang/build](https://github.com/golang/build)
-
-## Related projects
-
-* [rvc](https://github.com/vmware/rvc)
 
 ## License
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,5 +21,5 @@ const (
 	ClientName = "govmomi"
 
 	// ClientVersion is the version of this SDK
-	ClientVersion = "0.31.0"
+	ClientVersion = "0.44.0"
 )

--- a/vcsim/README.md
+++ b/vcsim/README.md
@@ -34,9 +34,7 @@ go install github.com/vmware/govmomi/vcsim@latest
 $GOPATH/bin/vcsim -h
 ```
 
-**Note:** `govmomi` and its binaries use [Go
-modules](https://golang.org/ref/mod), i.e. explicitly setting `GOPATH` is not
-required anymore. To inject build variables (see details
+**Note:** To inject build variables (see details
 [below](#install-via-goreleaser)) used by `vcsim version`, `GOFLAGS` can be
 defined and are honored by `go get`.
 
@@ -422,30 +420,6 @@ directly, rather than the vcsim binary.
 ## Feature Details
 
 For more details on vcsim features, see the project [wiki](https://github.com/vmware/govmomi/wiki/vcsim-features).
-
-## Projects using vcsim
-
-* [VMware VIC Engine](https://github.com/vmware/vic)
-
-* [Kubernetes](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/vsphere)
-
-* [Ansible](https://github.com/ansible/vcenter-test-container)
-
-* [Telegraf](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/vsphere)
-
-## Blog posts
-
-* [Beginning vCenter Server simulation with vcsim](https://opensourceforu.com/2017/10/vcenter-server-simulation-govcsim/) by Abhijeet Kasurde
-
-* [vCenter & ESXi API based simulator](https://www.virtuallyghetto.com/2017/04/govcsim-neat-incubation-project-vcenter-server-esxi-api-based-simulator.html) by William Lam
-
-* [vCenter Simulator Docker Container](https://www.brianbunke.com/blog/2018/12/31/vcenter-simulator-ci/) by Brian Bunke
-
-* [Using govc with vcsim in Kubernetes](https://www.mgasch.com/2021/05/vcsim-k8s/) by Michael Gasch
-
-## Related projects
-
-* [LocalStack](https://github.com/localstack/localstack/blob/master/README.md#why-localstack)
 
 ## License
 


### PR DESCRIPTION
chore: bump default ClientVersion
docs: sync CHANGELOG
chore: bump Go versions
chore: fix GH Action tag output param
docs: various updates

Note: some of the doc updates are just simplifying:
- Pruned the PR template
- Removed links such as used-by, blogs, etc., better left to search engines