### PR TITLE
api: support MOID conversion in Finder methods

### DIFF
--- a/find/doc.go
+++ b/find/doc.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2022 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,6 +31,9 @@ otherwise "find" mode is used.
 
 The exception is to use a "..." wildcard with a path to find all objects recursively underneath any root object.
 For example: VirtualMachineList("/DC1/...")
+
+Finder methods can also convert a managed object reference (aka MOID) to an object instance.
+For example: VirtualMachine("VirtualMachine:vm-123") or VirtualMachine("vm-123")
 
 See also: https://github.com/vmware/govmomi/blob/main/govc/README.md#usage
 */

--- a/find/finder_test.go
+++ b/find/finder_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -104,4 +104,49 @@ func TestFindNetwork(t *testing.T) {
 			}
 		}
 	}, model)
+}
+
+func TestFindByID(t *testing.T) {
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		find := find.NewFinder(c)
+
+		vms, err := find.VirtualMachineList(ctx, "*")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, vm := range vms {
+			ref := vm.Reference()
+			byRef, err := find.VirtualMachine(ctx, ref.String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if byRef.InventoryPath != vm.InventoryPath {
+				t.Errorf("InventoryPath=%q", byRef.InventoryPath)
+			}
+			if byRef.Reference() != ref {
+				t.Error(byRef.Reference())
+			}
+			_, err = find.VirtualMachine(ctx, ref.String()+"invalid")
+			if err == nil {
+				t.Error("expected error")
+			}
+
+			byID, err := find.VirtualMachine(ctx, ref.Value)
+			if err != nil {
+				t.Error(err)
+			}
+			if byID.InventoryPath != vm.InventoryPath {
+				t.Errorf("InventoryPath=%q", byID.InventoryPath)
+			}
+			if byID.Reference() != ref {
+				t.Error(byID.Reference())
+			}
+			_, err = find.VirtualMachine(ctx, ref.Value+"invalid")
+			if err == nil {
+				t.Error("expected error")
+			}
+
+		}
+	})
 }

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -2600,6 +2600,7 @@ The '-type' flag value can be a managed entity type or one of the following alia
 Examples:
   govc find
   govc find -l / # include object type in output
+  govc find -l -I / # include MOID in output
   govc find /dc1 -type c
   govc find vm -name my-vm-*
   govc find . -type n
@@ -2611,6 +2612,7 @@ Examples:
   govc find . -type h -hardware.cpuInfo.numCpuCores 16
 
 Options:
+  -I=false               Print the managed object ID
   -i=false               Print the managed object reference
   -l=false               Long listing format
   -maxdepth=-1           Max depth
