### PR TITLE
fix: vcsim: output signed byte in ByteSlice.MarshalXML

### DIFF
--- a/vim25/types/byte_slice.go
+++ b/vim25/types/byte_slice.go
@@ -36,7 +36,8 @@ func (b ByteSlice) MarshalXML(e *xml.Encoder, field xml.StartElement) error {
 		Name: field.Name,
 	}
 	for i := range b {
-		if err := e.EncodeElement(b[i], start); err != nil {
+		// Using int8() here to output a signed byte (issue #3615)
+		if err := e.EncodeElement(int8(b[i]), start); err != nil {
 			return err
 		}
 	}

--- a/vim25/types/byte_slice_test.go
+++ b/vim25/types/byte_slice_test.go
@@ -43,3 +43,33 @@ func TestByteSlice(t *testing.T) {
 		t.Errorf("out=%#v", out.Byte)
 	}
 }
+
+func TestSignedByteSlice(t *testing.T) {
+	//  int8: <byte>4</byte><byte>-80</byte><byte>-79</byte><byte>-78</byte>
+	// uint8: <byte>4</byte><byte>176</byte><byte>177</byte><byte>178</byte>
+	in := &ArrayOfByte{
+		Byte: []uint8{0x4, 0xb0, 0xb1, 0xb2},
+	}
+
+	res, err := xml.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out struct {
+		Byte []int8 `xml:"byte,omitempty" json:"_value"`
+	}
+
+	// ByteSlice.MarshalXML must output signed byte, otherwise this fails with:
+	// strconv.ParseInt: parsing "176": value out of range
+	if err := xml.Unmarshal(res, &out); err != nil {
+		t.Logf("%s", string(res))
+		t.Fatal(err)
+	}
+
+	for i := range in.Byte {
+		if in.Byte[i] != byte(out.Byte[i]) {
+			t.Errorf("out=%x", out.Byte[i])
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3615
