### PR TITLE
vcsim: fix save+load of Alarm objects

### DIFF
--- a/simulator/model.go
+++ b/simulator/model.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -232,6 +220,7 @@ func (*Model) fmtName(prefix string, num int) string {
 
 // kinds maps managed object types to their vcsim wrapper types
 var kinds = map[string]reflect.Type{
+	"Alarm":                              reflect.TypeOf((*Alarm)(nil)).Elem(),
 	"AlarmManager":                       reflect.TypeOf((*AlarmManager)(nil)).Elem(),
 	"AuthorizationManager":               reflect.TypeOf((*AuthorizationManager)(nil)).Elem(),
 	"ClusterComputeResource":             reflect.TypeOf((*ClusterComputeResource)(nil)).Elem(),

--- a/vim25/mo/registry.go
+++ b/vim25/mo/registry.go
@@ -1,21 +1,27 @@
-/*
-Copyright (c) 2014 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package mo
 
-import "reflect"
+import (
+	"reflect"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
 
 var t = map[string]reflect.Type{}
+
+// TODO: 9.0 mo below, not included in the generate mo/mo.go, since the generator still uses older rbvmomi vmodl.db
+
+type DirectPathProfileManager struct {
+	Self types.ManagedObjectReference `json:"self"`
+}
+
+func (m DirectPathProfileManager) Reference() types.ManagedObjectReference {
+	return m.Self
+}
+
+func init() {
+	t["DirectPathProfileManager"] = reflect.TypeOf((*DirectPathProfileManager)(nil)).Elem()
+}


### PR DESCRIPTION
govc object.save includes Alarm objects, but vcsim -load did not wrap the Alarm objects.
This causes panic when trying to call CreateAlarm() which expects wrapped Alarm objects.
