### PR TITLE
fix: ensure proper vSAN URI format in ResolveLibraryItemStorage

### DIFF
--- a/vapi/library/finder/path.go
+++ b/vapi/library/finder/path.go
@@ -196,6 +196,7 @@ func (f *PathFinder) ResolveLibraryItemStorage(ctx context.Context, storage []li
 			if err != nil {
 				return err
 			}
+			uri.OmitHost = false            // `ds://` required for ConvertNamespacePathToUuidPath()
 			uri.Path = path.Clean(uri.Path) // required for ConvertNamespacePathToUuidPath()
 			uri.RawQuery = ""
 			u, err := f.convertPath(ctx, b, uri.String())


### PR DESCRIPTION
ConvertNamespacePathToUuidPath() fails when given: "ds:/path..."
Requires:
"ds:///path..."
