### PR TITLE
vcsim: Lock alpine image to a recent tag

### DIFF
--- a/simulator/container_host_system.go
+++ b/simulator/container_host_system.go
@@ -216,7 +216,7 @@ func createSimulationHost(ctx *Context, host *HostSystem) (*simHost, error) {
 	execCmds = append(execCmds, netCmds...)
 
 	// create the container
-	sh.c, err = create(ctx, hName, hUuid, dockerNet, dockerVol, nil, dockerEnv, "alpine", []string{"sleep", "infinity"})
+	sh.c, err = create(ctx, hName, hUuid, dockerNet, dockerVol, nil, dockerEnv, "alpine:3.20.3", []string{"sleep", "infinity"})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
Lock the version of `alpine` used by vcsim to a recent one that supports `sleep infinity`.

## Background
Certain corporate-managed Docker Registry mirrors seem to never invalidate their cache for `latest`.  A machine configured with such a mirror will always pull an arbitrarily old version:

```shellsession
$ docker pull alpine
Using default tag: latest
latest: Pulling from library/alpine
e110a4a17941: Pull complete
Digest: sha256:3dcdb92d7432d56604d4545cbd324b14e647b313626d99b889d0626de158f73a
Status: Downloaded newer image for alpine:latest
docker.io/library/alpine:latest

$ docker images | grep alpine
alpine              latest            4e38e38c8ce0   8 years ago     4.8MB
```

On such a system, the simulator fails:
```shellsession
$ go test ./simulator
2024/11/15 14:35:08 unsupported placement type: unsupported
2024/11/15 14:35:16 vcsim-esx-23-966d6ec8-4532-57fb-b947-528df716074b: [docker exec 0ad68ea40428817cc1e6e844a831a2532f5474d6a400909c2d50f01a5e3de9f3 ln -s /vmfs/volumes/63a10537-d1862d42-ceb0-9d75883295f6 /vmfs/volumes/datastore1] (Error response from daemon: container 0ad68ea40428817cc1e6e844a831a2532f5474d6a400909c2d50f01a5e3de9f3 is not running
)
--- FAIL: TestHostContainerBacking (6.02s)
panic: failed to create simulation host and no path to return error: exit status 1 [recovered]
        panic: failed to create simulation host and no path to return error: exit status 1

... <snip>...
FAIL    github.com/vmware/govmomi/simulator     8.326s
FAIL

$ docker logs 0ad68ea40428817cc1e6e844a831a2532f5474d6a400909c2d50f01a5e3de9f3
sleep: invalid number 'infinity'
```

To get things working on such a machine, it is best to use an explicit version tag for container images.


## How Has This Been Tested?
Without this change, `make test` fails on my machine.

With this change, `make test` passes.
