### PR TITLE
fix: check `cerr != nil` but return a nil value error `err`

### DIFF
--- a/cli/fields/info.go
+++ b/cli/fields/info.go
@@ -134,7 +134,7 @@ func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
 	if cmd.name != "" {
 		fkey, cerr := m.FindKey(ctx, cmd.name)
 		if cerr != nil {
-			return err
+			return cerr
 		}
 		matches = func(key int32) bool {
 			return key == fkey

--- a/govc/test/fields.bats
+++ b/govc/test/fields.bats
@@ -35,7 +35,10 @@ load test_helper
   run govc fields.info vm/$vm_id
   assert_success
 
-  run govc fields.info -n $val vm/$vm_id
+  run govc fields.info -n "invalid" vm/$vm_id
+  assert_failure
+
+  run govc fields.info -n $field vm/$vm_id
   assert_success
 
   info=$(govc vm.info -json $vm_id | jq .virtualMachines[0].customValue[0])


### PR DESCRIPTION
## Description

the if branch just check `cerr !=nil` and return a nil value error `err`

so, it's a harmless bug.

I have an idea to detect the code that return a no-realte nilness error bug, and check the top 1000 github go repos, and found this. see https://github.com/alingse/sundrylint/issues/4


Closes: #(issue-number)

## How Has This Been Tested?

just use the cli can reproduce this

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
