### PR TITLE
govc: update help url

### DIFF
--- a/govc/cli/command.go
+++ b/govc/cli/command.go
@@ -65,7 +65,7 @@ It is licensed under the Apache License, Version 2.0
 
 The available commands are listed below. A detailed description of each
 command can be displayed with "govc <COMMAND> -h". The description of all
-commands can be also found at https://via.vmw.com/GJ98hk .
+commands can be also found at https://github.com/vmware/govmomi/blob/main/govc/USAGE.md.
 
 Examples:
   show usage of a command:       govc <COMMAND> -h


### PR DESCRIPTION
## Description

Updates the help to use the direct URL after the `via.vmw.com` URL shortener was removed from service by Broadcom GTO.

Closes: #3374 
