### PR TITLE
OVF package enhancements

### DIFF
--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -573,15 +573,20 @@ func (l VirtualDeviceList) CreateDisk(c types.BaseVirtualController, ds types.Ma
 		name += ".vmdk"
 	}
 
+	bi := types.VirtualDeviceFileBackingInfo{
+		FileName: name,
+	}
+
+	if ds.Value != "" {
+		bi.Datastore = &ds
+	}
+
 	device := &types.VirtualDisk{
 		VirtualDevice: types.VirtualDevice{
 			Backing: &types.VirtualDiskFlatVer2BackingInfo{
-				DiskMode:        string(types.VirtualDiskModePersistent),
-				ThinProvisioned: types.NewBool(true),
-				VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
-					FileName:  name,
-					Datastore: &ds,
-				},
+				DiskMode:                     string(types.VirtualDiskModePersistent),
+				ThinProvisioned:              types.NewBool(true),
+				VirtualDeviceFileBackingInfo: bi,
 			},
 		},
 	}

--- a/ovf/cim.go
+++ b/ovf/cim.go
@@ -21,6 +21,51 @@ import (
 )
 
 /*
+Source:
+  - https://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.24.0/CIM_ResourceAllocationSettingData.xsd
+  - https://schemas.dmtf.org/wbem/cim-html/2/CIM_ResourceAllocationSettingData.html
+*/
+type CIMResourceType uint16
+
+// Please note, the iota pattern is not used to ensure these constants remain
+// affixed to an explicit value.
+const (
+	Other              CIMResourceType = 1
+	ComputerSystem     CIMResourceType = 2
+	Processor          CIMResourceType = 3
+	Memory             CIMResourceType = 4
+	IdeController      CIMResourceType = 5
+	ParallelScsiHba    CIMResourceType = 6
+	FcHba              CIMResourceType = 7
+	IScsiHba           CIMResourceType = 8
+	IbHba              CIMResourceType = 9
+	EthernetAdapter    CIMResourceType = 10
+	OtherNetwork       CIMResourceType = 11
+	IoSlot             CIMResourceType = 12
+	IoDevice           CIMResourceType = 13
+	FloppyDrive        CIMResourceType = 14
+	CdDrive            CIMResourceType = 15
+	DvdDrive           CIMResourceType = 16
+	DiskDrive          CIMResourceType = 17
+	TapeDrive          CIMResourceType = 18
+	StorageExtent      CIMResourceType = 19
+	OtherStorage       CIMResourceType = 20
+	SerialPort         CIMResourceType = 21
+	ParallelPort       CIMResourceType = 22
+	UsbController      CIMResourceType = 23
+	Graphics           CIMResourceType = 24
+	Ieee1394           CIMResourceType = 25
+	PartitionableUnit  CIMResourceType = 26
+	BasePartitionable  CIMResourceType = 27
+	PowerSupply        CIMResourceType = 28
+	CoolingDevice      CIMResourceType = 29
+	EthernetSwitchPort CIMResourceType = 30
+	LogicalDisk        CIMResourceType = 31
+	StorageVolume      CIMResourceType = 32
+	EthernetConnection CIMResourceType = 33
+)
+
+/*
 Source: http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.24.0/CIM_VirtualSystemSettingData.xsd
 */
 
