### PR TITLE
vcsim: handle traversal spec object updates

### DIFF
--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -822,8 +822,6 @@ func TestPropertyCollectorInvalidSpecName(t *testing.T) {
 	obj := Map.Put(new(Folder))
 	folderPutChild(SpoofContext(), &obj.(*Folder).Folder, new(Folder))
 
-	pc := &PropertyCollector{}
-
 	req := types.RetrievePropertiesEx{
 		SpecSet: []types.PropertyFilterSpec{
 			{
@@ -853,7 +851,7 @@ func TestPropertyCollectorInvalidSpecName(t *testing.T) {
 		},
 	}
 
-	_, err := pc.collect(SpoofContext(), &req)
+	_, err := collect(SpoofContext(), &req)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/simulator/view_manager.go
+++ b/simulator/view_manager.go
@@ -275,9 +275,6 @@ func (v *ListView) ModifyListView(ctx *Context, req *types.ModifyListView) soap.
 
 	for _, ref := range req.Remove {
 		RemoveReference(&v.View, ref)
-		if ctx.Map.Get(ref) == nil {
-			body.Res.Returnval = append(body.Res.Returnval, ref)
-		}
 	}
 
 	if len(req.Remove) != 0 || len(req.Add) != 0 {

--- a/simulator/view_manager_test.go
+++ b/simulator/view_manager_test.go
@@ -222,5 +222,14 @@ func TestListViewModify(t *testing.T) {
 		if len(refs) != 1 {
 			t.Errorf("unresolved refs=%s", refs)
 		}
+
+		refs, err = list.Remove(ctx, add)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if len(refs) != 0 {
+			t.Errorf("unresolved refs=%s", refs)
+		}
 	})
 }


### PR DESCRIPTION
Handle the case when an object used for the traversal itself is updated (e.g. ListView).