### PR TITLE
govc: add disk.ls '-a' flag

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -2150,6 +2150,7 @@ Options:
   -L=false               Print disk backing path instead of disk name
   -R=false               Reconcile the datastore inventory info
   -T=false               List attached tags
+  -a=false               List IDs with missing file backing
   -c=                    Query tag category
   -ds=                   Datastore [GOVC_DATASTORE]
   -l=false               Long listing format

--- a/govc/test/disk.bats
+++ b/govc/test/disk.bats
@@ -204,13 +204,24 @@ load test_helper
 
   run govc disk.ls
   assert_success
+  [ ${#lines[@]} -eq 2 ]
 
   path=$(govc disk.ls -json "$id" | jq -r .objects[].config.backing.filePath)
   run govc datastore.rm "$path"
   assert_success
 
+  # file backing was removed without using disk.rm, results in NotFound fault
+  run govc disk.ls "$id"
+  assert_failure
+
   run govc disk.ls
-  assert_failure # file backing was removed without using disk.rm, results in NotFound fault
+  assert_success
+  [ ${#lines[@]} -eq 1 ]
+
+  run govc disk.ls -a
+  assert_success
+  [ ${#lines[@]} -eq 2 ]
+  assert_matches "not found"
 
   run govc disk.ls -R
   assert_success


### PR DESCRIPTION
Deleting an FCD file backing can create an orphan FCD. An orphaned ID is returned by the ListVStorageObject API, but calling RetrieveVStorageObject with an orphan ID results in a NotFound fault. The disk.ls command would return an error and suggest: use 'disk.ls -R' to reconcile datastore inventory The -R flag calls ReconcileDatastoreInventory, which normally cleans up such orphans, but we have seen cases where it does not.

This change ignores orphans by default. The new '-a' flag will list *all* orphans (if any) and includes the disk.ls -R suggestion.

Fixes #3639

Example output before change:
```console
% govc disk.ls
govc: 1ad1b6b7-b6e9-4c93-ba4d-bb4139acc08f not found: use 'disk.ls -R' to reconcile datastore inventory
```

After change:
```console
% govc disk.ls
43acf8ed-9a90-40fe-8ab8-e1102d162eb1  pvc-63f37324-d318-47a8-951b-6e41ab55a509

% govc disk.ls -a
1ad1b6b7-b6e9-4c93-ba4d-bb4139acc08f  not found: use 'disk.ls -R' to reconcile datastore inventory
43acf8ed-9a90-40fe-8ab8-e1102d162eb1  pvc-63f37324-d318-47a8-951b-6e41ab55a509
aa2ec397-330e-4ca1-9367-f803aa6fc571  not found: use 'disk.ls -R' to reconcile datastore inventory
```
