### PR TITLE
api: A generic copy function for vim25/types

### DIFF
--- a/vim25/types/deep_copy.go
+++ b/vim25/types/deep_copy.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"bytes"
+)
+
+// DeepCopyInto creates a deep-copy of src by encoding it to JSON and then
+// decoding that into dst.
+// Please note, empty slices or maps in src that are set to omitempty will be
+// nil in the copied object.
+func DeepCopyInto[T AnyType](dst *T, src T) error {
+	var w bytes.Buffer
+	e := NewJSONEncoder(&w)
+	if err := e.Encode(src); err != nil {
+		return err
+	}
+	d := NewJSONDecoder(&w)
+	if err := d.Decode(dst); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MustDeepCopyInto panics if DeepCopyInto returns an error.
+func MustDeepCopyInto[T AnyType](dst *T, src T) error {
+	if err := DeepCopyInto(dst, src); err != nil {
+		panic(err)
+	}
+	return nil
+}
+
+// DeepCopy creates a deep-copy of src by encoding it to JSON and then decoding
+// that into a new instance of T.
+// Please note, empty slices or maps in src that are set to omitempty will be
+// nil in the copied object.
+func DeepCopy[T AnyType](src T) (T, error) {
+	var dst T
+	err := DeepCopyInto(&dst, src)
+	return dst, err
+}
+
+// MustDeepCopy panics if DeepCopy returns an error.
+func MustDeepCopy[T AnyType](src T) T {
+	dst, err := DeepCopy(src)
+	if err != nil {
+		panic(err)
+	}
+	return dst
+}

--- a/vim25/types/deep_copy_test.go
+++ b/vim25/types/deep_copy_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMustDeepCopy(t *testing.T) {
+	newConfigSpec := func() VirtualMachineConfigSpec {
+		return VirtualMachineConfigSpec{
+			Name:     "vm-001",
+			GuestId:  "otherGuest",
+			Files:    &VirtualMachineFileInfo{VmPathName: "[datastore1]"},
+			NumCPUs:  1,
+			MemoryMB: 128,
+			DeviceChange: []BaseVirtualDeviceConfigSpec{
+				&VirtualDeviceConfigSpec{
+					Operation: VirtualDeviceConfigSpecOperationAdd,
+					Device: &VirtualLsiLogicController{VirtualSCSIController{
+						SharedBus: VirtualSCSISharingNoSharing,
+						VirtualController: VirtualController{
+							BusNumber: 0,
+							VirtualDevice: VirtualDevice{
+								Key: 1000,
+							},
+						},
+					}},
+				},
+				&VirtualDeviceConfigSpec{
+					Operation:     VirtualDeviceConfigSpecOperationAdd,
+					FileOperation: VirtualDeviceConfigSpecFileOperationCreate,
+					Device: &VirtualDisk{
+						VirtualDevice: VirtualDevice{
+							Key:           0,
+							ControllerKey: 1000,
+							UnitNumber:    NewInt32(10),
+							Backing: &VirtualDiskFlatVer2BackingInfo{
+								DiskMode:        string(VirtualDiskModePersistent),
+								ThinProvisioned: NewBool(true),
+								VirtualDeviceFileBackingInfo: VirtualDeviceFileBackingInfo{
+									FileName: "[datastore1]",
+								},
+							},
+						},
+						CapacityInKB: 4000000,
+					},
+				},
+				&VirtualDeviceConfigSpec{
+					Operation: VirtualDeviceConfigSpecOperationAdd,
+					Device: &VirtualE1000{VirtualEthernetCard{
+						VirtualDevice: VirtualDevice{
+							Key: 0,
+							DeviceInfo: &Description{
+								Label:   "Network Adapter 1",
+								Summary: "VM Network",
+							},
+							Backing: &VirtualEthernetCardNetworkBackingInfo{
+								VirtualDeviceDeviceBackingInfo: VirtualDeviceDeviceBackingInfo{
+									DeviceName: "VM Network",
+								},
+							},
+						},
+						AddressType: string(VirtualEthernetCardMacTypeGenerated),
+					}},
+				},
+			},
+			ExtraConfig: []BaseOptionValue{
+				&OptionValue{Key: "bios.bootOrder", Value: "ethernet0"},
+			},
+		}
+	}
+
+	t.Run("a string", func(t *testing.T) {
+		t.Parallel()
+		var dst AnyType
+		assert.NotPanics(t, func() {
+			dst = MustDeepCopy("hello")
+		})
+		assert.Equal(t, "hello", dst)
+	})
+
+	t.Run("a *uint8", func(t *testing.T) {
+		t.Parallel()
+		var dst AnyType
+		assert.NotPanics(t, func() {
+			dst = MustDeepCopy(New(uint8(42)))
+		})
+		assert.Equal(t, &[]uint8{42}[0], dst)
+	})
+
+	t.Run("a VirtualMachineConfigSpec", func(t *testing.T) {
+		t.Parallel()
+		var dst AnyType
+		assert.NotPanics(t, func() {
+			dst = MustDeepCopy(newConfigSpec())
+		})
+		assert.Equal(t, newConfigSpec(), dst)
+	})
+
+	t.Run("a *VirtualMachineConfigSpec", func(t *testing.T) {
+		t.Parallel()
+		var dst AnyType
+		assert.NotPanics(t, func() {
+			dst = MustDeepCopy(New(newConfigSpec()))
+		})
+		assert.Equal(t, New(newConfigSpec()), dst)
+	})
+
+	t.Run("a **VirtualMachineConfigSpec", func(t *testing.T) {
+		t.Parallel()
+
+		var dst AnyType
+		exp := newConfigSpec()
+		ptrExp := &exp
+		ptrPtrExp := &ptrExp
+
+		assert.NotPanics(t, func() {
+			dst = MustDeepCopy(New(New(newConfigSpec())))
+		})
+
+		assert.Equal(t, ptrPtrExp, dst)
+
+		exp.Name += "-not-equal"
+		assert.NotEqual(t, ptrPtrExp, dst)
+	})
+
+	t.Run("a VirtualMachineConfigSpec with nil DeviceChange vs empty", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("src is nil, exp is nil", func(t *testing.T) {
+			t.Parallel()
+			var dst AnyType
+			exp, src := newConfigSpec(), newConfigSpec()
+			exp.DeviceChange = nil
+			src.DeviceChange = nil
+			assert.NotPanics(t, func() {
+				dst = MustDeepCopy(src)
+			})
+			assert.Equal(t, exp, dst, cmp.Diff(exp, dst))
+		})
+
+		t.Run("src is empty, exp is nil", func(t *testing.T) {
+			t.Parallel()
+			var dst AnyType
+			exp, src := newConfigSpec(), newConfigSpec()
+			exp.DeviceChange = nil
+			src.DeviceChange = []BaseVirtualDeviceConfigSpec{}
+			assert.NotPanics(t, func() {
+				dst = MustDeepCopy(src)
+			})
+			assert.Equal(t, exp, dst, cmp.Diff(exp, dst))
+		})
+
+	})
+}

