### PR TITLE
fix: Set DuplicateName Object to duplicate object

### DIFF
--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -208,7 +208,7 @@ func (f *Folder) CreateFolder(ctx *Context, c *types.CreateFolder) soap.HasFault
 		if obj := ctx.Map.FindByName(name, f.ChildEntity); obj != nil {
 			r.Fault_ = Fault("", &types.DuplicateName{
 				Name:   name,
-				Object: f.Self,
+				Object: obj.Reference(),
 			})
 
 			return r
@@ -250,7 +250,7 @@ func (f *Folder) CreateStoragePod(ctx *Context, c *types.CreateStoragePod) soap.
 		if obj := ctx.Map.FindByName(c.Name, f.ChildEntity); obj != nil {
 			r.Fault_ = Fault("", &types.DuplicateName{
 				Name:   c.Name,
-				Object: f.Self,
+				Object: obj.Reference(),
 			})
 
 			return r


### PR DESCRIPTION
Closes: #3610

## Description

Updates the simulator CreateFolder / CreateStoragePod to set the DuplicateName's Object to the existing one, instead of the Folder the operation is called on.

Closes: #3610

## How Has This Been Tested?

Added unit test, and run with and without the fix.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
