### PR TITLE
fix: add controller type check in simulator configureDevice

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1289,11 +1289,13 @@ func (vm *VirtualMachine) configureDevice(
 	// Update device controller's key reference
 	if key != d.Key {
 		if device := devices.FindByKey(d.ControllerKey); device != nil {
-			c := device.(types.BaseVirtualController).GetVirtualController()
-			for i := range c.Device {
-				if c.Device[i] == key {
-					c.Device[i] = d.Key
-					break
+			if c, ok := device.(types.BaseVirtualController); ok {
+				c := c.GetVirtualController()
+				for i := range c.Device {
+					if c.Device[i] == key {
+						c.Device[i] = d.Key
+						break
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description

This PR fixes potential panic in simulator's `configureDevice` function by adding a type check for BaseVirtualController.

Closes: N/A.

## How Has This Been Tested?

N/A.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
