### PR TITLE
fix: support multiple property.Collector.Retrieve base type fields

### DIFF
--- a/object/datastore_test.go
+++ b/object/datastore_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package object_test
 
@@ -21,9 +9,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
@@ -95,4 +86,33 @@ func TestDatastoreFindInventoryPath(t *testing.T) {
 			}
 		}
 	}, model)
+}
+
+func TestDatastoreInfo(t *testing.T) {
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		obj, err := find.NewFinder(c).DefaultDatastore(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pc := property.DefaultCollector(c)
+
+		props := []string{
+			"info.url",
+			"info.name",
+		}
+
+		var ds mo.Datastore
+		err = pc.RetrieveOne(ctx, obj.Reference(), props, &ds)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		info := ds.Info.GetDatastoreInfo()
+		if info.Url == "" {
+			t.Error("no info.url")
+		}
+		if info.Name == "" {
+			t.Error("no info.name")
+		}
+	})
 }

--- a/vim25/mo/retrieve_test.go
+++ b/vim25/mo/retrieve_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2014-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package mo
 
@@ -225,6 +213,10 @@ func TestDatastoreInfoURL(t *testing.T) {
 					Name: "info.url",
 					Val:  "ds:///vmfs/volumes/666d7a79-cb0d28b2-57c8-0645602e1b58/",
 				},
+				{
+					Name: "info.name",
+					Val:  "foo",
+				},
 			},
 			MissingSet: nil,
 		},
@@ -240,5 +232,9 @@ func TestDatastoreInfoURL(t *testing.T) {
 
 	if info.Url != content[0].PropSet[0].Val.(string) {
 		t.Errorf("info.url=%s", info.Url)
+	}
+
+	if info.Name != content[0].PropSet[1].Val.(string) {
+		t.Errorf("info.name=%s", info.Name)
 	}
 }

--- a/vim25/mo/type_info.go
+++ b/vim25/mo/type_info.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2014-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package mo
 
@@ -192,8 +180,10 @@ var nilValue reflect.Value
 func assignValue(val reflect.Value, fi []int, pv reflect.Value, field ...string) {
 	// Indexed property path can only use base types
 	if val.Kind() == reflect.Interface {
-		base := baseType(val.Type())
-		val.Set(reflect.New(base))
+		if val.IsNil() {
+			base := baseType(val.Type())
+			val.Set(reflect.New(base))
+		}
 		val = val.Elem()
 	}
 


### PR DESCRIPTION
Prior to 3b7ff25f (PropertyCollector index support) mo.LoadObjectFromContent would panic when trying to load specific fields of a base type, e.g. a mo.Datastore "info.url". While that change fixed the panic, it only allowed 1 such field to be loaded - that is fixed with this change.
