### PR TITLE
fix: SOAP vcSessionCookie value must be from vim25.Client

### DIFF
--- a/pbm/client.go
+++ b/pbm/client.go
@@ -49,7 +49,7 @@ type Client struct {
 
 func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
 	sc := c.Client.NewServiceClient(Path, Namespace)
-	sc.Cookie = sc.SessionCookie // vcSessionCookie soap.Header
+	sc.Cookie = c.SessionCookie // vcSessionCookie soap.Header, value must be from vim25.Client
 
 	req := types.PbmRetrieveServiceContent{
 		This: ServiceInstance,

--- a/vslm/client.go
+++ b/vslm/client.go
@@ -46,7 +46,7 @@ type Client struct {
 
 func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
 	sc := c.Client.NewServiceClient(Path, Namespace)
-	sc.Cookie = sc.SessionCookie // vcSessionCookie soap.Header
+	sc.Cookie = c.SessionCookie // vcSessionCookie soap.Header, value must be from vim25.Client
 
 	req := types.RetrieveContent{
 		This: ServiceInstance,


### PR DESCRIPTION
Commit 19189841 refactored how we set vcSessionCookie for pbm and vslm endpoints. We need to use the value of vim25.Client's vmware_soap_session for vSessionCookie. Since the first response from pbm/vslm includes a 'Set-Cookie: vmware_soap_session=...', the value of which is _not_ valid for vcSessionCookie.
