### PR TITLE
fix: Add session lookup fallback for soap header auth

### DIFF
--- a/vim25/soap/client_test.go
+++ b/vim25/soap/client_test.go
@@ -229,3 +229,29 @@ func TestParseURL(t *testing.T) {
 		})
 	}
 }
+
+func TestSessionCookie(t *testing.T) {
+	u := &url.URL{
+		Scheme: "http",
+		Host:   "localhost:1080",
+		Path:   "sdk", // see comment in Client.SessionCookie
+	}
+
+	c := NewClient(u, true)
+
+	cookie := &http.Cookie{
+		Name:     SessionCookieName,
+		Value:    "ANY",
+		Path:     "/",
+		Domain:   "localhost",
+		HttpOnly: true,
+		Secure:   false,
+	}
+
+	c.Jar.SetCookies(u, []*http.Cookie{cookie})
+
+	val := c.SessionCookie()
+	if val == nil {
+		t.Fatal("no session cookie")
+	}
+}


### PR DESCRIPTION
In 19189841 / PR #3636 we deferred the http.CookieJar lookup until request time. Fallback to using Path="/" if initial lookup fails.
