### PR TITLE
govc: add GPU commands

### DIFF
--- a/cli/gpu/gpu.go
+++ b/cli/gpu/gpu.go
@@ -1,0 +1,11 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package gpu
+
+import (
+	_ "github.com/vmware/govmomi/cli/gpu/host"
+	_ "github.com/vmware/govmomi/cli/gpu/host/profile"
+	_ "github.com/vmware/govmomi/cli/gpu/vm"
+)

--- a/cli/gpu/host/info.go
+++ b/cli/gpu/host/info.go
@@ -1,0 +1,148 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package host
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/cli"
+	"github.com/vmware/govmomi/cli/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.HostSystemFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("gpu.host.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *info) Description() string {
+	return `Display GPU information for a host.
+
+Examples:
+  govc gpu.host.info -host hostname
+  govc gpu.host.info -host hostname -json | jq .
+  govc gpu.host.info -host hostname -json | jq -r '.devices[] | select(.deviceName | contains("NVIDIA"))'
+  govc find / -type h | xargs -n1 govc gpu.host.info -host # all hosts`
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Support NVIDIA devices, and exclude virtual GPUs, which have a SubDeviceId of 0x0000
+func isPhysicalGPU(device types.HostPciDevice) bool {
+	return device.VendorId == 0x10de && device.SubDeviceId != 0x0000
+}
+
+type gpuInfo struct {
+	PciId       string `json:"pciId"`
+	DeviceName  string `json:"deviceName"`
+	VendorName  string `json:"vendorName"`
+	DeviceId    int16  `json:"deviceId"`
+	VendorId    int16  `json:"vendorId"`
+	SubVendorId int16  `json:"subVendorId"`
+	SubDeviceId int16  `json:"subDeviceId"`
+	ClassId     int16  `json:"classId"`
+	Bus         uint8  `json:"bus"`
+	Slot        uint8  `json:"slot"`
+	Function    uint8  `json:"function"`
+	Bridge      string `json:"bridge,omitempty"`
+}
+
+type infoResult struct {
+	Devices []gpuInfo `json:"devices"`
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, gpu := range r.Devices {
+		fmt.Fprintf(tw, "PCI ID: %s\n", gpu.PciId)
+		fmt.Fprintf(tw, "  Device Name: %s\n", gpu.DeviceName)
+		fmt.Fprintf(tw, "  Vendor Name: %s\n", gpu.VendorName)
+		fmt.Fprintf(tw, "  Device ID: 0x%04x\n", gpu.DeviceId)
+		fmt.Fprintf(tw, "  Vendor ID: 0x%04x\n", gpu.VendorId)
+		fmt.Fprintf(tw, "  SubVendor ID: 0x%04x\n", gpu.SubVendorId)
+		fmt.Fprintf(tw, "  SubDevice ID: 0x%04x\n", gpu.SubDeviceId)
+		fmt.Fprintf(tw, "  Class ID: 0x%04x\n", gpu.ClassId)
+		fmt.Fprintf(tw, "  Bus: 0x%02x, Slot: 0x%02x, Function: 0x%02x\n", gpu.Bus, gpu.Slot, gpu.Function)
+		if gpu.Bridge != "" {
+			fmt.Fprintf(tw, "  Parent Bridge: %s\n", gpu.Bridge)
+		}
+	}
+
+	return tw.Flush()
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	if host == nil {
+		return flag.ErrHelp
+	}
+
+	var h mo.HostSystem
+	pc := property.DefaultCollector(host.Client())
+	err = pc.RetrieveOne(ctx, host.Reference(), []string{"hardware"}, &h)
+	if err != nil {
+		return err
+	}
+
+	var res infoResult
+	for _, device := range h.Hardware.PciDevice {
+		if isPhysicalGPU(device) {
+			res.Devices = append(res.Devices, gpuInfo{
+				PciId:       device.Id,
+				DeviceName:  device.DeviceName,
+				VendorName:  device.VendorName,
+				DeviceId:    device.DeviceId,
+				VendorId:    device.VendorId,
+				SubVendorId: device.SubVendorId,
+				SubDeviceId: device.SubDeviceId,
+				ClassId:     device.ClassId,
+				Bus:         device.Bus,
+				Slot:        device.Slot,
+				Function:    device.Function,
+				Bridge:      device.ParentBridge,
+			})
+		}
+	}
+
+	return cmd.WriteResult(&res)
+}

--- a/cli/gpu/host/profile/ls.go
+++ b/cli/gpu/host/profile/ls.go
@@ -1,0 +1,99 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/cli"
+	"github.com/vmware/govmomi/cli/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type ls struct {
+	*flags.ClientFlag
+	*flags.HostSystemFlag
+}
+
+func init() {
+	cli.Register("gpu.host.profile.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Description() string {
+	return `List available vGPU profiles on host.
+
+Examples:
+  govc gpu.host.profile.ls -host hostname
+  govc gpu.host.profile.ls -host hostname -json | jq -r '.profiles[]'
+  govc gpu.host.profile.ls -host hostname -json | jq -r '.profiles[] | select(contains("nvidia_a40"))'`
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+type lsResult struct {
+	Profiles []string `json:"profiles"`
+}
+
+func (r *lsResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "Available vGPU profiles:")
+	for _, profile := range r.Profiles {
+		fmt.Fprintf(tw, "  %s\n", profile)
+	}
+	return tw.Flush()
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	host, err := cmd.HostSystem()
+	if err != nil {
+		return err
+	}
+
+	if host == nil {
+		return flag.ErrHelp
+	}
+
+	var o mo.HostSystem
+	pc := property.DefaultCollector(host.Client())
+	err = pc.RetrieveOne(ctx, host.Reference(), []string{"config.sharedPassthruGpuTypes"}, &o)
+	if err != nil {
+		return err
+	}
+
+	if o.Config == nil {
+		return fmt.Errorf("failed to get host configuration")
+	}
+
+	if len(o.Config.SharedPassthruGpuTypes) == 0 {
+		return fmt.Errorf("no vGPU profiles available on this host")
+	}
+
+	res := &lsResult{
+		Profiles: o.Config.SharedPassthruGpuTypes,
+	}
+
+	return cmd.WriteResult(res)
+}

--- a/cli/gpu/vm/add.go
+++ b/cli/gpu/vm/add.go
@@ -1,0 +1,106 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/cli"
+	"github.com/vmware/govmomi/cli/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type add struct {
+	*flags.ClientFlag
+	*flags.VirtualMachineFlag
+	profile string
+}
+
+func init() {
+	cli.Register("gpu.vm.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.profile, "profile", "", "vGPU profile")
+}
+
+func (cmd *add) Description() string {
+	return `Add vGPU to VM.
+
+Examples:
+  govc gpu.vm.add -vm $vm -profile nvidia_a40-1b`
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachineFlag.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	if cmd.profile == "" {
+		return fmt.Errorf("profile argument must be specified")
+	}
+
+	// Check power state
+	var o mo.VirtualMachine
+	pc := property.DefaultCollector(vm.Client())
+	err = pc.RetrieveOne(ctx, vm.Reference(), []string{"runtime.powerState"}, &o)
+	if err != nil {
+		return err
+	}
+
+	if o.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
+		return fmt.Errorf("VM must be powered off to add vGPU")
+	}
+
+	device := &types.VirtualPCIPassthrough{
+		VirtualDevice: types.VirtualDevice{
+			Key: -100,
+			Backing: &types.VirtualPCIPassthroughVmiopBackingInfo{
+				Vgpu: cmd.profile,
+			},
+		},
+	}
+
+	vmConfigSpec := types.VirtualMachineConfigSpec{
+		DeviceChange: []types.BaseVirtualDeviceConfigSpec{
+			&types.VirtualDeviceConfigSpec{
+				Operation: types.VirtualDeviceConfigSpecOperationAdd,
+				Device:    device,
+			},
+		},
+	}
+
+	task, err := vm.Reconfigure(ctx, vmConfigSpec)
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}

