### PR TITLE
govc: support use of service version via GOVC_VIM_VERSION env var

### DIFF
--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -381,7 +381,7 @@ func (flag *ClientFlag) Client() (*vim25.Client, error) {
 		return nil, err
 	}
 
-	if flag.vimVersion == "" {
+	if flag.vimVersion == "" || flag.vimVersion == "-" {
 		err = c.UseServiceVersion()
 		if err != nil {
 			return nil, err

--- a/govc/test/cli.bats
+++ b/govc/test/cli.bats
@@ -34,6 +34,9 @@ load test_helper
   version=$(govc about -json -c -vim-version "" | jq -r .client.version)
   assert_equal uE53DA "$version" # vcsim's service version
 
+  version=$(env GOVC_VIM_VERSION=- govc about -json -c | jq -r .client.version)
+  assert_equal uE53DA "$version" # vcsim's service version
+
   version=$(govc about -json -c -vim-version 6.8.2 | jq -r .client.version)
   assert_equal 6.8.2 "$version" # client specified version
 


### PR DESCRIPTION
When the '-vim-version' flag is set to an empty value "", service version is used. Doing the same with a value of "-" allows service version to be used via the env var.