### PR TITLE
vcsim: create cls vmdk descriptor and backing files

### DIFF
--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -398,6 +398,16 @@ EOF
   run govc library.import published-content "$GOVC_IMAGES/ttylinux-latest.ova"
   assert_success
 
+  run govc library.info -L published-content/ttylinux-latest/*.vmdk
+  assert_success
+  vmdk="$output"
+
+  run govc datastore.ls "$vmdk"
+  assert_success
+
+  run govc datastore.ls "${vmdk/.vmdk/-flat.vmdk}"
+  assert_success
+
   run govc library.create -sub "$url" my-content
   assert_success
 
@@ -405,6 +415,16 @@ EOF
   assert_success
   assert_matches "Subscription:"
   assert_matches "$url"
+
+  run govc library.info -L my-content/ttylinux-latest/*.vmdk
+  assert_success
+  vmdk="$output"
+
+  run govc datastore.ls "$vmdk"
+  assert_success
+
+  run govc datastore.ls "${vmdk/.vmdk/-flat.vmdk}"
+  assert_success
 
   run govc library.import my-content "$GOVC_IMAGES/$TTYLINUX_NAME.iso"
   assert_failure # cannot add items to subscribed libraries

--- a/simulator/virtual_disk_manager.go
+++ b/simulator/virtual_disk_manager.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,9 +39,13 @@ func (m *VirtualDiskManager) MO() mo.VirtualDiskManager {
 	return m.VirtualDiskManager
 }
 
+func VirtualDiskBackingFileName(name string) string {
+	return strings.Replace(name, ".vmdk", "-flat.vmdk", 1)
+}
+
 func vdmNames(name string) []string {
 	return []string{
-		strings.Replace(name, ".vmdk", "-flat.vmdk", 1),
+		VirtualDiskBackingFileName(name),
 		name,
 	}
 }
@@ -219,9 +223,7 @@ func (m *VirtualDiskManager) MoveVirtualDiskTask(ctx *Context, req *types.MoveVi
 func (m *VirtualDiskManager) CopyVirtualDiskTask(ctx *Context, req *types.CopyVirtualDisk_Task) soap.HasFault {
 	task := CreateTask(m, "copyVirtualDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		if req.DestSpec != nil {
-			if ctx.Map.IsVPX() {
-				return nil, new(types.NotImplemented)
-			}
+			// TODO: apply to destination vmdk.Descriptor
 		}
 
 		fm := ctx.Map.FileManager()

--- a/vmdk/descriptor.go
+++ b/vmdk/descriptor.go
@@ -1,0 +1,173 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmdk
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+type Descriptor struct {
+	Encoding  string
+	Version   int
+	CID       DiskContentID
+	ParentCID DiskContentID
+	Type      string
+	Extent    []Extent
+	DDB       map[string]string
+}
+
+type DiskContentID uint32
+
+func (cid DiskContentID) String() string {
+	return fmt.Sprintf("%0.8x", uint32(cid))
+}
+
+type Extent struct {
+	Type       string
+	Permission string
+	Size       uint64
+	Info       string
+}
+
+func NewDescriptor(extent ...Extent) *Descriptor {
+	for i := range extent {
+		if extent[i].Type == "" {
+			extent[i].Type = "VMFS"
+		}
+		if extent[i].Permission == "" {
+			extent[i].Permission = "RW"
+		}
+	}
+	return &Descriptor{
+		Version:  1,
+		Encoding: "UTF-8",
+		Type:     "vmfs",
+		DDB:      map[string]string{},
+		Extent:   extent,
+	}
+}
+
+func ParseDescriptor(r io.Reader) (*Descriptor, error) {
+	d := NewDescriptor()
+
+	scanner := bufio.NewScanner(r)
+
+	// NOTE: not doing any validation currently, or using this function yet.
+	// Will add validation as needed when use-cases are implemented.
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if d.parseExtent(line) {
+			continue
+		}
+
+		s := strings.SplitN(line, "=", 2)
+
+		if len(s) != 2 {
+			continue
+		}
+
+		key, val := strings.TrimSpace(s[0]), strings.TrimSpace(s[1])
+		val = strings.Trim(val, `"`)
+		if strings.HasPrefix(key, "ddb") {
+			d.DDB[key] = val
+			continue
+		}
+
+		switch strings.ToLower(key) {
+		case "encoding":
+			d.Encoding = val
+		case "version":
+			d.Version, _ = strconv.Atoi(val)
+		case "cid":
+			_, _ = fmt.Sscanf(val, "%x", &d.CID)
+		case "parentcid":
+			_, _ = fmt.Sscanf(val, "%x", &d.ParentCID)
+		case "createType":
+			d.Type = val
+		}
+	}
+
+	return d, scanner.Err()
+}
+
+var permissions = []string{"RDONLY", "RW", "NOACCESS"}
+
+func (d *Descriptor) parseExtent(line string) bool {
+	// Each extent is defined by a line following this pattern:
+	// perm size type "%s"
+
+	s := strings.SplitN(line, " ", 2)
+
+	if len(s) != 2 || !slices.Contains(permissions, s[0]) {
+		return false
+	}
+
+	x := Extent{
+		Permission: s[0],
+	}
+
+	s = strings.SplitN(s[1], " ", 2)
+	size, err := strconv.ParseUint(s[0], 10, 64)
+	if len(s) != 2 || err != nil {
+		return false
+	}
+
+	x.Size = size
+
+	s = strings.SplitN(s[1], " ", 2)
+	x.Type = s[0]
+
+	if len(s) == 2 {
+		x.Info = strings.Trim(s[1], `"`)
+	}
+
+	d.Extent = append(d.Extent, x)
+
+	return true
+}
+
+var descriptor = `# Disk DescriptorFile
+version={{ .Version }}
+encoding="{{ .Encoding }}"
+CID={{ .CID }}
+parentCID={{ .ParentCID }}
+createType="{{ .Type }}"
+
+# Extent description{{range .Extent }}
+{{ .Permission }} {{ .Size }} {{ .Type }} "{{ .Info }}"{{end}}
+
+# The Disk Data Base
+#DDB{{ range $key, $val := .DDB }}
+{{ $key }} = "{{ $val }}"{{end}}
+`
+
+func (d *Descriptor) Write(w io.Writer) error {
+	t, err := template.New("vmdk").Parse(descriptor)
+	if err != nil {
+		return err
+	}
+	return t.Execute(w, d)
+}

--- a/vmdk/descriptor_test.go
+++ b/vmdk/descriptor_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmdk_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/vmware/govmomi/vmdk"
+)
+
+func TestDescriptor(t *testing.T) {
+	desc := &vmdk.Descriptor{
+		Version:  1,
+		Encoding: "UTF-8",
+		CID:      123,
+		Type:     "vmfs",
+		Extent: []vmdk.Extent{{
+			Type:       "VMFS",
+			Permission: "RW",
+			Size:       1024,
+			Info:       "test-flat.vmdk",
+		}},
+		DDB: map[string]string{
+			"ddb.adapterType":      "lsilogic",
+			"ddb.virtualHWVersion": "14",
+		},
+	}
+
+	var buf bytes.Buffer
+
+	err := desc.Write(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := vmdk.ParseDescriptor(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(desc, parsed) {
+		t.Error("not equal")
+	}
+}


### PR DESCRIPTION
Certain vcsim VirtualDiskManager methods (Copy,Move,Delete) expect a .vmdk descriptor and backing -flat.vmdk, create both when creating and syncing vmdk library items.

The new vmdk.Descriptor has more use cases in vcsim and client side, those will come in future PRs.
