### PR TITLE
bug: Do not panic on fault.In for valid errs

### DIFF
--- a/fault/fault.go
+++ b/fault/fault.go
@@ -255,6 +255,8 @@ func In(err any, onFaultFn OnFaultFn) {
 			}
 			In(uErr, onFaultFn)
 		}
+	case error:
+		// No-op
 	default:
 		panic("fault: err must implement error, types.BaseMethodFault, or " +
 			"types.HasLocalizedMethodFault")

--- a/fault/fault_test.go
+++ b/fault/fault_test.go
@@ -414,6 +414,12 @@ func TestIn(t *testing.T) {
 			expectedPanic:    unsupported,
 		},
 		{
+			name:             "err is unsupported but still an err",
+			err:              errors.New("error"),
+			callback:         &testHarness{},
+			expectedNumCalls: 0,
+		},
+		{
 			name:             "error is task.Error",
 			err:              task.Error{},
 			callback:         &testHarness{},


### PR DESCRIPTION


## Description

This patch prevents fault.In from panic'ing if a valid error is sent into the function.

Closes: `NA`

## How Has This Been Tested?

```shell
go test -v -count 1 -cover ./fault
...
PASS
coverage: 100.0% of statements
ok  	github.com/vmware/govmomi/fault	0.284s	coverage: 100.0% of statements
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