--- a/vim25/types/helpers.go
+++ b/vim25/types/helpers.go
@@ -34,6 +34,10 @@ func EnumValuesAsStrings[T ~string](enumValues []T) []string {
 	return stringValues
 }
 
+func New[T any](t T) *T {
+	return &t
+}
+
 func NewBool(v bool) *bool {
 	return &v
 }


### PR DESCRIPTION
## Description

This patch provides a helper function, `Copy[T any](src T) T` for creating deep copies of Go objects, specifically those from vim25/types. The copy function encodes the Go object to JSON using the vim JSON encoder. Then the copy function decodes the data to a new instance of the same type. The function is implemented using Go generics, so it does not depend directly on reflection (though Go's JSON encoder does).

Closes: `NA`

## How Has This Been Tested?

```shell
go test -count 1 -v -run TestMustDeepCopy ./vim25/types
```

The above command will emit output similar to the following:

```shell
=== RUN   TestMustDeepCopy
=== RUN   TestMustDeepCopy/a_string
=== PAUSE TestMustDeepCopy/a_string
=== RUN   TestMustDeepCopy/a_*uint8
=== PAUSE TestMustDeepCopy/a_*uint8
=== RUN   TestMustDeepCopy/a_VirtualMachineConfigSpec
=== PAUSE TestMustDeepCopy/a_VirtualMachineConfigSpec
=== RUN   TestMustDeepCopy/a_*VirtualMachineConfigSpec
=== PAUSE TestMustDeepCopy/a_*VirtualMachineConfigSpec
=== RUN   TestMustDeepCopy/a_**VirtualMachineConfigSpec
=== PAUSE TestMustDeepCopy/a_**VirtualMachineConfigSpec
=== RUN   TestMustDeepCopy/a_VirtualMachineConfigSpec_with_nil_DeviceChange_vs_empty
=== PAUSE TestMustDeepCopy/a_VirtualMachineConfigSpec_with_nil_DeviceChange_vs_empty
=== CONT  TestMustDeepCopy/a_string
=== CONT  TestMustDeepCopy/a_*VirtualMachineConfigSpec
=== CONT  TestMustDeepCopy/a_VirtualMachineConfigSpec
=== CONT  TestMustDeepCopy/a_*uint8
=== CONT  TestMustDeepCopy/a_VirtualMachineConfigSpec_with_nil_DeviceChange_vs_empty
=== RUN   TestMustDeepCopy/a_VirtualMachineConfigSpec_with_nil_DeviceChange_vs_empty/src_is_nil,_exp_is_nil
=== CONT  TestMustDeepCopy/a_**VirtualMachineConfigSpec
=== PAUSE TestMustDeepCopy/a_VirtualMachineConfigSpec_with_nil_DeviceChange_vs_empty/src_is_nil,_exp_is_nil
=== RUN   TestMustDeepCopy/a_VirtualMachineConfigSpec_with_nil_DeviceChange_vs_empty/src_is_empty,_exp_is_nil
=== PAUSE TestMustDeepCopy/a_VirtualMachineConfigSpec_with_nil_DeviceChange_vs_empty/src_is_empty,_exp_is_nil
=== CONT  TestMustDeepCopy/a_VirtualMachineConfigSpec_with_nil_DeviceChange_vs_empty/src_is_nil,_exp_is_nil
=== CONT  TestMustDeepCopy/a_VirtualMachineConfigSpec_with_nil_DeviceChange_vs_empty/src_is_empty,_exp_is_nil
--- PASS: TestMustDeepCopy (0.00s)
    --- PASS: TestMustDeepCopy/a_string (0.00s)
    --- PASS: TestMustDeepCopy/a_*uint8 (0.00s)
    --- PASS: TestMustDeepCopy/a_VirtualMachineConfigSpec_with_nil_DeviceChange_vs_empty (0.00s)
        --- PASS: TestMustDeepCopy/a_VirtualMachineConfigSpec_with_nil_DeviceChange_vs_empty/src_is_empty,_exp_is_nil (0.00s)
        --- PASS: TestMustDeepCopy/a_VirtualMachineConfigSpec_with_nil_DeviceChange_vs_empty/src_is_nil,_exp_is_nil (0.00s)
    --- PASS: TestMustDeepCopy/a_*VirtualMachineConfigSpec (0.00s)
    --- PASS: TestMustDeepCopy/a_VirtualMachineConfigSpec (0.00s)
    --- PASS: TestMustDeepCopy/a_**VirtualMachineConfigSpec (0.00s)
PASS
ok  	github.com/vmware/govmomi/vim25/types	0.376s
```


## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
