### PR TITLE
govc: remove minimum API version check

### DIFF
--- a/cli/flags/version_test.go
+++ b/cli/flags/version_test.go
@@ -74,17 +74,3 @@ func TestLte(t *testing.T) {
 		t.Errorf("Expected not 5.6 <= 5.5")
 	}
 }
-
-func TestDevelopmentVersion(t *testing.T) {
-	if !isDevelopmentVersion("6.5.x") {
-		t.Error("expected true")
-	}
-
-	if !isDevelopmentVersion("r4A70F") {
-		t.Error("expected true")
-	}
-
-	if isDevelopmentVersion("6.5") {
-		t.Error("expected false")
-	}
-}

--- a/govc/test/cli.bats
+++ b/govc/test/cli.bats
@@ -122,25 +122,6 @@ load test_helper
   assert_success
 }
 
-@test "API version check" {
-  vcsim_env -esx
-
-  run env GOVC_MIN_API_VERSION=24.4 govc about
-  assert grep -q "^govc: require API version \"24.4\"," <<<"${output}"
-
-  run env GOVC_MIN_API_VERSION=no.no govc about
-  assert_failure
-
-  run env GOVC_MIN_API_VERSION=- govc about
-  assert_success
-
-  run env GOVC_MIN_API_VERSION=5.0 govc about
-  assert_success
-
-  run govc about -vim-namespace urn:vim25 -vim-version 6.0
-  assert_success
-}
-
 @test "govc env" {
   output="$(govc env -x -u 'user:pass@enoent:99999?key=val#anchor')"
   assert grep -q GOVC_URL=enoent:99999 <<<${output}


### PR DESCRIPTION
This check hasn't been useful, except maybe in the early days of govc. It's only caused problems when dev/rc versioning changes in a way that breaks our parsing. Simpler to just remove than to maintain it.

Fixes #3643