@@ -4388,6 +4390,7 @@ Examples:
   govc ls -t Datastore host/ClusterA/* | grep -v local | xargs -n1 basename | sort | uniq
 
 Options:
+  -I=false               Print the managed object ID
   -L=false               Follow managed object references
   -i=false               Print the managed object reference
   -l=false               Long listing format

--- a/govc/flags/datacenter.go
+++ b/govc/flags/datacenter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -197,16 +197,6 @@ func (flag *DatacenterFlag) ManagedObjects(ctx context.Context, args []string) (
 	}
 
 	for _, arg := range args {
-		if ref := object.ReferenceFromString(arg); ref != nil {
-			// e.g. output from object.collect
-			refs = append(refs, *ref)
-			continue
-		}
-
-		if !strings.Contains(arg, "/") {
-			return nil, fmt.Errorf("%q must be qualified with a path", arg)
-		}
-
 		elements, err := finder.ManagedObjectList(ctx, arg)
 		if err != nil {
 			return nil, err
@@ -214,6 +204,10 @@ func (flag *DatacenterFlag) ManagedObjects(ctx context.Context, args []string) (
 
 		if len(elements) == 0 {
 			return nil, fmt.Errorf("object '%s' not found", arg)
+		}
+
+		if len(elements) > 1 && !strings.Contains(arg, "/") {
+			return nil, fmt.Errorf("%q must be qualified with a path", arg)
 		}
 
 		for _, e := range elements {

--- a/govc/ls/command.go
+++ b/govc/ls/command.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,6 +36,7 @@ type ls struct {
 	Long  bool
 	Type  string
 	ToRef bool
+	ToID  bool
 	DeRef bool
 }
 
@@ -49,6 +50,7 @@ func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
 
 	f.BoolVar(&cmd.Long, "l", false, "Long listing format")
 	f.BoolVar(&cmd.ToRef, "i", false, "Print the managed object reference")
+	f.BoolVar(&cmd.ToID, "I", false, "Print the managed object ID")
 	f.BoolVar(&cmd.DeRef, "L", false, "Follow managed object references")
 	f.StringVar(&cmd.Type, "t", "", "Object type")
 }
@@ -145,8 +147,13 @@ func (l listResult) Write(w io.Writer) error {
 	var err error
 
 	for _, e := range l.Elements {
-		if l.ToRef {
-			fmt.Fprint(w, e.Object.Reference().String())
+		if l.ToRef || l.ToID {
+			ref := e.Object.Reference()
+			id := ref.String()
+			if l.ToID {
+				id = ref.Value
+			}
+			fmt.Fprint(w, id)
 			if l.Long {
 				fmt.Fprintf(w, " %s", e.Path)
 			}

--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -493,6 +493,42 @@ EOF
   assert_success 2
 }
 
+@test "collect by id" {
+  vcsim_env -standalone-host 0 -pod 1 -app 1
+
+  run govc find -i /
+  assert_success
+
+  for ref in "${lines[@]}" ; do
+    run govc collect "$ref" name
+    assert_success
+  done
+
+  run govc find -I /
+  assert_success
+
+  for id in "${lines[@]}" ; do
+    run govc collect "$id" name
+    assert_success
+  done
+
+  run govc find -I -type m /
+  assert_success
+
+  for id in "${lines[@]}" ; do
+    run govc vm.info "$id"
+    assert_success
+  done
+
+  run govc find -I -type h /
+  assert_success
+
+  for id in "${lines[@]}" ; do
+    run govc host.info "$id"
+    assert_success
+  done
+}
+
 @test "object.find" {
   vcsim_env -ds 2
 

--- a/object/common_test.go
+++ b/object/common_test.go
@@ -18,11 +18,13 @@ package object_test
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 func TestCommonName(t *testing.T) {
@@ -62,4 +64,30 @@ func TestObjectName(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestReferenceFromString(t *testing.T) {
+	tests := []struct {
+		in  string
+		out *types.ManagedObjectReference
+	}{
+		{"no:no", nil},
+		{"Datacenter:yes", &types.ManagedObjectReference{Type: "Datacenter", Value: "yes"}},
+		{"datacenter-yes", &types.ManagedObjectReference{Type: "Datacenter", Value: "datacenter-yes"}},
+		{"VirtualMachine:vm-2", &types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-2"}},
+		{"vm-2", &types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-2"}},
+		{"domain-s2", &types.ManagedObjectReference{Type: "ComputeResource", Value: "domain-s2"}},
+		{"domain-c2", &types.ManagedObjectReference{Type: "ClusterComputeResource", Value: "domain-c2"}},
+		{"group-d1", &types.ManagedObjectReference{Type: "Folder", Value: "group-d1"}},
+		{"group-p2", &types.ManagedObjectReference{Type: "StoragePod", Value: "group-p2"}},
+		{"resgroup-42", &types.ManagedObjectReference{Type: "ResourcePool", Value: "resgroup-42"}},
+		{"resgroup-v32", &types.ManagedObjectReference{Type: "VirtualApp", Value: "resgroup-v32"}},
+	}
+
+	for _, test := range tests {
+		ref := object.ReferenceFromString(test.in)
+		if !reflect.DeepEqual(test.out, ref) {
+			t.Errorf("%s: expected %v, got %v", test.in, test.out, ref)
+		}
+	}
 }

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -41,11 +41,13 @@ var refValueMap = map[string]string{
 	"EnvironmentBrowser":             "envbrowser",
 	"HostSystem":                     "host",
 	"ResourcePool":                   "resgroup",
+	"VirtualApp":                     "resgroup-v",
 	"VirtualMachine":                 "vm",
 	"VirtualMachineSnapshot":         "snapshot",
 	"VmwareDistributedVirtualSwitch": "dvs",
 	"DistributedVirtualSwitch":       "dvs",
 	"ClusterComputeResource":         "domain-c",
+	"ComputeResource":                "domain-s",
 	"Folder":                         "group",
 	"StoragePod":                     "group-p",
 }

--- a/vim25/mo/type_info.go
+++ b/vim25/mo/type_info.go
@@ -337,6 +337,16 @@ func IsManagedObjectType(kind string) bool {
 	return ok
 }
 
+// Value returns a new mo instance of the given ref Type.
+func Value(ref types.ManagedObjectReference) (Reference, bool) {
+	if rt, ok := t[ref.Type]; ok {
+		val := reflect.New(rt)
+		val.Interface().(Entity).Entity().Self = ref
+		return val.Elem().Interface().(Reference), true
+	}
+	return nil, false
+}
+
 // Field of a ManagedObject in string form.
 type Field struct {
 	Path string


### PR DESCRIPTION
With this change, finder methods can convert ManagedObjectReference or MOID to an object instance. For example:

```console
# `-i` outputs MOR
% govc find -l -i -type m / -name nginx
VirtualMachine:vm-1100  /test-vpx-1730432486-649974-wcp.wcp-sanity/vm/nginx

% govc vm.info VirtualMachine:vm-1100
Name:           nginx
  Path:         /test-vpx-1730432486-649974-wcp.wcp-sanity/vm/nginx
  UUID:         421b8fd2-3006-0a69-1f16-7d088f90145f
  Guest name:   Other (32-bit)
   ...

# `-I` outputs MOID
% govc find -l -I -type m / -name nginx
vm-1100  /test-vpx-1730432486-649974-wcp.wcp-sanity/vm/nginx

% govc vm.info vm-1100
Name:           nginx
  Path:         /test-vpx-1730432486-649974-wcp.wcp-sanity/vm/nginx
  UUID:         421b8fd2-3006-0a69-1f16-7d088f90145f
  Guest name:   Other (32-bit)
...

% govc collect -s vm-1100 runtime.host | cut -d: -f2
host-14

% govc host.info host-14
Name:              10.192.85.11
  Path:            /test-vpx-1730432486-649974-wcp.wcp-sanity/host/test-vpx-1730432486-649974-wcp.wcp-sanity-cluster/10.192.85.11
  Manufacturer:    VMware, Inc.
  Logical CPUs:    4 CPUs @ 2100MHz
 ...
```