### PR TITLE
vcsim: fix object.save when run directly against ESX

### DIFF
--- a/cli/object/save.go
+++ b/cli/object/save.go
@@ -212,6 +212,9 @@ func (cmd *save) save(content []types.ObjectContent) error {
 				if fault.Is(err, &types.HostNotConnected{}) {
 					continue
 				}
+				if fault.Is(err, &types.NotSupported{}) {
+					continue
+				}
 				return err
 			}
 			dir := filepath.Join(cmd.dir, ref)

--- a/govc/test/object.bats
+++ b/govc/test/object.bats
@@ -750,6 +750,16 @@ EOF
   assert_equal 2 "$n" # LicenseManager + LicenseAssignmentManager
 }
 
+@test "object.save esx" {
+  vcsim_env -esx
+
+  dir="$BATS_TMPDIR/$(new_id)"
+  run govc object.save -v -d "$dir"
+  assert_success
+
+  rm -rf "$dir"
+}
+
 @test "tree" {
   vcsim_start -dc 2 -folder 1 -pod 1 -nsx 1 -pool 2
 

--- a/simulator/host_system.go
+++ b/simulator/host_system.go
@@ -597,8 +597,14 @@ func (h *HostSystem) ReconnectHostTask(ctx *Context, spec *types.ReconnectHost_T
 	}
 }
 
-func (s *HostSystem) QueryTpmAttestationReport(req *types.QueryTpmAttestationReport) soap.HasFault {
-	return &methods.QueryTpmAttestationReportBody{
-		Res: &s.QueryTpmAttestationReportResponse,
+func (s *HostSystem) QueryTpmAttestationReport(ctx *Context, req *types.QueryTpmAttestationReport) soap.HasFault {
+	body := new(methods.QueryTpmAttestationReportBody)
+
+	if ctx.Map.IsVPX() {
+		body.Res = &s.QueryTpmAttestationReportResponse
+	} else {
+		body.Fault_ = Fault("", new(types.NotSupported))
 	}
+
+	return body
 }


### PR DESCRIPTION
QueryTpmAttestationReport is NotImplemented, vCenter only method.
