### PR TITLE
vcsim: LicenseManager enhancements

### DIFF
--- a/cli/object/save.go
+++ b/cli/object/save.go
@@ -45,6 +45,7 @@ type save struct {
 	verbose bool
 	recurse bool
 	one     bool
+	license bool
 	kind    kinds
 	summary map[string]int
 }
@@ -60,6 +61,7 @@ func (cmd *save) Register(ctx context.Context, f *flag.FlagSet) {
 	f.BoolVar(&cmd.one, "1", false, "Save ROOT only, without its children")
 	f.StringVar(&cmd.dir, "d", "", "Save objects in directory")
 	f.BoolVar(&cmd.force, "f", false, "Remove existing object directory")
+	f.BoolVar(&cmd.license, "l", false, "Include license properties")
 	f.BoolVar(&cmd.recurse, "r", true, "Include children of the container view root")
 	f.Var(&cmd.kind, "type", "Resource types to save.  Defaults to all types")
 	f.BoolVar(&cmd.verbose, "v", false, "Verbose output")
@@ -168,6 +170,14 @@ func saveAlarmManager(ctx context.Context, c *vim25.Client, ref types.ManagedObj
 	return []saveMethod{{"GetAlarm", res}, {"", content}}, nil
 }
 
+func saveLicenseAssignmentManager(ctx context.Context, c *vim25.Client, ref types.ManagedObjectReference) ([]saveMethod, error) {
+	res, err := methods.QueryAssignedLicenses(ctx, c, &types.QueryAssignedLicenses{This: ref})
+	if err != nil {
+		return nil, err
+	}
+	return []saveMethod{{"QueryAssignedLicenses", res}}, nil
+}
+
 // saveObjects maps object types to functions that can save data that isn't available via the PropertyCollector
 var saveObjects = map[string]func(context.Context, *vim25.Client, types.ManagedObjectReference) ([]saveMethod, error){
 	"VmwareDistributedVirtualSwitch": saveDVS,
@@ -175,6 +185,7 @@ var saveObjects = map[string]func(context.Context, *vim25.Client, types.ManagedO
 	"HostNetworkSystem":              saveHostNetworkSystem,
 	"HostSystem":                     saveHostSystem,
 	"AlarmManager":                   saveAlarmManager,
+	"LicenseAssignmentManager":       saveLicenseAssignmentManager,
 }
 
 func (cmd *save) save(content []types.ObjectContent) error {
@@ -226,6 +237,10 @@ func (cmd *save) save(content []types.ObjectContent) error {
 }
 
 func (cmd *save) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() > 1 {
+		return flag.ErrHelp
+	}
+
 	cmd.summary = make(map[string]int)
 	c, err := cmd.Client()
 	if err != nil {
@@ -291,25 +306,35 @@ func (cmd *save) Run(ctx context.Context, f *flag.FlagSet) error {
 		for _, p := range content[0].PropSet {
 			if c, ok := p.Val.(types.ServiceContent); ok {
 				var path []string
+				var selectSet []types.BaseSelectionSpec
+				var propSet []types.PropertySpec
 				for _, ref := range mo.References(c) {
 					all := types.NewBool(true)
 					switch ref.Type {
 					case "LicenseManager":
-						// avoid saving "licenses" property as it includes the keys
-						path = []string{"licenseAssignmentManager"}
-						all = nil
+						selectSet = []types.BaseSelectionSpec{&types.TraversalSpec{
+							Type: ref.Type,
+							Path: "licenseAssignmentManager",
+						}}
+						propSet = []types.PropertySpec{{Type: "LicenseAssignmentManager", All: all}}
+						// avoid saving "licenses" property by default as it includes the keys
+						if cmd.license == false {
+							path = []string{selectSet[0].(*types.TraversalSpec).Path}
+							all, selectSet, propSet = nil, nil, nil
+						}
 					case "ServiceManager":
 						all = nil
 					}
 					req.SpecSet = append(req.SpecSet, types.PropertyFilterSpec{
 						ObjectSet: []types.ObjectSpec{{
-							Obj: ref,
+							Obj:       ref,
+							SelectSet: selectSet,
 						}},
-						PropSet: []types.PropertySpec{{
+						PropSet: append(propSet, types.PropertySpec{
 							Type:    ref.Type,
 							All:     all,
 							PathSet: path,
-						}},
+						}),
 					})
 				}
 				break

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -5000,6 +5000,7 @@ Options:
   -d=                    Save objects in directory
   -f=false               Remove existing object directory
   -folder=               Inventory folder [GOVC_FOLDER]
+  -l=false               Include license properties
   -r=true                Include children of the container view root
   -type=[]               Resource types to save.  Defaults to all types
   -v=false               Verbose output

--- a/govc/test/license.bats
+++ b/govc/test/license.bats
@@ -66,11 +66,18 @@ get_nlabel() {
   assert_success
 
   # Expect the test instance to run in evaluation mode
-  assert_equal "Evaluation Mode" "$(get_key 00000-00000-00000-00000-00000 <<<$output | jq -r ".name")"
+  mode="$(get_key 00000-00000-00000-00000-00000 <<<"$output" | jq -r ".name")"
+  assert_equal "Evaluation Mode" "$mode"
+
+  name=$(jq -r '.[].properties[] | select(.key == "ProductName") | .value' <<<"$output")
+  assert_equal "$(govc about -json | jq -r .about.licenseProductName)" "$name"
+
+  name=$(jq -r '.[].properties[] | select(.key == "ProductVersion") | .value' <<<"$output")
+  assert_equal "$(govc about -json | jq -r .about.licenseProductVersion)" "$name"
 }
 
 @test "license.decode" {
-  esx_env
+  vcsim_env
 
   verify_evaluation
 

--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -734,6 +734,20 @@ EOF
   n=$(ls "$dir"/*.xml | wc -l)
   rm -rf "$dir"
   assert_equal 10 "$n"
+
+  run govc object.save -v -d "$dir"
+  assert_success
+
+  n=$(ls "$dir"/*License*.xml | wc -l)
+  rm -rf "$dir"
+  assert_equal 1 "$n" # LicenseManager
+
+  run govc object.save -l -v -d "$dir"
+  assert_success
+
+  n=$(ls "$dir"/*License*.xml | wc -l)
+  rm -rf "$dir"
+  assert_equal 2 "$n" # LicenseManager + LicenseAssignmentManager
 }
 
 @test "tree" {

--- a/simulator/license_manager_test.go
+++ b/simulator/license_manager_test.go
@@ -75,8 +75,13 @@ func TestLicenseManagerVPX(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if len(la) != 1 {
-			t.Fatal("no licenses")
+		expect := 1
+		if name == "" {
+			count := m.Count()
+			expect = count.Host + count.ClusterHost + count.Cluster + 1 // (1 == vCenter)
+		}
+		if len(la) != expect {
+			t.Fatalf("%d licenses", len(la))
 		}
 
 		if !reflect.DeepEqual(la[0].AssignedLicense, EvalLicense) {

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -257,6 +257,7 @@ var kinds = map[string]reflect.Type{
 	"HostSystem":                         reflect.TypeOf((*HostSystem)(nil)).Elem(),
 	"IpPoolManager":                      reflect.TypeOf((*IpPoolManager)(nil)).Elem(),
 	"LicenseManager":                     reflect.TypeOf((*LicenseManager)(nil)).Elem(),
+	"LicenseAssignmentManager":           reflect.TypeOf((*LicenseAssignmentManager)(nil)).Elem(),
 	"OptionManager":                      reflect.TypeOf((*OptionManager)(nil)).Elem(),
 	"OvfManager":                         reflect.TypeOf((*OvfManager)(nil)).Elem(),
 	"PerformanceManager":                 reflect.TypeOf((*PerformanceManager)(nil)).Elem(),


### PR DESCRIPTION
- add ProductName + ProductVersion properties to default EvalLicense

- QueryAssignedLicenses defaults to listing license for all hosts and clusters

- govc object.save '-l' flag will include all LicenseManager properties and LicenseAssignmentManager QueryAssignedLicenses response
