### PR TITLE
fix: vcsim: avoid race in DestroyPropertyFilter

### DIFF
--- a/simulator/property_filter.go
+++ b/simulator/property_filter.go
@@ -57,7 +57,9 @@ func (_ *PropertyFilter) RemoveObject(_ *Context, _ types.ManagedObjectReference
 func (f *PropertyFilter) DestroyPropertyFilter(ctx *Context, c *types.DestroyPropertyFilter) soap.HasFault {
 	body := &methods.DestroyPropertyFilterBody{}
 
-	RemoveReference(&f.pc.Filter, c.This)
+	ctx.WithLock(f.pc, func() {
+		RemoveReference(&f.pc.Filter, c.This)
+	})
 
 	ctx.Session.Remove(ctx, c.This)
 


### PR DESCRIPTION
Need to lock the filter's PropertyCollector when removing reference to self.
