### PR TITLE
govc: add -b flag to volume.ls

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -25,8 +25,8 @@ import (
 )
 
 type CnsCreateVolumeRequestType struct {
-	This        types.ManagedObjectReference `xml:"_this"`
-	CreateSpecs []CnsVolumeCreateSpec        `xml:"createSpecs,omitempty"`
+	This        types.ManagedObjectReference `xml:"_this" json:"-"`
+	CreateSpecs []CnsVolumeCreateSpec        `xml:"createSpecs,omitempty" json:"createSpecs"`
 }
 
 func init() {
@@ -40,16 +40,16 @@ func init() {
 }
 
 type CnsCreateVolumeResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsEntityMetadata struct {
 	types.DynamicData
 
-	EntityName string           `xml:"entityName"`
-	Labels     []types.KeyValue `xml:"labels,omitempty"`
-	Delete     bool             `xml:"delete,omitempty"`
-	ClusterID  string           `xml:"clusterId,omitempty"`
+	EntityName string           `xml:"entityName" json:"entityName"`
+	Labels     []types.KeyValue `xml:"labels,omitempty" json:"labels"`
+	Delete     bool             `xml:"delete,omitempty" json:"delete"`
+	ClusterID  string           `xml:"clusterId,omitempty" json:"clusterID"`
 }
 
 func init() {
@@ -57,18 +57,18 @@ func init() {
 }
 
 type CnsKubernetesEntityReference struct {
-	EntityType string `xml:"entityType"`
-	EntityName string `xml:"entityName"`
-	Namespace  string `xml:"namespace,omitempty"`
-	ClusterID  string `xml:"clusterId,omitempty"`
+	EntityType string `xml:"entityType" json:"entityType"`
+	EntityName string `xml:"entityName" json:"entityName"`
+	Namespace  string `xml:"namespace,omitempty" json:"namespace"`
+	ClusterID  string `xml:"clusterId,omitempty" json:"clusterID"`
 }
 
 type CnsKubernetesEntityMetadata struct {
 	CnsEntityMetadata
 
-	EntityType     string                         `xml:"entityType"`
-	Namespace      string                         `xml:"namespace,omitempty"`
-	ReferredEntity []CnsKubernetesEntityReference `xml:"referredEntity,omitempty"`
+	EntityType     string                         `xml:"entityType" json:"entityType"`
+	Namespace      string                         `xml:"namespace,omitempty" json:"namespace"`
+	ReferredEntity []CnsKubernetesEntityReference `xml:"referredEntity,omitempty" json:"referredEntity"`
 }
 
 func init() {
@@ -78,9 +78,9 @@ func init() {
 type CnsVolumeMetadata struct {
 	types.DynamicData
 
-	ContainerCluster      CnsContainerCluster     `xml:"containerCluster"`
-	EntityMetadata        []BaseCnsEntityMetadata `xml:"entityMetadata,typeattr,omitempty"`
-	ContainerClusterArray []CnsContainerCluster   `xml:"containerClusterArray,omitempty"`
+	ContainerCluster      CnsContainerCluster     `xml:"containerCluster" json:"containerCluster"`
+	EntityMetadata        []BaseCnsEntityMetadata `xml:"entityMetadata,typeattr,omitempty" json:"entityMetadata"`
+	ContainerClusterArray []CnsContainerCluster   `xml:"containerClusterArray,omitempty" json:"containerClusterArray"`
 }
 
 func init() {
@@ -89,14 +89,14 @@ func init() {
 
 type CnsVolumeCreateSpec struct {
 	types.DynamicData
-	Name                 string                                `xml:"name"`
-	VolumeType           string                                `xml:"volumeType"`
-	Datastores           []types.ManagedObjectReference        `xml:"datastores,omitempty"`
-	Metadata             CnsVolumeMetadata                     `xml:"metadata,omitempty"`
-	BackingObjectDetails BaseCnsBackingObjectDetails           `xml:"backingObjectDetails,typeattr"`
-	Profile              []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
-	CreateSpec           BaseCnsBaseCreateSpec                 `xml:"createSpec,omitempty,typeattr"`
-	VolumeSource         BaseCnsVolumeSource                   `xml:"volumeSource,omitempty,typeattr"`
+	Name                 string                                `xml:"name" json:"name"`
+	VolumeType           string                                `xml:"volumeType" json:"volumeType"`
+	Datastores           []types.ManagedObjectReference        `xml:"datastores,omitempty" json:"datastores"`
+	Metadata             CnsVolumeMetadata                     `xml:"metadata,omitempty" json:"metadata"`
+	BackingObjectDetails BaseCnsBackingObjectDetails           `xml:"backingObjectDetails,typeattr" json:"backingObjectDetails"`
+	Profile              []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr" json:"profile"`
+	CreateSpec           BaseCnsBaseCreateSpec                 `xml:"createSpec,omitempty,typeattr" json:"createSpec"`
+	VolumeSource         BaseCnsVolumeSource                   `xml:"volumeSource,omitempty,typeattr" json:"volumeSource"`
 }
 
 func init() {
@@ -104,8 +104,8 @@ func init() {
 }
 
 type CnsUpdateVolumeMetadataRequestType struct {
-	This        types.ManagedObjectReference  `xml:"_this"`
-	UpdateSpecs []CnsVolumeMetadataUpdateSpec `xml:"updateSpecs,omitempty"`
+	This        types.ManagedObjectReference  `xml:"_this" json:"-"`
+	UpdateSpecs []CnsVolumeMetadataUpdateSpec `xml:"updateSpecs,omitempty" json:"updateSpecs"`
 }
 
 func init() {
@@ -119,14 +119,14 @@ func init() {
 }
 
 type CnsUpdateVolumeMetadataResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsVolumeMetadataUpdateSpec struct {
 	types.DynamicData
 
-	VolumeId CnsVolumeId       `xml:"volumeId"`
-	Metadata CnsVolumeMetadata `xml:"metadata,omitempty"`
+	VolumeId CnsVolumeId       `xml:"volumeId" json:"volumeId"`
+	Metadata CnsVolumeMetadata `xml:"metadata,omitempty" json:"metadata"`
 }
 
 func init() {
@@ -134,9 +134,9 @@ func init() {
 }
 
 type CnsDeleteVolumeRequestType struct {
-	This       types.ManagedObjectReference `xml:"_this"`
-	VolumeIds  []CnsVolumeId                `xml:"volumeIds"`
-	DeleteDisk bool                         `xml:"deleteDisk"`
+	This       types.ManagedObjectReference `xml:"_this" json:"-"`
+	VolumeIds  []CnsVolumeId                `xml:"volumeIds" json:"volumeIds"`
+	DeleteDisk bool                         `xml:"deleteDisk" json:"deleteDisk"`
 }
 
 func init() {
@@ -150,12 +150,12 @@ func init() {
 }
 
 type CnsDeleteVolumeResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsExtendVolumeRequestType struct {
-	This        types.ManagedObjectReference `xml:"_this"`
-	ExtendSpecs []CnsVolumeExtendSpec        `xml:"extendSpecs,omitempty"`
+	This        types.ManagedObjectReference `xml:"_this" json:"-"`
+	ExtendSpecs []CnsVolumeExtendSpec        `xml:"extendSpecs,omitempty" json:"extendSpecs"`
 }
 
 func init() {
@@ -169,14 +169,14 @@ func init() {
 }
 
 type CnsExtendVolumeResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsVolumeExtendSpec struct {
 	types.DynamicData
 
-	VolumeId     CnsVolumeId `xml:"volumeId"`
-	CapacityInMb int64       `xml:"capacityInMb"`
+	VolumeId     CnsVolumeId `xml:"volumeId" json:"volumeId"`
+	CapacityInMb int64       `xml:"capacityInMb" json:"capacityInMb"`
 }
 
 func init() {
@@ -184,8 +184,8 @@ func init() {
 }
 
 type CnsAttachVolumeRequestType struct {
-	This        types.ManagedObjectReference `xml:"_this"`
-	AttachSpecs []CnsVolumeAttachDetachSpec  `xml:"attachSpecs,omitempty"`
+	This        types.ManagedObjectReference `xml:"_this" json:"-"`
+	AttachSpecs []CnsVolumeAttachDetachSpec  `xml:"attachSpecs,omitempty" json:"attachSpecs"`
 }
 
 func init() {
@@ -199,12 +199,12 @@ func init() {
 }
 
 type CnsAttachVolumeResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsDetachVolumeRequestType struct {
-	This        types.ManagedObjectReference `xml:"_this"`
-	DetachSpecs []CnsVolumeAttachDetachSpec  `xml:"detachSpecs,omitempty"`
+	This        types.ManagedObjectReference `xml:"_this" json:"-"`
+	DetachSpecs []CnsVolumeAttachDetachSpec  `xml:"detachSpecs,omitempty" json:"detachSpecs"`
 }
 
 func init() {
@@ -218,14 +218,14 @@ func init() {
 }
 
 type CnsDetachVolumeResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsVolumeAttachDetachSpec struct {
 	types.DynamicData
 
-	VolumeId CnsVolumeId                  `xml:"volumeId"`
-	Vm       types.ManagedObjectReference `xml:"vm"`
+	VolumeId CnsVolumeId                  `xml:"volumeId" json:"volumeId"`
+	Vm       types.ManagedObjectReference `xml:"vm" json:"vm"`
 }
 
 func init() {
@@ -239,8 +239,8 @@ func init() {
 }
 
 type CnsQueryVolumeRequestType struct {
-	This   types.ManagedObjectReference `xml:"_this"`
-	Filter CnsQueryFilter               `xml:"filter"`
+	This   types.ManagedObjectReference `xml:"_this" json:"-"`
+	Filter CnsQueryFilter               `xml:"filter" json:"filter"`
 }
 
 func init() {
@@ -248,7 +248,7 @@ func init() {
 }
 
 type CnsQueryVolumeResponse struct {
-	Returnval CnsQueryResult `xml:"returnval"`
+	Returnval CnsQueryResult `xml:"returnval" json:"returnval"`
 }
 
 type CnsQueryVolumeInfo CnsQueryVolumeInfoRequestType
@@ -258,12 +258,12 @@ func init() {
 }
 
 type CnsQueryVolumeInfoRequestType struct {
-	This      types.ManagedObjectReference `xml:"_this"`
-	VolumeIds []CnsVolumeId                `xml:"volumes"`
+	This      types.ManagedObjectReference `xml:"_this" json:"-"`
+	VolumeIds []CnsVolumeId                `xml:"volumes" json:"volumeIds"`
 }
 
 type CnsQueryVolumeInfoResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsQueryAllVolume CnsQueryAllVolumeRequestType
@@ -273,9 +273,9 @@ func init() {
 }
 
 type CnsQueryAllVolumeRequestType struct {
-	This      types.ManagedObjectReference `xml:"_this"`
-	Filter    CnsQueryFilter               `xml:"filter"`
-	Selection CnsQuerySelection            `xml:"selection"`
+	This      types.ManagedObjectReference `xml:"_this" json:"-"`
+	Filter    CnsQueryFilter               `xml:"filter" json:"filter"`
+	Selection CnsQuerySelection            `xml:"selection" json:"selection"`
 }
 
 func init() {
@@ -283,17 +283,17 @@ func init() {
 }
 
 type CnsQueryAllVolumeResponse struct {
-	Returnval CnsQueryResult `xml:"returnval"`
+	Returnval CnsQueryResult `xml:"returnval" json:"returnval"`
 }
 
 type CnsContainerCluster struct {
 	types.DynamicData
 
-	ClusterType         string `xml:"clusterType"`
-	ClusterId           string `xml:"clusterId"`
-	VSphereUser         string `xml:"vSphereUser"`
-	ClusterFlavor       string `xml:"clusterFlavor,omitempty"`
-	ClusterDistribution string `xml:"clusterDistribution,omitempty"`
+	ClusterType         string `xml:"clusterType" json:"clusterType"`
+	ClusterId           string `xml:"clusterId" json:"clusterId"`
+	VSphereUser         string `xml:"vSphereUser" json:"vSphereUser"`
+	ClusterFlavor       string `xml:"clusterFlavor,omitempty" json:"clusterFlavor"`
+	ClusterDistribution string `xml:"clusterDistribution,omitempty" json:"clusterDistribution"`
 }
 
 func init() {
@@ -303,16 +303,16 @@ func init() {
 type CnsVolume struct {
 	types.DynamicData
 
-	VolumeId                     CnsVolumeId                 `xml:"volumeId"`
-	DatastoreUrl                 string                      `xml:"datastoreUrl,omitempty"`
-	Name                         string                      `xml:"name,omitempty"`
-	VolumeType                   string                      `xml:"volumeType,omitempty"`
-	StoragePolicyId              string                      `xml:"storagePolicyId,omitempty"`
-	Metadata                     CnsVolumeMetadata           `xml:"metadata,omitempty"`
-	BackingObjectDetails         BaseCnsBackingObjectDetails `xml:"backingObjectDetails,omitempty"`
-	ComplianceStatus             string                      `xml:"complianceStatus,omitempty"`
-	DatastoreAccessibilityStatus string                      `xml:"datastoreAccessibilityStatus,omitempty"`
-	HealthStatus                 string                      `xml:"healthStatus,omitempty"`
+	VolumeId                     CnsVolumeId                 `xml:"volumeId" json:"volumeId"`
+	DatastoreUrl                 string                      `xml:"datastoreUrl,omitempty" json:"datastoreUrl"`
+	Name                         string                      `xml:"name,omitempty" json:"name"`
+	VolumeType                   string                      `xml:"volumeType,omitempty" json:"volumeType"`
+	StoragePolicyId              string                      `xml:"storagePolicyId,omitempty" json:"storagePolicyId"`
+	Metadata                     CnsVolumeMetadata           `xml:"metadata,omitempty" json:"metadata"`
+	BackingObjectDetails         BaseCnsBackingObjectDetails `xml:"backingObjectDetails,omitempty" json:"backingObjectDetails"`
+	ComplianceStatus             string                      `xml:"complianceStatus,omitempty" json:"complianceStatus"`
+	DatastoreAccessibilityStatus string                      `xml:"datastoreAccessibilityStatus,omitempty" json:"datastoreAccessibilityStatus"`
+	HealthStatus                 string                      `xml:"healthStatus,omitempty" json:"healthStatus"`
 }
 
 func init() {
@@ -322,8 +322,8 @@ func init() {
 type CnsVolumeOperationResult struct {
 	types.DynamicData
 
-	VolumeId CnsVolumeId                 `xml:"volumeId,omitempty"`
-	Fault    *types.LocalizedMethodFault `xml:"fault,omitempty"`
+	VolumeId CnsVolumeId                 `xml:"volumeId,omitempty" json:"volumeId"`
+	Fault    *types.LocalizedMethodFault `xml:"fault,omitempty" json:"fault"`
 }
 
 func init() {
@@ -333,7 +333,7 @@ func init() {
 type CnsVolumeOperationBatchResult struct {
 	types.DynamicData
 
-	VolumeResults []BaseCnsVolumeOperationResult `xml:"volumeResults,omitempty,typeattr"`
+	VolumeResults []BaseCnsVolumeOperationResult `xml:"volumeResults,omitempty,typeattr" json:"volumeResults"`
 }
 
 func init() {
@@ -341,8 +341,8 @@ func init() {
 }
 
 type CnsPlacementResult struct {
-	Datastore       types.ManagedObjectReference  `xml:"datastore,omitempty"`
-	PlacementFaults []*types.LocalizedMethodFault `xml:"placementFaults,omitempty"`
+	Datastore       types.ManagedObjectReference  `xml:"datastore,omitempty" json:"datastore"`
+	PlacementFaults []*types.LocalizedMethodFault `xml:"placementFaults,omitempty" json:"placementFaults"`
 }
 
 func init() {
@@ -351,8 +351,8 @@ func init() {
 
 type CnsVolumeCreateResult struct {
 	CnsVolumeOperationResult
-	Name             string               `xml:"name,omitempty"`
-	PlacementResults []CnsPlacementResult `xml:"placementResults,omitempty"`
+	Name             string               `xml:"name,omitempty" json:"name"`
+	PlacementResults []CnsPlacementResult `xml:"placementResults,omitempty" json:"placementResults"`
 }
 
 func init() {
@@ -362,7 +362,7 @@ func init() {
 type CnsVolumeAttachResult struct {
 	CnsVolumeOperationResult
 
-	DiskUUID string `xml:"diskUUID,omitempty"`
+	DiskUUID string `xml:"diskUUID,omitempty" json:"diskUUID"`
 }
 
 func init() {
@@ -372,7 +372,7 @@ func init() {
 type CnsVolumeId struct {
 	types.DynamicData
 
-	Id string `xml:"id"`
+	Id string `xml:"id" json:"id"`
 }
 
 func init() {
@@ -382,7 +382,7 @@ func init() {
 type CnsBackingObjectDetails struct {
 	types.DynamicData
 
-	CapacityInMb int64 `xml:"capacityInMb,omitempty"`
+	CapacityInMb int64 `xml:"capacityInMb,omitempty" json:"capacityInMb"`
 }
 
 func init() {
@@ -392,11 +392,11 @@ func init() {
 type CnsBlockBackingDetails struct {
 	CnsBackingObjectDetails
 
-	BackingDiskId                  string `xml:"backingDiskId,omitempty"`
-	BackingDiskUrlPath             string `xml:"backingDiskUrlPath,omitempty"`
-	BackingDiskObjectId            string `xml:"backingDiskObjectId,omitempty"`
-	AggregatedSnapshotCapacityInMb int64  `xml:"aggregatedSnapshotCapacityInMb,omitempty"`
-	BackingDiskPath                string `xml:"backingDiskPath,omitempty"`
+	BackingDiskId                  string `xml:"backingDiskId,omitempty" json:"backingDiskId"`
+	BackingDiskUrlPath             string `xml:"backingDiskUrlPath,omitempty" json:"backingDiskUrlPath"`
+	BackingDiskObjectId            string `xml:"backingDiskObjectId,omitempty" json:"backingDiskObjectId"`
+	AggregatedSnapshotCapacityInMb int64  `xml:"aggregatedSnapshotCapacityInMb,omitempty" json:"aggregatedSnapshotCapacityInMb"`
+	BackingDiskPath                string `xml:"backingDiskPath,omitempty" json:"backingDiskPath"`
 }
 
 func init() {
@@ -406,7 +406,7 @@ func init() {
 type CnsFileBackingDetails struct {
 	CnsBackingObjectDetails
 
-	BackingFileId string `xml:"backingFileId,omitempty"`
+	BackingFileId string `xml:"backingFileId,omitempty" json:"backingFileId"`
 }
 
 func init() {
@@ -416,8 +416,8 @@ func init() {
 type CnsVsanFileShareBackingDetails struct {
 	CnsFileBackingDetails
 
-	Name         string           `xml:"name,omitempty"`
-	AccessPoints []types.KeyValue `xml:"accessPoints,omitempty"`
+	Name         string           `xml:"name,omitempty" json:"name"`
+	AccessPoints []types.KeyValue `xml:"accessPoints,omitempty" json:"accessPoints"`
 }
 
 func init() {
@@ -442,8 +442,8 @@ func init() {
 
 type CnsVSANFileCreateSpec struct {
 	CnsFileCreateSpec
-	SoftQuotaInMb int64                                    `xml:"softQuotaInMb,omitempty"`
-	Permission    []vsanfstypes.VsanFileShareNetPermission `xml:"permission,omitempty,typeattr"`
+	SoftQuotaInMb int64                                    `xml:"softQuotaInMb,omitempty" json:"softQuotaInMb"`
+	Permission    []vsanfstypes.VsanFileShareNetPermission `xml:"permission,omitempty,typeattr" json:"permission"`
 }
 
 func init() {
@@ -453,16 +453,16 @@ func init() {
 type CnsQueryFilter struct {
 	types.DynamicData
 
-	VolumeIds                    []CnsVolumeId                  `xml:"volumeIds,omitempty"`
-	Names                        []string                       `xml:"names,omitempty"`
-	ContainerClusterIds          []string                       `xml:"containerClusterIds,omitempty"`
-	StoragePolicyId              string                         `xml:"storagePolicyId,omitempty"`
-	Datastores                   []types.ManagedObjectReference `xml:"datastores,omitempty"`
-	Labels                       []types.KeyValue               `xml:"labels,omitempty"`
-	ComplianceStatus             string                         `xml:"complianceStatus,omitempty"`
-	DatastoreAccessibilityStatus string                         `xml:"datastoreAccessibilityStatus,omitempty"`
-	Cursor                       *CnsCursor                     `xml:"cursor,omitempty"`
-	HealthStatus                 string                         `xml:"healthStatus,omitempty"`
+	VolumeIds                    []CnsVolumeId                  `xml:"volumeIds,omitempty" json:"volumeIds"`
+	Names                        []string                       `xml:"names,omitempty" json:"names"`
+	ContainerClusterIds          []string                       `xml:"containerClusterIds,omitempty" json:"containerClusterIds"`
+	StoragePolicyId              string                         `xml:"storagePolicyId,omitempty" json:"storagePolicyId"`
+	Datastores                   []types.ManagedObjectReference `xml:"datastores,omitempty" json:"datastores"`
+	Labels                       []types.KeyValue               `xml:"labels,omitempty" json:"labels"`
+	ComplianceStatus             string                         `xml:"complianceStatus,omitempty" json:"complianceStatus"`
+	DatastoreAccessibilityStatus string                         `xml:"datastoreAccessibilityStatus,omitempty" json:"datastoreAccessibilityStatus"`
+	Cursor                       *CnsCursor                     `xml:"cursor,omitempty" json:"cursor"`
+	HealthStatus                 string                         `xml:"healthStatus,omitempty" json:"healthStatus"`
 }
 
 func init() {
@@ -472,14 +472,14 @@ func init() {
 type CnsQuerySelection struct {
 	types.DynamicData
 
-	Names []string `xml:"names,omitempty"`
+	Names []string `xml:"names,omitempty" json:"names"`
 }
 
 type CnsQueryResult struct {
 	types.DynamicData
 
-	Volumes []CnsVolume `xml:"volumes,omitempty"`
-	Cursor  CnsCursor   `xml:"cursor"`
+	Volumes []CnsVolume `xml:"volumes,omitempty" json:"volumes"`
+	Cursor  CnsCursor   `xml:"cursor" json:"cursor"`
 }
 
 func init() {
@@ -497,7 +497,7 @@ func init() {
 type CnsBlockVolumeInfo struct {
 	CnsVolumeInfo
 
-	VStorageObject types.VStorageObject `xml:"vStorageObject"`
+	VStorageObject types.VStorageObject `xml:"vStorageObject" json:"vStorageObject"`
 }
 
 func init() {
@@ -507,7 +507,7 @@ func init() {
 type CnsQueryVolumeInfoResult struct {
 	CnsVolumeOperationResult
 
-	VolumeInfo BaseCnsVolumeInfo `xml:"volumeInfo,typeattr,omitempty"`
+	VolumeInfo BaseCnsVolumeInfo `xml:"volumeInfo,typeattr,omitempty" json:"volumeInfo"`
 }
 
 func init() {
@@ -515,8 +515,8 @@ func init() {
 }
 
 type CnsRelocateVolumeRequestType struct {
-	This          types.ManagedObjectReference `xml:"_this"`
-	RelocateSpecs []BaseCnsVolumeRelocateSpec  `xml:"relocateSpecs,typeattr"`
+	This          types.ManagedObjectReference `xml:"_this" json:"-"`
+	RelocateSpecs []BaseCnsVolumeRelocateSpec  `xml:"relocateSpecs,typeattr" json:"relocateSpecs"`
 }
 
 func init() {
@@ -530,16 +530,16 @@ func init() {
 }
 
 type CnsRelocateVolumeResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsVolumeRelocateSpec struct {
 	types.DynamicData
 
-	VolumeId       CnsVolumeId                           `xml:"volumeId"`
-	Datastore      types.ManagedObjectReference          `xml:"datastore"`
-	Profile        []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
-	ServiceLocator *types.ServiceLocator                 `xml:"serviceLocator,omitempty"`
+	VolumeId       CnsVolumeId                           `xml:"volumeId" json:"volumeId"`
+	Datastore      types.ManagedObjectReference          `xml:"datastore" json:"datastore"`
+	Profile        []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr" json:"profile"`
+	ServiceLocator *types.ServiceLocator                 `xml:"serviceLocator,omitempty" json:"serviceLocator"`
 }
 
 func init() {
@@ -572,9 +572,9 @@ func init() {
 type CnsCursor struct {
 	types.DynamicData
 
-	Offset       int64 `xml:"offset"`
-	Limit        int64 `xml:"limit"`
-	TotalRecords int64 `xml:"totalRecords,omitempty"`
+	Offset       int64 `xml:"offset" json:"offset"`
+	Limit        int64 `xml:"limit" json:"limit"`
+	TotalRecords int64 `xml:"totalRecords,omitempty" json:"totalRecords"`
 }
 
 func init() {
@@ -584,7 +584,7 @@ func init() {
 type CnsFault struct {
 	types.BaseMethodFault `xml:"fault,typeattr"`
 
-	Reason string `xml:"reason,omitempty"`
+	Reason string `xml:"reason,omitempty" json:"reason"`
 }
 
 func init() {
@@ -594,7 +594,7 @@ func init() {
 type CnsVolumeNotFoundFault struct {
 	CnsFault
 
-	VolumeId CnsVolumeId `xml:"volumeId"`
+	VolumeId CnsVolumeId `xml:"volumeId" json:"volumeId"`
 }
 
 func init() {
@@ -604,7 +604,7 @@ func init() {
 type CnsAlreadyRegisteredFault struct {
 	CnsFault `xml:"fault,typeattr"`
 
-	VolumeId CnsVolumeId `xml:"volumeId,omitempty"`
+	VolumeId CnsVolumeId `xml:"volumeId,omitempty" json:"volumeId"`
 }
 
 func init() {
@@ -614,8 +614,8 @@ func init() {
 type CnsSnapshotNotFoundFault struct {
 	CnsFault
 
-	VolumeId   CnsVolumeId   `xml:"volumeId,omitempty"`
-	SnapshotId CnsSnapshotId `xml:"SnapshotId"`
+	VolumeId   CnsVolumeId   `xml:"volumeId,omitempty" json:"volumeId"`
+	SnapshotId CnsSnapshotId `xml:"SnapshotId" json:"snapshotId"`
 }
 
 func init() {
@@ -625,9 +625,9 @@ func init() {
 type CnsSnapshotCreatedFault struct {
 	CnsFault
 
-	VolumeId   CnsVolumeId                  `xml:"volumeId"`
-	SnapshotId CnsSnapshotId                `xml:"SnapshotId"`
-	Datastore  types.ManagedObjectReference `xml:"datastore"`
+	VolumeId   CnsVolumeId                  `xml:"volumeId" json:"volumeId"`
+	SnapshotId CnsSnapshotId                `xml:"SnapshotId" json:"snapshotId"`
+	Datastore  types.ManagedObjectReference `xml:"datastore" json:"datastore"`
 }
 
 func init() {
@@ -641,8 +641,8 @@ func init() {
 }
 
 type CnsConfigureVolumeACLsRequestType struct {
-	This           types.ManagedObjectReference `xml:"_this"`
-	ACLConfigSpecs []CnsVolumeACLConfigureSpec  `xml:"ACLConfigSpecs"`
+	This           types.ManagedObjectReference `xml:"_this" json:"-"`
+	ACLConfigSpecs []CnsVolumeACLConfigureSpec  `xml:"ACLConfigSpecs" json:"aclConfigSpecs"`
 }
 
 func init() {
@@ -650,20 +650,20 @@ func init() {
 }
 
 type CnsConfigureVolumeACLsResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsVolumeACLConfigureSpec struct {
 	types.DynamicData
 
-	VolumeId              CnsVolumeId               `xml:"volumeId"`
-	AccessControlSpecList []CnsNFSAccessControlSpec `xml:"accessControlSpecList,typeattr"`
+	VolumeId              CnsVolumeId               `xml:"volumeId" json:"volumeId"`
+	AccessControlSpecList []CnsNFSAccessControlSpec `xml:"accessControlSpecList,typeattr" json:"accessControlSpecList"`
 }
 
 type CnsNFSAccessControlSpec struct {
 	types.DynamicData
-	Permission []vsanfstypes.VsanFileShareNetPermission `xml:"netPermission,omitempty,typeattr"`
-	Delete     bool                                     `xml:"delete,omitempty"`
+	Permission []vsanfstypes.VsanFileShareNetPermission `xml:"netPermission,omitempty,typeattr" json:"permission"`
+	Delete     bool                                     `xml:"delete,omitempty" json:"delete"`
 }
 
 func init() {
@@ -677,9 +677,9 @@ func init() {
 }
 
 type CnsQueryAsyncRequestType struct {
-	This      types.ManagedObjectReference `xml:"_this"`
-	Filter    CnsQueryFilter               `xml:"filter"`
-	Selection *CnsQuerySelection           `xml:"selection,omitempty"`
+	This      types.ManagedObjectReference `xml:"_this" json:"-"`
+	Filter    CnsQueryFilter               `xml:"filter" json:"filter"`
+	Selection *CnsQuerySelection           `xml:"selection,omitempty" json:"selection"`
 }
 
 func init() {
@@ -687,13 +687,13 @@ func init() {
 }
 
 type CnsQueryAsyncResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsAsyncQueryResult struct {
 	CnsVolumeOperationResult
 
-	QueryResult CnsQueryResult `xml:"queryResult,omitempty"`
+	QueryResult CnsQueryResult `xml:"queryResult,omitempty" json:"queryResult"`
 }
 
 func init() {
@@ -703,8 +703,8 @@ func init() {
 // Cns Snapshot Types
 
 type CnsCreateSnapshotsRequestType struct {
-	This          types.ManagedObjectReference `xml:"_this"`
-	SnapshotSpecs []CnsSnapshotCreateSpec      `xml:"snapshotSpecs,omitempty"`
+	This          types.ManagedObjectReference `xml:"_this" json:"-"`
+	SnapshotSpecs []CnsSnapshotCreateSpec      `xml:"snapshotSpecs,omitempty" json:"snapshotSpecs"`
 }
 
 func init() {
@@ -718,14 +718,14 @@ func init() {
 }
 
 type CnsCreateSnapshotsResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsSnapshotCreateSpec struct {
 	types.DynamicData
 
-	VolumeId    CnsVolumeId `xml:"volumeId"`
-	Description string      `xml:"description"`
+	VolumeId    CnsVolumeId `xml:"volumeId" json:"volumeId"`
+	Description string      `xml:"description" json:"description"`
 }
 
 func init() {
@@ -733,8 +733,8 @@ func init() {
 }
 
 type CnsDeleteSnapshotsRequestType struct {
-	This                types.ManagedObjectReference `xml:"_this"`
-	SnapshotDeleteSpecs []CnsSnapshotDeleteSpec      `xml:"snapshotDeleteSpecs,omitempty"`
+	This                types.ManagedObjectReference `xml:"_this" json:"-"`
+	SnapshotDeleteSpecs []CnsSnapshotDeleteSpec      `xml:"snapshotDeleteSpecs,omitempty" json:"snapshotDeleteSpecs"`
 }
 
 func init() {
@@ -748,13 +748,13 @@ func init() {
 }
 
 type CnsDeleteSnapshotsResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsSnapshotId struct {
 	types.DynamicData
 
-	Id string `xml:"id"`
+	Id string `xml:"id" json:"id"`
 }
 
 func init() {
@@ -764,8 +764,8 @@ func init() {
 type CnsSnapshotDeleteSpec struct {
 	types.DynamicData
 
-	VolumeId   CnsVolumeId   `xml:"volumeId"`
-	SnapshotId CnsSnapshotId `xml:"snapshotId"`
+	VolumeId   CnsVolumeId   `xml:"volumeId" json:"volumeId"`
+	SnapshotId CnsSnapshotId `xml:"snapshotId" json:"snapshotId"`
 }
 
 func init() {
@@ -775,10 +775,10 @@ func init() {
 type CnsSnapshot struct {
 	types.DynamicData
 
-	SnapshotId  CnsSnapshotId `xml:"snapshotId"`
-	VolumeId    CnsVolumeId   `xml:"volumeId"`
-	Description string        `xml:"description,omitempty"`
-	CreateTime  time.Time     `xml:"createTime"`
+	SnapshotId  CnsSnapshotId `xml:"snapshotId" json:"snapshotId"`
+	VolumeId    CnsVolumeId   `xml:"volumeId" json:"volumeId"`
+	Description string        `xml:"description,omitempty" json:"description"`
+	CreateTime  time.Time     `xml:"createTime" json:"createTime"`
 }
 
 func init() {
@@ -795,8 +795,8 @@ func init() {
 
 type CnsSnapshotCreateResult struct {
 	CnsSnapshotOperationResult
-	Snapshot                       CnsSnapshot `xml:"snapshot,omitempty"`
-	AggregatedSnapshotCapacityInMb int64       `xml:"aggregatedSnapshotCapacityInMb,omitempty"`
+	Snapshot                       CnsSnapshot `xml:"snapshot,omitempty" json:"snapshot"`
+	AggregatedSnapshotCapacityInMb int64       `xml:"aggregatedSnapshotCapacityInMb,omitempty" json:"aggregatedSnapshotCapacityInMb"`
 }
 
 func init() {
@@ -805,8 +805,8 @@ func init() {
 
 type CnsSnapshotDeleteResult struct {
 	CnsSnapshotOperationResult
-	SnapshotId                     CnsSnapshotId `xml:"snapshotId,omitempty"`
-	AggregatedSnapshotCapacityInMb int64         `xml:"aggregatedSnapshotCapacityInMb,omitempty"`
+	SnapshotId                     CnsSnapshotId `xml:"snapshotId,omitempty" json:"snapshotId"`
+	AggregatedSnapshotCapacityInMb int64         `xml:"aggregatedSnapshotCapacityInMb,omitempty" json:"aggregatedSnapshotCapacityInMb"`
 }
 
 func init() {
@@ -824,8 +824,8 @@ func init() {
 type CnsSnapshotVolumeSource struct {
 	CnsVolumeSource
 
-	VolumeId   CnsVolumeId   `xml:"volumeId,omitempty"`
-	SnapshotId CnsSnapshotId `xml:"snapshotId,omitempty"`
+	VolumeId   CnsVolumeId   `xml:"volumeId,omitempty" json:"volumeId"`
+	SnapshotId CnsSnapshotId `xml:"snapshotId,omitempty" json:"snapshotId"`
 }
 
 func init() {
@@ -835,8 +835,8 @@ func init() {
 // CNS QuerySnapshots related types
 
 type CnsQuerySnapshotsRequestType struct {
-	This                types.ManagedObjectReference `xml:"_this"`
-	SnapshotQueryFilter CnsSnapshotQueryFilter       `xml:"snapshotQueryFilter"`
+	This                types.ManagedObjectReference `xml:"_this" json:"-"`
+	SnapshotQueryFilter CnsSnapshotQueryFilter       `xml:"snapshotQueryFilter" json:"snapshotQueryFilter"`
 }
 
 func init() {
@@ -850,14 +850,14 @@ func init() {
 }
 
 type CnsQuerySnapshotsResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsSnapshotQueryResult struct {
 	types.DynamicData
 
-	Entries []CnsSnapshotQueryResultEntry `xml:"entries,omitempty"`
-	Cursor  CnsCursor                     `xml:"cursor"`
+	Entries []CnsSnapshotQueryResultEntry `xml:"entries,omitempty" json:"entries"`
+	Cursor  CnsCursor                     `xml:"cursor" json:"cursor"`
 }
 
 func init() {
@@ -867,8 +867,8 @@ func init() {
 type CnsSnapshotQueryResultEntry struct {
 	types.DynamicData
 
-	Snapshot CnsSnapshot                 `xml:"snapshot,omitempty"`
-	Error    *types.LocalizedMethodFault `xml:"error,omitempty"`
+	Snapshot CnsSnapshot                 `xml:"snapshot,omitempty" json:"snapshot"`
+	Error    *types.LocalizedMethodFault `xml:"error,omitempty" json:"error"`
 }
 
 func init() {
@@ -878,8 +878,8 @@ func init() {
 type CnsSnapshotQueryFilter struct {
 	types.DynamicData
 
-	SnapshotQuerySpecs []CnsSnapshotQuerySpec `xml:"snapshotQuerySpecs,omitempty"`
-	Cursor             *CnsCursor             `xml:"cursor,omitempty"`
+	SnapshotQuerySpecs []CnsSnapshotQuerySpec `xml:"snapshotQuerySpecs,omitempty" json:"snapshotQuerySpecs"`
+	Cursor             *CnsCursor             `xml:"cursor,omitempty" json:"cursor"`
 }
 
 func init() {
@@ -889,8 +889,8 @@ func init() {
 type CnsSnapshotQuerySpec struct {
 	types.DynamicData
 
-	VolumeId   CnsVolumeId    `xml:"volumeId"`
-	SnapshotId *CnsSnapshotId `xml:"snapshotId,omitempty"`
+	VolumeId   CnsVolumeId    `xml:"volumeId" json:"volumeId"`
+	SnapshotId *CnsSnapshotId `xml:"snapshotId,omitempty" json:"snapshotId"`
 }
 
 func init() {
@@ -904,8 +904,8 @@ func init() {
 }
 
 type CnsReconfigVolumePolicyRequestType struct {
-	This                      types.ManagedObjectReference  `xml:"_this"`
-	VolumePolicyReconfigSpecs []CnsVolumePolicyReconfigSpec `xml:"volumePolicyReconfigSpecs,omitempty"`
+	This                      types.ManagedObjectReference  `xml:"_this" json:"-"`
+	VolumePolicyReconfigSpecs []CnsVolumePolicyReconfigSpec `xml:"volumePolicyReconfigSpecs,omitempty" json:"volumePolicyReconfigSpecs"`
 }
 
 func init() {
@@ -913,14 +913,14 @@ func init() {
 }
 
 type CnsReconfigVolumePolicyResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsVolumePolicyReconfigSpec struct {
 	types.DynamicData
 
-	VolumeId CnsVolumeId                           `xml:"volumeId"`
-	Profile  []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
+	VolumeId CnsVolumeId                           `xml:"volumeId" json:"volumeId"`
+	Profile  []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr" json:"profile"`
 }
 
 func init() {
@@ -934,9 +934,9 @@ func init() {
 }
 
 type CnsSyncDatastoreRequestType struct {
-	This         types.ManagedObjectReference `xml:"_this"`
-	DatastoreUrl string                       `xml:"datastoreUrl,omitempty"`
-	FullSync     *bool                        `xml:"fullSync"`
+	This         types.ManagedObjectReference `xml:"_this" json:"-"`
+	DatastoreUrl string                       `xml:"datastoreUrl,omitempty" json:"datastoreUrl"`
+	FullSync     *bool                        `xml:"fullSync" json:"fullSync"`
 }
 
 func init() {
@@ -944,5 +944,5 @@ func init() {
 }
 
 type CnsSyncDatastoreResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }

--- a/cns/types/unreleased_types.go
+++ b/cns/types/unreleased_types.go
@@ -28,7 +28,7 @@ type CnsBlockCreateSpec struct {
 
 	// Crypto specifies the encryption settings for the volume to be created.
 	// Works with block volumes only.
-	CryptoSpec types.BaseCryptoSpec `xml:"cryptoSpec,omitempty,typeattr"`
+	CryptoSpec types.BaseCryptoSpec `xml:"cryptoSpec,omitempty,typeattr" json:"cryptoSpec"`
 }
 
 func init() {
@@ -36,8 +36,8 @@ func init() {
 }
 
 type CnsUpdateVolumeCryptoRequestType struct {
-	This        types.ManagedObjectReference `xml:"_this"`
-	UpdateSpecs []CnsVolumeCryptoUpdateSpec  `xml:"updateSpecs,omitempty"`
+	This        types.ManagedObjectReference `xml:"_this" json:"-"`
+	UpdateSpecs []CnsVolumeCryptoUpdateSpec  `xml:"updateSpecs,omitempty" json:"updateSpecs"`
 }
 
 func init() {
@@ -51,16 +51,16 @@ func init() {
 }
 
 type CnsUpdateVolumeCryptoResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 // CnsVolumeCryptoUpdateSpec is the specification for volume crypto update operation.
 type CnsVolumeCryptoUpdateSpec struct {
 	types.DynamicData
 
-	VolumeId    CnsVolumeId                           `xml:"volumeId"`
-	Profile     []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
-	DisksCrypto *types.DiskCryptoSpec                 `xml:"disksCrypto,omitempty"`
+	VolumeId    CnsVolumeId                           `xml:"volumeId" json:"volumeId"`
+	Profile     []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr" json:"profile"`
+	DisksCrypto *types.DiskCryptoSpec                 `xml:"disksCrypto,omitempty" json:"disksCrypto"`
 }
 
 func init() {

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -7398,10 +7398,13 @@ Examples:
   govc volume.ls -l
   govc volume.ls -ds vsanDatastore
   govc volume.ls df86393b-5ae0-4fca-87d0-b692dbc67d45
+  govc volume.ls -json $id | jq -r .volume[].backingObjectDetails.backingDiskPath
+  govc volume.ls -b $id # verify backingDiskPath exists
   govc disk.ls -l $(govc volume.ls -L pvc-9744a4ff-07f4-43c4-b8ed-48ea7a528734)
 
 Options:
   -L=false               List volume disk or file backing ID only
+  -b=false               List file backing path
   -ds=                   Datastore [GOVC_DATASTORE]
   -i=false               List volume ID only
   -l=false               Long listing format


### PR DESCRIPTION
cns: add json tags

PR #3007 added camelCase json tags for generated types
PR #3247 added camelCase json tags for govc commands

This change does the same for cns/types.

Testing of the `-b` flag has been done manually for now, as we still don't have a `govc volume.create` command.
A volume's backing file can already being seen using `-json`:
```console
% govc volume.ls -json a24b36ff-c407-46ef-b068-a9620145a0cb | jq -r .volume[].backingObjectDetails.backingDiskPath
[sharedVmfs-0] fcd/861ed49f57e549c3a5ea25780c13fdf7.vmdk
```

With the `-b` flag, backing is included in the friendly output and also uses `QueryVolumeInfo` to verify the backing file exists, for example:

```console
% govc volume.ls -b
0b9d71d2-2236-4d67-96e7-89a46292e430	pvc-c3b456c7-01d8-4576-b3eb-6c1b0833fcea	[sharedVmfs-0] fcd/f10e825975bb4b079cba05ca8da86116.vmdk
a24b36ff-c407-46ef-b068-a9620145a0cb	pvc-6584bf4c-fe95-4451-bb45-6d4a5b03b88a	Failed to retrieve the vstorage object for fcd id a24b36ff-c407-46ef-b068-a9620145a0cb
e777a2db-84b9-4a7b-a967-fde885b61592	pvc-01ba5707-6333-49e9-b8e3-abe3654ff2e6	[sharedVmfs-0] fcd/4a601cd0caef43a39fe886e2794dbab9.vmdk
```

The QueryVolumeInfo task result can also be output as Go code, example with fault:

```go
// govc volume.ls -b -dump a24b36ff-c407-46ef-b068-a9620145a0cb
[]types.BaseCnsVolumeOperationResult{
    &types.CnsQueryVolumeInfoResult{
        CnsVolumeOperationResult: types.CnsVolumeOperationResult{
            VolumeId: types.CnsVolumeId{},
            Fault:    &types.LocalizedMethodFault{
                Fault: types.CnsFault{
                    BaseMethodFault: nil,
                    Reason:          "Failed to retrieve the vstorage object for fcd id a24b36ff-c407-46ef-b068-a9620145a0cb",
                },
                LocalizedMessage: "CnsFault error: Failed to retrieve the vstorage object for fcd id a24b36ff-c407-46ef-b068-a9620145a0cb",
            },
        },
        VolumeInfo: nil,
    },
}
```

Example when found:
```go
// govc volume.ls -b -dump 0b9d71d2-2236-4d67-96e7-89a46292e430
[]types.BaseCnsVolumeOperationResult{
    &types.CnsQueryVolumeInfoResult{
        CnsVolumeOperationResult: types.CnsVolumeOperationResult{},
        VolumeInfo:               &types.CnsBlockVolumeInfo{
            CnsVolumeInfo:  types.CnsVolumeInfo{},
            VStorageObject: types.VStorageObject{
                Config: types.VStorageObjectConfigInfo{
                    BaseConfigInfo: types.BaseConfigInfo{
                        Id: types.ID{
                            Id: "0b9d71d2-2236-4d67-96e7-89a46292e430",
                        },
                        Name:                        "pvc-c3b456c7-01d8-4576-b3eb-6c1b0833fcea",
                        CreateTime:                  time.Now(),
                        KeepAfterDeleteVm:           types.NewBool(true),
                        RelocationDisabled:          types.NewBool(false),
                        NativeSnapshotSupported:     types.NewBool(false),
                        ChangedBlockTrackingEnabled: types.NewBool(false),
                        Backing:                     &types.BaseConfigInfoDiskFileBackingInfo{
                            BaseConfigInfoFileBackingInfo: types.BaseConfigInfoFileBackingInfo{
                                BaseConfigInfoBackingInfo: types.BaseConfigInfoBackingInfo{
                                    Datastore: types.ManagedObjectReference{Type:"Datastore", Value:"datastore-42", ServerGUID:""},
                                },
                                FilePath:        "[sharedVmfs-0] fcd/f10e825975bb4b079cba05ca8da86116.vmdk",
                                BackingObjectId: "",
                                Parent:          nil,
                                DeltaSizeInMB:   0,
                                KeyId:           (*types.CryptoKeyId)(nil),
                            },
                            ProvisioningType: "thin",
                        },
                        Metadata: nil,
                        Vclock:   (*types.VslmVClockInfo)(nil),
                        Iofilter: nil,
                    },
                    DescriptorVersion: 5,
                    CapacityInMB:      100,
                    ConsumptionType:   []string{"disk"},
                    ConsumerId:        []types.ID{
                        {
                            Id: "6bf965f5-0348-4687-beca-8c89a0624168",
                        },
                    },
                },
            },
        },
    },
}
```