### PR TITLE
api: Support DC for ResolveLibItemStor

### DIFF
--- a/cli/library/info.go
+++ b/cli/library/info.go
@@ -277,7 +277,7 @@ func (r infoResultsWriter) writeFile(
 		}
 		if r.cmd.Stor {
 			label = "Resolved URI"
-			err = r.cmd.pathFinder.ResolveLibraryItemStorage(r.ctx, s)
+			err = r.cmd.pathFinder.ResolveLibraryItemStorage(r.ctx, nil, s)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION


## Description

This patch adds support for a variant of the ResolveLibraryItemStorage function named ResolveLibraryItemStorageWithDatacenter, for when the datacenter is known in advance. This is far more efficient since the ancestors of each storage item no longer need to be queried.

Closes: `NA`

## How Has This Been Tested?

@dougm, please note the test switched to an instance of vC Sim *per* test case as re-using the same one caused test cases to fail randomly. We can look more into why later.

```shell
$ go test -v -count 1 -run TestResolveLibraryItemStorageWithDatacenter ./vapi/library/finder
=== RUN   TestResolveLibraryItemStorageWithDatacenter
=== RUN   TestResolveLibraryItemStorageWithDatacenter/Nil_datacenter_and_nil_topLevelCreate
=== RUN   TestResolveLibraryItemStorageWithDatacenter/Nil_datacenter_and_false_topLevelCreate
=== RUN   TestResolveLibraryItemStorageWithDatacenter/Nil_datacenter_and_true_topLevelCreate
=== RUN   TestResolveLibraryItemStorageWithDatacenter/Non-nil_datacenter_and_nil_topLevelCreate
=== RUN   TestResolveLibraryItemStorageWithDatacenter/Non-Nil_datacenter_and_false_topLevelCreate
=== RUN   TestResolveLibraryItemStorageWithDatacenter/Non-Nil_datacenter_and_true_topLevelCreate
--- PASS: TestResolveLibraryItemStorageWithDatacenter (2.51s)
    --- PASS: TestResolveLibraryItemStorageWithDatacenter/Nil_datacenter_and_nil_topLevelCreate (0.42s)
    --- PASS: TestResolveLibraryItemStorageWithDatacenter/Nil_datacenter_and_false_topLevelCreate (0.44s)
    --- PASS: TestResolveLibraryItemStorageWithDatacenter/Nil_datacenter_and_true_topLevelCreate (0.40s)
    --- PASS: TestResolveLibraryItemStorageWithDatacenter/Non-nil_datacenter_and_nil_topLevelCreate (0.41s)
    --- PASS: TestResolveLibraryItemStorageWithDatacenter/Non-Nil_datacenter_and_false_topLevelCreate (0.41s)
    --- PASS: TestResolveLibraryItemStorageWithDatacenter/Non-Nil_datacenter_and_true_topLevelCreate (0.43s)
PASS
ok  	github.com/vmware/govmomi/vapi/library/finder	3.051s
```

Please describe any manual tests done to verify your changes.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
