### PR TITLE
fix: CreateSATAController to return error when no bus numbers

### DIFF
--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -402,6 +402,10 @@ func (l VirtualDeviceList) FindSATAController(name string) (types.BaseVirtualCon
 func (l VirtualDeviceList) CreateSATAController() (types.BaseVirtualDevice, error) {
 	sata := &types.VirtualAHCIController{}
 	sata.BusNumber = l.newSATABusNumber()
+	if sata.BusNumber == -1 {
+		return nil, errors.New("no bus numbers available")
+	}
+
 	sata.Key = l.NewKey()
 
 	return sata, nil

--- a/object/virtual_device_list_test.go
+++ b/object/virtual_device_list_test.go
@@ -768,6 +768,24 @@ func TestCreateSCSIController(t *testing.T) {
 	}
 }
 
+func TestCreateSATAController(t *testing.T) {
+	l := VirtualDeviceList{}
+	for _, i := range sataBusNumbers {
+		c, err := l.CreateSATAController()
+		if err != nil {
+			t.Error(err)
+		}
+		if j := c.(types.BaseVirtualController).GetVirtualController().BusNumber; j != int32(i) {
+			t.Errorf("expected bus number: %d, got: %d", i, j)
+		}
+		l = append(l, c)
+	}
+
+	if _, err := l.CreateSATAController(); err == nil {
+		t.Error("should fail")
+	}
+}
+
 func TestCreateEthernetCard(t *testing.T) {
 	_, err := EthernetCardTypes().CreateEthernetCard("enoent", nil)
 	if err == nil {


### PR DESCRIPTION
## Description

This PR updates the `CreateSATAController()` to return an error when there is no available bus number.

## How Has This Been Tested?

Added `TestCreateSATAController`.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
