### PR TITLE
fix: govc: wire up flags for namespace service create

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -4750,6 +4750,9 @@ Examples:
   govc namespace.service.create manifest.yaml
 
 Options:
+  -accept-eula=false     Auto accept EULA
+  -spec-type=vsphere     Type of Spec: only vsphere is supported right now
+  -trusted=false         Define if this is a trusted provider
 ```
 
 ## namespace.service.deactivate

--- a/govc/namespace/service/create.go
+++ b/govc/namespace/service/create.go
@@ -44,10 +44,9 @@ func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
 	cmd.ClientFlag.Register(ctx, f)
 
-	flag.StringVar(&cmd.specType, "spec-type", "vsphere", "Type of Spec: only vsphere is supported right now")
-	flag.BoolVar(&cmd.trustedProvider, "trusted", false, "Define if this is a trusted provider")
-	flag.BoolVar(&cmd.acceptEULA, "accept-eula", false, "Auto accept EULA")
-
+	f.StringVar(&cmd.specType, "spec-type", "vsphere", "Type of Spec: only vsphere is supported right now")
+	f.BoolVar(&cmd.trustedProvider, "trusted", false, "Define if this is a trusted provider")
+	f.BoolVar(&cmd.acceptEULA, "accept-eula", false, "Auto accept EULA")
 }
 
 func (cmd *create) Description() string {


### PR DESCRIPTION
## Description

`govc namespace.service.create` had flags defined in code that were never usable.

## How Has This Been Tested?

```
govc namespace.service.create -h
```

Now shows the `spec-type` `trusted` and `accept-eula` flags.  Before this commit, those flags weren't shown in help and caused an error if provided.

## Other notes
I looked for other incorrect usages like this, by doing `rg 'flag.*Var' ./govc`.  This was the only one.
