### PR TITLE
govc: sha256 for session cache

### DIFF
--- a/session/cache/session.go
+++ b/session/cache/session.go
@@ -18,7 +18,7 @@ package cache
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -105,7 +105,7 @@ func (s *Session) key(path string) string {
 	// Key session file off of full URI and insecure setting.
 	// Hash key to get a predictable, canonical format.
 	key := fmt.Sprintf("%s#insecure=%t", p.String(), s.Insecure)
-	return fmt.Sprintf("%040x", sha1.Sum([]byte(key)))
+	return fmt.Sprintf("%064x", sha256.Sum256([]byte(key)))
 }
 
 func (s *Session) file(p string) string {


### PR DESCRIPTION
## Description

Use sha256 for session cache file names

This maintains compatibility between govc and Terraform, allowing the two to share the same cache while also ensureing SHA1 is eliminated.

Ref: 
- https://github.com/hashicorp/terraform-provider-vsphere/issues/2328
- https://github.com/vmware/govmomi/pull/1898
- https://github.com/hashicorp/terraform-provider-vsphere/pull/1808
- https://github.com/hashicorp/terraform-provider-vsphere/issues/1807
- https://github.com/hashicorp/terraform-provider-vsphere/pull/1051