### PR TITLE
fix: Cross-platform path handling for OVF FileArchive uploads

### DIFF
--- a/ovf/importer/archive.go
+++ b/ovf/importer/archive.go
@@ -112,11 +112,8 @@ type FileArchive struct {
 
 func (t *FileArchive) Open(name string) (io.ReadCloser, int64, error) {
 	fpath := name
-	if name != t.Path {
-		index := strings.LastIndex(t.Path, "/")
-		if index != -1 {
-			fpath = t.Path[:index] + "/" + name
-		}
+	if name != t.Path && !filepath.IsAbs(name) {
+		fpath = filepath.Join(filepath.Dir(t.Path), name)
 	}
 
 	return t.OpenFile(fpath)


### PR DESCRIPTION
## Description

Path handling for OVF uploads was using hardcoded path separators that did not support usage on Windows. This change handles paths in a cross-platform manner and ensures the absolute path is being used at all times.

Closes: #3555 

## How Has This Been Tested?

We have tested this in our own environment and confirmed it resolves the issues we were seeing with relative paths having paths prefixed on incorrectly.

