### PR TITLE
api: Support CnsBlockCreateSpec

### DIFF
--- a/cns/types/unreleased_types.go
+++ b/cns/types/unreleased_types.go
@@ -1,0 +1,36 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"reflect"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// CnsBlockCreateSpec is the specification for creating block volumes.
+type CnsBlockCreateSpec struct {
+	CnsBaseCreateSpec
+
+	// Crypto specifies the encryption settings for the volume to be created.
+	// Works with block volumes only.
+	CryptoSpec *types.CryptoSpec `xml:"cryptoSpec,omitempty"`
+}
+
+func init() {
+	types.Add("CnsBlockCreateSpec", reflect.TypeOf((*CnsBlockCreateSpec)(nil)).Elem())
+}


### PR DESCRIPTION


## Description

This patch adds support for the CNS type, BlockCreateSpec.

Closes: `NA`

## How Has This Been Tested?

It was reviewed by folks who work on CNS.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
