### PR TITLE
api: Support returning DS info when resolving lib stor

### DIFF
--- a/cli/library/info.go
+++ b/cli/library/info.go
@@ -277,7 +277,7 @@ func (r infoResultsWriter) writeFile(
 		}
 		if r.cmd.Stor {
 			label = "Resolved URI"
-			err = r.cmd.pathFinder.ResolveLibraryItemStorage(r.ctx, nil, s)
+			err = r.cmd.pathFinder.ResolveLibraryItemStorage(r.ctx, nil, nil, s)
 			if err != nil {
 				return err
 			}

--- a/vapi/library/finder/path.go
+++ b/vapi/library/finder/path.go
@@ -176,6 +176,11 @@ func (f *PathFinder) convertPath(
 // to the format that includes the datastore name, ex.
 // "[DATASTORE_NAME] contentlib-LIB_UUID/ITEM_UUID/file.vmdk".
 //
+// If datastoreMap is provided, then it will be updated with the datastores
+// involved in the resolver. The properties name, summary.url, and
+// capability.topLevelDirectoryCreateSupported will be available after the
+// resolver completes.
+//
 // If a storage item resides on a datastore that does not support the creation
 // of top-level directories, then this means the datastore is vSAN and the
 // storage item path needs to be further converted. If this occurs, then the
@@ -187,16 +192,18 @@ func (f *PathFinder) convertPath(
 func (f *PathFinder) ResolveLibraryItemStorage(
 	ctx context.Context,
 	datacenter *object.Datacenter,
+	datastoreMap map[string]mo.Datastore,
 	storage []library.Storage) error {
 
 	// TODO:
 	// - reuse PathFinder.cache
 	// - the transform here isn't Content Library specific, but is currently
 	//   the only known use case
-	var (
-		ids          []types.ManagedObjectReference
+	var ids []types.ManagedObjectReference
+
+	if datastoreMap == nil {
 		datastoreMap = map[string]mo.Datastore{}
-	)
+	}
 
 	// Currently ContentLibrary only supports a single storage backing, but this
 	// future proofs things.


### PR DESCRIPTION

## Description

This patch updates the ResolveLibraryItemStorage method with the ability to return the resolve datastore information beyond just the resolved URIs. Now the datastore name, URL, and whether it supports top-level directory create can be returned.

Closes: `NA`

## How Has This Been Tested?

```shell
$ go test -v -count 1 -run TestResolveLibraryItemStorage ./vapi/library/finder
=== RUN   TestResolveLibraryItemStorage
=== RUN   TestResolveLibraryItemStorage/Nil_datacenter_and_nil_topLevelCreate
=== RUN   TestResolveLibraryItemStorage/Nil_datacenter_and_false_topLevelCreate
=== RUN   TestResolveLibraryItemStorage/Nil_datacenter_and_true_topLevelCreate
=== RUN   TestResolveLibraryItemStorage/Non-nil_datacenter_and_nil_topLevelCreate
=== RUN   TestResolveLibraryItemStorage/Non-Nil_datacenter_and_false_topLevelCreate
=== RUN   TestResolveLibraryItemStorage/Non-Nil_datacenter_and_true_topLevelCreate
=== RUN   TestResolveLibraryItemStorage/Nil_datastoreMap
=== RUN   TestResolveLibraryItemStorage/Non-Nil_datastoreMap_and_true_topLevelCreate
--- PASS: TestResolveLibraryItemStorage (3.43s)
    --- PASS: TestResolveLibraryItemStorage/Nil_datacenter_and_nil_topLevelCreate (0.39s)
    --- PASS: TestResolveLibraryItemStorage/Nil_datacenter_and_false_topLevelCreate (0.41s)
    --- PASS: TestResolveLibraryItemStorage/Nil_datacenter_and_true_topLevelCreate (0.40s)
    --- PASS: TestResolveLibraryItemStorage/Non-nil_datacenter_and_nil_topLevelCreate (0.38s)
    --- PASS: TestResolveLibraryItemStorage/Non-Nil_datacenter_and_false_topLevelCreate (0.43s)
    --- PASS: TestResolveLibraryItemStorage/Non-Nil_datacenter_and_true_topLevelCreate (0.49s)
    --- PASS: TestResolveLibraryItemStorage/Nil_datastoreMap (0.46s)
    --- PASS: TestResolveLibraryItemStorage/Non-Nil_datastoreMap_and_true_topLevelCreate (0.46s)
PASS
ok  	github.com/vmware/govmomi/vapi/library/finder	3.838s
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
