### PR TITLE
Add ResourcePool.resourceConfigSpecDetailed to missingSet filter

### DIFF
--- a/vim25/mo/retrieve.go
+++ b/vim25/mo/retrieve.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2014-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package mo
 
@@ -34,6 +22,11 @@ func ignoreMissingProperty(ref types.ManagedObjectReference, p types.MissingProp
 			return true
 		case "alarmActionsEnabled":
 			// Seen with vApp child VM
+			return true
+		}
+	case "ResourcePool":
+		switch p.Path {
+		case "resourceConfigSpecDetailed":
 			return true
 		}
 	}

--- a/vim25/mo/retrieve_test.go
+++ b/vim25/mo/retrieve_test.go
@@ -238,3 +238,39 @@ func TestDatastoreInfoURL(t *testing.T) {
 		t.Errorf("info.name=%s", info.Name)
 	}
 }
+
+func TestIgnoreMissingProperty(t *testing.T) {
+	// subset of RetrievePropertiesEx response, see ignoreMissingProperty()
+	content := []types.ObjectContent{{
+		Obj: types.ManagedObjectReference{Type: "ResourcePool", Value: "ha-root-pool"},
+		PropSet: []types.DynamicProperty{{
+			Name: "config",
+			Val: types.ResourceConfigSpec{
+				CpuAllocation: types.ResourceAllocationInfo{
+					Reservation: types.NewInt64(5585),
+					Limit:       types.NewInt64(5585),
+				},
+				MemoryAllocation: types.ResourceAllocationInfo{
+					Reservation: types.NewInt64(13652),
+					Limit:       types.NewInt64(13652),
+				},
+			},
+		}},
+		MissingSet: []types.MissingProperty{
+			{
+				Path: "resourceConfigSpecDetailed",
+				Fault: types.LocalizedMethodFault{
+					Fault: &types.SystemError{
+						Reason: "unexpected error reading property",
+					},
+				},
+			},
+		},
+	}}
+
+	var pool ResourcePool
+
+	if err := LoadObjectContent(content, &pool); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
New property (resourceConfigSpecDetailed) is only valid when collected against vCenter. Against ESX is NotSupported and returned by RetrievePropertiesEx in the missingSet when all properties are requested, which by default is propagated as an error.