--- a/cli/gpu/vm/info.go
+++ b/cli/gpu/vm/info.go
@@ -1,0 +1,126 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/cli"
+	"github.com/vmware/govmomi/cli/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("gpu.vm.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Description() string {
+	return `Display GPU information for a VM.
+
+Examples:
+  govc gpu.vm.info -vm $vm
+  govc gpu.vm.info -vm $vm -json | jq -r '.gpus[].summary'
+  govc gpu.vm.info -vm $vm -json | jq -r '.gpus[] | select(.summary | contains("nvidia_a40"))'`
+}
+
+type gpuInfo struct {
+	Index    int    `json:"index"`
+	Label    string `json:"label"`
+	Summary  string `json:"summary"`
+	NumaNode int32  `json:"numaNode"`
+	Key      int32  `json:"key"`
+}
+
+type infoResult struct {
+	GPUs []gpuInfo `json:"gpus"`
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+	for _, gpu := range r.GPUs {
+		fmt.Fprintf(tw, "GPU %d:\n", gpu.Index)
+		fmt.Fprintf(tw, "  Label: %s\n", gpu.Label)
+		fmt.Fprintf(tw, "  Summary: %s\n", gpu.Summary)
+		fmt.Fprintf(tw, "  Numa Node: %d\n", gpu.NumaNode)
+		fmt.Fprintf(tw, "  Key: %d\n", gpu.Key)
+	}
+	return tw.Flush()
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	var o mo.VirtualMachine
+	pc := property.DefaultCollector(c)
+	err = pc.RetrieveOne(ctx, vm.Reference(), []string{"name", "config.hardware", "runtime.powerState"}, &o)
+	if err != nil {
+		return err
+	}
+
+	if o.Config == nil {
+		return fmt.Errorf("VM configuration not available")
+	}
+
+	var res infoResult
+	gpuCount := 0
+	for _, device := range o.Config.Hardware.Device {
+		if pciDevice, ok := device.(*types.VirtualPCIPassthrough); ok {
+			gpu := gpuInfo{
+				Index:    gpuCount,
+				NumaNode: pciDevice.NumaNode,
+				Key:      pciDevice.Key,
+			}
+			if desc := pciDevice.DeviceInfo.GetDescription(); desc != nil {
+				gpu.Label = desc.Label
+				gpu.Summary = desc.Summary
+			}
+			res.GPUs = append(res.GPUs, gpu)
+			gpuCount++
+		}
+	}
+
+	return cmd.WriteResult(&res)
+}