@@ -57,9 +102,9 @@ type CIMResourceAllocationSettingData struct {
 	ElementName string `xml:"ElementName"`
 	InstanceID  string `xml:"InstanceID"`
 
-	ResourceType      *uint16 `xml:"ResourceType"`
-	OtherResourceType *string `xml:"OtherResourceType"`
-	ResourceSubType   *string `xml:"ResourceSubType"`
+	ResourceType      *CIMResourceType `xml:"ResourceType"`
+	OtherResourceType *string          `xml:"OtherResourceType"`
+	ResourceSubType   *string          `xml:"ResourceSubType"`
 
 	AddressOnParent       *string  `xml:"AddressOnParent"`
 	Address               *string  `xml:"Address"`
@@ -88,9 +133,9 @@ type CIMStorageAllocationSettingData struct {
 	ElementName string `xml:"ElementName"`
 	InstanceID  string `xml:"InstanceID"`
 
-	ResourceType      *uint16 `xml:"ResourceType"`
-	OtherResourceType *string `xml:"OtherResourceType"`
-	ResourceSubType   *string `xml:"ResourceSubType"`
+	ResourceType      *CIMResourceType `xml:"ResourceType"`
+	OtherResourceType *string          `xml:"OtherResourceType"`
+	ResourceSubType   *string          `xml:"ResourceSubType"`
 
 	Access                       *uint16         `xml:"Access"`
 	Address                      *string         `xml:"Address"`

--- a/ovf/configspec.go
+++ b/ovf/configspec.go
@@ -1,0 +1,983 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovf
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	ResourceSubTypeSoundCardSB16          = "vmware.soundcard.sb16"
+	ResourceSubTypeSoundCardEnsoniq1371   = "vmware.soundcard.ensoniq1371"
+	ResourceSubTypeSoundCardHDAudio       = "vmware.soundcard.hdaudio"
+	ResourceSubTypePCIController          = "vmware.pcicontroller"
+	ResourceSubTypePS2Controller          = "vmware.ps2controller"
+	ResourceSubTypeSIOController          = "vmware.siocontroller"
+	ResourceSubTypeKeyboard               = "vmware.keyboard"
+	ResourceSubTypePointingDevice         = "vmware.pointingdevice"
+	ResourceSubTypeVMCI                   = "vmware.vmci"
+	ResourceSubTypeUSBEHCI                = "vmware.usb.ehci" /* USB 2.0 */
+	ResourceSubTypeUSBXHCI                = "vmware.usb.xhci" /* USB 3.0 */
+	ResourceSubTypeCdromISO               = "vmware.cdrom.iso"
+	ResourceSubTypeCDROMRemotePassthrough = "vmware.cdrom.remotepassthrough"
+	ResourceSubTypeCDROMRemoteATAPI       = "vmware.cdrom.remoteatapi"
+	ResourceSubTypeCDROMPassthrough       = "vmware.cdrom.passthrough"
+	ResourceSubTypeCDROMATAPI             = "vmware.cdrom.atapi"
+	ResourceSubTypeFloppyDevice           = "vmware.floppy.device"
+	ResourceSubTypeFloppyImage            = "vmware.floppy.image"
+	ResourceSubTypeFloppyRemoveDevice     = "vmware.floppy.remotedevice"
+	ResourceSubTypeSCSIPassthrough        = "vmware.scsi.passthrough"
+	ResourceSubTypeParallelPortDevice     = "vmware.parallelport.device"
+	ResourceSubTypeParallelPortFile       = "vmware.parallelport.file"
+	ResourceSubTypeSerialPortDevice       = "vmware.serialport.device"
+	ResourceSubTypeSerialPortFile         = "vmware.serialport.file"
+	ResourceSubTypeSerialPortPipe         = "vmware.serialport.pipe"
+	ResourceSubTypeSerialPortURI          = "vmware.serialport.uri"
+	ResourceSubTypeSerialPortThinPrint    = "vmware.serialport.thinprint"
+	ResourceSubTypeSATAAHCI               = "vmware.sata.ahci"
+	ResourceSubTypeSATAAHCIAlter          = "ahci"
+	ResourceSubTypeNVMEController         = "vmware.nvme.controller"
+	ResourceSubTypeNVDIMMController       = "vmware.nvdimm.controller"
+	ResourceSubTypeNVDIMMDevice           = "vmware.nvdimm.device"
+	ResourceSubTypePCIPassthrough         = "vmware.pci.passthrough"
+	ResourceSubTypePCIPassthroughDVX      = "vmware.pci.passthrough-dvx"
+	ResourceSubTypePCIPassthroughAH       = "vmware.pci.passthrough-ah"
+	ResourceSubTypePCIPassthroughVMIOP    = "vmware.pci.passthrough-vmiop"
+	ResourceSubTypePrecisionClock         = "vmware.precisionclock"
+	ResourceSubTypeWatchdogTimer          = "vmware.watchdogtimer"
+	ResourceSubTypeVTPM                   = "vmware.vtpm"
+)
+
+// ErrUnsupportedItem is returned by Envelope.ToConfigSpec when there is an
+// invalid item configuration.
+type ErrUnsupportedItem struct {
+	Name             string
+	Index            int
+	InstanceID       string
+	DeviceType       CIMResourceType
+	LocalizedMessage string
+}
+
+func (e ErrUnsupportedItem) Error() string {
+	msg := fmt.Sprintf(
+		"unsupported item name=%q, index=%d, instanceID=%q",
+		e.Name, e.Index, e.InstanceID)
+	if e.DeviceType > 0 {
+		msg = fmt.Sprintf("%s, type=%d", msg, e.DeviceType)
+	}
+	if e.LocalizedMessage != "" {
+		msg = fmt.Sprintf("%s, msg=%q", msg, e.LocalizedMessage)
+	}
+	return msg
+}
+
+type configSpec = types.VirtualMachineConfigSpec
+
+// ToConfigSpec transforms the envelope into a ConfigSpec that may be used to
+// create a new virtual machine.
+// Please note, at this time:
+//   - Only a single VirtualSystem is supported. The VirtualSystemCollection
+//     section is ignored.
+//   - Only the first VirtualHardware section is supported.
+//   - Only the default deployment option configuration is considered. Elements
+//     part of a non-default configuration are ignored.
+//   - Disks must specify zero or one HostResource elements.
+//   - Many, many more constraints...
+func (e Envelope) ToConfigSpec() (types.VirtualMachineConfigSpec, error) {
+
+	vs := e.VirtualSystem
+	if vs == nil {
+		return configSpec{}, errors.New("no VirtualSystem")
+	}
+
+	// Determine if there is a default configuration.
+	var defaultConfigName string
+	if do := e.DeploymentOption; do != nil {
+		for _, c := range do.Configuration {
+			if d := c.Default; d != nil && *d {
+				defaultConfigName = c.ID
+				break
+			}
+		}
+	}
+
+	dst := configSpec{
+		Files: &types.VirtualMachineFileInfo{},
+		Name:  vs.ID,
+	}
+
+	// Set the guest ID.
+	if os := vs.OperatingSystem; os != nil && os.OSType != nil {
+		dst.GuestId = *os.OSType
+	}
+
+	// Parse the hardware.
+	if err := e.toHardware(&dst, defaultConfigName, vs); err != nil {
+		return configSpec{}, err
+	}
+
+	// Parse the vApp config.
+	if err := e.toVAppConfig(&dst, defaultConfigName, vs); err != nil {
+		return configSpec{}, err
+	}
+
+	return dst, nil
+}
+
+func (e Envelope) toHardware(
+	dst *configSpec,
+	configName string,
+	vs *VirtualSystem) error {
+
+	var hw VirtualHardwareSection
+	if len(vs.VirtualHardware) == 0 {
+		return errors.New("no VirtualHardware")
+	}
+	hw = vs.VirtualHardware[0]
+
+	// Set the hardware version.
+	if vmx := hw.System.VirtualSystemType; vmx != nil {
+		dst.Version = *vmx
+	}
+
+	// Parse the config
+	e.toConfig(dst, hw)
+
+	// Parse the extra config.
+	e.toExtraConfig(dst, hw)
+
+	var (
+		devices   object.VirtualDeviceList
+		resources = map[string]types.BaseVirtualDevice{}
+	)
+
+	for index := range hw.Item {
+		item := hw.Item[index]
+
+		if c := item.Configuration; c != nil {
+			if *c != configName {
+				// Skip items that do not belong to the provided config.
+				continue
+			}
+		}
+
+		rt := item.ResourceType
+		if rt == nil {
+			return e.errUnsupportedItem(
+				index, item, nil, "nil ResourceType")
+		}
+
+		var (
+			d   types.BaseVirtualDevice
+			err error
+		)
+
+		switch *rt {
+		case Other:
+			d, err = e.toOther(item, devices, resources)
+
+		case Processor:
+			if item.VirtualQuantity == nil {
+				return e.errUnsupportedItem(
+					index, item, nil, "nil VirtualQuantity")
+			}
+			dst.NumCPUs = int32(*item.VirtualQuantity)
+			if cps := item.CoresPerSocket; cps != nil {
+				dst.NumCoresPerSocket = cps.Value
+			}
+
+		case Memory:
+			if item.VirtualQuantity == nil {
+				return e.errUnsupportedItem(
+					index, item, nil, "nil VirtualQuantity")
+			}
+			dst.MemoryMB = int64(*item.VirtualQuantity)
+
+		case IdeController:
+			d, err = e.toIDEController(item, devices, resources)
+
+		case ParallelScsiHba:
+			d, err = e.toSCSIController(item, devices, resources)
+
+		case EthernetAdapter:
+			d, err = e.toNetworkInterface(item, devices, resources)
+
+		case FloppyDrive:
+			if devices.PickController((*types.VirtualSIOController)(nil)) == nil {
+				c := &types.VirtualSIOController{}
+				c.Key = devices.NewKey()
+				devices = append(devices, c)
+			}
+			d, err = e.toFloppyDrive(item, devices, resources)
+
+		case CdDrive, DvdDrive:
+			d, err = e.toCDOrDVDDrive(item, devices, resources)
+
+		case DiskDrive:
+			d, err = e.toVirtualDisk(item, devices, resources)
+
+		case OtherStorage:
+			d, err = e.toOtherStorage(item, devices, resources)
+
+		case UsbController:
+			d, err = e.toUSB(item, devices, resources)
+
+		case Graphics:
+			d, err = e.toVideoCard(item, devices, resources)
+
+		default:
+			return e.errUnsupportedItem(
+				index, item, nil, "unsupported resource type")
+		}
+
+		if err != nil {
+			return e.errUnsupportedItem(index, item, err)
+		}
+
+		if d != nil {
+			setConnectable(d, item)
+			if err := e.setUnitNumber(item, d); err != nil {
+				return e.errUnsupportedItem(index, item, err)
+			}
+			if err := e.setPCISlotNumber(item, d); err != nil {
+				return e.errUnsupportedItem(index, item, err)
+			}
+			devices = append(devices, d)
+		}
+	}
+
+	// Add the devices to the ConfigSpec.
+	dst.DeviceChange, _ = devices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+
+	return nil
+}
+
+func (e Envelope) errUnsupportedItem(
+	index int,
+	item ResourceAllocationSettingData,
+	inner error,
+	args ...any) error {
+
+	err := ErrUnsupportedItem{
+		Name:       item.ElementName,
+		InstanceID: item.InstanceID,
+		Index:      index,
+	}
+
+	if item.ResourceType != nil {
+		err.DeviceType = *item.ResourceType
+	}
+
+	if len(args) == 1 {
+		err.LocalizedMessage = args[0].(string)
+	} else if len(args) > 1 {
+		err.LocalizedMessage = fmt.Sprintf(args[0].(string), args[1:]...)
+	}
+
+	if inner != nil {
+		return fmt.Errorf("%w, inner=%w", err, inner)
+	}
+
+	return err
+}
+
+func (e Envelope) setUnitNumber(
+	item ResourceAllocationSettingData,
+	d types.BaseVirtualDevice) error {
+
+	if item.AddressOnParent == nil || *item.AddressOnParent == "" {
+		return nil
+	}
+
+	unitNumber, err := strconv.ParseInt(*item.AddressOnParent, 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid AddressOnParent=%q", *item.AddressOnParent)
+	}
+
+	d.GetVirtualDevice().UnitNumber = types.NewInt32(int32(unitNumber))
+	return nil
+}
+
+func (e Envelope) setBusNumber(
+	item ResourceAllocationSettingData,
+	d types.BaseVirtualDevice) error {
+
+	if item.Address == nil || *item.Address == "" {
+		return nil
+	}
+
+	c, ok := d.(types.BaseVirtualController)
+	if !ok {
+		return fmt.Errorf("expectedType=%s, actualType=%T",
+			"types.BaseVirtualController", d)
+	}
+
+	busNumber, err := strconv.ParseInt(*item.Address, 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid Address=%q", *item.Address)
+	}
+
+	c.GetVirtualController().BusNumber = int32(busNumber)
+	return nil
+}
+
+func (e Envelope) setPCISlotNumber(
+	item ResourceAllocationSettingData,
+	d types.BaseVirtualDevice) error {
+
+	var pciSlotNumber int32 = -1
+
+	for i := range item.Config {
+		c := item.Config[i]
+		if c.Key == "slotInfo.pciSlotNumber" {
+			if c.Value != "" {
+				v, err := strconv.ParseInt(c.Value, 10, 32)
+				if err != nil {
+					return fmt.Errorf("invalid pci slot number %s", c.Value)
+				}
+				pciSlotNumber = int32(v)
+			}
+			break
+		}
+	}
+
+	if pciSlotNumber >= 0 {
+		vd := d.GetVirtualDevice()
+		if vd.SlotInfo == nil {
+			vd.SlotInfo = &types.VirtualDevicePciBusSlotInfo{}
+		}
+		si, ok := vd.SlotInfo.(*types.VirtualDevicePciBusSlotInfo)
+		if !ok {
+			return fmt.Errorf("expectedType=%s, actualType=%T",
+				"*types.VirtualDevicePciBusSlotInfo", vd.SlotInfo)
+		}
+		si.PciSlotNumber = pciSlotNumber
+	}
+
+	return nil
+}
+
+func (e Envelope) ovfDisk(diskID string) *VirtualDiskDesc {
+	for _, disk := range e.Disk.Disks {
+		if strings.HasSuffix(diskID, disk.DiskID) {
+			return &disk
+		}
+	}
+	return nil
+}
+
+func (e Envelope) toVirtualDisk(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	resources map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	if item.Parent == nil {
+		return nil, fmt.Errorf("missing Parent")
+	}
+
+	r, ok := resources[*item.Parent]
+	if !ok {
+		return nil, nil
+	}
+
+	c, ok := r.(types.BaseVirtualController)
+	if !ok {
+		return nil, fmt.Errorf("expectedType=%s, actualType=%T",
+			"types.BaseVirtualController", r)
+	}
+
+	d := devices.CreateDisk(c, types.ManagedObjectReference{}, "")
+
+	devices.AssignController(d, c)
+
+	d.VirtualDevice.DeviceInfo = &types.Description{
+		Label: item.ElementName,
+	}
+
+	// Find the disk's capacity.
+	var capacityInBytes uint64
+	switch len(item.HostResource) {
+
+	case 0:
+		var allocUnitsSz string
+		if item.AllocationUnits != nil {
+			allocUnitsSz = *item.AllocationUnits
+		}
+		capacityInBytes = uint64(ParseCapacityAllocationUnits(allocUnitsSz))
+		if r := item.VirtualQuantity; r != nil {
+			capacityInBytes *= uint64(*r)
+		}
+
+	case 1:
+		diskID := item.HostResource[0]
+		dd := e.ovfDisk(diskID)
+		if dd == nil {
+			return nil, fmt.Errorf("missing diskID %q", diskID)
+		}
+
+		var allocUnitsSz string
+		if dd.CapacityAllocationUnits != nil {
+			allocUnitsSz = *dd.CapacityAllocationUnits
+		}
+		capacityInBytes = uint64(ParseCapacityAllocationUnits(allocUnitsSz))
+		if capSz := dd.Capacity; capSz != "" {
+			cap, err := strconv.ParseUint(dd.Capacity, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("disk=%s has invalid capacity=%q",
+					diskID, capSz)
+			}
+			capacityInBytes *= cap
+		}
+
+	default:
+		return nil, fmt.Errorf("multiple HostResource elements")
+	}
+
+	if capacityInBytes > math.MaxInt64 {
+		return nil, fmt.Errorf(
+			"capacityInBytes=%d exceeds math.MaxInt64", capacityInBytes)
+	}
+
+	d.CapacityInBytes = int64(capacityInBytes)
+
+	return d, nil
+}
+
+func (e Envelope) toCDOrDVDDrive(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	resources map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	if item.Parent == nil {
+		return nil, fmt.Errorf("missing Parent")
+	}
+
+	r, ok := resources[*item.Parent]
+	if !ok {
+		return nil, nil // Parent is unsupported
+	}
+
+	c, ok := r.(*types.VirtualIDEController)
+	if !ok {
+		return nil, fmt.Errorf("expectedType=%s, actualType=%T",
+			"*types.VirtualIDEController", r)
+	}
+
+	d, err := devices.CreateCdrom(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+func (e Envelope) toSCSIController(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	resources map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	d, err := devices.CreateSCSIController(item.toResourceSubType())
+	if err != nil {
+		return nil, err
+	}
+	if err := e.setBusNumber(item, d); err != nil {
+		return nil, err
+	}
+	resources[item.InstanceID] = d
+
+	return d, nil
+}
+
+func (e Envelope) toIDEController(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	resources map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	d, err := devices.CreateIDEController()
+	if err != nil {
+		return nil, err
+	}
+	if err := e.setBusNumber(item, d); err != nil {
+		return nil, err
+	}
+	resources[item.InstanceID] = d
+	return d, nil
+}
+
+func (e Envelope) toOtherStorage(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	resources map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	rst := item.toResourceSubType()
+	switch rst {
+	case ResourceSubTypeSATAAHCI, ResourceSubTypeSATAAHCIAlter:
+		return e.toSATAController(item, devices, resources)
+	case ResourceSubTypeNVMEController:
+		return e.toNVMEController(item, devices, resources)
+	}
+	return nil, fmt.Errorf("unknown subtype %q", rst)
+}
+
+func (e Envelope) toSATAController(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	resources map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	d, err := devices.CreateSATAController()
+	if err != nil {
+		return nil, err
+	}
+	if err := e.setBusNumber(item, d); err != nil {
+		return nil, err
+	}
+	resources[item.InstanceID] = d
+	return d, nil
+}
+
+func (e Envelope) toNVMEController(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	resources map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	d, err := devices.CreateNVMEController()
+	if err != nil {
+		return nil, err
+	}
+	if err := e.setBusNumber(item, d); err != nil {
+		return nil, err
+	}
+	resources[item.InstanceID] = d
+	return d, nil
+}
+
+func (e Envelope) toUSB(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	resources map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	var d types.BaseVirtualDevice
+
+	vc := types.VirtualController{
+		VirtualDevice: types.VirtualDevice{
+			Key: devices.NewKey(),
+		},
+	}
+
+	rst := item.toResourceSubType()
+	switch rst {
+	case ResourceSubTypeUSBEHCI:
+		c := &types.VirtualUSBController{VirtualController: vc}
+		for i := range item.Config {
+			ic := item.Config[i]
+			switch ic.Key {
+			case "autoConnectDevices":
+				c.AutoConnectDevices = szToBoolPtr(ic.Value)
+			case "ehciEnabled":
+				c.EhciEnabled = szToBoolPtr(ic.Value)
+			}
+		}
+		d = c
+	case ResourceSubTypeUSBXHCI:
+		c := &types.VirtualUSBXHCIController{VirtualController: vc}
+		for i := range item.Config {
+			ic := item.Config[i]
+			switch ic.Key {
+			case "autoConnectDevices":
+				c.AutoConnectDevices = szToBoolPtr(ic.Value)
+			}
+		}
+		d = c
+	default:
+		return nil, fmt.Errorf("invalid subtype %q", rst)
+	}
+
+	if err := e.setBusNumber(item, d); err != nil {
+		return nil, err
+	}
+
+	resources[item.InstanceID] = d
+	return d, nil
+}
+
+func (e Envelope) toNetworkInterface(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	_ map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	d, err := devices.CreateEthernetCard(item.toResourceSubType(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	nic := d.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+
+	for i := range item.Config {
+		c := item.Config[i]
+		switch c.Key {
+		case "wakeOnLanEnabled":
+			nic.WakeOnLanEnabled = szToBoolPtr(c.Value)
+		case "uptCompatibilityEnabled":
+			nic.UptCompatibilityEnabled = szToBoolPtr(c.Value)
+		}
+	}
+
+	return d, nil
+}
+
+func (e Envelope) toFloppyDrive(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	resources map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	d, err := devices.CreateFloppy()
+	if err != nil {
+		return nil, err
+	}
+	resources[item.InstanceID] = d
+
+	return d, nil
+}
+
+func (e Envelope) toVideoCard(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	_ map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	d := &types.VirtualMachineVideoCard{
+		VirtualDevice: types.VirtualDevice{
+			Key: devices.NewKey(),
+		},
+	}
+
+	for i := range item.Config {
+		c := item.Config[i]
+		switch c.Key {
+		case "enable3DSupport":
+			d.Enable3DSupport = szToBoolPtr(c.Value)
+		case "graphicsMemorySizeInKB":
+			v, err := strconv.ParseInt(c.Value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %q=%s", c.Key, c.Value)
+			}
+			d.GraphicsMemorySizeInKB = v
+		case "useAutoDetect":
+			d.UseAutoDetect = szToBoolPtr(c.Value)
+		case "videoRamSizeInKB":
+			v, err := strconv.ParseInt(c.Value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %q=%s", c.Key, c.Value)
+			}
+			d.VideoRamSizeInKB = v
+		case "numDisplays":
+			v, err := strconv.ParseInt(c.Value, 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %q=%s", c.Key, c.Value)
+			}
+			d.NumDisplays = int32(v)
+		case "use3dRenderer":
+			d.Use3dRenderer = c.Value
+		}
+	}
+
+	return d, nil
+}
+
+func (e Envelope) toOther(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	resources map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	switch item.toResourceSubType() {
+	case ResourceSubTypeVMCI:
+		return e.toVMCI(item, devices, resources)
+	}
+	return nil, nil
+}
+
+func (e Envelope) toVMCI(
+	item ResourceAllocationSettingData,
+	devices object.VirtualDeviceList,
+	_ map[string]types.BaseVirtualDevice) (types.BaseVirtualDevice, error) {
+
+	d := &types.VirtualMachineVMCIDevice{
+		VirtualDevice: types.VirtualDevice{
+			Key: devices.NewKey(),
+		},
+	}
+
+	for i := range item.Config {
+		c := item.Config[i]
+		switch c.Key {
+		case "allowUnrestrictedCommunication":
+			d.AllowUnrestrictedCommunication = szToBoolPtr(c.Value)
+		}
+	}
+
+	return d, nil
+}
+
+func (r *ResourceAllocationSettingData) toResourceSubType() string {
+	rst := "unknown"
+	if r != nil {
+		if r.ResourceSubType != nil {
+			rst = strings.ToLower(*r.ResourceSubType)
+		}
+	}
+	return rst
+}
+
+func (e Envelope) toConfig(
+	dst *configSpec,
+	hw VirtualHardwareSection) {
+
+	for i := range hw.Config {
+		c := hw.Config[i]
+		switch c.Key {
+		case "cpuHotAddEnabled":
+			dst.CpuHotAddEnabled = szToBoolPtr(c.Value)
+		case "cpuHotRemoveEnabled":
+			dst.CpuHotRemoveEnabled = szToBoolPtr(c.Value)
+		case "bootOptions.efiSecureBootEnabled":
+			initBootOptions(dst)
+			dst.BootOptions.EfiSecureBootEnabled = szToBoolPtr(c.Value)
+		case "firmware":
+			dst.Firmware = c.Value
+		case "flags.vbsEnabled":
+			initFlags(dst)
+			dst.Flags.VbsEnabled = szToBoolPtr(c.Value)
+		case "flags.vvtdEnabled":
+			initFlags(dst)
+			dst.Flags.VvtdEnabled = szToBoolPtr(c.Value)
+		case "memoryHotAddEnabled":
+			dst.MemoryHotAddEnabled = szToBoolPtr(c.Value)
+		case "nestedHVEnabled":
+			dst.NestedHVEnabled = szToBoolPtr(c.Value)
+		case "virtualICH7MPresent":
+			dst.VirtualICH7MPresent = szToBoolPtr(c.Value)
+		case "virtualSMCPresent":
+			dst.VirtualSMCPresent = szToBoolPtr(c.Value)
+		case "cpuAllocation.shares.shares":
+			initCPUAllocationShares(dst)
+			dst.CpuAllocation.Shares.Shares = szToInt32(c.Value)
+		case "cpuAllocation.shares.level":
+			initCPUAllocationShares(dst)
+			dst.CpuAllocation.Shares.Level = types.SharesLevel(c.Value)
+		case "simultaneousThreads":
+			dst.SimultaneousThreads = szToInt32(c.Value)
+		case "tools.syncTimeWithHost":
+			initToolsConfig(dst)
+			dst.Tools.SyncTimeWithHost = szToBoolPtr(c.Value)
+		case "tools.syncTimeWithHostAllowed":
+			initToolsConfig(dst)
+			dst.Tools.SyncTimeWithHostAllowed = szToBoolPtr(c.Value)
+		case "tools.afterPowerOn":
+			initToolsConfig(dst)
+			dst.Tools.AfterPowerOn = szToBoolPtr(c.Value)
+		case "tools.afterResume":
+			initToolsConfig(dst)
+			dst.Tools.AfterResume = szToBoolPtr(c.Value)
+		case "tools.beforeGuestShutdown":
+			initToolsConfig(dst)
+			dst.Tools.BeforeGuestShutdown = szToBoolPtr(c.Value)
+		case "tools.beforeGuestStandby":
+			initToolsConfig(dst)
+			dst.Tools.BeforeGuestStandby = szToBoolPtr(c.Value)
+		case "tools.toolsUpgradePolicy":
+			initToolsConfig(dst)
+			dst.Tools.ToolsUpgradePolicy = c.Value
+		case "powerOpInfo.powerOffType":
+			initPowerOpInfo(dst)
+			dst.PowerOpInfo.PowerOffType = c.Value
+		case "powerOpInfo.resetType":
+			initPowerOpInfo(dst)
+			dst.PowerOpInfo.ResetType = c.Value
+		case "powerOpInfo.suspendType":
+			initPowerOpInfo(dst)
+			dst.PowerOpInfo.SuspendType = c.Value
+		case "powerOpInfo.standbyAction":
+			initPowerOpInfo(dst)
+			dst.PowerOpInfo.StandbyAction = c.Value
+		case "vPMCEnabled":
+			dst.VPMCEnabled = szToBoolPtr(c.Value)
+		}
+	}
+}
+
+func (e Envelope) toExtraConfig(
+	dst *configSpec,
+	hw VirtualHardwareSection) {
+
+	var newEC object.OptionValueList
+	for i := range hw.ExtraConfig {
+		newEC = append(newEC, &types.OptionValue{
+			Key:   hw.ExtraConfig[i].Key,
+			Value: hw.ExtraConfig[i].Value,
+		})
+	}
+	dst.ExtraConfig = newEC.Join(dst.ExtraConfig...)
+}
+
+func initToolsConfig(dst *configSpec) {
+	if dst.Tools == nil {
+		dst.Tools = &types.ToolsConfigInfo{}
+	}
+}
+
+func initPowerOpInfo(dst *configSpec) {
+	if dst.PowerOpInfo == nil {
+		dst.PowerOpInfo = &types.VirtualMachineDefaultPowerOpInfo{}
+	}
+}
+
+func initCPUAllocation(dst *configSpec) {
+	if dst.CpuAllocation == nil {
+		dst.CpuAllocation = &types.ResourceAllocationInfo{}
+	}
+}
+
+func initCPUAllocationShares(dst *configSpec) {
+	initCPUAllocation(dst)
+	if dst.CpuAllocation.Shares == nil {
+		dst.CpuAllocation.Shares = &types.SharesInfo{}
+	}
+}
+
+func initFlags(dst *configSpec) {
+	if dst.Flags == nil {
+		dst.Flags = &types.VirtualMachineFlagInfo{}
+	}
+}
+
+func initBootOptions(dst *configSpec) {
+	if dst.BootOptions == nil {
+		dst.BootOptions = &types.VirtualMachineBootOptions{}
+	}
+}
+
+func setConnectable(
+	dst types.BaseVirtualDevice,
+	src ResourceAllocationSettingData) {
+
+	d := dst.GetVirtualDevice()
+	for i := range src.Config {
+		c := src.Config[i]
+		switch c.Key {
+		case "connectable.allowGuestControl":
+			if d.Connectable == nil {
+				d.Connectable = &types.VirtualDeviceConnectInfo{}
+			}
+			d.Connectable.AllowGuestControl = szToBool(c.Value)
+		}
+	}
+}
+
+func szToBoolPtr(s string) *bool {
+	if s == "" {
+		return nil
+	}
+	b, _ := strconv.ParseBool(s)
+	return &b
+}
+
+func szToBool(s string) bool {
+	b, _ := strconv.ParseBool(s)
+	return b
+}
+
+func szToInt32(s string) int32 {
+	v, _ := strconv.ParseInt(s, 10, 32)
+	return int32(v)
+}
+
+func deref[T any](pT *T) T {
+	var t T
+	if pT != nil {
+		t = *pT
+	}
+	return t
+}
+
+func (e Envelope) toVAppConfig(
+	dst *configSpec,
+	configName string,
+	vs *VirtualSystem) error {
+
+	if len(vs.Product) == 0 {
+		return nil
+	}
+
+	vapp := &types.VAppConfigSpec{}
+
+	index := 0
+	for i, product := range vs.Product {
+		vapp.Product = append(vapp.Product, types.VAppProductSpec{
+			ArrayUpdateSpec: types.ArrayUpdateSpec{
+				Operation: types.ArrayUpdateOperationAdd,
+			},
+			Info: &types.VAppProductInfo{
+				Key:         int32(i),
+				ClassId:     deref(product.Class),
+				InstanceId:  deref(product.Instance),
+				Name:        product.Product,
+				Vendor:      product.Vendor,
+				Version:     product.Version,
+				FullVersion: product.FullVersion,
+				ProductUrl:  product.ProductURL,
+				VendorUrl:   product.VendorURL,
+				AppUrl:      product.AppURL,
+			},
+		})
+
+		for _, p := range product.Property {
+			if p.Configuration != nil && *p.Configuration != configName {
+				// Skip properties that are not part of the provided
+				// configuration.
+				continue
+			}
+			vapp.Property = append(vapp.Property, types.VAppPropertySpec{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: types.ArrayUpdateOperationAdd,
+				},
+				Info: &types.VAppPropertyInfo{
+					Key:              int32(index),
+					ClassId:          deref(product.Class),
+					InstanceId:       deref(product.Instance),
+					Id:               p.Key,
+					Category:         product.Category,
+					Label:            deref(p.Label),
+					Type:             p.Type,
+					UserConfigurable: p.UserConfigurable,
+					DefaultValue:     deref(p.Default),
+					Value:            "",
+					Description:      deref(p.Description),
+				},
+			})
+			index++
+		}
+	}
+
+	dst.VAppConfig = vapp
+	return nil
+}

--- a/ovf/configspec_test.go
+++ b/ovf/configspec_test.go
@@ -1,0 +1,491 @@
+/*
+Copyright (c) 2015-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovf
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestEnvelopeToConfigSpec(t *testing.T) {
+	e := testEnvelope(t, "fixtures/haproxy-vsphere.ovf")
+
+	cs, err := e.ToConfigSpec()
+
+	var w bytes.Buffer
+	enc := types.NewJSONEncoder(&w)
+	enc.SetIndent("", "    ")
+	assert.NoError(t, enc.Encode(cs))
+	t.Logf("\n\nconfigSpec=%s\n\n", w.String())
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, cs)
+
+	assert.Equal(t, "haproxy", cs.Name)
+	assert.Equal(t, int32(2), cs.NumCPUs)
+	assert.Equal(t, int32(2), cs.NumCoresPerSocket)
+	assert.Equal(t, int64(4096), cs.MemoryMB)
+	assert.Equal(t, "vmx-13", cs.Version)
+
+	if assert.Len(t, cs.DeviceChange, 21) {
+
+		var scsiController1Key int32
+		if d, ok := cs.DeviceChange[0].GetVirtualDeviceConfigSpec().Device.(*types.VirtualLsiLogicController); assert.True(t, ok) {
+			scsiController1Key = d.Key
+			assert.Equal(t, int32(0), d.BusNumber)
+			if assert.NotNil(t, d.SlotInfo) {
+				si, ok := d.SlotInfo.(*types.VirtualDevicePciBusSlotInfo)
+				assert.True(t, ok)
+				assert.Equal(t, int32(128), si.PciSlotNumber)
+			}
+		}
+
+		if d, ok := cs.DeviceChange[1].GetVirtualDeviceConfigSpec().Device.(*types.VirtualDisk); assert.True(t, ok) {
+			assert.Equal(t, scsiController1Key, d.ControllerKey)
+			if assert.NotNil(t, d.UnitNumber) {
+				assert.Equal(t, int32(0), *d.UnitNumber)
+			}
+			db, ok := d.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+			assert.True(t, ok)
+			assert.Equal(t, string(types.VirtualDiskModePersistent), db.DiskMode)
+			if assert.NotNil(t, db.ThinProvisioned) {
+				assert.True(t, *db.ThinProvisioned)
+			}
+			assert.Equal(t, int64(20*1024*1024*1024), d.CapacityInBytes)
+		}
+
+		if bd, ok := cs.DeviceChange[2].GetVirtualDeviceConfigSpec().Device.(types.BaseVirtualEthernetCard); assert.True(t, ok) {
+			d := bd.GetVirtualEthernetCard()
+			if assert.NotNil(t, d.UnitNumber) {
+				assert.Equal(t, int32(2), *d.UnitNumber)
+			}
+			if assert.NotNil(t, d.Connectable) {
+				assert.True(t, d.Connectable.AllowGuestControl)
+			}
+			if assert.NotNil(t, d.WakeOnLanEnabled) {
+				assert.False(t, *d.WakeOnLanEnabled)
+			}
+			if assert.NotNil(t, d.SlotInfo) {
+				si, ok := d.SlotInfo.(*types.VirtualDevicePciBusSlotInfo)
+				assert.True(t, ok)
+				assert.Equal(t, int32(160), si.PciSlotNumber)
+			}
+		}
+
+		if bd, ok := cs.DeviceChange[3].GetVirtualDeviceConfigSpec().Device.(types.BaseVirtualEthernetCard); assert.True(t, ok) {
+			d := bd.GetVirtualEthernetCard()
+			if assert.NotNil(t, d.UnitNumber) {
+				assert.Equal(t, int32(3), *d.UnitNumber)
+			}
+			if assert.NotNil(t, d.Connectable) {
+				assert.True(t, d.Connectable.AllowGuestControl)
+			}
+			if assert.NotNil(t, d.WakeOnLanEnabled) {
+				assert.False(t, *d.WakeOnLanEnabled)
+			}
+			if assert.NotNil(t, d.SlotInfo) {
+				si, ok := d.SlotInfo.(*types.VirtualDevicePciBusSlotInfo)
+				assert.True(t, ok)
+				assert.Equal(t, int32(192), si.PciSlotNumber)
+			}
+			if assert.NotNil(t, d.UptCompatibilityEnabled) {
+				assert.False(t, *d.UptCompatibilityEnabled)
+			}
+		}
+
+		if d, ok := cs.DeviceChange[4].GetVirtualDeviceConfigSpec().Device.(*types.VirtualMachineVideoCard); assert.True(t, ok) {
+			if assert.NotNil(t, d.Enable3DSupport) {
+				assert.False(t, *d.Enable3DSupport)
+			}
+			assert.Equal(t, int64(262144), d.GraphicsMemorySizeInKB)
+			if assert.NotNil(t, d.UseAutoDetect) {
+				assert.False(t, *d.UseAutoDetect)
+			}
+			assert.Equal(t, int64(4096), d.VideoRamSizeInKB)
+			assert.Equal(t, int32(1), d.NumDisplays)
+			assert.Equal(t, "automatic", d.Use3dRenderer)
+		}
+
+		var ideControllerKey int32
+		if d, ok := cs.DeviceChange[5].GetVirtualDeviceConfigSpec().Device.(*types.VirtualIDEController); assert.True(t, ok) {
+			ideControllerKey = d.Key
+			assert.Equal(t, int32(1), d.BusNumber)
+		}
+
+		if d, ok := cs.DeviceChange[6].GetVirtualDeviceConfigSpec().Device.(*types.VirtualIDEController); assert.True(t, ok) {
+			assert.Equal(t, int32(0), d.BusNumber)
+		}
+
+		if d, ok := cs.DeviceChange[7].GetVirtualDeviceConfigSpec().Device.(*types.VirtualCdrom); assert.True(t, ok) {
+			if assert.NotNil(t, d.UnitNumber) {
+				assert.Equal(t, int32(0), *d.UnitNumber)
+			}
+			assert.Equal(t, ideControllerKey, d.ControllerKey)
+		}
+
+		var sioControllerKey int32
+		if d, ok := cs.DeviceChange[8].GetVirtualDeviceConfigSpec().Device.(*types.VirtualSIOController); assert.True(t, ok) {
+			sioControllerKey = d.Key
+		}
+
+		if d, ok := cs.DeviceChange[9].GetVirtualDeviceConfigSpec().Device.(*types.VirtualFloppy); assert.True(t, ok) {
+			if assert.NotNil(t, d.UnitNumber) {
+				assert.Equal(t, int32(0), *d.UnitNumber)
+			}
+			assert.Equal(t, sioControllerKey, d.ControllerKey)
+		}
+
+		if d, ok := cs.DeviceChange[10].GetVirtualDeviceConfigSpec().Device.(*types.VirtualMachineVMCIDevice); assert.True(t, ok) {
+			if assert.NotNil(t, d.AllowUnrestrictedCommunication) {
+				assert.False(t, *d.AllowUnrestrictedCommunication)
+			}
+		}
+
+		var scsiController2Key int32
+		if d, ok := cs.DeviceChange[11].GetVirtualDeviceConfigSpec().Device.(*types.ParaVirtualSCSIController); assert.True(t, ok) {
+			scsiController2Key = d.Key
+			assert.Equal(t, int32(1), d.BusNumber)
+			assert.Nil(t, d.SlotInfo)
+		}
+
+		if d, ok := cs.DeviceChange[12].GetVirtualDeviceConfigSpec().Device.(*types.VirtualDisk); assert.True(t, ok) {
+			assert.Equal(t, scsiController2Key, d.ControllerKey)
+			if assert.NotNil(t, d.UnitNumber) {
+				assert.Equal(t, int32(0), *d.UnitNumber)
+			}
+			db, ok := d.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+			assert.True(t, ok)
+			assert.Equal(t, string(types.VirtualDiskModePersistent), db.DiskMode)
+			if assert.NotNil(t, db.ThinProvisioned) {
+				assert.True(t, *db.ThinProvisioned)
+			}
+			assert.Equal(t, int64(10*1024*1024*1024), d.CapacityInBytes)
+		}
+
+		var sataController1Key int32
+		if d, ok := cs.DeviceChange[13].GetVirtualDeviceConfigSpec().Device.(*types.VirtualAHCIController); assert.True(t, ok) {
+			sataController1Key = d.Key
+			assert.Equal(t, int32(0), d.BusNumber)
+			assert.Nil(t, d.SlotInfo)
+		}
+
+		if d, ok := cs.DeviceChange[14].GetVirtualDeviceConfigSpec().Device.(*types.VirtualDisk); assert.True(t, ok) {
+			assert.Equal(t, sataController1Key, d.ControllerKey)
+			if assert.NotNil(t, d.UnitNumber) {
+				assert.Equal(t, int32(0), *d.UnitNumber)
+			}
+			db, ok := d.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+			assert.True(t, ok)
+			assert.Equal(t, string(types.VirtualDiskModePersistent), db.DiskMode)
+			if assert.NotNil(t, db.ThinProvisioned) {
+				assert.True(t, *db.ThinProvisioned)
+			}
+			assert.Equal(t, int64(10*1024*1024*1024), d.CapacityInBytes)
+		}
+
+		var sataController2Key int32
+		if d, ok := cs.DeviceChange[15].GetVirtualDeviceConfigSpec().Device.(*types.VirtualAHCIController); assert.True(t, ok) {
+			sataController2Key = d.Key
+			assert.Equal(t, int32(1), d.BusNumber)
+			assert.Nil(t, d.SlotInfo)
+		}
+
+		if d, ok := cs.DeviceChange[16].GetVirtualDeviceConfigSpec().Device.(*types.VirtualDisk); assert.True(t, ok) {
+			assert.Equal(t, sataController2Key, d.ControllerKey)
+			if assert.NotNil(t, d.UnitNumber) {
+				assert.Equal(t, int32(0), *d.UnitNumber)
+			}
+			db, ok := d.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+			assert.True(t, ok)
+			assert.Equal(t, string(types.VirtualDiskModePersistent), db.DiskMode)
+			if assert.NotNil(t, db.ThinProvisioned) {
+				assert.True(t, *db.ThinProvisioned)
+			}
+			assert.Equal(t, int64(10*1024*1024*1024), d.CapacityInBytes)
+		}
+
+		var nvmeController1Key int32
+		if d, ok := cs.DeviceChange[17].GetVirtualDeviceConfigSpec().Device.(*types.VirtualNVMEController); assert.True(t, ok) {
+			nvmeController1Key = d.Key
+			assert.Equal(t, int32(0), d.BusNumber)
+			assert.Nil(t, d.SlotInfo)
+		}
+
+		if d, ok := cs.DeviceChange[18].GetVirtualDeviceConfigSpec().Device.(*types.VirtualDisk); assert.True(t, ok) {
+			assert.Equal(t, nvmeController1Key, d.ControllerKey)
+			if assert.NotNil(t, d.UnitNumber) {
+				assert.Equal(t, int32(0), *d.UnitNumber)
+			}
+			db, ok := d.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+			assert.True(t, ok)
+			assert.Equal(t, string(types.VirtualDiskModePersistent), db.DiskMode)
+			if assert.NotNil(t, db.ThinProvisioned) {
+				assert.True(t, *db.ThinProvisioned)
+			}
+			assert.Equal(t, int64(10*1024*1024*1024), d.CapacityInBytes)
+		}
+
+		if d, ok := cs.DeviceChange[19].GetVirtualDeviceConfigSpec().Device.(*types.VirtualUSBController); assert.True(t, ok) {
+			if assert.NotNil(t, d.AutoConnectDevices) {
+				assert.True(t, *d.AutoConnectDevices)
+			}
+			if assert.NotNil(t, d.EhciEnabled) {
+				assert.False(t, *d.EhciEnabled)
+			}
+		}
+
+		if d, ok := cs.DeviceChange[20].GetVirtualDeviceConfigSpec().Device.(*types.VirtualUSBXHCIController); assert.True(t, ok) {
+			if assert.NotNil(t, d.AutoConnectDevices) {
+				assert.True(t, *d.AutoConnectDevices)
+			}
+		}
+	}
+
+	assert.ElementsMatch(t, cs.ExtraConfig, []types.BaseOptionValue{
+		&types.OptionValue{
+			Key:   "guest_rpc.auth.cloud-init.set",
+			Value: "FALSE",
+		},
+	})
+
+	if assert.NotNil(t, cs.Flags) {
+		if assert.NotNil(t, cs.Flags.VbsEnabled) {
+			assert.False(t, *cs.Flags.VbsEnabled)
+		}
+		if assert.NotNil(t, cs.Flags.VvtdEnabled) {
+			assert.False(t, *cs.Flags.VvtdEnabled)
+		}
+	}
+
+	assert.Equal(t, "bios", cs.Firmware)
+
+	if assert.NotNil(t, cs.BootOptions) {
+		if assert.NotNil(t, cs.BootOptions.EfiSecureBootEnabled) {
+			assert.False(t, *cs.BootOptions.EfiSecureBootEnabled)
+		}
+	}
+
+	if assert.NotNil(t, cs.CpuHotAddEnabled) {
+		assert.False(t, *cs.CpuHotAddEnabled)
+	}
+	if assert.NotNil(t, cs.CpuHotRemoveEnabled) {
+		assert.False(t, *cs.CpuHotRemoveEnabled)
+	}
+	if assert.NotNil(t, cs.MemoryHotAddEnabled) {
+		assert.False(t, *cs.MemoryHotAddEnabled)
+	}
+	if assert.NotNil(t, cs.NestedHVEnabled) {
+		assert.False(t, *cs.NestedHVEnabled)
+	}
+	if assert.NotNil(t, cs.VirtualICH7MPresent) {
+		assert.False(t, *cs.VirtualICH7MPresent)
+	}
+
+	assert.Equal(t, int32(1), cs.SimultaneousThreads)
+
+	if assert.NotNil(t, cs.VPMCEnabled) {
+		assert.False(t, *cs.VPMCEnabled)
+	}
+
+	if assert.NotNil(t, cs.CpuAllocation) {
+		if assert.NotNil(t, cs.CpuAllocation.Shares) {
+			assert.Equal(t, &types.SharesInfo{
+				Shares: 2000,
+				Level:  types.SharesLevelNormal,
+			}, cs.CpuAllocation.Shares)
+		}
+	}
+
+	if assert.NotNil(t, cs.PowerOpInfo) {
+		assert.Equal(t, &types.VirtualMachineDefaultPowerOpInfo{
+			PowerOffType:  "soft",
+			ResetType:     "soft",
+			SuspendType:   "hard",
+			StandbyAction: "checkpoint",
+		}, cs.PowerOpInfo)
+	}
+
+	if assert.NotNil(t, cs.Tools) {
+		assert.Equal(t, &types.ToolsConfigInfo{
+			SyncTimeWithHost:        types.NewBool(false),
+			SyncTimeWithHostAllowed: types.NewBool(true),
+			AfterPowerOn:            types.NewBool(true),
+			AfterResume:             types.NewBool(true),
+			BeforeGuestShutdown:     types.NewBool(true),
+			BeforeGuestStandby:      types.NewBool(true),
+			ToolsUpgradePolicy:      "manual",
+		}, cs.Tools)
+	}
+
+	if va, ok := cs.VAppConfig.(*types.VAppConfigSpec); assert.True(t, ok) {
+		if assert.Len(t, va.Product, 4) {
+			assert.ElementsMatch(t,
+				[]types.VAppProductSpec{
+					{
+						ArrayUpdateSpec: types.ArrayUpdateSpec{
+							Operation: types.ArrayUpdateOperationAdd,
+						},
+						Info: &types.VAppProductInfo{
+							Key:         0,
+							Name:        "HAProxy for the Load Balancer API v0.2.0",
+							Vendor:      "VMware Inc.",
+							Version:     "v0.2.0",
+							FullVersion: "v0.2.0",
+							ProductUrl:  "https://vmware.com",
+							VendorUrl:   "https://vmware.com",
+						},
+					},
+					{
+						ArrayUpdateSpec: types.ArrayUpdateSpec{
+							Operation: types.ArrayUpdateOperationAdd,
+						},
+						Info: &types.VAppProductInfo{
+							Key:     1,
+							ClassId: "appliance",
+						},
+					},
+					{
+						ArrayUpdateSpec: types.ArrayUpdateSpec{
+							Operation: types.ArrayUpdateOperationAdd,
+						},
+						Info: &types.VAppProductInfo{
+							Key:     2,
+							ClassId: "network",
+						},
+					},
+					{
+						ArrayUpdateSpec: types.ArrayUpdateSpec{
+							Operation: types.ArrayUpdateOperationAdd,
+						},
+						Info: &types.VAppProductInfo{
+							Key:     3,
+							ClassId: "loadbalance",
+						},
+					},
+				},
+				va.Product,
+			)
+		}
+		if assert.Len(t, va.Property, 6) {
+			assert.ElementsMatch(t,
+				[]types.VAppPropertySpec{
+
+					// default
+					{
+						ArrayUpdateSpec: types.ArrayUpdateSpec{
+							Operation: types.ArrayUpdateOperationAdd,
+						},
+						Info: &types.VAppPropertyInfo{
+							Key:              0,
+							Category:         "Load Balancer API",
+							Id:               "BUILD_TIMESTAMP",
+							Type:             "string",
+							UserConfigurable: types.NewBool(false),
+							DefaultValue:     "1615488399",
+						},
+					},
+					{
+						ArrayUpdateSpec: types.ArrayUpdateSpec{
+							Operation: types.ArrayUpdateOperationAdd,
+						},
+						Info: &types.VAppPropertyInfo{
+							Key:              1,
+							Category:         "Load Balancer API",
+							Id:               "BUILD_DATE",
+							Type:             "string",
+							UserConfigurable: types.NewBool(false),
+							DefaultValue:     "2021-03-11T18:46:39Z",
+						},
+					},
+
+					// appliance
+					{
+						ArrayUpdateSpec: types.ArrayUpdateSpec{
+							Operation: types.ArrayUpdateOperationAdd,
+						},
+						Info: &types.VAppPropertyInfo{
+							Key:              2,
+							Category:         "1. Appliance Configuration",
+							ClassId:          "appliance",
+							Id:               "root_pwd",
+							Label:            "1.1. Root Password",
+							Type:             "string",
+							UserConfigurable: types.NewBool(true),
+							Description:      "The initial password of the root user. Subsequent changes of password should be performed in operating system. (6-128 characters)",
+						},
+					},
+
+					// network
+					{
+						ArrayUpdateSpec: types.ArrayUpdateSpec{
+							Operation: types.ArrayUpdateOperationAdd,
+						},
+						Info: &types.VAppPropertyInfo{
+							Key:              3,
+							Category:         "2. Network Config",
+							ClassId:          "network",
+							Id:               "hostname",
+							Label:            "2.1. Host Name",
+							Type:             "string",
+							UserConfigurable: types.NewBool(true),
+							DefaultValue:     "haproxy.local",
+							Description:      "The host name. A fully-qualified domain name is also supported.",
+						},
+					},
+
+					// loadbalance
+					{
+						ArrayUpdateSpec: types.ArrayUpdateSpec{
+							Operation: types.ArrayUpdateOperationAdd,
+						},
+						Info: &types.VAppPropertyInfo{
+							Key:              4,
+							Category:         "3. Load Balancing",
+							ClassId:          "loadbalance",
+							Id:               "service_ip_range",
+							Label:            "3.1. Load Balancer IP Ranges, comma-separated in CIDR format (Eg 1.2.3.4/28,5.6.7.8/28)",
+							Type:             "string",
+							UserConfigurable: types.NewBool(true),
+							Description:      "The IP ranges the load balancer will use for Kubernetes Services and Control Planes. The Appliance will currently respond to ALL the IPs in these ranges whether they're assigned or not. As such, these ranges must not overlap with the IPs assigned for the appliance or any other VMs on the network.",
+						},
+					},
+					{
+						ArrayUpdateSpec: types.ArrayUpdateSpec{
+							Operation: types.ArrayUpdateOperationAdd,
+						},
+						Info: &types.VAppPropertyInfo{
+							Key:              5,
+							Category:         "3. Load Balancing",
+							ClassId:          "loadbalance",
+							Id:               "dataplane_port",
+							Label:            "3.2. Dataplane API Management Port",
+							Type:             "int",
+							UserConfigurable: types.NewBool(true),
+							DefaultValue:     "5556",
+							Description:      "Specifies the port on which the Dataplane API will be advertized on the Management Network.",
+						},
+					},
+				},
+				va.Property,
+			)
+		}
+	}
+}

--- a/ovf/envelope.go
+++ b/ovf/envelope.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015-2023 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,32 +20,46 @@ import (
 	"fmt"
 )
 
+// Envelope is defined according to
+// https://www.dmtf.org/sites/default/files/standards/documents/DSP0243_2.1.1.pdf.
+//
+// Section 9 describes the parent/child relationships.
+//
+// A VirtualSystem may have zero or more VirtualHardware sections.
 type Envelope struct {
 	References []File `xml:"References>File"`
 
 	// Package level meta-data
-	Annotation         *AnnotationSection         `xml:"AnnotationSection"`
-	Product            *ProductSection            `xml:"ProductSection"`
-	Network            *NetworkSection            `xml:"NetworkSection"`
-	Disk               *DiskSection               `xml:"DiskSection"`
-	OperatingSystem    *OperatingSystemSection    `xml:"OperatingSystemSection"`
-	Eula               *EulaSection               `xml:"EulaSection"`
-	VirtualHardware    *VirtualHardwareSection    `xml:"VirtualHardwareSection"`
-	ResourceAllocation *ResourceAllocationSection `xml:"ResourceAllocationSection"`
-	DeploymentOption   *DeploymentOptionSection   `xml:"DeploymentOptionSection"`
+	Disk             *DiskSection             `xml:"DiskSection,omitempty"`
+	Network          *NetworkSection          `xml:"NetworkSection,omitempty"`
+	DeploymentOption *DeploymentOptionSection `xml:"DeploymentOptionSection,omitempty"`
 
 	// Content: A VirtualSystem or a VirtualSystemCollection
-	VirtualSystem *VirtualSystem `xml:"VirtualSystem"`
+	VirtualSystem           *VirtualSystem           `xml:"VirtualSystem,omitempty"`
+	VirtualSystemCollection *VirtualSystemCollection `xml:"VirtualSystemCollection,omitempty"`
 }
 
 type VirtualSystem struct {
 	Content
 
-	Annotation      []AnnotationSection      `xml:"AnnotationSection"`
-	Product         []ProductSection         `xml:"ProductSection"`
-	OperatingSystem []OperatingSystemSection `xml:"OperatingSystemSection"`
-	Eula            []EulaSection            `xml:"EulaSection"`
-	VirtualHardware []VirtualHardwareSection `xml:"VirtualHardwareSection"`
+	Annotation      *AnnotationSection       `xml:"AnnotationSection,omitempty"`
+	Product         []ProductSection         `xml:"ProductSection,omitempty"`
+	Eula            []EulaSection            `xml:"EulaSection,omitempty"`
+	OperatingSystem *OperatingSystemSection  `xml:"OperatingSystemSection,omitempty"`
+	VirtualHardware []VirtualHardwareSection `xml:"VirtualHardwareSection,omitempty"`
+}
+
+type VirtualSystemCollection struct {
+	Content
+
+	// Collection level meta-data
+	ResourceAllocation *ResourceAllocationSection `xml:"ResourceAllocationSection,omitempty"`
+	Annotation         *AnnotationSection         `xml:"AnnotationSection,omitempty"`
+	Product            []ProductSection           `xml:"ProductSection,omitempty"`
+	Eula               []EulaSection              `xml:"EulaSection,omitempty"`
+
+	// Content: One or more VirtualSystems
+	VirtualSystem []VirtualSystem `xml:"VirtualSystem,omitempty"`
 }
 
 type File struct {

--- a/ovf/envelope.go
+++ b/ovf/envelope.go
@@ -125,6 +125,7 @@ type Property struct {
 	UserConfigurable *bool   `xml:"userConfigurable,attr"`
 	Default          *string `xml:"value,attr"`
 	Password         *bool   `xml:"password,attr"`
+	Configuration    *string `xml:"configuration,attr"`
 
 	Label       *string `xml:"Label"`
 	Description *string `xml:"Description"`
@@ -207,9 +208,11 @@ type VirtualSystemSettingData struct {
 type ResourceAllocationSettingData struct {
 	CIMResourceAllocationSettingData
 
-	Required      *bool   `xml:"required,attr"`
-	Configuration *string `xml:"configuration,attr"`
-	Bound         *string `xml:"bound,attr"`
+	Required       *bool           `xml:"required,attr"`
+	Configuration  *string         `xml:"configuration,attr"`
+	Bound          *string         `xml:"bound,attr"`
+	Config         []Config        `xml:"Config"`
+	CoresPerSocket *CoresPerSocket `xml:"CoresPerSocket"`
 }
 
 type StorageAllocationSettingData struct {
@@ -238,4 +241,9 @@ type DeploymentOptionConfiguration struct {
 
 	Label       string `xml:"Label"`
 	Description string `xml:"Description"`
+}
+
+type CoresPerSocket struct {
+	Required *bool `xml:"required,attr"`
+	Value    int32 `xml:",chardata"`
 }

--- a/ovf/fixtures/haproxy-vsphere.ovf
+++ b/ovf/fixtures/haproxy-vsphere.ovf
@@ -1,0 +1,594 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1"
+          xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1"
+          xmlns:vmw="http://www.vmware.com/schema/ovf"
+          xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData"
+          xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData"
+          xmlns:sasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_StorageAllocationSettingData">
+  <References>
+    <File ovf:id="file1" ovf:href="haproxy.ova.vmdk" ovf:size="625911296"/>
+  </References>
+  <DiskSection>
+    <Info>List of the virtual disks</Info>
+    <Disk ovf:capacity="20" ovf:capacityAllocationUnits="byte * 2^30" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:populatedSize="1287454720"/>
+  </DiskSection>
+  <NetworkSection>
+    <Info>The list of logical networks</Info>
+    <Network ovf:name="Management">
+      <Description>Please select the Management network the Supervisor cluster uses to program HAProxy</Description>
+    </Network>
+    <Network ovf:name="Workload">
+      <Description>Please select the Workload network routable to Supervisor and Guest cluster nodes</Description>
+    </Network>
+    <Network ovf:name="Frontend" ovf:configuration="frontend">
+      <Description>(Optional) Please select the client-facing network for frontend, load balanced virtual servers</Description>
+    </Network>
+  </NetworkSection>
+  <DeploymentOptionSection>
+    <Info>The list of deployment options</Info>
+    <Configuration ovf:id="default" ovf:default="true">
+      <Label ovf:msgid="config.default.label"/>
+      <Description ovf:msgid="config.default.description"/>
+    </Configuration>
+    <Configuration ovf:id="frontend">
+      <Label ovf:msgid="config.frontend.label"/>
+      <Description ovf:msgid="config.frontend.description"/>
+    </Configuration>
+  </DeploymentOptionSection>
+  <vmw:StorageGroupSection ovf:required="false" vmw:id="group1" vmw:name="vSAN Default Storage Policy">
+    <Info>Storage policy for group of disks</Info>
+    <vmw:Description>The vSAN Default Storage Policy storage policy group</vmw:Description>
+  </vmw:StorageGroupSection>
+  <VirtualSystem ovf:id="haproxy">
+    <Info>A Virtual system</Info>
+    <Name>haproxy</Name>
+    <AnnotationSection>
+      <Info>A human-readable annotation</Info>
+      <Annotation>HAProxy for the Load Balancer API (v0.2.0)</Annotation>
+    </AnnotationSection>
+    <OperatingSystemSection ovf:id="101" vmw:osType="other3xLinux64Guest">
+      <Info>The operating system installed</Info>
+      <Description>Other 3.x or later Linux (64-bit)</Description>
+    </OperatingSystemSection>
+    <VirtualHardwareSection ovf:transport="com.vmware.guestInfo">
+      <Info>Virtual hardware requirements</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemType>vmx-13</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+        <rasd:Description>Number of Virtual CPUs</rasd:Description>
+        <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+        <vmw:CoresPerSocket ovf:required="false">2</vmw:CoresPerSocket>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>4096MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>4096</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>SCSI Controller</rasd:Description>
+        <rasd:ElementName>SCSI Controller 1</rasd:ElementName>
+        <rasd:InstanceID>3</rasd:InstanceID>
+        <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+        <rasd:ResourceType>6</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="128"/>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:ElementName>Hard Disk 1</rasd:ElementName>
+        <rasd:HostResource>ovf:/disk/vmdisk1</rasd:HostResource>
+        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:Parent>3</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>2</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Connection>Management</rasd:Connection>
+        <rasd:ElementName>Management Network</rasd:ElementName>
+        <rasd:InstanceID>5</rasd:InstanceID>
+        <rasd:ResourceSubType>VmxNet3</rasd:ResourceSubType>
+        <rasd:ResourceType>10</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="160"/>
+        <vmw:Config ovf:required="false" vmw:key="connectable.allowGuestControl" vmw:value="true"/>
+        <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>3</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Connection>Workload</rasd:Connection>
+        <rasd:ElementName>Workload Network</rasd:ElementName>
+        <rasd:InstanceID>6</rasd:InstanceID>
+        <rasd:ResourceSubType>VmxNet3</rasd:ResourceSubType>
+        <rasd:ResourceType>10</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="192"/>
+        <vmw:Config ovf:required="false" vmw:key="connectable.allowGuestControl" vmw:value="true"/>
+        <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>
+        <vmw:Config ovf:required="false" vmw:key="uptCompatibilityEnabled" vmw:value="false"/>
+      </Item>
+      <Item ovf:configuration="frontend">
+        <rasd:AddressOnParent>4</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Connection>Frontend</rasd:Connection>
+        <rasd:ElementName>Frontend Network</rasd:ElementName>
+        <rasd:InstanceID>7</rasd:InstanceID>
+        <rasd:ResourceSubType>VmxNet3</rasd:ResourceSubType>
+        <rasd:ResourceType>10</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="224"/>
+        <vmw:Config ovf:required="false" vmw:key="connectable.allowGuestControl" vmw:value="true"/>
+        <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>
+      </Item>
+      <Item ovf:required="false">
+        <rasd:ElementName>Video card</rasd:ElementName>
+        <rasd:InstanceID>8</rasd:InstanceID>
+        <rasd:ResourceType>24</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="enable3DSupport" vmw:value="false"/>
+        <vmw:Config ovf:required="false" vmw:key="graphicsMemorySizeInKB" vmw:value="262144"/>
+        <vmw:Config ovf:required="false" vmw:key="useAutoDetect" vmw:value="false"/>
+        <vmw:Config ovf:required="false" vmw:key="videoRamSizeInKB" vmw:value="4096"/>
+        <vmw:Config ovf:required="false" vmw:key="numDisplays" vmw:value="1"/>
+        <vmw:Config ovf:required="false" vmw:key="use3dRenderer" vmw:value="automatic"/>
+      </Item>
+      <Item>
+        <rasd:Address>1</rasd:Address>
+        <rasd:Description>IDE Controller</rasd:Description>
+        <rasd:ElementName>IDE 1</rasd:ElementName>
+        <rasd:InstanceID>9</rasd:InstanceID>
+        <rasd:ResourceType>5</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>IDE Controller</rasd:Description>
+        <rasd:ElementName>IDE 0</rasd:ElementName>
+        <rasd:InstanceID>10</rasd:InstanceID>
+        <rasd:ResourceType>5</rasd:ResourceType>
+      </Item>
+      <Item ovf:required="false">
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+        <rasd:ElementName>cdrom1</rasd:ElementName>
+        <rasd:InstanceID>11</rasd:InstanceID>
+        <rasd:Parent>9</rasd:Parent>
+        <rasd:ResourceType>15</rasd:ResourceType>
+      </Item>
+      <Item ovf:required="false">
+        <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+        <rasd:ElementName>floppy1</rasd:ElementName>
+        <rasd:InstanceID>12</rasd:InstanceID>
+        <rasd:ResourceType>14</rasd:ResourceType>
+      </Item>
+      <Item ovf:required="false">
+        <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+        <rasd:ElementName>VMCI device</rasd:ElementName>
+        <rasd:InstanceID>13</rasd:InstanceID>
+        <rasd:ResourceSubType>vmware.vmci</rasd:ResourceSubType>
+        <rasd:ResourceType>1</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="allowUnrestrictedCommunication" vmw:value="false"/>
+      </Item>
+      <Item>
+        <rasd:Address>1</rasd:Address>
+        <rasd:Description>SCSI Controller</rasd:Description>
+        <rasd:ElementName>SCSI Controller 2</rasd:ElementName>
+        <rasd:InstanceID>14</rasd:InstanceID>
+        <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
+        <rasd:ResourceType>6</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:ElementName>Hard Disk 2</rasd:ElementName>
+        <rasd:InstanceID>15</rasd:InstanceID>
+        <rasd:Parent>14</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+        <sasd:AllocationUnits>byte*1024*1024</sasd:AllocationUnits>
+        <sasd:VirtualQuantity>10240</sasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>SATA Controller</rasd:Description>
+        <rasd:ElementName>SATA Controller 1</rasd:ElementName>
+        <rasd:InstanceID>16</rasd:InstanceID>
+        <rasd:ResourceSubType>vmware.sata.ahci</rasd:ResourceSubType>
+        <rasd:ResourceType>20</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:ElementName>Hard Disk 3</rasd:ElementName>
+        <rasd:InstanceID>17</rasd:InstanceID>
+        <rasd:Parent>16</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+        <sasd:AllocationUnits>byte*1024*1024</sasd:AllocationUnits>
+        <sasd:VirtualQuantity>10240</sasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>1</rasd:Address>
+        <rasd:Description>SATA Controller</rasd:Description>
+        <rasd:ElementName>SATA Controller 2</rasd:ElementName>
+        <rasd:InstanceID>18</rasd:InstanceID>
+        <rasd:ResourceSubType>ahci</rasd:ResourceSubType>
+        <rasd:ResourceType>20</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:ElementName>Hard Disk 4</rasd:ElementName>
+        <rasd:InstanceID>19</rasd:InstanceID>
+        <rasd:Parent>18</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+        <sasd:AllocationUnits>byte*1024*1024</sasd:AllocationUnits>
+        <sasd:VirtualQuantity>10240</sasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>NVME Controller</rasd:Description>
+        <rasd:ElementName>NVME Controller 1</rasd:ElementName>
+        <rasd:InstanceID>20</rasd:InstanceID>
+        <rasd:ResourceSubType>vmware.nvme.controller</rasd:ResourceSubType>
+        <rasd:ResourceType>20</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:ElementName>Hard Disk 5</rasd:ElementName>
+        <rasd:InstanceID>21</rasd:InstanceID>
+        <rasd:Parent>20</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+        <sasd:AllocationUnits>byte*1024*1024</sasd:AllocationUnits>
+        <sasd:VirtualQuantity>10240</sasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:ElementName>USB 2.0 Controller</rasd:ElementName>
+        <rasd:InstanceID>22</rasd:InstanceID>
+        <rasd:ResourceType>23</rasd:ResourceType>
+        <rasd:ResourceSubType>vmware.usb.ehci</rasd:ResourceSubType>
+        <vmw:Config ovf:required="false" vmw:key="autoConnectDevices" vmw:value="true"/>
+        <vmw:Config ovf:required="false" vmw:key="ehciEnabled" vmw:value="false"/>
+      </Item>
+      <Item>
+        <rasd:ElementName>USB 3.0 Controller</rasd:ElementName>
+        <rasd:InstanceID>23</rasd:InstanceID>
+        <rasd:ResourceType>23</rasd:ResourceType>
+        <rasd:ResourceSubType>vmware.usb.xhci</rasd:ResourceSubType>
+        <vmw:Config ovf:required="false" vmw:key="autoConnectDevices" vmw:value="true"/>
+      </Item>
+
+      <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
+      <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="cpuAllocation.shares.shares" vmw:value="2000"/>
+      <vmw:Config ovf:required="false" vmw:key="cpuAllocation.shares.level" vmw:value="normal"/>
+      <vmw:Config ovf:required="false" vmw:key="simultaneousThreads" vmw:value="1"/>
+      <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHostAllowed" vmw:value="true"/>
+      <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
+      <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
+      <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestShutdown" vmw:value="true"/>
+      <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
+      <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
+      <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
+      <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
+      <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="hard"/>
+      <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="vPMCEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="flags.vvtdEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="flags.vbsEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="powerOpInfo.standbyAction" vmw:value="checkpoint"/>
+
+      <vmw:ExtraConfig ovf:required="false" vmw:key="guest_rpc.auth.cloud-init.set" vmw:value="FALSE"/>
+
+    </VirtualHardwareSection>
+    <vmw:StorageSection ovf:required="false" vmw:group="group1">
+      <Info>Storage policy group reference</Info>
+    </vmw:StorageSection>
+    <EulaSection>
+      <Info>An end-user license agreement</Info>
+      <License>VMWARE END USER LICENSE AGREEMENT
+
+
+
+PLEASE NOTE THAT THE TERMS OF THIS END USER LICENSE AGREEMENT SHALL GOVERN YOUR USE OF THE SOFTWARE, REGARDLESS OF ANY TERMS THAT MAY APPEAR DURING THE INSTALLATION OF THE SOFTWARE.
+
+
+
+IMPORTANT-READ CAREFULLY:   BY DOWNLOADING, INSTALLING, OR USING THE SOFTWARE, YOU (THE INDIVIDUAL OR LEGAL ENTITY) AGREE TO BE BOUND BY THE TERMS OF THIS END USER LICENSE AGREEMENT ("EULA").  IF YOU DO NOT AGREE TO THE TERMS OF THIS EULA, YOU MUST NOT DOWNLOAD, INSTALL, OR USE THE SOFTWARE, AND YOU MUST DELETE OR RETURN THE UNUSED SOFTWARE TO THE VENDOR FROM WHICH YOU ACQUIRED IT WITHIN THIRTY (30) DAYS AND REQUEST A REFUND OF THE LICENSE FEE, IF ANY, THAT YOU PAID FOR THE SOFTWARE.
+
+
+
+EVALUATION LICENSE.  If You are licensing the Software for evaluation purposes, Your use of the Software is only permitted in a non-production environment and for the period limited by the License Key.  Notwithstanding any other provision in this EULA, an Evaluation License of the Software is provided "AS-IS" without indemnification, support or warranty of any kind, expressed or implied.
+
+
+
+1.	DEFINITIONS.
+
+
+
+1.1	 "Affiliate" means, with respect to a party at a given time, an entity that then is directly or indirectly controlled by, is under common control with, or controls that party, and here "control" means an ownership, voting or similar interest representing fifty percent (50%) or more of the total interests then outstanding of that entity.
+
+
+
+1.2	"Documentation" means that documentation that is generally provided to You by VMware with the Software, as revised by VMware from time to time, and which may include end user manuals, operation instructions, installation guides, release notes, and on-line help files regarding the use of the Software.
+
+
+
+1.3	"Guest Operating Systems" means instances of third-party operating systems licensed by You, installed in a Virtual Machine and run using the Software.
+
+
+
+1.4	"Intellectual Property Rights" means all worldwide intellectual property rights, including without limitation, copyrights, trademarks, service marks, trade secrets, know how, inventions, patents, patent applications, moral rights and all other proprietary rights, whether registered or unregistered.
+
+
+
+1.5	"License" means a license granted under Section 2.1 (General License Grant).
+
+
+
+1.6    	"License Key" means a serial number that enables You to activate and use the Software.
+
+
+
+1.7	"License Term" means the duration of a License as specified in the Order.
+
+
+
+1.8	"License Type" means the type of License applicable to the Software, as more fully described in the Order.
+
+
+
+1.9 "Open Source Software" or "OSS" means software components embedded in the Software and provided under separate license terms, which can be found either in the open_source_licenses.txt file (or similar file) provided within the Software or at www.vmware.com/download/open_source.html.
+
+
+
+1.10 "Order" means a purchase order, enterprise license agreement, or other ordering document issued by You to VMware or a VMware authorized reseller that references and incorporates this EULA and is accepted by VMware as set forth in Section 4 (Order).
+
+1.11 "Product Guide" means the current version of the VMware Product Guide at the time of Your Order, copies of which are found at www.vmware.com/download/eula.
+
+
+
+1.12 "Support Services Terms" means VMware's then-current support policies, copies of which are posted at www.vmware.com/support/policies.
+
+
+
+1.13	"Software" means the VMware Tools and the VMware computer programs listed on VMware's commercial price list to which You acquire a license under an Order, together with any software code relating to the foregoing that is provided to You pursuant to a support and subscription service contract and that is not subject to a separate license agreement.
+
+
+
+1.14 "Territory" means the country or countries in which You have been invoiced; provided, however, that if You have been invoiced within any of the European Economic Area member states, You may deploy the corresponding Software throughout the European Economic Area.
+
+
+
+1.15 "Third Party Agent" means a third party delivering information technology services to You pursuant to a written contract with You.
+
+
+
+1.16	"Virtual Machine" means a software container that can run its own operating system and execute applications like a physical machine.
+
+
+
+1.17	"VMware" means VMware, Inc., a Delaware corporation, if You are purchasing Licenses or services for use in the United States and VMware International Limited, a company organized and existing under the laws of Ireland, for all other purchases.
+
+1.18	"VMware Tools" means the suite of utilities and drivers, Licensed by VMware under the "VMware Tools" name, that can be installed in a Guest Operating System to enhance the performance and functionality of a Guest Operating System when running in a Virtual Machine.
+
+
+
+2.		LICENSE GRANT.
+
+
+
+2.1	General License Grant.  VMware grants to You a non-exclusive, non-transferable (except as set forth in Section 12.1 (Transfers; Assignment)) license to use the Software and the Documentation during the period of the license and within the Territory, solely for Your internal business operations, and subject to the provisions of the Product Guide. Unless otherwise indicated in the Order, licenses granted to You will be perpetual, will be for use of object code only, and will commence on either delivery of the physical media or the date You are notified of availability for electronic download.
+
+
+
+2.2	Third Party Agents.  Under the License granted to You in Section 2.1 (General License Grant) above, You may permit Your Third Party Agents to access, use and/or operate the Software on Your behalf for the sole purpose of delivering services to You, provided that You will be fully responsible for Your Third Party Agents' compliance with terms and conditions of this EULA and any breach of this EULA by a Third Party Agent shall be deemed to be a breach by You.
+
+
+
+2.3       Copying Permitted.  You may copy the Software and Documentation as necessary to install and run the quantity of copies licensed, but otherwise for archival purposes only.
+
+
+
+2.4	Benchmarking.  You may use the Software to conduct internal performance testing and benchmarking studies. You may only publish or otherwise distribute the results of such studies to third parties as follows:  (a) if with respect to VMware's Workstation or Fusion products, only if You provide a copy of Your study to benchmark@vmware.com prior to distribution;   (b) if with respect to any other Software, only if VMware has reviewed and approved of the methodology, assumptions and other parameters of the study  (please contact VMware at benchmark@vmware.com to request such review and approval) prior to such publication and distribution.
+
+
+
+2.5	VMware Tools.  You may distribute the VMware Tools to third parties solely when installed in a Guest Operating System within a Virtual Machine. You are liable for compliance by those third parties with the terms and conditions of this EULA.
+
+
+
+2.6	Open Source Software.  Notwithstanding anything herein to the contrary, Open Source Software is licensed to You under such OSS's own applicable license terms, which can be found in the open_source_licenses.txt file, the Documentation or as applicable, the corresponding source files for the Software available at www.vmware.com/download/open_source.html. These OSS license terms are consistent with the license granted in Section 2 (License Grant), and may contain additional rights benefiting You.  The OSS license terms shall take precedence over this EULA to the extent that this EULA imposes greater restrictions on You than the applicable OSS license terms. To the extent the license for any Open Source Software requires VMware to make available to You the corresponding source code and/or modifications (the "Source Files"), You may obtain a copy of the applicable Source Files from VMware's website at www.vmware.com/download/open_source.html or by sending a written request, with Your name and address to: VMware, Inc., 3401 Hillview Avenue, Palo Alto, CA 94304, United States of America. All requests should clearly specify:  Open Source Files Request, Attention: General Counsel.  This offer to obtain a copy of the Source Files is valid for three years from the date You acquired this Software.
+
+
+
+3.	RESTRICTIONS; OWNERSHIP.
+
+
+
+3.1	License Restrictions.  Without VMware's prior written consent, You must not, and must not allow any third party to: (a) use Software in an application services provider, service bureau, or similar capacity for third parties, except that You may use the Software to deliver hosted services to Your Affiliates; (b) disclose to any third party the results of any benchmarking testing or comparative or competitive analyses of VMware's Software done by or on behalf of You, except as specified in Section 2.4 (Benchmarking); (c) make available Software in any form to anyone other than Your employees or contractors reasonably acceptable to VMware and require access to use Software on behalf of You in a matter permitted by this EULA, except as specified in Section 2.2 (Third Party Agents); (d) transfer or sublicense Software or Documentation to an Affiliate or any third party, except as expressly permitted in Section 12.1 (Transfers; Assignment); (e) use Software in conflict with the terms and restrictions of the Software's licensing model and other requirements specified in Product Guide and/or VMware quote; (f) except to the extent permitted by applicable mandatory law, modify, translate, enhance, or create derivative works from the Software, or  reverse engineer, decompile, or otherwise attempt to derive source code from the Software, except as specified in Section 3.2 (Decompilation); (g) remove any copyright or other proprietary notices on or in any copies of Software; or (h) violate or circumvent any technological restrictions within the Software or specified in this EULA, such as via software or services.
+
+
+
+3.2	Decompilation.  Notwithstanding the foregoing, decompiling the Software is permitted to the extent the laws of the Territory give You the express right to do so to obtain information necessary to render the Software interoperable with other software; provided, however, You must first request such information from VMware, provide all reasonably requested information to allow VMware to assess Your claim, and VMware may, in its discretion, either provide such interoperability information to You, impose reasonable conditions, including a reasonable fee, on such use of the Software, or offer to provide alternatives to ensure that VMware's proprietary rights in the Software are protected and to reduce any adverse impact on VMware's proprietary rights.
+
+
+
+3.3	Ownership.  The Software and Documentation, all copies and portions thereof, and all improvements, enhancements, modifications and derivative works thereof, and all Intellectual Property Rights therein, are and shall remain the sole and exclusive property of VMware and its licensors. Your rights to use the Software and Documentation shall be limited to those expressly granted in this EULA and any applicable Order.  No other rights with respect to the Software or any related Intellectual Property Rights are implied.  You are not authorized to use (and shall not permit any third party to use) the Software, Documentation or any portion thereof except as expressly authorized by this EULA or the applicable Order.  VMware reserves all rights not expressly granted to You. VMware does not transfer any ownership rights in any Software.
+
+
+
+3.4	Guest Operating Systems.  Certain Software allows Guest Operating Systems and application programs to run on a computer system. You acknowledge that You are responsible for obtaining and complying with any licenses necessary to operate any such third-party software.
+
+
+
+4.	ORDER.  Your Order is subject to this EULA.  No Orders are binding on VMware until accepted by VMware.  Orders for Software are deemed to be accepted upon VMware's delivery of the Software included in such Order. Orders issued to VMware do not have to be signed to be valid and enforceable.
+
+
+
+5.	RECORDS AND AUDIT.  During the License Term for Software and for two (2) years after its expiration or termination, You will maintain accurate records of Your use of the Software sufficient to show compliance with the terms of this EULA. During this period, VMware will have the right to audit Your use of the Software to confirm compliance with the terms of this EULA. That audit is subject to reasonable notice by VMware and will not unreasonably interfere with Your business activities. VMware may conduct no more than one (1) audit in any twelve (12) month period, and only during normal business hours. You will reasonably cooperate with VMware and any third party auditor and will, without prejudice to other rights of VMware, address any non-compliance identified by the audit by promptly paying additional fees. You will promptly reimburse VMware for all reasonable costs of the audit if the audit reveals either underpayment of more than five (5%) percent of the Software fees payable by You for the period audited, or that You have materially failed to maintain accurate records of Software use.
+
+
+
+6.	SUPPORT AND SUBSCRIPTION SERVICES.  Except as expressly specified in the Product Guide, VMware does not provide any support or subscription services for the Software under this EULA.  You have no rights to any updates, upgrades or extensions or enhancements to the Software developed by VMware unless you separately purchase VMware support or subscription services.  These support or subscription services are subject to the Support Services Terms.
+
+
+
+7.    WARRANTIES.
+
+
+
+7.1 Software Warranty, Duration and Remedy.  VMware warrants to You that the Software will, for a period of ninety (90) days following notice of availability for electronic download or delivery ("Warranty Period"), substantially conform to the applicable Documentation, provided that the Software: (a) has been properly installed and used at all times in accordance with the applicable Documentation; and (b) has not been modified or added to by persons other than VMware or its authorized representative. VMware will, at its own expense and as its sole obligation and Your exclusive remedy for any breach of this warranty, either replace that Software or correct any reproducible error in that Software reported to VMware by You in writing during the Warranty Period. If VMware determines that it is unable to correct the error or replace the Software, VMware will refund to You the amount paid by You for that Software, in which case the License for that Software will terminate.
+
+
+
+7.2 Software Disclaimer of Warranty.  OTHER THAN THE WARRANTY ABOVE, AND TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, VMWARE AND ITS SUPPLIERS MAKE NO OTHER EXPRESS WARRANTIES UNDER THIS EULA, AND DISCLAIM ALL IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT, AND ANY WARRANTY ARISING BY STATUTE, OPERATION OF LAW, COURSE OF DEALING OR PERFORMANCE, OR USAGE OF TRADE. VMWARE AND ITS LICENSORS DO NOT WARRANT THAT THE SOFTWARE WILL OPERATE UNINTERRUPTED OR THAT IT WILL BE FREE FROM DEFECTS OR THAT IT WILL MEET YOUR REQUIREMENTS.
+
+
+
+8.     INTELLECTUAL PROPERTY INDEMNIFICATION.
+
+
+
+8.1 Defense and Indemnification.  Subject to the remainder of this Section 8 (Intellectual Property Indemnification), VMware shall defend You against any third party claim that the Software infringes any patent, trademark or copyright of such third party, or misappropriates a trade secret (but only to the extent that the misappropriation is not a result of Your actions) under the laws of: (a) the United States and Canada; (b) the European Economic Area; (c) Australia; (d) New Zealand; (e) Japan; or (f) the People's Republic of China, to the extent that such countries are part of the Territory for the License ("Infringement Claim") and indemnify You from the resulting costs and damages finally awarded against You to such third party by a court of competent jurisdiction or agreed to in settlement. The foregoing obligations are applicable only if You:  (i) promptly notify VMware in writing of the Infringement Claim; (ii) allow VMware sole control over the defense for the claim and any settlement negotiations; and (iii) reasonably cooperate in response to VMware requests for assistance.  You may not settle or compromise any Infringement Claim without the prior written consent of VMware.
+
+8.2 Remedies.  If the alleged infringing Software become, or in VMware's opinion be likely to become, the subject of an Infringement Claim, VMware will, at VMware's option and expense, do one of the following:  (a) procure the rights necessary for You to make continued use of the affected Software; (b) replace or modify the affected Software to make it non-infringing; or (c) terminate the License to the affected Software and discontinue the related support services, and, upon Your certified deletion of the affected Software, refund: (i) the fees paid by You for the License to the affected Software, less straight-line depreciation over a three (3) year useful life beginning on the date such Software was delivered; and (ii) any pre-paid service fee attributable to related support services to be delivered after the date such service is stopped. Nothing in this Section 8.2 (Remedies) shall limit VMware's obligation under Section 8.1 (Defense and Indemnification) to defend and indemnify You, provided that You replace the allegedly infringing Software upon VMware's making alternate Software available to You and/or You discontinue using the allegedly infringing Software upon receiving VMware's notice terminating the affected License.
+
+8.3 Exclusions.  Notwithstanding the foregoing, VMware will have no obligation under this Section 8 (Intellectual Property Indemnification) or otherwise with respect to any claim based on:  (a) a combination of Software with non-VMware products (other than non-VMware products that are listed on the Order and used in an unmodified form); (b) use for a purpose or in a manner for which the Software was not designed; (c) use of any older version of the Software when use of a newer VMware version would have avoided the infringement; (d) any modification to the Software made without VMware's express written approval; (e) any claim that relates to open source software or freeware technology or any derivatives or other adaptations thereof that is not embedded by VMware into Software listed on VMware's commercial price list; or (f) any Software provided on a no charge, beta or evaluation basis.  THIS SECTION 8 (INTELLECTUAL PROPERTY INDEMNIFICATION) STATES YOUR SOLE AND EXCLUSIVE REMEDY AND VMWARE'S ENTIRE LIABILITY FOR ANY INFRINGEMENT CLAIMS OR ACTIONS.
+
+
+
+9. LIMITATION OF LIABILITY.
+
+
+
+9.1 Limitation of Liability.  TO THE MAXIMUM EXTENT MANDATED BY LAW, IN NO EVENT WILL VMWARE AND ITS LICENSORS BE LIABLE FOR ANY LOST PROFITS OR BUSINESS OPPORTUNITIES, LOSS OF USE, LOSS OF REVENUE, LOSS OF GOODWILL, BUSINESS INTERRUPTION, LOSS OF DATA, OR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES UNDER ANY THEORY OF LIABILITY, WHETHER BASED IN CONTRACT, TORT, NEGLIGENCE, PRODUCT LIABILITY, OR OTHERWISE.  BECAUSE SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF LIABILITY FOR CONSEQUENTIAL OR INCIDENTAL DAMAGES, THE PRECEDING LIMITATION MAY NOT APPLY TO YOU.  VMWARE'S AND ITS LICENSORS' LIABILITY UNDER THIS EULA WILL NOT, IN ANY EVENT, REGARDLESS OF WHETHER THE CLAIM IS BASED IN CONTRACT, TORT, STRICT LIABILITY, OR OTHERWISE, EXCEED THE GREATER OF THE LICENSE FEES YOU PAID FOR THE SOFTWARE GIVING RISE TO THE CLAIM OR $5000. THE FOREGOING LIMITATIONS SHALL APPLY REGARDLESS OF WHETHER VMWARE OR ITS LICENSORS HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND REGARDLESS OF WHETHER ANY REMEDY FAILS OF ITS ESSENTIAL PURPOSE.
+
+
+
+9.2 Further Limitations.  VMware's licensors shall have no liability of any kind under this EULA and VMware's liability with respect to any third party software embedded in the Software shall be subject to Section 9.1 (Limitation of Liability).  You may not bring a claim under this EULA more than eighteen (18) months after the cause of action arises.
+
+
+
+10.     TERMINATION.
+
+10.1	EULA Term. The term of this EULA begins on the notice of availability for electronic download or delivery of the Software and continues until this EULA is terminated in accordance with this Section 10.
+
+10.2	Termination for Breach.  VMware may terminate this EULA effective immediately upon written notice to You if: (a) You fail to pay any portion of the fees under an applicable Order within ten (10) days after receiving written notice from VMware that payment is past due; or (b) You breach any other provision of this EULA and fail to cure within thirty (30) days after receipt of VMware's written notice thereof.
+
+10.3	Termination for Insolvency.  VMware may terminate this EULA effective immediately upon written notice to You if You: (a) terminate or suspend your business; (b) become insolvent, admit in writing Your inability to pay Your debts as they mature, make an assignment for the benefit of creditors; or become subject to control of a trustee, receiver or similar authority; or (c) become subject to any bankruptcy or insolvency proceeding.
+
+10.4	Effect of Termination.  Upon VMware's termination of this EULA: (a) all Licensed rights to all Software granted to You under this EULA will immediately cease; and (b) You must cease all use of all Software, and return or certify destruction of all Software and License Keys (including copies) to VMware, and return, or if requested by VMware, destroy, any related VMware Confidential Information in Your possession or control and certify in writing to VMware that You have fully complied with these requirements. Any provision will survive any termination or expiration if by its nature and context it is intended to survive, including Sections 1 (Definitions), 2.6 (Open Source Software), 3 (Restrictions; Ownership), 5 (Records and Audit), 7.2 (Software Disclaimer of Warranty), 9 (Limitation of Liability), 10 (Termination), 11 (Confidential Information) and 12 (General).
+
+
+
+11.	CONFIDENTIAL INFORMATION.
+
+
+
+11.1	Definition.  "Confidential Information"  means information or materials provided by one party ("Discloser") to the other party ("Recipient") which are in tangible form and labelled "confidential" or the like, or, information which a reasonable person knew or should have known to be confidential.  The following information shall be considered Confidential Information whether or not marked or identified as such:  (a) License Keys; (b) information regarding VMware's pricing, product roadmaps or strategic marketing plans; and (c) non-public materials relating to the Software.
+
+
+
+11.2	Protection.  Recipient may use Confidential Information of Discloser; (a) to exercise its rights and perform its obligations under this EULA; or (b) in connection with the parties' ongoing business relationship.  Recipient will not use any Confidential Information of Discloser for any purpose not expressly permitted by this EULA, and will disclose the Confidential Information of Discloser only to the employees or contractors of Recipient who have a need to know such Confidential Information for purposes of this EULA and who are under a duty of confidentiality no less restrictive than Recipient's duty hereunder.  Recipient will protect Confidential Information from unauthorized use, access, or disclosure in the same manner as Recipient protects its own confidential or proprietary information of a similar nature but with no less than reasonable care.
+
+11.3 Exceptions.  Recipient's obligations under Section 11.2 (Protection) with respect to any Confidential Information will terminate if Recipient can show by written records that such information:  (a) was already known to Recipient at the time of disclosure by Discloser; (b) was disclosed to Recipient by a third party who had the right to make such disclosure without any confidentiality restrictions; (c) is, or through no fault of Recipient has become, generally available to the public; or (d) was independently developed by Recipient without access to, or use of, Discloser's Information.  In addition, Recipient will be allowed to disclose Confidential Information to the extent that such disclosure is required by law or by the order of a court of similar judicial or administrative body, provided that Recipient notifies Discloser of such required disclosure promptly and in writing and cooperates with Discloser, at Discloser's request and expense, in any lawful action to contest or limit the scope of such required disclosure.
+
+11.4	Data Privacy.  You agree that VMware may process technical and related information about Your use of the Software which may include internet protocol address, hardware identification, operating system, application software, peripheral hardware, and non-personally identifiable Software usage statistics to facilitate the provisioning of updates, support, invoicing or online services and may transfer such information to other companies in the VMware worldwide group of companies from time to time. To the extent that this information constitutes personal data, VMware shall be the controller of such personal data. To the extent that it acts as a controller, each party shall comply at all times with its obligations under applicable data protection legislation.
+
+
+
+12.	GENERAL.
+
+
+
+12.1	Transfers; Assignment.  Except to the extent transfer may not legally be restricted or as permitted by VMware's transfer and assignment policies, in all cases following the process set forth at www.vmware.com/support/policies/licensingpolicies.html, You will not assign this EULA, any Order, or any right or obligation herein or delegate any performance without VMware's prior written consent, which consent will not be unreasonably withheld. Any other attempted assignment or transfer by You will be void. VMware may use its Affiliates or other sufficiently qualified subcontractors to provide services to You, provided that VMware remains responsible to You for the performance of the services.
+
+
+
+12.2	Notices.  Any notice delivered by VMware to You under this EULA will be delivered via mail, email or fax.
+
+
+
+12.3	Waiver.  Failure to enforce a provision of this EULA will not constitute a waiver.
+
+12.4     Severability.  If any part of this EULA is held unenforceable, the validity of all remaining parts will not be affected.
+
+12.5	Compliance with Laws; Export Control; Government Regulations. Each party shall comply with all laws applicable to the actions contemplated by this EULA. You acknowledge that the Software is of United States origin, is provided subject to the U.S. Export Administration Regulations, may be subject to the export control laws of the applicable territory, and that diversion contrary to applicable export control laws is prohibited. You represent that (1) you are not, and are not acting on behalf of, (a) any person who is a citizen, national, or resident of, or who is controlled by the government of any country to which the United States has prohibited export transactions; or (b) any person or entity listed on the U.S. Treasury Department list of Specially Designated Nationals and Blocked Persons, or the U.S. Commerce Department Denied Persons List or Entity List; and (2) you will not permit the Software to be used for, any purposes prohibited by law, including, any prohibited development, design, manufacture or production of missiles or nuclear, chemical or biological weapons. The Software and accompanying documentation are deemed to be "commercial computer software" and "commercial computer software documentation", respectively, pursuant to DFARS Section 227.7202 and FAR Section 12.212(b), as applicable.  Any use, modification, reproduction, release, performing, displaying or disclosing of the Software and documentation by or for the U.S. Government shall be governed solely by the terms and conditions of this EULA.
+
+12.6	Construction.  The headings of sections of this EULA are for convenience and are not to be used in interpreting this EULA. As used in this EULA, the word 'including' means "including but not limited to".
+
+12.7	Governing Law.  This EULA is governed by the laws of the State of California, United States of America (excluding its conflict of law rules), and the federal laws of the United States. To the extent permitted by law, the state and federal courts located in Santa Clara County, California will be the exclusive jurisdiction for disputes arising out of or in connection with this EULA. The U.N. Convention on Contracts for the International Sale of Goods does not apply.
+
+12.8	Third Party Rights.  Other than as expressly set out in this EULA, this EULA does not create any rights for any person who is not a party to it, and no person who is not a party to this EULA may enforce any of its terms or rely on any exclusion or limitation contained in it.
+
+12.9	Order of Precedence.  In the event of conflict or inconsistency among the Product Guide, this EULA and the Order, the following order of precedence shall apply: (a) the Product Guide, (b) this EULA and (c) the Order. With respect to any inconsistency between this EULA and an Order, the terms of this EULA shall supersede and control over any conflicting or additional terms and conditions of any Order, acknowledgement or confirmation or other document issued by You.
+
+12.10  Entire Agreement.  This EULA, including accepted Orders and any amendments hereto, and the Product Guide contain the entire agreement of the parties with respect to the subject matter of this EULA and supersede all previous or contemporaneous communications, representations, proposals, commitments, understandings and agreements, whether written or oral, between the parties regarding the subject matter hereof.  This EULA may be amended only in writing signed by authorized representatives of both parties.
+
+12.11  Contact Information.  Please direct legal notices or other correspondence to VMware, Inc., 3401 Hillview Avenue, Palo Alto, California 94304, United States of America, Attention: Legal Department.</License>
+    </EulaSection>
+    <ProductSection>
+      <Info>Information about the installed software</Info>
+      <Product>HAProxy for the Load Balancer API v0.2.0</Product>
+      <Vendor>VMware Inc.</Vendor>
+      <Version>v0.2.0</Version>
+      <FullVersion>v0.2.0</FullVersion>
+      <ProductUrl>https://vmware.com</ProductUrl>
+      <VendorUrl>https://vmware.com</VendorUrl>
+      <Category>Load Balancer API</Category>
+      <Property ovf:userConfigurable="false" ovf:value="1615488399" ovf:type="string" ovf:key="BUILD_TIMESTAMP"></Property>
+      <Property ovf:userConfigurable="false" ovf:value="2021-03-11T18:46:39Z" ovf:type="string" ovf:key="BUILD_DATE"></Property>
+    </ProductSection>
+    <ProductSection ovf:class="appliance" ovf:required="false">
+      <Info>Appliance Properties</Info>
+      <Category>1. Appliance Configuration</Category>
+      <Property ovf:key="root_pwd" ovf:password="true" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+        <Label>1.1. Root Password</Label>
+        <Description>The initial password of the root user. Subsequent changes of password should be performed in operating system. (6-128 characters)</Description>
+      </Property>
+    </ProductSection>
+    <ProductSection ovf:class="network" ovf:required="false">
+      <Info>Management Networking Properties</Info>
+      <Category>2. Network Config</Category>
+      <Property ovf:key="hostname" ovf:type="string" ovf:userConfigurable="true" ovf:value="haproxy.local">
+        <Label>2.1. Host Name</Label>
+        <Description>The host name. A fully-qualified domain name is also supported.</Description>
+      </Property>
+      <Property ovf:key="frontend_ip" ovf:type="string" ovf:userConfigurable="true" ovf:configuration="frontend">
+        <Label>2.2. Frontend IP</Label>
+        <Description>(Optional) The static IP address for the appliance on the Frontend Port Group in CIDR format (Eg. ip/subnet mask bits). This IP must be outside of the Load Balancer IP Range</Description>
+      </Property>
+      <Property ovf:key="frontend_gateway" ovf:type="string" ovf:userConfigurable="true" ovf:configuration="frontend">
+        <Label>2.3. Frontend Gateway</Label>
+        <Description>(Optional) The gateway address for the frontend network</Description>
+      </Property>
+    </ProductSection>
+    <ProductSection ovf:class="loadbalance" ovf:required="false">
+      <Info>Load Balancer Properties</Info>
+      <Category>3. Load Balancing</Category>
+      <Property ovf:key="service_ip_range" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+        <Label>3.1. Load Balancer IP Ranges, comma-separated in CIDR format (Eg 1.2.3.4/28,5.6.7.8/28)</Label>
+        <Description>The IP ranges the load balancer will use for Kubernetes Services and Control Planes. The Appliance will currently respond to ALL the IPs in these ranges whether they're assigned or not. As such, these ranges must not overlap with the IPs assigned for the appliance or any other VMs on the network.</Description>
+      </Property>
+      <Property ovf:key="dataplane_port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="5556">
+        <Label>3.2. Dataplane API Management Port</Label>
+        <Description>Specifies the port on which the Dataplane API will be advertized on the Management Network.</Description>
+      </Property>
+    </ProductSection>
+  </VirtualSystem>
+  <Strings>
+    <Msg ovf:msgid="config.default.label">Default</Msg>
+    <Msg ovf:msgid="config.default.description">Deploy the Appliance with 2 nics: a Management network (Supervisor -> HAProxy dataplane) and a single Workload network. Load-balanced IPs are assigned on the Workload network. NOTE: Deployment will ignore all "frontend" options</Msg>
+    <Msg ovf:msgid="config.frontend.label">Frontend Network</Msg>
+    <Msg ovf:msgid="config.frontend.description">Deploy the Appliance with 3 nics: a Management network (Supervisor -> HAProxy dataplane), a single Workload network and a dedicated Frontend network. Load-balanced IPs are assigned on the Frontend network</Msg>
+  </Strings>
+</Envelope>

--- a/ovf/fixtures/virtualsystemcollection.ovf
+++ b/ovf/fixtures/virtualsystemcollection.ovf
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+Example 3 from https://www.dmtf.org/sites/default/files/standards/documents/DSP0243_2.1.1.pdf
+-->
+<Envelope
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/2"
+    xmlns="http://schemas.dmtf.org/ovf/envelope/2"
+    xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData"
+    xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData"
+    xmlns:epasd="http://schemas.dmtf.org/wbem/wscim/1/cim2608 schema/2/CIM_EthernetPortAllocationSettingData"
+    xmlns:sasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_StorageAllocationSettingData">
+    <!-- References to all external files -->
+    <References>
+        <File ovf:id="file1" ovf:href="vmdisk1.vmdk" ovf:size="2000000000" />
+    </References>
+    <!-- Describes meta-information for all virtual disks in the package -->
+    <DiskSection>
+        <Info>Describes the set of virtual disks</Info>
+        <Disk ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:capacity="4294967296"
+            ovf:format="http://www.examplecompany.com/interfaces/specifications/vmdk.html#sparse" />
+    </DiskSection>
+    <!-- Describes all networks used in the package -->
+    <NetworkSection>
+        <Info>List of logical networks used in the package</Info>
+        <Network ovf:name="VS Network">
+            <Description>The network that the VSs connect to</Description>
+            <!-- Network port profile for storage traffic -->
+
+            <NetworkPortProfileURI>http://www.dmtf.org/networkportprofiles/networkportprofile1.xml</NetworkPortProfileURI>
+            <!-- Network port profile for networking traffic -->
+
+            <NetworkPortProfileURI>http://www.dmtf.org/networkportprofiles/networkportprofile2.xml</NetworkPortProfileURI>
+        </Network>
+    </NetworkSection>
+    <VirtualSystemCollection ovf:id="vsc1">
+        <Info>Collection of 2 VSs</Info>
+        <VirtualSystem ovf:id="storage server">
+            <Info>Describes a virtual system</Info>
+            <Name>Virtual Appliance One</Name>
+            <ProductSection>
+                <Info>Describes product information for the appliance</Info>
+                <Product>The Great Appliance</Product>
+                <Vendor>Some Great Corporation</Vendor>
+                <Version>13.00</Version>
+                <FullVersion>13.00-b5</FullVersion>
+                <ProductUrl>http://www.somegreatcorporation.com/greatappliance</ProductUrl>
+                <VendorUrl>http://www.somegreatcorporation.com/</VendorUrl>
+                <Property ovf:key="adminemail" ovf:type="string">
+                    <Description>Email address of administrator</Description>
+                </Property>
+                <Property ovf:key="app_ip" ovf:type="string" ovf:defaultValue="192.168.0.10">
+                    <Description>The IP address of this appliance</Description>
+                </Property>
+            </ProductSection>
+            <AnnotationSection ovf:required="false">
+                <Info>A random annotation on this service. It can be ignored</Info>
+                <Annotation>Contact customer support if you have any problems</Annotation>
+            </AnnotationSection>
+            <EulaSection>
+                <Info>License information for the appliance</Info>
+                <License>Insert your favorite license here</License>
+            </EulaSection>
+            <VirtualHardwareSection>
+                <Info>Memory = 4 GB, CPU = 1 GHz, Disk = 100 GB, 1 Ethernet nic</Info>
+                <Item>
+                    <rasd:AllocationUnits>Hertz*10^9</rasd:AllocationUnits>
+                    <rasd:Description>Virtual CPU</rasd:Description>
+                    <rasd:ElementName>1 GHz virtual CPU</rasd:ElementName>
+                    <rasd:InstanceID>1</rasd:InstanceID>
+                    <rasd:Reservation>1</rasd:Reservation>
+                    <rasd:ResourceType>3</rasd:ResourceType>
+                    <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                </Item>
+                <Item>
+                    <rasd:AllocationUnits>byte*2^30</rasd:AllocationUnits>
+                    <rasd:Description>Memory</rasd:Description>
+                    <rasd:ElementName>1 GByte of memory</rasd:ElementName>
+                    <rasd:InstanceID>2</rasd:InstanceID>
+                    <rasd:ResourceType>4</rasd:ResourceType>
+                    <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                </Item>
+                <EthernetPortItem>
+                    <epasd:Address>00-16-8B-DB-00-5E</epasd:Address>
+                    <epasd:Connection>VS Network</epasd:Connection>
+                    <epasd:Description>Virtual NIC</epasd:Description>
+
+                    <epasd:ElementName>Ethernet Port</epasd:ElementName>
+
+                    <epasd:InstanceID>3</epasd:InstanceID>
+
+                    <epasd:NetworkPortProfileID>
+                        http://www.dmtf.org/networkportprofiles/networkportprofile1.xml</epasd:NetworkPortProfileID>
+                    <epasd:NetworkPortProfileIDType>2</epasd:NetworkPortProfileIDType>
+                    <epasd:ResourceType>10</epasd:ResourceType>
+                    <epasd:VirtualQuantityUnits>1</epasd:VirtualQuantityUnits>
+                </EthernetPortItem>
+                <StorageItem>
+                    <sasd:AllocationUnits>byte*2^30</sasd:AllocationUnits>
+                    <sasd:Description>Virtual Disk</sasd:Description>
+                    <sasd:ElementName>100 GByte Virtual Disk</sasd:ElementName>
+                    <sasd:InstanceID>4</sasd:InstanceID>
+                    <sasd:Reservation>100</sasd:Reservation>
+                    <sasd:ResourceType>31</sasd:ResourceType>
+                    <sasd:VirtualQuantity>1</sasd:VirtualQuantity>
+                </StorageItem>
+            </VirtualHardwareSection>
+            <OperatingSystemSection ovf:id="58" ovf:required="false">
+                <Info>Guest Operating System</Info>
+                <Description>OS</Description>
+            </OperatingSystemSection>
+        </VirtualSystem>
+        <VirtualSystem ovf:id="web-server">
+            <Info>Describes a virtual system</Info>
+            <Name>Virtual Appliance Two</Name>
+            <ProductSection>
+                <Info>Describes product information for the appliance</Info>
+                <Product>The Great Appliance</Product>
+                <Vendor>Some Great Corporation</Vendor>
+                <Version>13.00</Version>
+                <FullVersion>13.00-b5</FullVersion>
+                <ProductUrl>http://www.somegreatcorporation.com/greatappliance</ProductUrl>
+                <VendorUrl>http://www.somegreatcorporation.com/</VendorUrl>
+                <Property ovf:key="adminemail" ovf:type="string">
+                    <Description>Email address of administrator</Description>
+                </Property>
+                <Property ovf:key="app_ip" ovf:type="string" ovf:defaultValue="192.168.0.10">
+                    <Description>The IP address of this appliance</Description>
+                </Property>
+            </ProductSection>
+            <AnnotationSection ovf:required="false">
+                <Info>A random annotation on this service. It can be ignored</Info>
+                <Annotation>Contact customer support if you have any problems</Annotation>
+            </AnnotationSection>
+            <EulaSection>
+                <Info>License information for the appliance</Info>
+                <License>Insert your favorite license here</License>
+            </EulaSection>
+            <VirtualHardwareSection>
+                <Info>Memory = 4 GB, CPU = 1 GHz, Disk = 100 GB, 1 Ethernet nic</Info>
+                <Item>
+                    <rasd:AllocationUnits>Hertz*10^9</rasd:AllocationUnits>
+                    <rasd:Description>Virtual CPU</rasd:Description>
+                    <rasd:ElementName>1 GHz virtual CPU</rasd:ElementName>
+                    <rasd:InstanceID>1</rasd:InstanceID>
+                    <rasd:Reservation>1</rasd:Reservation>
+                    <rasd:ResourceType>3</rasd:ResourceType>
+                    <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                </Item>
+                <Item>
+                    <rasd:AllocationUnits>byte*2^30</rasd:AllocationUnits>
+                    <rasd:Description>Memory</rasd:Description>
+                    <rasd:ElementName>1 GByte of memory</rasd:ElementName>
+                    <rasd:InstanceID>2</rasd:InstanceID>
+                    <rasd:ResourceType>4</rasd:ResourceType>
+                    <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                </Item>
+                <EthernetPortItem>
+                    <epasd:Address>00-16-8B-DB-00-5F</epasd:Address>
+                    <epasd:Connection>VS Network</epasd:Connection>
+                    <epasd:Description>Virtual NIC</epasd:Description>
+
+                    <epasd:ElementName>Ethernet Port</epasd:ElementName>
+                    <!-- Virtual NIC for networking traffic -->
+                    <epasd:InstanceID>3</epasd:InstanceID>
+
+                    <epasd:NetworkPortProfileID>
+                        http://www.dmtf.org/networkportprofiles/networkportprofile2.xml</epasd:NetworkPortProfileID>
+                    <epasd:NetworkPortProfileIDType>2</epasd:NetworkPortProfileIDType>
+                    <epasd:ResourceType>10</epasd:ResourceType>
+                    <epasd:VirtualQuantityUnits>1</epasd:VirtualQuantityUnits>
+                </EthernetPortItem>
+                <StorageItem>
+                    <sasd:AllocationUnits>byte*2^30</sasd:AllocationUnits>
+                    <sasd:Description>Virtual Disk</sasd:Description>
+                    <sasd:ElementName>100 GByte Virtual Disk</sasd:ElementName>
+                    <sasd:InstanceID>4</sasd:InstanceID>
+                    <sasd:Reservation>100</sasd:Reservation>
+                    <sasd:ResourceType>31</sasd:ResourceType>
+                    <sasd:VirtualQuantity>1</sasd:VirtualQuantity>
+                </StorageItem>
+            </VirtualHardwareSection>
+            <OperatingSystemSection ovf:id="58" ovf:required="false">
+                <Info>Guest Operating System</Info>
+                <Description>OS</Description>
+            </OperatingSystemSection>
+        </VirtualSystem>
+    </VirtualSystemCollection>
+</Envelope>

--- a/ovf/importer/spec.go
+++ b/ovf/importer/spec.go
@@ -114,9 +114,7 @@ func Spec(fpath string, a Archive, hidden, verbose bool) (*Options, error) {
 	}
 
 	if e.VirtualSystem != nil && e.VirtualSystem.Annotation != nil {
-		for _, a := range e.VirtualSystem.Annotation {
-			o.Annotation += a.Annotation
-		}
+		o.Annotation = e.VirtualSystem.Annotation.Annotation
 	}
 
 	if e.Network != nil {

--- a/ovf/ovf_test.go
+++ b/ovf/ovf_test.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"testing"
 	"text/tabwriter"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func testEnvelope(t *testing.T, fn string) *Envelope {
@@ -94,4 +96,14 @@ func TestDeploymentOptions(t *testing.T) {
 	}
 	tw.Flush()
 	t.Log(b.String())
+}
+
+func TestVirtualSystemCollection(t *testing.T) {
+	e := testEnvelope(t, "fixtures/virtualsystemcollection.ovf")
+
+	assert.Nil(t, e.VirtualSystem)
+	assert.NotNil(t, e.VirtualSystemCollection)
+	assert.Len(t, e.VirtualSystemCollection.VirtualSystem, 2)
+	assert.Equal(t, e.VirtualSystemCollection.VirtualSystem[0].ID, "storage server")
+	assert.Equal(t, e.VirtualSystemCollection.VirtualSystem[1].ID, "web-server")
 }

--- a/ovf/ovf_test.go
+++ b/ovf/ovf_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -106,4 +106,28 @@ func TestVirtualSystemCollection(t *testing.T) {
 	assert.Len(t, e.VirtualSystemCollection.VirtualSystem, 2)
 	assert.Equal(t, e.VirtualSystemCollection.VirtualSystem[0].ID, "storage server")
 	assert.Equal(t, e.VirtualSystemCollection.VirtualSystem[1].ID, "web-server")
+}
+
+func TestMultipleDeploymentConfigs(t *testing.T) {
+	e := testEnvelope(t, "fixtures/haproxy-vsphere.ovf")
+
+	assert.NotNil(t, e.VirtualSystem)
+	assert.Nil(t, e.VirtualSystemCollection)
+	assert.NotNil(t, e.DeploymentOption)
+	assert.Len(t, e.DeploymentOption.Configuration, 2)
+
+	assert.NotNil(t, e.DeploymentOption.Configuration[0].Default)
+	assert.True(t, *e.DeploymentOption.Configuration[0].Default)
+	assert.Equal(t, "default", e.DeploymentOption.Configuration[0].ID)
+
+	assert.Nil(t, e.DeploymentOption.Configuration[1].Default)
+	assert.Equal(t, "frontend", e.DeploymentOption.Configuration[1].ID)
+
+	assert.Len(t, e.VirtualSystem.VirtualHardware, 1)
+	assert.Len(t, e.VirtualSystem.VirtualHardware[0].Item, 23)
+	assert.Len(t, e.VirtualSystem.VirtualHardware[0].Item[2].Config, 1)
+	assert.NotNil(t, e.VirtualSystem.VirtualHardware[0].Item[2].Config[0].Required)
+	assert.False(t, *e.VirtualSystem.VirtualHardware[0].Item[2].Config[0].Required)
+	assert.Equal(t, "slotInfo.pciSlotNumber", e.VirtualSystem.VirtualHardware[0].Item[2].Config[0].Key)
+	assert.Equal(t, "128", e.VirtualSystem.VirtualHardware[0].Item[2].Config[0].Value)
 }

--- a/simulator/ovf_manager.go
+++ b/simulator/ovf_manager.go
@@ -185,8 +185,8 @@ func (m *OvfManager) CreateImportSpec(ctx *Context, req *types.CreateImportSpec)
 		}
 	}
 
-	if os := env.VirtualSystem.OperatingSystem; len(os) != 0 {
-		if id := os[0].OSType; id != nil {
+	if os := env.VirtualSystem.OperatingSystem; os != nil {
+		if id := os.OSType; id != nil {
 			spec.ConfigSpec.GuestId = *id
 		}
 	}


### PR DESCRIPTION
## Description

This PR includes several enhancements to the `ovf` package:

* The OVF parser now conform to the DMTF spec for OVF content. This includes:
    * support for VirtualSystemCollection
    * a single OperatingSystem section in VirtualSystem
    * removing the roll-up sections at the root of the Envelope that belong only under a VirtualSystem or VirtualSystemCollection
    * :warning: **Breaking** :warning: Users of the `ovf` package will need to update their sources to conform to the changes from this patch. It should be a fairly simple change.

* The OVF parser now supports an enum used to define the CIM ResourceType.
    * :warning: **Breaking** :warning: Users of the `ovf` package may need to cast ResourceType to a uint16 depending on how they have used the value. 

* It is now possible to transform an `ovf.Envelope` into a `types.VirtualMachineConfigSpec`

Closes: #(issue-number)

## How Has This Been Tested?

```shell
go test -v -count 1 ./ovf
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
