### PR TITLE
fix: vcsim: swap order of xsi type attribute

### DIFF
--- a/vim25/xml/marshal.go
+++ b/vim25/xml/marshal.go
@@ -497,11 +497,6 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 		start.Name.Local = name
 	}
 
-	// Add type attribute if necessary
-	if finfo != nil && finfo.flags&fTypeAttr != 0 {
-		start.Attr = append(start.Attr, Attr{xmlSchemaInstance, typeToString(typ)})
-	}
-
 	// Attributes
 	for i := range tinfo.fields {
 		finfo := &tinfo.fields[i]
@@ -522,6 +517,11 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 		if err := p.marshalAttr(&start, name, fv); err != nil {
 			return err
 		}
+	}
+
+	// Add type attribute if necessary
+	if finfo != nil && finfo.flags&fTypeAttr != 0 {
+		start.Attr = append(start.Attr, Attr{xmlSchemaInstance, typeToString(typ)})
 	}
 
 	if err := p.writeStart(&start); err != nil {


### PR DESCRIPTION
PropertyCollector responses always included the 'xsi:type' attribute. When a property type is ManagedObjectReference, there are 2 'type' attributes in the response, for example:
```xml
 <val xsi:type="ManagedObjectReference" type="LicenseAssignmentManager">LicenseAssignmentManager</val>
```
Some clients (Java) have problems with this. Changing the order to be the same as real vCenter to workaround:
```xml
 <val type="LicenseAssignmentManager" xsi:type="ManagedObjectReference">LicenseAssignmentManager</val>
```

Fixes #2114
