### PR TITLE
api: Fix object.VirtualDiskManager::Copy

### DIFF
--- a/object/virtual_disk_manager.go
+++ b/object/virtual_disk_manager.go
@@ -41,7 +41,7 @@ func (m VirtualDiskManager) CopyVirtualDisk(
 	ctx context.Context,
 	sourceName string, sourceDatacenter *Datacenter,
 	destName string, destDatacenter *Datacenter,
-	destSpec *types.VirtualDiskSpec, force bool) (*Task, error) {
+	destSpec types.BaseVirtualDiskSpec, force bool) (*Task, error) {
 
 	req := types.CopyVirtualDisk_Task{
 		This:       m.Reference(),


### PR DESCRIPTION


## Description

This patch fixes object.VirtualDiskManager::CopyVirtualDisk so it takes an interface instead of a concrete type for the destination disk spec.

Closes: `NA`

## How Has This Been Tested?

The GitHub actions.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
