### PR TITLE
add delete flag for CnsContainerCluster type

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -294,6 +294,7 @@ type CnsContainerCluster struct {
 	VSphereUser         string `xml:"vSphereUser" json:"vSphereUser"`
 	ClusterFlavor       string `xml:"clusterFlavor,omitempty" json:"clusterFlavor"`
 	ClusterDistribution string `xml:"clusterDistribution,omitempty" json:"clusterDistribution"`
+	Delete              bool   `xml:"delete,omitempty" json:"delete"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

add `delete` flag for `CnsContainerCluster` type.

UpdateVolumeMetadata API has support for deleting containercluster metadata if delete flag is set to true.
We have requirement to allow deleting reference to older container cluster when container cluster ID changes from cluster-Moref to supervisor-id.