--- a/cli/gpu/vm/remove.go
+++ b/cli/gpu/vm/remove.go
@@ -1,0 +1,107 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vm
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/cli"
+	"github.com/vmware/govmomi/cli/flags"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type remove struct {
+	*flags.ClientFlag
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("gpu.vm.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Description() string {
+	return `Remove all vGPUs from VM.
+
+Examples:
+  govc gpu.vm.remove -vm $vm`
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachineFlag.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	// Check power state and get device list
+	var o mo.VirtualMachine
+	pc := property.DefaultCollector(vm.Client())
+	err = pc.RetrieveOne(ctx, vm.Reference(), []string{"runtime.powerState", "config.hardware"}, &o)
+	if err != nil {
+		return err
+	}
+
+	if o.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
+		return fmt.Errorf("VM must be powered off to remove vGPU")
+	}
+
+	if o.Config == nil {
+		return fmt.Errorf("failed to get VM configuration")
+	}
+
+	// Find vGPU devices
+	var deviceChanges []types.BaseVirtualDeviceConfigSpec
+	for _, device := range o.Config.Hardware.Device {
+		if pci, ok := device.(*types.VirtualPCIPassthrough); ok {
+			if _, ok := pci.Backing.(*types.VirtualPCIPassthroughVmiopBackingInfo); ok {
+				spec := &types.VirtualDeviceConfigSpec{
+					Operation: types.VirtualDeviceConfigSpecOperationRemove,
+					Device:    pci,
+				}
+				deviceChanges = append(deviceChanges, spec)
+			}
+		}
+	}
+
+	if len(deviceChanges) == 0 {
+		return fmt.Errorf("no vGPU devices found")
+	}
+
+	vmConfigSpec := types.VirtualMachineConfigSpec{
+		DeviceChange: deviceChanges,
+	}
+
+	task, err := vm.Reconfigure(ctx, vmConfigSpec)
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -159,6 +159,11 @@ but appear via `govc $cmd -h`:
  - [firewall.ruleset.find](#firewallrulesetfind)
  - [folder.create](#foldercreate)
  - [folder.info](#folderinfo)
+ - [gpu.host.info](#gpuhostinfo)
+ - [gpu.host.profile.ls](#gpuhostprofilels)
+ - [gpu.vm.add](#gpuvmadd)
+ - [gpu.vm.info](#gpuvminfo)
+ - [gpu.vm.remove](#gpuvmremove)
  - [guest.chmod](#guestchmod)
  - [guest.chown](#guestchown)
  - [guest.df](#guestdf)
@@ -2741,6 +2746,84 @@ Options:
 Usage: govc folder.info [OPTIONS] [PATH]...
 
 Options:
+```
+
+## gpu.host.info
+
+```
+Usage: govc gpu.host.info [OPTIONS]
+
+Display GPU information for a host.
+
+Examples:
+  govc gpu.host.info -host hostname
+  govc gpu.host.info -host hostname -json | jq .
+  govc gpu.host.info -host hostname -json | jq -r '.devices[] | select(.deviceName | contains("NVIDIA"))'
+  govc find / -type h | xargs -n1 govc gpu.host.info -host # all hosts
+
+Options:
+  -host=                 Host system [GOVC_HOST]
+```
+
+## gpu.host.profile.ls
+
+```
+Usage: govc gpu.host.profile.ls [OPTIONS]
+
+List available vGPU profiles on host.
+
+Examples:
+  govc gpu.host.profile.ls -host hostname
+  govc gpu.host.profile.ls -host hostname -json | jq -r '.profiles[]'
+  govc gpu.host.profile.ls -host hostname -json | jq -r '.profiles[] | select(contains("nvidia_a40"))'
+
+Options:
+  -host=                 Host system [GOVC_HOST]
+```
+
+## gpu.vm.add
+
+```
+Usage: govc gpu.vm.add [OPTIONS]
+
+Add vGPU to VM.
+
+Examples:
+  govc gpu.vm.add -vm $vm -profile nvidia_a40-1b
+
+Options:
+  -profile=              vGPU profile
+  -vm=                   Virtual machine [GOVC_VM]
+```
+
+## gpu.vm.info
+
+```
+Usage: govc gpu.vm.info [OPTIONS]
+
+Display GPU information for a VM.
+
+Examples:
+  govc gpu.vm.info -vm $vm
+  govc gpu.vm.info -vm $vm -json | jq -r '.gpus[].summary'
+  govc gpu.vm.info -vm $vm -json | jq -r '.gpus[] | select(.summary | contains("nvidia_a40"))'
+
+Options:
+  -vm=                   Virtual machine [GOVC_VM]
+```
+
+## gpu.vm.remove
+
+```
+Usage: govc gpu.vm.remove [OPTIONS]
+
+Remove all vGPUs from VM.
+
+Examples:
+  govc gpu.vm.remove -vm $vm
+
+Options:
+  -vm=                   Virtual machine [GOVC_VM]
 ```
 
 ## guest.chmod

--- a/govc/main.go
+++ b/govc/main.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2014-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 
@@ -57,6 +45,7 @@ import (
 	_ "github.com/vmware/govmomi/cli/extension"
 	_ "github.com/vmware/govmomi/cli/fields"
 	_ "github.com/vmware/govmomi/cli/folder"
+	_ "github.com/vmware/govmomi/cli/gpu"
 	_ "github.com/vmware/govmomi/cli/host"
 	_ "github.com/vmware/govmomi/cli/host/account"
 	_ "github.com/vmware/govmomi/cli/host/autostart"

--- a/govc/test/gpu.bats
+++ b/govc/test/gpu.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "gpu.vm" {
+  vcsim_env
+
+  run govc gpu.vm.info
+  assert_failure
+
+  run govc gpu.vm.info '*'
+  assert_failure
+
+  run govc gpu.vm.info -vm DC0_H0_VM0
+  assert_success ""
+}
+
+@test "gpu.host" {
+  vcsim_start
+
+  run govc gpu.host.info
+  assert_failure
+
+  run govc gpu.host.info -host DC0_C0_H0
+  assert_success ""
+
+  run govc gpu.host.profile.ls -host DC0_C0_H0
+  assert_failure
+}


### PR DESCRIPTION
## Description

This PR adds GPU management commands to the govc CLI tool, including:

- `govc gpu.host.info`: Display GPU information for a host, including physical NVIDIA GPUs
- `govc gpu.host.profile.ls`: List available vGPU profiles on a host
- `govc gpu.vm.add`: Add vGPU to VM with specified profile
- `govc gpu.vm.info`: Display GPU information for a VM
- `govc gpu.vm.remove`: Remove all vGPUs from VM

Commands support standard and JSON formatting.

Closes: #3689

## How Has This Been Tested?

- We've done ad-hoc testing with NVIDIA A40 and L40 GPUs.
- We've asked for guidance about modifying vcsim, so that it can be properly unit tested.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
