### PR TITLE
govc: add datastore.download -json support

### DIFF
--- a/cli/datastore/download.go
+++ b/cli/datastore/download.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package datastore
 
@@ -23,10 +11,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 
 	"github.com/vmware/govmomi/cli"
 	"github.com/vmware/govmomi/cli/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/ovf"
 	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vmdk"
 )
 
 type download struct {
@@ -67,13 +59,26 @@ If DEST name is "-", source is written to stdout.
 
 Examples:
   govc datastore.download vm-name/vmware.log ./local.log
-  govc datastore.download vm-name/vmware.log - | grep -i error`
+  govc datastore.download vm-name/vmware.log - | grep -i error
+  govc datastore.download -json vm-name/vm-name.vmdk - | jq .ddb
+  ovf=$(govc library.info -l -L vmservice/photon-5.0/*.ovf)
+  govc datastore.download -json "$ovf" - | jq -r .diskSection.disk[].capacity`
 }
 
 func (cmd *download) Run(ctx context.Context, f *flag.FlagSet) error {
 	args := f.Args()
 	if len(args) != 2 {
 		return errors.New("invalid arguments")
+	}
+
+	src := args[0]
+	dst := args[1]
+
+	var dp object.DatastorePath
+	if dp.FromString(src) {
+		// e.g. `govc library.info -l -L ...`
+		cmd.DatastoreFlag.Name = dp.Datastore
+		src = dp.Path
 	}
 
 	ds, err := cmd.Datastore()
@@ -95,14 +100,29 @@ func (cmd *download) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	p := soap.DefaultDownload
 
-	src := args[0]
-	dst := args[1]
-
 	if dst == "-" {
 		f, _, err := ds.Download(ctx, src, &p)
 		if err != nil {
 			return err
 		}
+
+		if cmd.DatastoreFlag.All() {
+			switch path.Ext(src) {
+			case ".vmdk":
+				data, err := vmdk.ParseDescriptor(f)
+				if err != nil {
+					return err
+				}
+				return cmd.DatastoreFlag.WriteResult(data)
+			case ".ovf":
+				data, err := ovf.Unmarshal(f)
+				if err != nil {
+					return err
+				}
+				return cmd.DatastoreFlag.WriteResult(data)
+			}
+		}
+
 		_, err = io.Copy(os.Stdout, f)
 		return err
 	}

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1427,6 +1427,9 @@ If DEST name is "-", source is written to stdout.
 Examples:
   govc datastore.download vm-name/vmware.log ./local.log
   govc datastore.download vm-name/vmware.log - | grep -i error
+  govc datastore.download -json vm-name/vm-name.vmdk - | jq .ddb
+  ovf=$(govc library.info -l -L vmservice/photon-5.0/*.ovf)
+  govc datastore.download -json "$ovf" - | jq -r .diskSection.disk[].capacity
 
 Options:
   -ds=                   Datastore [GOVC_DATASTORE]

--- a/ovf/ovf.go
+++ b/ovf/ovf.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package ovf
 
@@ -32,4 +20,9 @@ func Unmarshal(r io.Reader) (*Envelope, error) {
 	}
 
 	return &e, nil
+}
+
+// Write satisfies the flags.OutputWriter interface.
+func (e *Envelope) Write(w io.Writer) error {
+	return xml.NewEncoder(w).Encode(e)
 }

--- a/vmdk/descriptor.go
+++ b/vmdk/descriptor.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package vmdk
 
@@ -27,13 +15,13 @@ import (
 )
 
 type Descriptor struct {
-	Encoding  string
-	Version   int
-	CID       DiskContentID
-	ParentCID DiskContentID
-	Type      string
-	Extent    []Extent
-	DDB       map[string]string
+	Encoding  string            `json:"encoding"`
+	Version   int               `json:"version"`
+	CID       DiskContentID     `json:"cid"`
+	ParentCID DiskContentID     `json:"parentCID"`
+	Type      string            `json:"type"`
+	Extent    []Extent          `json:"extent"`
+	DDB       map[string]string `json:"ddb"`
 }
 
 type DiskContentID uint32
@@ -43,10 +31,10 @@ func (cid DiskContentID) String() string {
 }
 
 type Extent struct {
-	Type       string
-	Permission string
-	Size       uint64
-	Info       string
+	Type       string `json:"type"`
+	Permission string `json:"permission"`
+	Size       uint64 `json:"size"`
+	Info       string `json:"info"`
 }
 
 func NewDescriptor(extent ...Extent) *Descriptor {
@@ -91,8 +79,8 @@ func ParseDescriptor(r io.Reader) (*Descriptor, error) {
 
 		key, val := strings.TrimSpace(s[0]), strings.TrimSpace(s[1])
 		val = strings.Trim(val, `"`)
-		if strings.HasPrefix(key, "ddb") {
-			d.DDB[key] = val
+		if k := strings.TrimPrefix(key, "ddb."); k != key {
+			d.DDB[k] = val
 			continue
 		}
 
@@ -161,7 +149,7 @@ createType="{{ .Type }}"
 
 # The Disk Data Base
 #DDB{{ range $key, $val := .DDB }}
-{{ $key }} = "{{ $val }}"{{end}}
+ddb.{{ $key }} = "{{ $val }}"{{end}}
 `
 
 func (d *Descriptor) Write(w io.Writer) error {

--- a/vmdk/descriptor_test.go
+++ b/vmdk/descriptor_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package vmdk_test
 
@@ -37,8 +25,8 @@ func TestDescriptor(t *testing.T) {
 			Info:       "test-flat.vmdk",
 		}},
 		DDB: map[string]string{
-			"ddb.adapterType":      "lsilogic",
-			"ddb.virtualHWVersion": "14",
+			"adapterType":      "lsilogic",
+			"virtualHWVersion": "14",
 		},
 	}
 


### PR DESCRIPTION
Only applies to ".ovf" and ".vmdk" files currently.
