### PR TITLE
govc: add session.login -jwt option

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -5471,6 +5471,7 @@ The session.login command can be used to:
 - Login using a vCenter Extension certificate
 - Issue a SAML token
 - Renew a SAML token
+- Exchange a SAML token for a JSON Web Token (JWT)
 - Login using a SAML token
 - Impersonate a user
 - Avoid passing credentials to other govc commands
@@ -5492,6 +5493,7 @@ Examples:
   token=$(govc session.login -u host -cert user.crt -key user.key -issue -token "$bearer")
   govc session.login -u host -cert user.crt -key user.key -token "$token"
   token=$(govc session.login -u host -cert user.crt -key user.key -renew -lifetime 24h -token "$token")
+  govc session.login -jwt vmware-tes:vc:nsxd-v2:nsx -token "$token"
   # HTTP requests
   govc session.login -r -X GET /api/vcenter/namespace-management/clusters | jq .
   govc session.login -r -X POST /rest/vcenter/cluster/modules <<<'{"spec": {"cluster": "domain-c9"}}'
@@ -5503,6 +5505,7 @@ Options:
   -cookie=               Set HTTP cookie for an existing session
   -extension=            Extension name
   -issue=false           Issue SAML token
+  -jwt=                  Exchange SAML token for JWT audience
   -l=false               Output session cookie
   -lifetime=10m0s        SAML token lifetime
   -r=false               REST login

--- a/vapi/authentication/authentication.go
+++ b/vapi/authentication/authentication.go
@@ -1,0 +1,62 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package authentication
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+// Manager extends rest.Client, adding authentication related methods.
+type Manager struct {
+	*rest.Client
+}
+
+// NewManager creates a new Manager instance with the given client.
+func NewManager(client *rest.Client) *Manager {
+	return &Manager{
+		Client: client,
+	}
+}
+
+type TokenIssueSpec struct {
+	SubjectToken       string `json:"subject_token"`
+	SubjectTokenType   string `json:"subject_token_type"`
+	GrantType          string `json:"grant_type"`
+	ActorToken         string `json:"actor_token,omitempty"`
+	ActorTokenType     string `json:"actor_token_type,omitempty"`
+	RequestedTokenType string `json:"requested_token_type,omitempty"`
+	Resource           string `json:"resource,omitempty"`
+	Scope              string `json:"scope,omitempty"`
+	Audience           string `json:"audience,omitempty"`
+}
+
+type TokenInfo struct {
+	AccessToken     string `json:"access_token"`
+	TokenType       string `json:"token_type"`
+	ExpiresIn       int    `json:"expires_in,omitempty"`
+	IssuedTokenType string `json:"issued_token_type,omitempty"`
+	RefreshToken    string `json:"refresh_token,omitempty"`
+	Scope           string `json:"scope,omitempty"`
+}
+
+func (c *Manager) Issue(ctx context.Context, token TokenIssueSpec) (*TokenInfo, error) {
+	url := c.Resource("/vcenter/tokenservice/token-exchange")
+
+	var res TokenInfo
+
+	spec := struct {
+		Spec TokenIssueSpec `json:"spec"`
+	}{Spec: token}
+
+	err := c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}


### PR DESCRIPTION
Fixes #3041

Example:
```console
% token=$(govc session.login -issue)
% govc session.login -jwt vmware-tes:vc:nsxd-v2:nsx -token "$token"
eyJraWQiOiJBNzU5OUE4Q...
```