### PR TITLE
vcsim: remove simulator.Map package variable

### DIFF
--- a/cns/simulator/simulator_test.go
+++ b/cns/simulator/simulator_test.go
@@ -58,7 +58,7 @@ func TestSimulator(t *testing.T) {
 	existingNumDisks := len(queryResult.Volumes)
 
 	// Get a simulator DS
-	datastore := simulator.Map.Any("Datastore").(*simulator.Datastore)
+	datastore := model.Map().Any("Datastore").(*simulator.Datastore)
 
 	// Create volume for static provisioning
 	var capacityInMb int64 = 1024
@@ -229,7 +229,7 @@ func TestSimulator(t *testing.T) {
 	}
 
 	// Attach
-	nodeVM := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	nodeVM := model.Map().Any("VirtualMachine").(*simulator.VirtualMachine)
 	attachSpecList := []cnstypes.CnsVolumeAttachDetachSpec{
 		{
 			VolumeId: createVolumeOperationRes.VolumeId,

--- a/eam/simulator/agency.go
+++ b/eam/simulator/agency.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2021 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -28,6 +16,7 @@ import (
 	"github.com/vmware/govmomi/eam/mo"
 	"github.com/vmware/govmomi/eam/types"
 	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 	vim "github.com/vmware/govmomi/vim25/types"
 )
@@ -76,7 +65,7 @@ func NewAgency(
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	// Alias the registry that contains the vim25 objects.
-	vimMap := simulator.Map
+	vimMap := ctx.For(vim25.Path).Map
 
 	// Create the agents.
 	for i, agentConfig := range agencyConfig.AgentConfig {

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -418,11 +418,14 @@ EOF
   [[ "$url" == *"https://127.0.0.1:"* ]]
   vcsim_stop
 
-  vcsim_start -dc 0 -l 0.0.0.0:0
-  url=$(govc option.ls vcsim.server.url)
-  [[ "$url" != *"https://127.0.0.1:"* ]]
-  [[ "$url" != *"https://[::]:"* ]]
-  vcsim_stop
+  # Symantec WSS Agent may block this :shrug:
+  if [ -z "$(pidof wssa-ui_netext)" ] ; then
+    vcsim_start -dc 0 -l 0.0.0.0:0
+    url=$(govc option.ls vcsim.server.url)
+    [[ "$url" != *"https://127.0.0.1:"* ]]
+    [[ "$url" != *"https://[::]:"* ]]
+    vcsim_stop
+  fi
 }
 
 @test "vcsim vapi auth" {

--- a/guest/file_manager_test.go
+++ b/guest/file_manager_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2020 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package guest_test
 
@@ -29,8 +17,8 @@ import (
 
 func TestTranferURL(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
-		host := simulator.Map.Get(*vm.Runtime.Host).(*simulator.HostSystem)
+		vm := simulator.Map(ctx).Any("VirtualMachine").(*simulator.VirtualMachine)
+		host := simulator.Map(ctx).Get(*vm.Runtime.Host).(*simulator.HostSystem)
 
 		ops := guest.NewOperationsManager(c, vm.Reference())
 		m, err := ops.FileManager(ctx)

--- a/lookup/client_test.go
+++ b/lookup/client_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package lookup_test
 
@@ -44,7 +32,7 @@ import (
 func TestEndpointURL(t *testing.T) {
 	// these client calls should fail since we'll break the URL paths
 	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
-		lsim.BreakLookupServiceURLs()
+		lsim.BreakLookupServiceURLs(ctx)
 
 		{
 			_, err := ssoadmin.NewClient(ctx, vc)
@@ -105,7 +93,7 @@ func TestEndpointURL(t *testing.T) {
 		model := simulator.VPX()
 		model.Create()
 		simulator.Test(func(ctx context.Context, vc *vim25.Client) {
-			lsim.BreakLookupServiceURLs()
+			lsim.BreakLookupServiceURLs(ctx)
 			// Map Envoy sidecar on the same port as the vcsim client.
 			os.Setenv("GOVMOMI_ENVOY_SIDECAR_PORT", vc.Client.URL().Port())
 			os.Setenv("GOVMOMI_ENVOY_SIDECAR_HOST", vc.Client.URL().Hostname())

--- a/lookup/simulator/simulator.go
+++ b/lookup/simulator/simulator.go
@@ -5,6 +5,7 @@
 package simulator
 
 import (
+	"context"
 	"net/url"
 	"strings"
 	"sync"
@@ -172,8 +173,8 @@ func (s *ServiceRegistration) List(ctx *simulator.Context, req *types.List) soap
 }
 
 // BreakLookupServiceURLs makes the path of all lookup service urls invalid
-func BreakLookupServiceURLs() {
-	setting := simulator.Map.OptionManager().Setting
+func BreakLookupServiceURLs(ctx context.Context) {
+	setting := simulator.Map(ctx).OptionManager().Setting
 
 	for _, s := range setting {
 		o := s.GetOptionValue()

--- a/object/common_test.go
+++ b/object/common_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2016 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package object_test
 
@@ -51,7 +39,7 @@ func TestObjectName(t *testing.T) {
 		kinds := []string{"VirtualMachine", "Network", "DistributedVirtualPortgroup"}
 
 		for _, kind := range kinds {
-			ref := simulator.Map.Any(kind)
+			ref := simulator.Map(ctx).Any(kind)
 			obj := object.NewReference(c, ref.Reference())
 
 			name, err := obj.(common).ObjectName(ctx)

--- a/object/datastore_test.go
+++ b/object/datastore_test.go
@@ -27,7 +27,7 @@ func TestDatastoreFindInventoryPath(t *testing.T) {
 	model.Datastore = 2
 
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		refs := simulator.Map.All("Datastore")
+		refs := simulator.Map(ctx).All("Datastore")
 
 		for _, obj := range refs {
 			ds := object.NewDatastore(c, obj.Reference())

--- a/object/distributed_virtual_portgroup_test.go
+++ b/object/distributed_virtual_portgroup_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package object_test
 
@@ -33,7 +21,7 @@ var _ object.NetworkReference = object.DistributedVirtualPortgroup{}
 
 func TestDistributedVirtualPortgroupEthernetCardBackingInfo(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		obj := simulator.Map.Any("DistributedVirtualPortgroup").(*simulator.DistributedVirtualPortgroup)
+		obj := simulator.Map(ctx).Any("DistributedVirtualPortgroup").(*simulator.DistributedVirtualPortgroup)
 
 		pg := object.NewDistributedVirtualPortgroup(c, obj.Self)
 		_, err := pg.EthernetCardBackingInfo(ctx)

--- a/object/distributed_virtual_switch_test.go
+++ b/object/distributed_virtual_switch_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2020 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package object_test
 
@@ -27,7 +15,7 @@ import (
 
 func TestDistributedVirtualSwitchEthernetCardBackingInfo(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		obj := simulator.Map.Any("DistributedVirtualSwitch").(*simulator.DistributedVirtualSwitch)
+		obj := simulator.Map(ctx).Any("DistributedVirtualSwitch").(*simulator.DistributedVirtualSwitch)
 
 		dvs := object.NewDistributedVirtualSwitch(c, obj.Self)
 

--- a/object/host_config_manager_test.go
+++ b/object/host_config_manager_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2019 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package object_test
 
@@ -28,7 +16,7 @@ import (
 
 func TestHostConfigManager(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		obj := simulator.Map.Any("HostSystem").(*simulator.HostSystem)
+		obj := simulator.Map(ctx).Any("HostSystem").(*simulator.HostSystem)
 		host := object.NewHostSystem(c, obj.Self)
 
 		m := host.ConfigManager()

--- a/object/host_system_test.go
+++ b/object/host_system_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2019-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package object_test
 
@@ -48,7 +36,7 @@ func TestHostSystemManagementIPs(t *testing.T) {
 		}
 
 		// These fields can be nil while ESX is being upgraded
-		hs := simulator.Map.Get(host.Reference()).(*simulator.HostSystem)
+		hs := simulator.Map(ctx).Get(host.Reference()).(*simulator.HostSystem)
 		tests := []func(){
 			func() { hs.Config.VirtualNicManagerInfo = nil },
 			func() { hs.Config = nil },

--- a/object/namespace_manager_test.go
+++ b/object/namespace_manager_test.go
@@ -31,7 +31,7 @@ func TestDatastoreNamespaceManager(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		store := simulator.Map.Get(ds.Reference()).(*simulator.Datastore)
+		store := simulator.Map(ctx).Get(ds.Reference()).(*simulator.Datastore)
 
 		name := "foo"
 

--- a/pbm/simulator/simulator.go
+++ b/pbm/simulator/simulator.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2018-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -26,6 +14,7 @@ import (
 	"github.com/vmware/govmomi/pbm/methods"
 	"github.com/vmware/govmomi/pbm/types"
 	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 	vim "github.com/vmware/govmomi/vim25/types"
 )
@@ -271,11 +260,11 @@ type PlacementSolver struct {
 	vim.ManagedObjectReference
 }
 
-func (m *PlacementSolver) PbmCheckRequirements(req *types.PbmCheckRequirements) soap.HasFault {
+func (m *PlacementSolver) PbmCheckRequirements(ctx *simulator.Context, req *types.PbmCheckRequirements) soap.HasFault {
 	body := new(methods.PbmCheckRequirementsBody)
 	body.Res = new(types.PbmCheckRequirementsResponse)
 
-	for _, ds := range simulator.Map.All("Datastore") {
+	for _, ds := range ctx.For(vim25.Path).Map.All("Datastore") {
 		// TODO: filter
 		ref := ds.Reference()
 		body.Res.Returnval = append(body.Res.Returnval, types.PbmPlacementCompatibilityResult{
@@ -294,11 +283,11 @@ func (m *PlacementSolver) PbmCheckRequirements(req *types.PbmCheckRequirements) 
 	return body
 }
 
-func (m *PlacementSolver) PbmCheckCompatibility(req *types.PbmCheckCompatibility) soap.HasFault {
+func (m *PlacementSolver) PbmCheckCompatibility(ctx *simulator.Context, _ *types.PbmCheckCompatibility) soap.HasFault {
 	body := new(methods.PbmCheckCompatibilityBody)
 	body.Res = new(types.PbmCheckCompatibilityResponse)
 
-	for _, ds := range simulator.Map.All("Datastore") {
+	for _, ds := range ctx.For(vim25.Path).Map.All("Datastore") {
 		// TODO: filter
 		ref := ds.Reference()
 		body.Res.Returnval = append(body.Res.Returnval, types.PbmPlacementCompatibilityResult{

--- a/property/wait_test.go
+++ b/property/wait_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2019-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package property_test
 
@@ -48,7 +36,7 @@ func TestWaitPermissionFault(t *testing.T) {
 
 	pc := new(propCollForWaitForPermsTest)
 	pc.Self = model.ServiceContent.PropertyCollector
-	simulator.Map.Put(pc)
+	model.Map().Put(pc)
 
 	dm := object.NewVirtualDiskManager(c.Client)
 
@@ -101,7 +89,7 @@ func TestWaitExPermissionFault(t *testing.T) {
 
 	pc := new(propCollForWaitForPermsTest)
 	pc.Self = model.ServiceContent.PropertyCollector
-	simulator.Map.Put(pc)
+	model.Map().Put(pc)
 
 	dm := object.NewVirtualDiskManager(c.Client)
 

--- a/simulator/authorization_manager.go
+++ b/simulator/authorization_manager.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -66,8 +54,8 @@ func (m *AuthorizationManager) init(r *Registry) {
 	}
 }
 
-func (m *AuthorizationManager) RetrieveEntityPermissions(req *types.RetrieveEntityPermissions) soap.HasFault {
-	e := Map.Get(req.Entity).(mo.Entity)
+func (m *AuthorizationManager) RetrieveEntityPermissions(ctx *Context, req *types.RetrieveEntityPermissions) soap.HasFault {
+	e := ctx.Map.Get(req.Entity).(mo.Entity)
 
 	p := m.permissions[e.Reference()]
 
@@ -78,7 +66,7 @@ func (m *AuthorizationManager) RetrieveEntityPermissions(req *types.RetrieveEnti
 				break
 			}
 
-			e = Map.Get(parent.Reference()).(mo.Entity)
+			e = ctx.Map.Get(parent.Reference()).(mo.Entity)
 
 			p = append(p, m.permissions[e.Reference()]...)
 		}

--- a/simulator/authorization_manager_test.go
+++ b/simulator/authorization_manager_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -26,10 +14,10 @@ import (
 func TestAuthorizationManager(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		model := VPX()
+		ctx := NewContext()
+		_ = New(NewServiceInstance(ctx, model.ServiceContent, model.RootFolder)) // 2nd pass panics w/o copying RoleList
 
-		_ = New(NewServiceInstance(SpoofContext(), model.ServiceContent, model.RootFolder)) // 2nd pass panics w/o copying RoleList
-
-		authz := Map.Get(*vpx.ServiceContent.AuthorizationManager).(*AuthorizationManager)
+		authz := ctx.Map.Get(*vpx.ServiceContent.AuthorizationManager).(*AuthorizationManager)
 		authz.RemoveAuthorizationRole(&types.RemoveAuthorizationRole{
 			RoleId: -2, // ReadOnly
 		})

--- a/simulator/cluster_compute_resource.go
+++ b/simulator/cluster_compute_resource.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -66,7 +54,7 @@ func (add *addHost) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 		template.Network = cr.Network[:1] // VM Network
 	}
 
-	host := NewHostSystem(template)
+	host := NewHostSystem(task.ctx, template)
 	host.configure(task.ctx, spec, add.req.AsConnected)
 
 	task.ctx.Map.PutEntity(cr, task.ctx.Map.NewEntity(host))
@@ -658,7 +646,7 @@ func CreateClusterComputeResource(ctx *Context, f *Folder, name string, spec typ
 	config.VmSwapPlacement = string(types.VirtualMachineConfigInfoSwapPlacementTypeVmDirectory)
 	config.DrsConfig.Enabled = types.NewBool(true)
 
-	pool := NewResourcePool()
+	pool := NewResourcePool(ctx)
 	ctx.Map.PutEntity(cluster, ctx.Map.NewEntity(pool))
 	cluster.ResourcePool = &pool.Self
 

--- a/simulator/cluster_compute_resource_test.go
+++ b/simulator/cluster_compute_resource_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -35,7 +23,7 @@ import (
 
 func TestClusterESX(t *testing.T) {
 	content := esx.ServiceContent
-	s := New(NewServiceInstance(SpoofContext(), content, esx.RootFolder))
+	s := New(NewServiceInstance(NewContext(), content, esx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()
@@ -61,7 +49,7 @@ func TestClusterESX(t *testing.T) {
 
 func TestClusterVC(t *testing.T) {
 	content := vpx.ServiceContent
-	s := New(NewServiceInstance(SpoofContext(), content, vpx.RootFolder))
+	s := New(NewServiceInstance(NewContext(), content, vpx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()
@@ -189,8 +177,8 @@ func TestPlaceVmReconfigure(t *testing.T) {
 				t.Fatalf("failed to get default datacenter: %v", err)
 			}
 			finder.SetDatacenter(datacenter)
-			vmMoRef := Map.Any("VirtualMachine").(*VirtualMachine).Reference()
-			clusterMoRef := Map.Any("ClusterComputeResource").(*ClusterComputeResource).Reference()
+			vmMoRef := Map(ctx).Any("VirtualMachine").(*VirtualMachine).Reference()
+			clusterMoRef := Map(ctx).Any("ClusterComputeResource").(*ClusterComputeResource).Reference()
 			clusterObj := object.NewClusterComputeResource(c, clusterMoRef)
 
 			// PlaceVm.
@@ -217,9 +205,9 @@ func TestPlaceVmRelocate(t *testing.T) {
 		}
 		finder.SetDatacenter(datacenter)
 
-		vmMoRef := Map.Any("VirtualMachine").(*VirtualMachine).Reference()
-		hostMoRef := Map.Any("HostSystem").(*HostSystem).Reference()
-		dsMoRef := Map.Any("Datastore").(*Datastore).Reference()
+		vmMoRef := Map(ctx).Any("VirtualMachine").(*VirtualMachine).Reference()
+		hostMoRef := Map(ctx).Any("HostSystem").(*HostSystem).Reference()
+		dsMoRef := Map(ctx).Any("Datastore").(*Datastore).Reference()
 
 		tests := []struct {
 			name         string
@@ -355,7 +343,7 @@ func TestPlaceVmRelocate(t *testing.T) {
 				PlacementType: string(types.PlacementSpecPlacementTypeRelocate),
 			}
 
-			clusterMoRef := Map.Any("ClusterComputeResource").(*ClusterComputeResource).Reference()
+			clusterMoRef := Map(ctx).Any("ClusterComputeResource").(*ClusterComputeResource).Reference()
 			clusterObj := object.NewClusterComputeResource(c, clusterMoRef)
 			_, err = clusterObj.PlaceVm(ctx, placementSpec)
 			if err == nil && test.expectedErr != "" {

--- a/simulator/container.go
+++ b/simulator/container.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -697,7 +685,7 @@ func (c *container) updated() {
 // returns:
 //
 //	err - uninitializedContainer error - if c.id is empty
-func (c *container) watchContainer(ctx context.Context, updateFn func(*containerDetails, *container) error) error {
+func (c *container) watchContainer(ctx *Context, updateFn func(*containerDetails, *container) error) error {
 	c.Lock()
 	defer c.Unlock()
 
@@ -725,7 +713,7 @@ func (c *container) watchContainer(ctx context.Context, updateFn func(*container
 			var removing bool
 			if _, ok := err.(uninitializedContainer); ok {
 				removing = true
-				rmErr = c.remove(SpoofContext())
+				rmErr = c.remove(ctx)
 			}
 
 			updateErr := updateFn(&details, c)

--- a/simulator/container_host_system_test.go
+++ b/simulator/container_host_system_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2023-2023 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -38,9 +26,11 @@ func TestHostOptionManager(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hs := NewHostSystem(esx.HostSystem)
+	ctx := m.Service.Context
 
-	advOpts, ok := Map.Get(hs.ConfigManager.AdvancedOption.Reference()).(*OptionManager)
+	hs := NewHostSystem(ctx, esx.HostSystem)
+
+	advOpts, ok := m.Map().Get(hs.ConfigManager.AdvancedOption.Reference()).(*OptionManager)
 	require.True(t, ok, "Expected to inflate OptionManager from reference")
 
 	option := &types.OptionValue{
@@ -70,7 +60,7 @@ func TestHostOptionManager(t *testing.T) {
 	require.Equal(t, 1, len(queryRes.Returnval), "Expected query of updated option to succeed")
 	require.Equal(t, option2.Value, queryRes.Returnval[0].GetOptionValue().Value, "Expected updated value")
 
-	hs.configure(SpoofContext(), types.HostConnectSpec{}, true)
+	hs.configure(ctx, types.HostConnectSpec{}, true)
 	assert.Nil(t, hs.sh, "Expected not to have container backing if not requested")
 }
 
@@ -84,9 +74,10 @@ func TestSyncWithOptionsStruct(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hs := NewHostSystem(esx.HostSystem)
+	ctx := m.Service.Context
+	hs := NewHostSystem(ctx, esx.HostSystem)
 
-	advOpts, ok := Map.Get(hs.ConfigManager.AdvancedOption.Reference()).(*OptionManager)
+	advOpts, ok := m.Map().Get(hs.ConfigManager.AdvancedOption.Reference()).(*OptionManager)
 	require.True(t, ok, "Expected to inflate OptionManager from reference")
 
 	option := &types.OptionValue{
@@ -110,13 +101,14 @@ func TestPerHostOptionManager(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hs := NewHostSystem(esx.HostSystem)
-	hs2 := NewHostSystem(esx.HostSystem)
+	ctx := m.Service.Context
+	hs := NewHostSystem(ctx, esx.HostSystem)
+	hs2 := NewHostSystem(ctx, esx.HostSystem)
 
-	advOpts, ok := Map.Get(hs.ConfigManager.AdvancedOption.Reference()).(*OptionManager)
+	advOpts, ok := m.Map().Get(hs.ConfigManager.AdvancedOption.Reference()).(*OptionManager)
 	require.True(t, ok, "Expected to inflate OptionManager from reference")
 
-	advOpts2 := Map.Get(hs2.ConfigManager.AdvancedOption.Reference()).(*OptionManager)
+	advOpts2 := m.Map().Get(hs2.ConfigManager.AdvancedOption.Reference()).(*OptionManager)
 
 	option := &types.OptionValue{
 		Key:   "TEST.hello",
@@ -150,12 +142,12 @@ func TestPerHostOptionManager(t *testing.T) {
 
 	assert.Equal(t, option2, hs.Config.Option[1], "Expected mirror to reflect changes")
 
-	hs.configure(SpoofContext(), types.HostConnectSpec{}, true)
+	hs.configure(ctx, types.HostConnectSpec{}, true)
 	assert.Nil(t, hs.sh, "Expected not to have container backing if not requested")
 
-	hs3 := NewHostSystem(esx.HostSystem)
+	hs3 := NewHostSystem(ctx, esx.HostSystem)
 
-	advOpts3 := Map.Get(hs3.ConfigManager.AdvancedOption.Reference()).(*OptionManager)
+	advOpts3 := m.Map().Get(hs3.ConfigManager.AdvancedOption.Reference()).(*OptionManager)
 	fault = advOpts3.QueryOptions(&types.QueryOptions{Name: option.Key}).(*methods.QueryOptionsBody).Fault()
 	require.IsType(t, &types.InvalidName{}, fault.VimFault(), "Expected host created after update not to inherit change")
 
@@ -175,9 +167,9 @@ func TestHostContainerBacking(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := SpoofContext()
+	ctx := m.Service.Context
 
-	hs := NewHostSystem(esx.HostSystem)
+	hs := NewHostSystem(ctx, esx.HostSystem)
 	hs.configureContainerBacking(ctx, "alpine", defaultSimVolumes, "vcsim-mgmt-underlay")
 
 	details, err := hs.getNetConfigInterface(ctx, "management")
@@ -204,12 +196,12 @@ func TestMultipleSimHost(t *testing.T) {
 	err := m.Create()
 	require.Nil(t, err, "expected successful creation of model")
 
-	ctx := SpoofContext()
+	ctx := m.Service.Context
 
-	hs := NewHostSystem(esx.HostSystem)
+	hs := NewHostSystem(ctx, esx.HostSystem)
 	hs.configureContainerBacking(ctx, "alpine", defaultSimVolumes)
 
-	hs2 := NewHostSystem(esx.HostSystem)
+	hs2 := NewHostSystem(ctx, esx.HostSystem)
 	hs2.configureContainerBacking(ctx, "alpine", defaultSimVolumes)
 
 	details, err := hs.getNetConfigInterface(ctx, "management")

--- a/simulator/container_virtual_machine.go
+++ b/simulator/container_virtual_machine.go
@@ -1,24 +1,11 @@
-/*
-Copyright (c) 2023-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
 import (
 	"archive/tar"
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -296,12 +283,10 @@ func (svm *simVM) start(ctx *Context) error {
 	}
 
 	callback := func(details *containerDetails, c *container) error {
-		spoofctx := SpoofContext()
-
 		if c.id == "" && svm.vm != nil {
 			// If the container cannot be found then destroy this VM unless the VM is no longer configured for container backing (svm.vm == nil)
-			taskRef := svm.vm.DestroyTask(spoofctx, &types.Destroy_Task{This: svm.vm.Self}).(*methods.Destroy_TaskBody).Res.Returnval
-			task, ok := spoofctx.Map.Get(taskRef).(*Task)
+			taskRef := svm.vm.DestroyTask(ctx, &types.Destroy_Task{This: svm.vm.Self}).(*methods.Destroy_TaskBody).Res.Returnval
+			task, ok := ctx.Map.Get(taskRef).(*Task)
 			if !ok {
 				panic(fmt.Sprintf("couldn't retrieve task for moref %+q while deleting VM %s", taskRef, svm.vm.Name))
 			}
@@ -320,7 +305,7 @@ func (svm *simVM) start(ctx *Context) error {
 	}
 
 	// Start watching the container resource.
-	err = svm.c.watchContainer(context.Background(), callback)
+	err = svm.c.watchContainer(ctx, callback)
 	if _, ok := err.(uninitializedContainer); ok {
 		// the container has been deleted before we could watch, despite successful launch so clean up.
 		callback(nil, svm.c)

--- a/simulator/custom_fields_manager_test.go
+++ b/simulator/custom_fields_manager_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -92,7 +80,7 @@ func TestCustomFieldsManager(t *testing.T) {
 		t.Fatalf("expect field.name to be %s; got %s", "new_field_name", fields[0].Name)
 	}
 
-	vm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vm := m.Map().Any("VirtualMachine").(*VirtualMachine)
 	err = fieldsManager.Set(ctx, vm.Reference(), field.Key, "value")
 	if err != nil {
 		t.Fatal(err)

--- a/simulator/datacenter.go
+++ b/simulator/datacenter.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -110,7 +98,7 @@ func (dc *Datacenter) defaultNetwork() []types.ManagedObjectReference {
 }
 
 // folder returns the Datacenter folder that can contain the given object type
-func (dc *Datacenter) folder(obj mo.Entity) *mo.Folder {
+func (dc *Datacenter) folder(ctx *Context, obj mo.Entity) *mo.Folder {
 	folders := []types.ManagedObjectReference{
 		dc.VmFolder,
 		dc.HostFolder,
@@ -121,7 +109,7 @@ func (dc *Datacenter) folder(obj mo.Entity) *mo.Folder {
 	rtype := obj.Reference().Type
 
 	for i := range folders {
-		folder, _ := asFolderMO(Map.Get(folders[i]))
+		folder, _ := asFolderMO(ctx.Map.Get(folders[i]))
 		for _, kind := range folder.ChildType {
 			if rtype == kind {
 				return folder
@@ -136,10 +124,10 @@ func (dc *Datacenter) folder(obj mo.Entity) *mo.Folder {
 	return nil
 }
 
-func datacenterEventArgument(obj mo.Entity) *types.DatacenterEventArgument {
+func datacenterEventArgument(ctx *Context, obj mo.Entity) *types.DatacenterEventArgument {
 	dc, ok := obj.(*Datacenter)
 	if !ok {
-		dc = Map.getEntityDatacenter(obj)
+		dc = ctx.Map.getEntityDatacenter(obj)
 	}
 	return &types.DatacenterEventArgument{
 		Datacenter:          dc.Self,

--- a/simulator/datacenter_test.go
+++ b/simulator/datacenter_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -46,7 +34,7 @@ func TestDatacenterCreateFolders(t *testing.T) {
 	for _, model := range models {
 		_ = model.Create()
 
-		dc := Map.Any("Datacenter").(*Datacenter)
+		dc := model.Map().Any("Datacenter").(*Datacenter)
 
 		folders := []types.ManagedObjectReference{
 			dc.VmFolder,
@@ -60,7 +48,7 @@ func TestDatacenterCreateFolders(t *testing.T) {
 				t.Errorf("invalid moref=%#v", ref)
 			}
 
-			e := Map.Get(ref).(mo.Entity)
+			e := model.Map().Get(ref).(mo.Entity)
 
 			if e.Entity().Name == "" {
 				t.Error("empty name")
@@ -75,7 +63,7 @@ func TestDatacenterCreateFolders(t *testing.T) {
 				t.Fatalf("unexpected type (%T) for %#v", e, ref)
 			}
 
-			if Map.IsVPX() {
+			if model.Map().IsVPX() {
 				if len(f.ChildType) < 2 {
 					t.Fail()
 				}

--- a/simulator/datastore.go
+++ b/simulator/datastore.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -99,7 +87,7 @@ func (ds *Datastore) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.Has
 		for _, mount := range ds.Host {
 			host := ctx.Map.Get(mount.Key).(*HostSystem)
 			ctx.Map.RemoveReference(ctx, host, &host.Datastore, ds.Self)
-			parent := hostParent(&host.HostSystem)
+			parent := hostParent(ctx, &host.HostSystem)
 			ctx.Map.RemoveReference(ctx, parent, &parent.Datastore, ds.Self)
 		}
 

--- a/simulator/datastore_namespace_manager.go
+++ b/simulator/datastore_namespace_manager.go
@@ -92,7 +92,7 @@ func (m *DatastoreNamespaceManager) CreateDirectory(ctx *Context, req *types.Cre
 
 	fm := ctx.Map.FileManager()
 
-	fault := fm.MakeDirectory(&types.MakeDirectory{
+	fault := fm.MakeDirectory(ctx, &types.MakeDirectory{
 		This:       fm.Self,
 		Name:       p.String(),
 		Datacenter: &dc.Self,
@@ -153,7 +153,7 @@ func (m *DatastoreNamespaceManager) DeleteDirectory(ctx *Context, req *types.Del
 
 	fm := ctx.Map.FileManager()
 
-	fault := fm.deleteDatastoreFile(&types.DeleteDatastoreFile_Task{
+	fault := fm.deleteDatastoreFile(ctx, &types.DeleteDatastoreFile_Task{
 		Name:       name.String(),
 		Datacenter: req.Datacenter,
 	})

--- a/simulator/dvs_test.go
+++ b/simulator/dvs_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -38,14 +26,14 @@ func TestDVS(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	c := m.Service.client
+	c := m.Service.client()
 
 	finder := find.NewFinder(c, false)
 	dc, _ := finder.DatacenterList(ctx, "*")
 	finder.SetDatacenter(dc[0])
 	folders, _ := dc[0].Folders(ctx)
 	hosts, _ := finder.HostSystemList(ctx, "*/*")
-	vswitch := Map.Any("DistributedVirtualSwitch").(*DistributedVirtualSwitch)
+	vswitch := m.Map().Any("DistributedVirtualSwitch").(*DistributedVirtualSwitch)
 	dvs0 := object.NewDistributedVirtualSwitch(c, vswitch.Reference())
 
 	if len(vswitch.Summary.HostMember) == 0 {
@@ -53,11 +41,11 @@ func TestDVS(t *testing.T) {
 	}
 
 	for _, ref := range vswitch.Summary.HostMember {
-		host := Map.Get(ref).(*HostSystem)
+		host := m.Map().Get(ref).(*HostSystem)
 		if len(host.Network) == 0 {
 			t.Fatalf("%s.Network=%v", ref, host.Network)
 		}
-		parent := hostParent(&host.HostSystem)
+		parent := hostParent(m.Service.Context, &host.HostSystem)
 		if len(parent.Network) != len(host.Network) {
 			t.Fatalf("%s.Network=%v", parent.Reference(), parent.Network)
 		}
@@ -182,12 +170,12 @@ func TestFetchDVPortsCriteria(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	c := m.Service.client
+	c := m.Service.client()
 
 	finder := find.NewFinder(c, false)
 	dc, _ := finder.DatacenterList(ctx, "*")
 	finder.SetDatacenter(dc[0])
-	vswitch := Map.Any("DistributedVirtualSwitch").(*DistributedVirtualSwitch)
+	vswitch := m.Map().Any("DistributedVirtualSwitch").(*DistributedVirtualSwitch)
 	dvs0 := object.NewDistributedVirtualSwitch(c, vswitch.Reference())
 	pgs := vswitch.Portgroup
 	if len(pgs) != 2 {

--- a/simulator/entity_test.go
+++ b/simulator/entity_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -38,28 +26,29 @@ func TestRename(t *testing.T) {
 	s := m.Service.NewServer()
 	defer s.Close()
 
-	dc := Map.Any("Datacenter").(*Datacenter)
-	vmFolder := Map.Get(dc.VmFolder).(*Folder)
+	ctx := m.Service.Context
+	dc := ctx.Map.Any("Datacenter").(*Datacenter)
+	vmFolder := ctx.Map.Get(dc.VmFolder).(*Folder)
 
-	f1 := Map.Get(vmFolder.ChildEntity[0]).(*Folder) // "F1"
+	f1 := ctx.Map.Get(vmFolder.ChildEntity[0]).(*Folder) // "F1"
 
-	id := vmFolder.CreateFolder(SpoofContext(), &types.CreateFolder{
+	id := vmFolder.CreateFolder(ctx, &types.CreateFolder{
 		This: vmFolder.Reference(),
 		Name: "F2",
 	}).(*methods.CreateFolderBody).Res.Returnval
 
-	f2 := Map.Get(id).(*Folder) // "F2"
+	f2 := ctx.Map.Get(id).(*Folder) // "F2"
 
 	states := []types.TaskInfoState{types.TaskInfoStateError, types.TaskInfoStateSuccess}
 	name := f1.Name
 
 	for _, expect := range states {
-		id = f2.RenameTask(SpoofContext(), &types.Rename_Task{
+		id = f2.RenameTask(ctx, &types.Rename_Task{
 			This:    f2.Reference(),
 			NewName: name,
 		}).(*methods.Rename_TaskBody).Res.Returnval
 
-		task := Map.Get(id).(*Task)
+		task := ctx.Map.Get(id).(*Task)
 		task.Wait()
 
 		if task.Info.State != expect {

--- a/simulator/environment_browser.go
+++ b/simulator/environment_browser.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -41,7 +29,7 @@ func newEnvironmentBrowser(
 
 	env := new(EnvironmentBrowser)
 	env.initDescriptorReturnVal(ctx, hostRefs...)
-	Map.Put(env)
+	ctx.Map.Put(env)
 	return &env.Self
 }
 

--- a/simulator/event_manager_test.go
+++ b/simulator/event_manager_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -52,8 +40,8 @@ func TestEventManagerVPX(t *testing.T) {
 	count := m.Count()
 
 	root := c.ServiceContent.RootFolder
-	vm := Map.Any("VirtualMachine").(*VirtualMachine)
-	host := Map.Get(vm.Runtime.Host.Reference()).(*HostSystem)
+	vm := m.Map().Any("VirtualMachine").(*VirtualMachine)
+	host := m.Map().Get(vm.Runtime.Host.Reference()).(*HostSystem)
 
 	vmEvents := 6 // BeingCreated + InstanceUuid + Uuid + Created + Starting + PoweredOn
 	tests := []struct {
@@ -251,7 +239,7 @@ func TestEventManagerRead(t *testing.T) {
 
 	event := &types.GeneralEvent{Message: "vcsim"}
 	event.Datacenter = &types.DatacenterEventArgument{
-		Datacenter: Map.Any("Datacenter").Reference(),
+		Datacenter: m.Map().Any("Datacenter").Reference(),
 	}
 	err = em.PostEvent(ctx, event)
 	if err != nil {

--- a/simulator/example_extend_test.go
+++ b/simulator/example_extend_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator_test
 
@@ -79,14 +67,14 @@ func Example() {
 	c, _ := govmomi.NewClient(ctx, s.URL, true)
 
 	// Shortcut to choose any VM, rather than using the more verbose Finder or ContainerView.
-	obj := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	obj := model.Map().Any("VirtualMachine").(*simulator.VirtualMachine)
 	// Validate VM is powered on
 	if obj.Runtime.PowerState != "poweredOn" {
 		log.Fatal(obj.Runtime.PowerState)
 	}
 
 	// Wrap the existing vm object, using the same vm.Self (ManagedObjectReference) value as the Map key.
-	simulator.Map.Put(&BusyVM{obj})
+	model.Map().Put(&BusyVM{obj})
 
 	vm := object.NewVirtualMachine(c.Client, obj.Reference())
 

--- a/simulator/example_test.go
+++ b/simulator/example_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator_test
 
@@ -132,6 +120,7 @@ func ExampleTest() {
 // Folder.AddOpaqueNetwork can be used to create an NSX backed OpaqueNetwork.
 func ExampleFolder_AddOpaqueNetwork() {
 	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
+		sctx := ctx.(*simulator.Context)
 		finder := find.NewFinder(c)
 
 		// Find the network folder via vSphere API
@@ -141,7 +130,7 @@ func ExampleFolder_AddOpaqueNetwork() {
 		}
 
 		// Get vcsim's network Folder object
-		folder := simulator.Map.Get(obj.Reference()).(*simulator.Folder)
+		folder := sctx.Map.Get(obj.Reference()).(*simulator.Folder)
 
 		spec := types.OpaqueNetworkSummary{
 			NetworkSummary: types.NetworkSummary{
@@ -152,7 +141,7 @@ func ExampleFolder_AddOpaqueNetwork() {
 		}
 
 		// Add NSX backed OpaqueNetwork, calling the simulator.Folder method directly.
-		err = folder.AddOpaqueNetwork(simulator.SpoofContext(), spec)
+		err = folder.AddOpaqueNetwork(sctx, spec)
 		if err != nil {
 			return err
 		}

--- a/simulator/file_manager.go
+++ b/simulator/file_manager.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -33,7 +21,7 @@ type FileManager struct {
 	mo.FileManager
 }
 
-func (f *FileManager) findDatastore(ref mo.Reference, name string) (*Datastore, types.BaseMethodFault) {
+func (f *FileManager) findDatastore(ctx *Context, ref mo.Reference, name string) (*Datastore, types.BaseMethodFault) {
 	var refs []types.ManagedObjectReference
 
 	if d, ok := asFolderMO(ref); ok {
@@ -44,19 +32,19 @@ func (f *FileManager) findDatastore(ref mo.Reference, name string) (*Datastore, 
 	}
 
 	for _, ref := range refs {
-		obj := Map.Get(ref)
+		obj := ctx.Map.Get(ref)
 
 		if ds, ok := obj.(*Datastore); ok && ds.Name == name {
 			return ds, nil
 		}
 		if p, ok := obj.(*StoragePod); ok {
-			ds, _ := f.findDatastore(p, name)
+			ds, _ := f.findDatastore(ctx, p, name)
 			if ds != nil {
 				return ds, nil
 			}
 		}
 		if d, ok := asFolderMO(obj); ok {
-			ds, _ := f.findDatastore(d, name)
+			ds, _ := f.findDatastore(ctx, d, name)
 			if ds != nil {
 				return ds, nil
 			}
@@ -66,23 +54,23 @@ func (f *FileManager) findDatastore(ref mo.Reference, name string) (*Datastore, 
 	return nil, &types.InvalidDatastore{Name: name}
 }
 
-func (f *FileManager) resolve(dc *types.ManagedObjectReference, name string) (string, types.BaseMethodFault) {
+func (f *FileManager) resolve(ctx *Context, dc *types.ManagedObjectReference, name string) (string, types.BaseMethodFault) {
 	p, fault := parseDatastorePath(name)
 	if fault != nil {
 		return "", fault
 	}
 
 	if dc == nil {
-		if Map.IsESX() {
+		if ctx.Map.IsESX() {
 			dc = &esx.Datacenter.Self
 		} else {
 			return "", &types.InvalidArgument{InvalidProperty: "dc"}
 		}
 	}
 
-	folder := Map.Get(*dc).(*Datacenter).DatastoreFolder
+	folder := ctx.Map.Get(*dc).(*Datacenter).DatastoreFolder
 
-	ds, fault := f.findDatastore(Map.Get(folder), p.Datastore)
+	ds, fault := f.findDatastore(ctx, ctx.Map.Get(folder), p.Datastore)
 	if fault != nil {
 		return "", fault
 	}
@@ -105,8 +93,8 @@ func (f *FileManager) fault(name string, err error, fault types.BaseFileFault) t
 	return fault.(types.BaseMethodFault)
 }
 
-func (f *FileManager) deleteDatastoreFile(req *types.DeleteDatastoreFile_Task) types.BaseMethodFault {
-	file, fault := f.resolve(req.Datacenter, req.Name)
+func (f *FileManager) deleteDatastoreFile(ctx *Context, req *types.DeleteDatastoreFile_Task) types.BaseMethodFault {
+	file, fault := f.resolve(ctx, req.Datacenter, req.Name)
 	if fault != nil {
 		return fault
 	}
@@ -128,7 +116,7 @@ func (f *FileManager) deleteDatastoreFile(req *types.DeleteDatastoreFile_Task) t
 
 func (f *FileManager) DeleteDatastoreFileTask(ctx *Context, req *types.DeleteDatastoreFile_Task) soap.HasFault {
 	task := CreateTask(f, "deleteDatastoreFile", func(*Task) (types.AnyType, types.BaseMethodFault) {
-		return nil, f.deleteDatastoreFile(req)
+		return nil, f.deleteDatastoreFile(ctx, req)
 	})
 
 	return &methods.DeleteDatastoreFile_TaskBody{
@@ -138,10 +126,10 @@ func (f *FileManager) DeleteDatastoreFileTask(ctx *Context, req *types.DeleteDat
 	}
 }
 
-func (f *FileManager) MakeDirectory(req *types.MakeDirectory) soap.HasFault {
+func (f *FileManager) MakeDirectory(ctx *Context, req *types.MakeDirectory) soap.HasFault {
 	body := &methods.MakeDirectoryBody{}
 
-	name, fault := f.resolve(req.Datacenter, req.Name)
+	name, fault := f.resolve(ctx, req.Datacenter, req.Name)
 	if fault != nil {
 		body.Fault_ = Fault("", fault)
 		return body
@@ -164,13 +152,13 @@ func (f *FileManager) MakeDirectory(req *types.MakeDirectory) soap.HasFault {
 	return body
 }
 
-func (f *FileManager) moveDatastoreFile(req *types.MoveDatastoreFile_Task) types.BaseMethodFault {
-	src, fault := f.resolve(req.SourceDatacenter, req.SourceName)
+func (f *FileManager) moveDatastoreFile(ctx *Context, req *types.MoveDatastoreFile_Task) types.BaseMethodFault {
+	src, fault := f.resolve(ctx, req.SourceDatacenter, req.SourceName)
 	if fault != nil {
 		return fault
 	}
 
-	dst, fault := f.resolve(req.DestinationDatacenter, req.DestinationName)
+	dst, fault := f.resolve(ctx, req.DestinationDatacenter, req.DestinationName)
 	if fault != nil {
 		return fault
 	}
@@ -192,7 +180,7 @@ func (f *FileManager) moveDatastoreFile(req *types.MoveDatastoreFile_Task) types
 
 func (f *FileManager) MoveDatastoreFileTask(ctx *Context, req *types.MoveDatastoreFile_Task) soap.HasFault {
 	task := CreateTask(f, "moveDatastoreFile", func(*Task) (types.AnyType, types.BaseMethodFault) {
-		return nil, f.moveDatastoreFile(req)
+		return nil, f.moveDatastoreFile(ctx, req)
 	})
 
 	return &methods.MoveDatastoreFile_TaskBody{
@@ -202,13 +190,13 @@ func (f *FileManager) MoveDatastoreFileTask(ctx *Context, req *types.MoveDatasto
 	}
 }
 
-func (f *FileManager) copyDatastoreFile(req *types.CopyDatastoreFile_Task) types.BaseMethodFault {
-	src, fault := f.resolve(req.SourceDatacenter, req.SourceName)
+func (f *FileManager) copyDatastoreFile(ctx *Context, req *types.CopyDatastoreFile_Task) types.BaseMethodFault {
+	src, fault := f.resolve(ctx, req.SourceDatacenter, req.SourceName)
 	if fault != nil {
 		return fault
 	}
 
-	dst, fault := f.resolve(req.DestinationDatacenter, req.DestinationName)
+	dst, fault := f.resolve(ctx, req.DestinationDatacenter, req.DestinationName)
 	if fault != nil {
 		return fault
 	}
@@ -241,7 +229,7 @@ func (f *FileManager) copyDatastoreFile(req *types.CopyDatastoreFile_Task) types
 
 func (f *FileManager) CopyDatastoreFileTask(ctx *Context, req *types.CopyDatastoreFile_Task) soap.HasFault {
 	task := CreateTask(f, "copyDatastoreFile", func(*Task) (types.AnyType, types.BaseMethodFault) {
-		return nil, f.copyDatastoreFile(req)
+		return nil, f.copyDatastoreFile(ctx, req)
 	})
 
 	return &methods.CopyDatastoreFile_TaskBody{

--- a/simulator/host_certificate_manager.go
+++ b/simulator/host_certificate_manager.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -47,10 +35,10 @@ func (m *HostCertificateManager) init(r *Registry) {
 	}
 }
 
-func NewHostCertificateManager(h *mo.HostSystem) *HostCertificateManager {
+func NewHostCertificateManager(ctx *Context, h *mo.HostSystem) *HostCertificateManager {
 	m := &HostCertificateManager{Host: h}
 
-	_ = m.InstallServerCertificate(SpoofContext(), &types.InstallServerCertificate{
+	_ = m.InstallServerCertificate(ctx, &types.InstallServerCertificate{
 		Cert: string(m.Host.Config.Certificate),
 	})
 

--- a/simulator/host_datastore_browser.go
+++ b/simulator/host_datastore_browser.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -187,15 +175,14 @@ func (s *searchDatastore) Run(task *Task) (types.AnyType, types.BaseMethodFault)
 		return nil, fault
 	}
 
-	ref := Map.FindByName(p.Datastore, s.Datastore)
+	ref := task.ctx.Map.FindByName(p.Datastore, s.Datastore)
 	if ref == nil {
 		return nil, &types.InvalidDatastore{Name: p.Datastore}
 	}
 
 	ds := ref.(*Datastore)
 
-	isolatedLockContext := &Context{} // we don't need/want to share the task lock
-	Map.WithLock(isolatedLockContext, task, func() {
+	task.ctx.WithLock(task, func() {
 		task.Info.Entity = &ds.Self // TODO: CreateTask() should require mo.Entity, rather than mo.Reference
 		task.Info.EntityName = ds.Name
 	})

--- a/simulator/host_datastore_system.go
+++ b/simulator/host_datastore_system.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -93,7 +81,7 @@ func (dss *HostDatastoreSystem) add(ctx *Context, ds *Datastore) *soap.Fault {
 
 	dss.Datastore = append(dss.Datastore, ds.Self)
 	dss.Host.Datastore = dss.Datastore
-	parent := hostParent(dss.Host)
+	parent := hostParent(ctx, dss.Host)
 	ctx.Map.AddReference(ctx, parent, &parent.Datastore, ds.Self)
 
 	// NOTE: browser must be created after ds is appended to dss.Datastore

--- a/simulator/host_datastore_system_test.go
+++ b/simulator/host_datastore_system_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -29,7 +17,7 @@ import (
 )
 
 func TestHostDatastoreSystem(t *testing.T) {
-	s := New(NewServiceInstance(SpoofContext(), esx.ServiceContent, esx.RootFolder))
+	s := New(NewServiceInstance(NewContext(), esx.ServiceContent, esx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()
@@ -100,7 +88,7 @@ func TestHostDatastoreSystem(t *testing.T) {
 }
 
 func TestCreateNasDatastoreValidation(t *testing.T) {
-	s := New(NewServiceInstance(SpoofContext(), esx.ServiceContent, esx.RootFolder))
+	s := New(NewServiceInstance(NewContext(), esx.ServiceContent, esx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()

--- a/simulator/host_firewall_system_test.go
+++ b/simulator/host_firewall_system_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -36,7 +24,7 @@ func TestHostFirewallSystem(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := m.Service.client
+	c := m.Service.client()
 
 	host := object.NewHostSystem(c, esx.HostSystem.Reference())
 

--- a/simulator/host_local_account_manager.go
+++ b/simulator/host_local_account_manager.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -29,9 +17,9 @@ type HostLocalAccountManager struct {
 	mo.HostLocalAccountManager
 }
 
-func (h *HostLocalAccountManager) CreateUser(req *types.CreateUser) soap.HasFault {
+func (h *HostLocalAccountManager) CreateUser(ctx *Context, req *types.CreateUser) soap.HasFault {
 	spec := req.User.GetHostAccountSpec()
-	userDirectory := Map.UserDirectory()
+	userDirectory := ctx.Map.UserDirectory()
 
 	found := userDirectory.search(true, false, compareFunc(spec.Id, true))
 	if len(found) > 0 {
@@ -47,8 +35,8 @@ func (h *HostLocalAccountManager) CreateUser(req *types.CreateUser) soap.HasFaul
 	}
 }
 
-func (h *HostLocalAccountManager) RemoveUser(req *types.RemoveUser) soap.HasFault {
-	userDirectory := Map.UserDirectory()
+func (h *HostLocalAccountManager) RemoveUser(ctx *Context, req *types.RemoveUser) soap.HasFault {
+	userDirectory := ctx.Map.UserDirectory()
 
 	found := userDirectory.search(true, false, compareFunc(req.UserName, true))
 

--- a/simulator/host_network_system.go
+++ b/simulator/host_network_system.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -58,9 +46,9 @@ func (s *HostNetworkSystem) init(r *Registry) {
 	}
 }
 
-func (s *HostNetworkSystem) folder() *Folder {
-	f := Map.getEntityDatacenter(s.Host).NetworkFolder
-	return Map.Get(f).(*Folder)
+func (s *HostNetworkSystem) folder(ctx *Context) *Folder {
+	f := ctx.Map.getEntityDatacenter(s.Host).NetworkFolder
+	return ctx.Map.Get(f).(*Folder)
 }
 
 func (s *HostNetworkSystem) AddVirtualSwitch(c *types.AddVirtualSwitch) soap.HasFault {
@@ -126,7 +114,7 @@ func (s *HostNetworkSystem) AddPortGroup(ctx *Context, c *types.AddPortGroup) so
 	network.Name = c.Portgrp.Name
 	network.Entity().Name = network.Name
 
-	folder := s.folder()
+	folder := s.folder(ctx)
 
 	if obj := ctx.Map.FindByName(c.Portgrp.Name, folder.ChildEntity); obj != nil {
 		r.Fault_ = Fault("", &types.DuplicateName{
@@ -171,7 +159,7 @@ func (s *HostNetworkSystem) RemovePortGroup(ctx *Context, c *types.RemovePortGro
 		return r
 	}
 
-	folder := s.folder()
+	folder := s.folder(ctx)
 	e := ctx.Map.FindByName(c.PgName, folder.ChildEntity)
 	folderRemoveChild(ctx, &folder.Folder, e.Reference())
 

--- a/simulator/host_network_system_test.go
+++ b/simulator/host_network_system_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -30,17 +18,18 @@ import (
 func TestHostNetworkSystem(t *testing.T) {
 	ctx := context.Background()
 
-	s := New(NewServiceInstance(SpoofContext(), esx.ServiceContent, esx.RootFolder))
+	s := New(NewServiceInstance(NewContext(), esx.ServiceContent, esx.RootFolder))
 
-	host := object.NewHostSystem(s.client, esx.HostSystem.Reference())
+	c := s.client()
+	host := object.NewHostSystem(c, esx.HostSystem.Reference())
 
 	ns, err := host.ConfigManager().NetworkSystem(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	finder := find.NewFinder(s.client, false)
-	finder.SetDatacenter(object.NewDatacenter(s.client, esx.Datacenter.Reference()))
+	finder := find.NewFinder(c, false)
+	finder.SetDatacenter(object.NewDatacenter(c, esx.Datacenter.Reference()))
 
 	// created by default
 	_, err = finder.Network(ctx, "VM Network")

--- a/simulator/license_manager.go
+++ b/simulator/license_manager.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -188,7 +176,7 @@ type LicenseAssignmentManager struct {
 var licensedTypes = []string{"HostSystem", "ClusterComputeResource"}
 
 // PutObject assigns a license when a host or cluster is created.
-func (m *LicenseAssignmentManager) PutObject(obj mo.Reference) {
+func (m *LicenseAssignmentManager) PutObject(ctx *Context, obj mo.Reference) {
 	ref := obj.Reference()
 
 	if !slices.Contains(licensedTypes, ref.Type) {
@@ -204,7 +192,7 @@ func (m *LicenseAssignmentManager) PutObject(obj mo.Reference) {
 
 	la := types.LicenseAssignmentManagerLicenseAssignment{
 		EntityId:          ref.Value,
-		Scope:             Map.content().About.InstanceUuid,
+		Scope:             ctx.Map.content().About.InstanceUuid,
 		EntityDisplayName: obj.(mo.Entity).Entity().Name,
 		AssignedLicense:   EvalLicense,
 	}

--- a/simulator/object.go
+++ b/simulator/object.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -30,7 +18,7 @@ import (
 func SetCustomValue(ctx *Context, req *types.SetCustomValue) soap.HasFault {
 	body := &methods.SetCustomValueBody{}
 
-	cfm := Map.CustomFieldsManager()
+	cfm := ctx.Map.CustomFieldsManager()
 
 	_, field := cfm.findByNameType(req.Key, req.This.Type)
 	if field == nil {

--- a/simulator/object_test.go
+++ b/simulator/object_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -49,7 +37,7 @@ func TestObjectCustomFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vm := m.Map().Any("VirtualMachine").(*VirtualMachine)
 	vmm := object.NewVirtualMachine(c.Client, vm.Reference())
 
 	fieldName := "testField"

--- a/simulator/option_manager_test.go
+++ b/simulator/option_manager_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -37,7 +25,7 @@ func TestOptionManagerESX(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := model.Service.client
+	c := model.Service.client()
 
 	m := object.NewOptionManager(c, *c.ServiceContent.Setting)
 	_, err = m.Query(ctx, "config.vpxd.")
@@ -82,7 +70,7 @@ func TestOptionManagerVPX(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := model.Service.client
+	c := model.Service.client()
 
 	m := object.NewOptionManager(c, *c.ServiceContent.Setting)
 	_, err = m.Query(ctx, "enoent")

--- a/simulator/performance_manager.go
+++ b/simulator/performance_manager.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -136,13 +124,13 @@ func (p *PerformanceManager) buildAvailablePerfMetricsQueryResponse(ids []types.
 	return r
 }
 
-func (p *PerformanceManager) queryAvailablePerfMetric(entity types.ManagedObjectReference, interval int32) *types.QueryAvailablePerfMetricResponse {
+func (p *PerformanceManager) queryAvailablePerfMetric(ctx *Context, entity types.ManagedObjectReference, interval int32) *types.QueryAvailablePerfMetricResponse {
 	switch entity.Type {
 	case "VirtualMachine":
-		vm := Map.Get(entity).(*VirtualMachine)
+		vm := ctx.Map.Get(entity).(*VirtualMachine)
 		return p.buildAvailablePerfMetricsQueryResponse(p.vmMetrics, int(vm.Summary.Config.NumCpu), vm.Datastore[0].Value)
 	case "HostSystem":
-		host := Map.Get(entity).(*HostSystem)
+		host := ctx.Map.Get(entity).(*HostSystem)
 		return p.buildAvailablePerfMetricsQueryResponse(p.hostMetrics, int(host.Hardware.CpuInfo.NumCpuThreads), host.Datastore[0].Value)
 	case "ResourcePool":
 		return p.buildAvailablePerfMetricsQueryResponse(p.rpMetrics, 0, "")
@@ -166,7 +154,7 @@ func (p *PerformanceManager) queryAvailablePerfMetric(entity types.ManagedObject
 
 func (p *PerformanceManager) QueryAvailablePerfMetric(ctx *Context, req *types.QueryAvailablePerfMetric) soap.HasFault {
 	body := new(methods.QueryAvailablePerfMetricBody)
-	body.Res = p.queryAvailablePerfMetric(req.Entity, req.IntervalId)
+	body.Res = p.queryAvailablePerfMetric(ctx, req.Entity, req.IntervalId)
 
 	return body
 }

--- a/simulator/performance_manager_test.go
+++ b/simulator/performance_manager_test.go
@@ -1,18 +1,7 @@
-/*
-Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package simulator
 
 import (
@@ -94,8 +83,6 @@ func TestMetricsDuplicates(t *testing.T) {
 }
 
 func TestQueryProviderSummary(t *testing.T) {
-	ctx := context.Background()
-
 	m := VPX()
 
 	err := m.Create()
@@ -105,11 +92,12 @@ func TestQueryProviderSummary(t *testing.T) {
 
 	defer m.Remove()
 
-	c := m.Service.client
+	c := m.Service.client()
 
 	p := performance.NewManager(c)
+	ctx := m.Service.Context
 
-	vm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vm := ctx.Map.Any("VirtualMachine").(*VirtualMachine)
 	if info, err := p.ProviderSummary(ctx, vm.Reference()); err != nil {
 		t.Fatal(err)
 	} else {
@@ -118,7 +106,7 @@ func TestQueryProviderSummary(t *testing.T) {
 		}
 	}
 
-	host := Map.Any("HostSystem").(*HostSystem)
+	host := ctx.Map.Any("HostSystem").(*HostSystem)
 	if info, err := p.ProviderSummary(ctx, host.Reference()); err != nil {
 		t.Fatal(err)
 	} else {
@@ -127,7 +115,7 @@ func TestQueryProviderSummary(t *testing.T) {
 		}
 	}
 
-	pool := Map.Any("ResourcePool").(*ResourcePool)
+	pool := ctx.Map.Any("ResourcePool").(*ResourcePool)
 	if info, err := p.ProviderSummary(ctx, pool.Reference()); err != nil {
 		t.Fatal(err)
 	} else {
@@ -136,7 +124,7 @@ func TestQueryProviderSummary(t *testing.T) {
 		}
 	}
 
-	cluster := Map.Any("ClusterComputeResource").(*ClusterComputeResource)
+	cluster := ctx.Map.Any("ClusterComputeResource").(*ClusterComputeResource)
 	if info, err := p.ProviderSummary(ctx, cluster.Reference()); err != nil {
 		t.Fatal(err)
 	} else {
@@ -145,7 +133,7 @@ func TestQueryProviderSummary(t *testing.T) {
 		}
 	}
 
-	datastore := Map.Any("Datastore").(*Datastore)
+	datastore := ctx.Map.Any("Datastore").(*Datastore)
 	if info, err := p.ProviderSummary(ctx, datastore.Reference()); err != nil {
 		t.Fatal(err)
 	} else {
@@ -164,8 +152,6 @@ func TestQueryProviderSummary(t *testing.T) {
 }
 
 func TestQueryAvailablePerfMetric(t *testing.T) {
-	ctx := context.Background()
-
 	m := VPX()
 
 	err := m.Create()
@@ -175,10 +161,11 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 
 	defer m.Remove()
 
-	c := m.Service.client
+	c := m.Service.client()
 	p := performance.NewManager(c)
+	ctx := m.Service.Context
 
-	vm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vm := ctx.Map.Any("VirtualMachine").(*VirtualMachine)
 	if info, err := p.AvailableMetric(ctx, vm.Reference(), 20); err != nil {
 		t.Fatal(err)
 	} else {
@@ -187,7 +174,7 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 		}
 	}
 
-	host := Map.Any("HostSystem").(*HostSystem)
+	host := ctx.Map.Any("HostSystem").(*HostSystem)
 	if info, err := p.AvailableMetric(ctx, host.Reference(), 20); err != nil {
 		t.Fatal(err)
 	} else {
@@ -207,7 +194,7 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 		}
 	}
 
-	pool := Map.Any("ResourcePool").(*ResourcePool)
+	pool := ctx.Map.Any("ResourcePool").(*ResourcePool)
 	if info, err := p.AvailableMetric(ctx, pool.Reference(), 20); err != nil {
 		t.Fatal(err)
 	} else {
@@ -216,7 +203,7 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 		}
 	}
 
-	cluster := Map.Any("ClusterComputeResource").(*ClusterComputeResource)
+	cluster := ctx.Map.Any("ClusterComputeResource").(*ClusterComputeResource)
 	if info, err := p.AvailableMetric(ctx, cluster.Reference(), 300); err != nil {
 		t.Fatal(err)
 	} else {
@@ -233,7 +220,7 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 		}
 	}
 
-	ds := Map.Any("Datastore").(*Datastore)
+	ds := ctx.Map.Any("Datastore").(*Datastore)
 	if info, err := p.AvailableMetric(ctx, ds.Reference(), 300); err != nil {
 		t.Fatal(err)
 	} else {
@@ -250,7 +237,7 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 		}
 	}
 
-	dc := Map.Any("Datacenter").(*Datacenter)
+	dc := ctx.Map.Any("Datacenter").(*Datacenter)
 	if info, err := p.AvailableMetric(ctx, dc.Reference(), 300); err != nil {
 		t.Fatal(err)
 	} else {
@@ -270,7 +257,7 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 }
 
 func testPerfQuery(ctx context.Context, m *Model, e mo.Entity, interval int32, maxSample int32) error {
-	c := m.Service.client
+	c := m.Service.client()
 
 	p := performance.NewManager(c)
 
@@ -308,7 +295,7 @@ func testPerfQuery(ctx context.Context, m *Model, e mo.Entity, interval int32, m
 }
 
 func testPerfQueryCSV(ctx context.Context, m *Model, e mo.Entity, interval int32, maxSample int32) error {
-	c := m.Service.client
+	c := m.Service.client()
 
 	p := performance.NewManager(c)
 
@@ -355,8 +342,6 @@ func testPerfQueryCSV(ctx context.Context, m *Model, e mo.Entity, interval int32
 }
 
 func TestQueryPerf(t *testing.T) {
-	ctx := context.Background()
-
 	m := VPX()
 
 	err := m.Create()
@@ -366,43 +351,45 @@ func TestQueryPerf(t *testing.T) {
 
 	defer m.Remove()
 
+	ctx := m.Service.Context
+
 	for _, maxSample := range []int32{4, 0} {
-		if err := testPerfQuery(ctx, m, Map.Any("VirtualMachine"), 20, maxSample); err != nil {
+		if err := testPerfQuery(ctx, m, ctx.Map.Any("VirtualMachine"), 20, maxSample); err != nil {
 			t.Fatal(err)
 		}
-		if err := testPerfQuery(ctx, m, Map.Any("HostSystem"), 20, maxSample); err != nil {
+		if err := testPerfQuery(ctx, m, ctx.Map.Any("HostSystem"), 20, maxSample); err != nil {
 			t.Fatal(err)
 		}
-		if err := testPerfQuery(ctx, m, Map.Any("ClusterComputeResource"), 300, maxSample); err != nil {
+		if err := testPerfQuery(ctx, m, ctx.Map.Any("ClusterComputeResource"), 300, maxSample); err != nil {
 			t.Fatal(err)
 		}
-		if err := testPerfQuery(ctx, m, Map.Any("Datastore"), 300, maxSample); err != nil {
+		if err := testPerfQuery(ctx, m, ctx.Map.Any("Datastore"), 300, maxSample); err != nil {
 			t.Fatal(err)
 		}
-		if err := testPerfQuery(ctx, m, Map.Any("Datacenter"), 300, maxSample); err != nil {
+		if err := testPerfQuery(ctx, m, ctx.Map.Any("Datacenter"), 300, maxSample); err != nil {
 			t.Fatal(err)
 		}
-		if err := testPerfQuery(ctx, m, Map.Any("ResourcePool"), 300, maxSample); err != nil {
+		if err := testPerfQuery(ctx, m, ctx.Map.Any("ResourcePool"), 300, maxSample); err != nil {
 			t.Fatal(err)
 		}
 
 		//csv format
-		if err := testPerfQueryCSV(ctx, m, Map.Any("VirtualMachine"), 20, maxSample); err != nil {
+		if err := testPerfQueryCSV(ctx, m, ctx.Map.Any("VirtualMachine"), 20, maxSample); err != nil {
 			t.Fatal(err)
 		}
-		if err := testPerfQueryCSV(ctx, m, Map.Any("HostSystem"), 20, maxSample); err != nil {
+		if err := testPerfQueryCSV(ctx, m, ctx.Map.Any("HostSystem"), 20, maxSample); err != nil {
 			t.Fatal(err)
 		}
-		if err := testPerfQueryCSV(ctx, m, Map.Any("ClusterComputeResource"), 300, maxSample); err != nil {
+		if err := testPerfQueryCSV(ctx, m, ctx.Map.Any("ClusterComputeResource"), 300, maxSample); err != nil {
 			t.Fatal(err)
 		}
-		if err := testPerfQueryCSV(ctx, m, Map.Any("Datastore"), 300, maxSample); err != nil {
+		if err := testPerfQueryCSV(ctx, m, ctx.Map.Any("Datastore"), 300, maxSample); err != nil {
 			t.Fatal(err)
 		}
-		if err := testPerfQueryCSV(ctx, m, Map.Any("Datacenter"), 300, maxSample); err != nil {
+		if err := testPerfQueryCSV(ctx, m, ctx.Map.Any("Datacenter"), 300, maxSample); err != nil {
 			t.Fatal(err)
 		}
-		if err := testPerfQueryCSV(ctx, m, Map.Any("ResourcePool"), 300, maxSample); err != nil {
+		if err := testPerfQueryCSV(ctx, m, ctx.Map.Any("ResourcePool"), 300, maxSample); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/simulator/portgroup.go
+++ b/simulator/portgroup.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -32,7 +20,7 @@ func (p *DistributedVirtualPortgroup) event(ctx *Context) types.DVPortgroupEvent
 
 	return types.DVPortgroupEvent{
 		Event: types.Event{
-			Datacenter: datacenterEventArgument(p),
+			Datacenter: datacenterEventArgument(ctx, p),
 			Net: &types.NetworkEventArgument{
 				EntityEventArgument: types.EntityEventArgument{
 					Name: p.Name,

--- a/simulator/portgroup_test.go
+++ b/simulator/portgroup_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -29,8 +17,6 @@ import (
 )
 
 func TestReconfigurePortgroup(t *testing.T) {
-	ctx := context.Background()
-
 	m := VPX()
 
 	err := m.Create()
@@ -40,10 +26,11 @@ func TestReconfigurePortgroup(t *testing.T) {
 
 	defer m.Remove()
 
-	c := m.Service.client
+	c := m.Service.client()
+	ctx := m.Service.Context
 
 	dvs := object.NewDistributedVirtualSwitch(c,
-		Map.Any("DistributedVirtualSwitch").Reference())
+		ctx.Map.Any("DistributedVirtualSwitch").Reference())
 
 	spec := []types.DVPortgroupConfigSpec{
 		{
@@ -63,7 +50,7 @@ func TestReconfigurePortgroup(t *testing.T) {
 	}
 
 	pg := object.NewDistributedVirtualPortgroup(c,
-		Map.Any("DistributedVirtualPortgroup").Reference())
+		ctx.Map.Any("DistributedVirtualPortgroup").Reference())
 	pgspec := types.DVPortgroupConfigSpec{
 		NumPorts: 5,
 		Name:     "pg1",
@@ -79,7 +66,7 @@ func TestReconfigurePortgroup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pge := Map.Get(pg.Reference()).(*DistributedVirtualPortgroup)
+	pge := ctx.Map.Get(pg.Reference()).(*DistributedVirtualPortgroup)
 	if pge.Config.Name != "pg1" || pge.Config.NumPorts != 5 {
 		t.Fatalf("expect pg.Name==pg1 && pg.Config.NumPort==5; got %s,%d",
 			pge.Config.Name, pge.Config.NumPorts)
@@ -108,9 +95,9 @@ func TestPortgroupBacking(t *testing.T) {
 
 	defer m.Remove()
 
-	c := m.Service.client
+	c := m.Service.client()
 
-	pg := Map.Any("DistributedVirtualPortgroup").(*DistributedVirtualPortgroup)
+	pg := m.Map().Any("DistributedVirtualPortgroup").(*DistributedVirtualPortgroup)
 
 	net := object.NewDistributedVirtualPortgroup(c, pg.Reference())
 	t.Logf("pg=%s", net.Reference())
@@ -134,8 +121,8 @@ func TestPortgroupBackingWithNSX(t *testing.T) {
 	model.Portgroup = 0
 	model.PortgroupNSX = 1
 
-	Test(func(context.Context, *vim25.Client) {
-		pgs := Map.All("DistributedVirtualPortgroup")
+	Test(func(ctx context.Context, _ *vim25.Client) {
+		pgs := Map(ctx).All("DistributedVirtualPortgroup")
 		n := len(pgs) - 1
 		if model.PortgroupNSX != n {
 			t.Errorf("%d pgs", n)

--- a/simulator/property_collector.go
+++ b/simulator/property_collector.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -755,7 +743,7 @@ func (pc *PropertyCollector) update(u types.ObjectUpdate) {
 	pc.mu.Unlock()
 }
 
-func (pc *PropertyCollector) PutObject(o mo.Reference) {
+func (pc *PropertyCollector) PutObject(_ *Context, o mo.Reference) {
 	pc.update(types.ObjectUpdate{
 		Obj:       o.Reference(),
 		Kind:      types.ObjectUpdateKindEnter,

--- a/simulator/property_filter.go
+++ b/simulator/property_filter.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -50,7 +38,7 @@ func (f *PropertyFilter) UpdateObject(ctx *Context, o mo.Reference, changes []ty
 	}
 }
 
-func (_ *PropertyFilter) PutObject(_ mo.Reference) {}
+func (_ *PropertyFilter) PutObject(_ *Context, _ mo.Reference) {}
 
 func (_ *PropertyFilter) RemoveObject(_ *Context, _ types.ManagedObjectReference) {}
 

--- a/simulator/registry_test.go
+++ b/simulator/registry_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -38,7 +26,7 @@ func TestRegistry(t *testing.T) {
 		t.Fail()
 	}
 
-	r.Remove(SpoofContext(), ref)
+	r.Remove(NewContext(), ref)
 
 	if r.Get(ref) != nil {
 		t.Fail()

--- a/simulator/resource_pool_test.go
+++ b/simulator/resource_pool_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -45,7 +33,7 @@ func TestResourcePool(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := m.Service.client
+	c := m.Service.client()
 
 	finder := find.NewFinder(c, false)
 	finder.SetDatacenter(object.NewDatacenter(c, esx.Datacenter.Reference()))
@@ -175,7 +163,7 @@ func TestCreateVAppESX(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := m.Service.client
+	c := m.Service.client()
 
 	parent := object.NewResourcePool(c, esx.ResourcePool.Self)
 
@@ -206,9 +194,9 @@ func TestCreateVAppVPX(t *testing.T) {
 
 	defer m.Remove()
 
-	c := m.Service.client
+	c := m.Service.client()
 
-	pool := Map.Any("ResourcePool")
+	pool := m.Map().Any("ResourcePool")
 	parent := object.NewResourcePool(c, pool.Reference())
 	rspec := types.DefaultResourceConfigSpec()
 	vspec := NewVAppConfigSpec()
@@ -260,7 +248,7 @@ func TestCreateVAppVPX(t *testing.T) {
 		t.Errorf("FindChild(%s)==nil", spec.Name)
 	}
 
-	ref := Map.Get(Map.getEntityDatacenter(pool).VmFolder).Reference()
+	ref := m.Map().Get(m.Map().getEntityDatacenter(pool).VmFolder).Reference()
 	folder, err := object.NewFolder(c, ref).CreateFolder(ctx, "myapp-clone")
 	if err != nil {
 		t.Fatal(err)

--- a/simulator/search_index_test.go
+++ b/simulator/search_index_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -59,7 +47,7 @@ func TestSearchIndex(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		vm := Map.Get(vms[0].Reference()).(*VirtualMachine)
+		vm := model.Map().Get(vms[0].Reference()).(*VirtualMachine)
 
 		si := object.NewSearchIndex(c.Client)
 
@@ -117,7 +105,7 @@ func TestSearchIndex(t *testing.T) {
 			t.Error("expected nil")
 		}
 
-		host := Map.Any("HostSystem").(*HostSystem)
+		host := model.Map().Any("HostSystem").(*HostSystem)
 
 		ref, err = si.FindByUuid(ctx, dc, host.Summary.Hardware.Uuid, false, nil)
 		if err != nil {

--- a/simulator/session_manager_test.go
+++ b/simulator/session_manager_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -226,7 +214,7 @@ func TestSessionManagerAuth(t *testing.T) {
 func TestSessionManagerLoginExtension(t *testing.T) {
 	ctx := context.Background()
 
-	s := New(NewServiceInstance(SpoofContext(), vpx.ServiceContent, vpx.RootFolder))
+	s := New(NewServiceInstance(NewContext(), vpx.ServiceContent, vpx.RootFolder))
 	s.TLS = new(tls.Config)
 	ts := s.NewServer()
 	defer ts.Close()

--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -33,8 +21,8 @@ type VirtualMachineSnapshot struct {
 	DataSets map[string]*DataSet
 }
 
-func (v *VirtualMachineSnapshot) createSnapshotFiles() types.BaseMethodFault {
-	vm := Map.Get(v.Vm).(*VirtualMachine)
+func (v *VirtualMachineSnapshot) createSnapshotFiles(ctx *Context) types.BaseMethodFault {
+	vm := ctx.Map.Get(v.Vm).(*VirtualMachine)
 
 	snapshotDirectory := vm.Config.Files.SnapshotDirectory
 	if snapshotDirectory == "" {
@@ -44,7 +32,7 @@ func (v *VirtualMachineSnapshot) createSnapshotFiles() types.BaseMethodFault {
 	index := 1
 	for {
 		fileName := fmt.Sprintf("%s-Snapshot%d.vmsn", vm.Name, index)
-		f, err := vm.createFile(snapshotDirectory, fileName, false)
+		f, err := vm.createFile(ctx, snapshotDirectory, fileName, false)
 		if err != nil {
 			switch err.(type) {
 			case *types.FileAlreadyExists:
@@ -58,15 +46,15 @@ func (v *VirtualMachineSnapshot) createSnapshotFiles() types.BaseMethodFault {
 		_ = f.Close()
 
 		p, _ := parseDatastorePath(snapshotDirectory)
-		vm.useDatastore(p.Datastore)
+		vm.useDatastore(ctx, p.Datastore)
 		datastorePath := object.DatastorePath{
 			Datastore: p.Datastore,
 			Path:      path.Join(p.Path, fileName),
 		}
 
-		dataLayoutKey := vm.addFileLayoutEx(datastorePath, 0)
-		vm.addSnapshotLayout(v.Self, dataLayoutKey)
-		vm.addSnapshotLayoutEx(v.Self, dataLayoutKey, -1)
+		dataLayoutKey := vm.addFileLayoutEx(ctx, datastorePath, 0)
+		vm.addSnapshotLayout(ctx, v.Self, dataLayoutKey)
+		vm.addSnapshotLayoutEx(ctx, v.Self, dataLayoutKey, -1)
 
 		return nil
 	}

--- a/simulator/storage_resource_manager.go
+++ b/simulator/storage_resource_manager.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -33,7 +21,7 @@ type StorageResourceManager struct {
 
 func (m *StorageResourceManager) ConfigureStorageDrsForPodTask(ctx *Context, req *types.ConfigureStorageDrsForPod_Task) soap.HasFault {
 	task := CreateTask(m, "configureStorageDrsForPod", func(*Task) (types.AnyType, types.BaseMethodFault) {
-		cluster := Map.Get(req.Pod).(*StoragePod)
+		cluster := ctx.Map.Get(req.Pod).(*StoragePod)
 
 		if s := req.Spec.PodConfigSpec; s != nil {
 			config := &cluster.PodStorageDrsEntry.StorageDrsConfig.PodConfig
@@ -56,11 +44,11 @@ func (m *StorageResourceManager) ConfigureStorageDrsForPodTask(ctx *Context, req
 	}
 }
 
-func (m *StorageResourceManager) pod(ref *types.ManagedObjectReference) *StoragePod {
+func (m *StorageResourceManager) pod(ctx *Context, ref *types.ManagedObjectReference) *StoragePod {
 	if ref == nil {
 		return nil
 	}
-	cluster := Map.Get(*ref).(*StoragePod)
+	cluster := ctx.Map.Get(*ref).(*StoragePod)
 	config := &cluster.PodStorageDrsEntry.StorageDrsConfig.PodConfig
 
 	if !config.Enabled {
@@ -74,7 +62,7 @@ func (m *StorageResourceManager) pod(ref *types.ManagedObjectReference) *Storage
 	return cluster
 }
 
-func (m *StorageResourceManager) RecommendDatastores(req *types.RecommendDatastores) soap.HasFault {
+func (m *StorageResourceManager) RecommendDatastores(ctx *Context, req *types.RecommendDatastores) soap.HasFault {
 	spec := req.StorageSpec.PodSelectionSpec
 	body := new(methods.RecommendDatastoresBody)
 	res := new(types.RecommendDatastoresResponse)
@@ -141,7 +129,7 @@ func (m *StorageResourceManager) RecommendDatastores(req *types.RecommendDatasto
 		for _, d := range req.StorageSpec.ConfigSpec.DeviceChange {
 			devices = append(devices, d.GetVirtualDeviceConfigSpec().Device)
 		}
-		cluster := m.pod(spec.StoragePod)
+		cluster := m.pod(ctx, spec.StoragePod)
 		if cluster == nil {
 			if f := req.StorageSpec.ConfigSpec.Files; f == nil || f.VmPathName == "" {
 				return invalid("configSpec.files")
@@ -163,7 +151,7 @@ func (m *StorageResourceManager) RecommendDatastores(req *types.RecommendDatasto
 	}
 
 	for _, placement := range spec.InitialVmConfig {
-		cluster := m.pod(&placement.StoragePod)
+		cluster := m.pod(ctx, &placement.StoragePod)
 		if cluster == nil {
 			return invalid("podSelectionSpec.storagePod")
 		}

--- a/simulator/task_manager.go
+++ b/simulator/task_manager.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -66,13 +54,11 @@ func recentTask(recent []types.ManagedObjectReference, ref types.ManagedObjectRe
 	return []types.PropertyChange{{Name: "recentTask", Val: recent}}
 }
 
-func (m *TaskManager) PutObject(obj mo.Reference) {
+func (m *TaskManager) PutObject(ctx *Context, obj mo.Reference) {
 	task, ok := obj.(*Task)
 	if !ok {
 		return
 	}
-
-	ctx := SpoofContext()
 
 	// propagate new Tasks to:
 	// - TaskManager.RecentTask

--- a/simulator/task_manager_test.go
+++ b/simulator/task_manager_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator_test
 
@@ -31,7 +19,7 @@ import (
 
 func TestTaskManagerRecent(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		ref := simulator.Map.Any("VirtualMachine").Reference()
+		ref := simulator.Map(ctx).Any("VirtualMachine").Reference()
 		vm := object.NewVirtualMachine(c, ref)
 
 		tasks := func() int {
@@ -148,7 +136,7 @@ func TestTaskManagerRead(t *testing.T) {
 			t.Errorf("expected 0 tasks, got %d", len(tasks))
 		}
 
-		ref := simulator.Map.Any("VirtualMachine").Reference()
+		ref := simulator.Map(ctx).Any("VirtualMachine").Reference()
 		vm := object.NewVirtualMachine(vc, ref)
 		if _, err = vm.PowerOff(ctx); err != nil {
 			t.Fatal(err)

--- a/simulator/task_test.go
+++ b/simulator/task_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -34,8 +22,9 @@ func (a *addWaterTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 }
 
 func TestNewTask(t *testing.T) {
+	ctx := NewContext()
 	f := &mo.Folder{}
-	Map.NewEntity(f)
+	ctx.Map.NewEntity(f)
 
 	add := &addWaterTask{f, nil}
 	task := NewTask(add)
@@ -49,7 +38,7 @@ func TestNewTask(t *testing.T) {
 		t.Errorf("descriptionId=%s", info.DescriptionId)
 	}
 
-	task.RunBlocking(SpoofContext())
+	task.RunBlocking(ctx)
 
 	if info.State != types.TaskInfoStateSuccess {
 		t.Fail()
@@ -57,10 +46,18 @@ func TestNewTask(t *testing.T) {
 
 	add.fault = &types.ManagedObjectNotFound{}
 
-	task.Run(SpoofContext())
+	task.Run(ctx)
 	task.Wait()
 
 	if info.State != types.TaskInfoStateError {
 		t.Fail()
+	}
+
+	if info.Key == "" {
+		t.Error("empty info.key")
+	}
+
+	if info.Task.Type == "" {
+		t.Error("empty info.task.type")
 	}
 }

--- a/simulator/user_directory_test.go
+++ b/simulator/user_directory_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -27,7 +15,7 @@ import (
 )
 
 func TestUserDirectory(t *testing.T) {
-	s := New(NewServiceInstance(SpoofContext(), esx.ServiceContent, esx.RootFolder))
+	s := New(NewServiceInstance(NewContext(), esx.ServiceContent, esx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()
@@ -92,7 +80,7 @@ func TestUserDirectory(t *testing.T) {
 }
 
 func TestUserDirectoryExactlyMatch(t *testing.T) {
-	s := New(NewServiceInstance(SpoofContext(), esx.ServiceContent, esx.RootFolder))
+	s := New(NewServiceInstance(NewContext(), esx.ServiceContent, esx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()

--- a/simulator/view_manager_test.go
+++ b/simulator/view_manager_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -78,7 +66,7 @@ func TestContainerViewVPX(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
-	vapp := object.NewVirtualApp(c.Client, Map.Any("VirtualApp").Reference())
+	vapp := object.NewVirtualApp(c.Client, m.Map().Any("VirtualApp").Reference())
 
 	count := m.Count()
 

--- a/simulator/virtual_machine_fault_test.go
+++ b/simulator/virtual_machine_fault_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2020 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator_test
 
@@ -40,8 +28,8 @@ func TestSwitchMembers(t *testing.T) {
 		// The proper way to remove a host from is with dvs.Reconfigure + types.ConfigSpecOperationRemove,
 		// but that would fail here with ResourceInUse. And creating a new DVS + PG is cumbersome,
 		// so just force the removal of host from the DVS + PG, which has the same effect on vm.AddDevice().
-		dswitch := simulator.Map.Get(dvs.Reference()).(*simulator.DistributedVirtualSwitch)
-		portgrp := simulator.Map.Get(pg.Reference()).(*simulator.DistributedVirtualPortgroup)
+		dswitch := simulator.Map(ctx).Get(dvs.Reference()).(*simulator.DistributedVirtualSwitch)
+		portgrp := simulator.Map(ctx).Get(pg.Reference()).(*simulator.DistributedVirtualPortgroup)
 		simulator.RemoveReference(&dswitch.Summary.HostMember, host.Reference())
 		simulator.RemoveReference(&portgrp.Host, host.Reference())
 

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -388,7 +376,7 @@ func TestCloneVm(t *testing.T) {
 
 				vmFolder := folders.VmFolder
 
-				vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+				vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
 				vm := object.NewVirtualMachine(c, vmm.Reference())
 
 				task, err := vm.Clone(ctx, vmFolder, test.vmName, test.config)
@@ -556,7 +544,7 @@ func TestConnectVmDevice(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
 	vm := object.NewVirtualMachine(c.Client, vmm.Reference())
 
 	l := object.VirtualDeviceList{} // used only for Connect/Disconnect function
@@ -654,7 +642,7 @@ func TestVAppConfigAdd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
 	vm := object.NewVirtualMachine(c.Client, vmm.Reference())
 
 	tests := []struct {
@@ -770,7 +758,7 @@ func TestVAppConfigEdit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
 	vm := object.NewVirtualMachine(c.Client, vmm.Reference())
 
 	tests := []struct {
@@ -886,7 +874,7 @@ func TestVAppConfigRemove(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
 	vm := object.NewVirtualMachine(c.Client, vmm.Reference())
 
 	tests := []struct {
@@ -991,7 +979,7 @@ func TestReconfigVm(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
 	vm := object.NewVirtualMachine(c.Client, vmm.Reference())
 
 	tests := []struct {
@@ -1190,7 +1178,7 @@ func TestCreateVmWithDevices(t *testing.T) {
 	s := m.Service.NewServer()
 	defer s.Close()
 
-	c := m.Service.client
+	c := m.Service.client()
 
 	folder := object.NewFolder(c, esx.Datacenter.VmFolder)
 	pool := object.NewResourcePool(c, esx.ResourcePool.Self)
@@ -1238,7 +1226,7 @@ func TestCreateVmWithDevices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vm := Map.Get(info.Result.(types.ManagedObjectReference)).(*VirtualMachine)
+	vm := m.Map().Get(info.Result.(types.ManagedObjectReference)).(*VirtualMachine)
 
 	expect := len(esx.VirtualDevice) + len(devices)
 	ndevice := len(vm.Config.Hardware.Device)
@@ -1331,10 +1319,10 @@ func TestAddedDiskCapacity(t *testing.T) {
 			m := ESX()
 
 			Test(func(ctx context.Context, c *vim25.Client) {
-				vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+				vmm := Map(ctx).Any("VirtualMachine").(*VirtualMachine)
 				vm := object.NewVirtualMachine(c, vmm.Reference())
 
-				ds := Map.Any("Datastore").(*Datastore)
+				ds := Map(ctx).Any("Datastore").(*Datastore)
 
 				devices, err := vm.Device(ctx)
 				if err != nil {
@@ -1445,9 +1433,9 @@ func TestEditedDiskCapacity(t *testing.T) {
 			m := ESX()
 
 			Test(func(ctx context.Context, c *vim25.Client) {
-				vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+				vmm := Map(ctx).Any("VirtualMachine").(*VirtualMachine)
 				vm := object.NewVirtualMachine(c, vmm.Reference())
-				ds := Map.Any("Datastore").(*Datastore)
+				ds := Map(ctx).Any("Datastore").(*Datastore)
 
 				// create a new 10GB disk
 				devices, err := vm.Device(ctx)
@@ -1595,10 +1583,10 @@ func TestReconfigureDevicesDatastoreFreespace(t *testing.T) {
 			m := ESX()
 
 			Test(func(ctx context.Context, c *vim25.Client) {
-				vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+				vmm := Map(ctx).Any("VirtualMachine").(*VirtualMachine)
 				vm := object.NewVirtualMachine(c, vmm.Reference())
 
-				ds := Map.Any("Datastore").(*Datastore)
+				ds := Map(ctx).Any("Datastore").(*Datastore)
 				freespaceBefore := ds.Datastore.Summary.FreeSpace
 
 				devices, err := vm.Device(ctx)
@@ -1624,7 +1612,7 @@ func TestReconfigureDevicesDatastoreFreespace(t *testing.T) {
 
 func TestShutdownGuest(t *testing.T) {
 	Test(func(ctx context.Context, c *vim25.Client) {
-		vm := object.NewVirtualMachine(c, Map.Any("VirtualMachine").Reference())
+		vm := object.NewVirtualMachine(c, Map(ctx).Any("VirtualMachine").Reference())
 
 		for _, timeout := range []bool{false, true} {
 			if timeout {
@@ -1711,7 +1699,7 @@ func TestVmSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	simVm := Map.Any("VirtualMachine")
+	simVm := m.Map().Any("VirtualMachine")
 	vm := object.NewVirtualMachine(c.Client, simVm.Reference())
 
 	_, err = fieldValue(reflect.ValueOf(simVm), "snapshot")
@@ -1850,7 +1838,7 @@ func TestVmMarkAsTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vm := object.NewVirtualMachine(c.Client, Map.Any("VirtualMachine").Reference())
+	vm := object.NewVirtualMachine(c.Client, m.Map().Any("VirtualMachine").Reference())
 
 	err = vm.MarkAsTemplate(ctx)
 	if err == nil {
@@ -1893,7 +1881,7 @@ func TestVmRefreshStorageInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vmm := Map.Any("VirtualMachine").(*VirtualMachine)
+	vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
 	vm := object.NewVirtualMachine(c.Client, vmm.Reference())
 
 	// take snapshot
@@ -1976,8 +1964,8 @@ func TestVmRefreshStorageInfo(t *testing.T) {
 	}
 
 	findDsStorage := func(dsName string) *types.VirtualMachineUsageOnDatastore {
-		host := Map.Get(*vmm.Runtime.Host).(*HostSystem)
-		ds := Map.FindByName(dsName, host.Datastore).(*Datastore)
+		host := m.Map().Get(*vmm.Runtime.Host).(*HostSystem)
+		ds := m.Map().FindByName(dsName, host.Datastore).(*Datastore)
 
 		for _, dsUsage := range vmm.Storage.PerDatastoreUsage {
 			if dsUsage.Datastore == ds.Self {
@@ -2090,7 +2078,7 @@ func TestVmRefreshStorageInfo(t *testing.T) {
 		t.Fatalf("could not parse datastore path: %s", vmm.Config.Files.LogDirectory)
 	}
 
-	f, fault := vmm.createFile(p.String(), "test.log", false)
+	f, fault := vmm.createFile(m.Service.Context, p.String(), "test.log", false)
 	if fault != nil {
 		t.Fatal("could not create log file")
 	}
@@ -2182,7 +2170,7 @@ func TestApplyExtraConfig(t *testing.T) {
 	}
 
 	Test(func(ctx context.Context, c *vim25.Client) {
-		vm := object.NewVirtualMachine(c, Map.Any("VirtualMachine").Reference())
+		vm := object.NewVirtualMachine(c, Map(ctx).Any("VirtualMachine").Reference())
 		applyAndAssertExtraConfigValue(ctx, vm, "world", false)
 		applyAndAssertExtraConfigValue(ctx, vm, "there", false)
 		applyAndAssertExtraConfigValue(ctx, vm, "", true)
@@ -2191,7 +2179,7 @@ func TestApplyExtraConfig(t *testing.T) {
 
 func TestLastModifiedAndChangeVersionAreUpdated(t *testing.T) {
 	Test(func(ctx context.Context, c *vim25.Client) {
-		vm := object.NewVirtualMachine(c, Map.Any("VirtualMachine").Reference())
+		vm := object.NewVirtualMachine(c, Map(ctx).Any("VirtualMachine").Reference())
 		var vmMo mo.VirtualMachine
 		if err := vm.Properties(
 			ctx,
@@ -2262,11 +2250,12 @@ func TestUpgradeVm(t *testing.T) {
 	model.Host = 1
 
 	Test(func(ctx context.Context, c *vim25.Client) {
+		sctx := ctx.(*Context)
 		props := []string{"config.version", "summary.config.hwVersion"}
 
-		vm := object.NewVirtualMachine(c, Map.Any("VirtualMachine").Reference())
-		vm2 := Map.Get(vm.Reference()).(*VirtualMachine)
-		Map.WithLock(SpoofContext(), vm2.Reference(), func() {
+		vm := object.NewVirtualMachine(c, sctx.Map.Any("VirtualMachine").Reference())
+		vm2 := sctx.Map.Get(vm.Reference()).(*VirtualMachine)
+		sctx.WithLock(vm2.Reference(), func() {
 			vm2.Config.Version = vmx15
 		})
 
@@ -2274,31 +2263,31 @@ func TestUpgradeVm(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get vm's host: %v", err)
 		}
-		host2 := Map.Get(host.Reference()).(*HostSystem)
+		host2 := sctx.Map.Get(host.Reference()).(*HostSystem)
 
 		var eb *EnvironmentBrowser
 		{
-			ref := Map.Get(host.Reference()).(*HostSystem).Parent
+			ref := sctx.Map.Get(host.Reference()).(*HostSystem).Parent
 			switch ref.Type {
 			case "ClusterComputeResource":
-				obj := Map.Get(*ref).(*ClusterComputeResource)
-				eb = Map.Get(*obj.EnvironmentBrowser).(*EnvironmentBrowser)
+				obj := sctx.Map.Get(*ref).(*ClusterComputeResource)
+				eb = sctx.Map.Get(*obj.EnvironmentBrowser).(*EnvironmentBrowser)
 			case "ComputeResource":
-				obj := Map.Get(*ref).(*mo.ComputeResource)
-				eb = Map.Get(*obj.EnvironmentBrowser).(*EnvironmentBrowser)
+				obj := sctx.Map.Get(*ref).(*mo.ComputeResource)
+				eb = sctx.Map.Get(*obj.EnvironmentBrowser).(*EnvironmentBrowser)
 			}
 		}
 
 		baseline := func() {
-			Map.WithLock(SpoofContext(), vm2.Reference(), func() {
+			sctx.WithLock(vm2.Reference(), func() {
 				vm2.Config.Version = vmx15
 				vm2.Config.Template = false
 				vm2.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOff
 			})
-			Map.WithLock(SpoofContext(), host2.Reference(), func() {
+			sctx.WithLock(host2.Reference(), func() {
 				host2.Runtime.InMaintenanceMode = false
 			})
-			Map.WithLock(SpoofContext(), eb.Reference(), func() {
+			sctx.WithLock(eb.Reference(), func() {
 				for i := range eb.QueryConfigOptionDescriptorResponse.Returnval {
 					cod := &eb.QueryConfigOptionDescriptorResponse.Returnval[i]
 					hostFound := false
@@ -2317,7 +2306,7 @@ func TestUpgradeVm(t *testing.T) {
 
 		t.Run("InvalidPowerState", func(t *testing.T) {
 			baseline()
-			Map.WithLock(SpoofContext(), vm2.Reference(), func() {
+			sctx.WithLock(vm2.Reference(), func() {
 				vm2.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOn
 			})
 
@@ -2346,7 +2335,7 @@ func TestUpgradeVm(t *testing.T) {
 		t.Run("InvalidState", func(t *testing.T) {
 			t.Run("MaintenanceMode", func(t *testing.T) {
 				baseline()
-				Map.WithLock(SpoofContext(), host2.Reference(), func() {
+				sctx.WithLock(host2.Reference(), func() {
 					host2.Runtime.InMaintenanceMode = true
 				})
 
@@ -2369,7 +2358,7 @@ func TestUpgradeVm(t *testing.T) {
 
 			t.Run("Template", func(t *testing.T) {
 				baseline()
-				Map.WithLock(SpoofContext(), vm2.Reference(), func() {
+				sctx.WithLock(vm2.Reference(), func() {
 					vm2.Config.Template = true
 				})
 
@@ -2392,7 +2381,7 @@ func TestUpgradeVm(t *testing.T) {
 
 			t.Run("LatestHardwareVersion", func(t *testing.T) {
 				baseline()
-				Map.WithLock(SpoofContext(), vm.Reference(), func() {
+				sctx.WithLock(vm.Reference(), func() {
 					vm2.Config.Version = vmx21
 				})
 
@@ -2436,7 +2425,7 @@ func TestUpgradeVm(t *testing.T) {
 			})
 			t.Run("OnVmHost", func(t *testing.T) {
 				baseline()
-				Map.WithLock(SpoofContext(), eb.Reference(), func() {
+				sctx.WithLock(eb.Reference(), func() {
 					for i := range eb.QueryConfigOptionDescriptorResponse.Returnval {
 						cod := &eb.QueryConfigOptionDescriptorResponse.Returnval[i]
 						if cod.Key == vmx17 {
@@ -2481,7 +2470,7 @@ func TestUpgradeVm(t *testing.T) {
 
 			t.Run("GreaterThanTargetVersion", func(t *testing.T) {
 				baseline()
-				Map.WithLock(SpoofContext(), vm2.Reference(), func() {
+				sctx.WithLock(vm2.Reference(), func() {
 					vm2.Config.Version = vmx20
 				})
 				if tsk, err := vm.UpgradeVM(ctx, vmx17); err != nil {
@@ -2500,10 +2489,10 @@ func TestUpgradeVm(t *testing.T) {
 
 		t.Run("InvalidArgument", func(t *testing.T) {
 			baseline()
-			Map.WithLock(SpoofContext(), vm2.Reference(), func() {
+			sctx.WithLock(vm2.Reference(), func() {
 				vm2.Config.Version = vmx1
 			})
-			Map.WithLock(SpoofContext(), eb.Reference(), func() {
+			sctx.WithLock(eb.Reference(), func() {
 				eb.QueryConfigOptionDescriptorResponse.Returnval = append(
 					eb.QueryConfigOptionDescriptorResponse.Returnval,
 					types.VirtualMachineConfigOptionDescriptor{
@@ -2579,7 +2568,7 @@ func TestUpgradeVm(t *testing.T) {
 		t.Run("UpgradeFrom17To20", func(t *testing.T) {
 			const targetVersion = vmx20
 			baseline()
-			Map.WithLock(SpoofContext(), vm2.Reference(), func() {
+			sctx.WithLock(vm2.Reference(), func() {
 				vm2.Config.Version = vmx17
 			})
 
@@ -2714,7 +2703,7 @@ func TestEncryptDecryptVM(t *testing.T) {
 			},
 			isGeneratedKey: true,
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, ctx.Map.CryptoManager(), func() {
+				ctx.WithLock(ctx.Map.CryptoManager(), func() {
 					m := ctx.Map.CryptoManager()
 					m.KmipServers = append(m.KmipServers, types.KmipClusterInfo{
 						ClusterId: types.KeyProviderId{
@@ -2739,7 +2728,7 @@ func TestEncryptDecryptVM(t *testing.T) {
 			},
 			isGeneratedKey: true,
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, ctx.Map.CryptoManager(), func() {
+				ctx.WithLock(ctx.Map.CryptoManager(), func() {
 					m := ctx.Map.CryptoManager()
 					m.KmipServers = append(m.KmipServers, types.KmipClusterInfo{
 						ClusterId: types.KeyProviderId{
@@ -2753,8 +2742,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "encrypt w already encrypted",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -2824,8 +2813,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "decrypt",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -2849,8 +2838,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "decrypt w powered on",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -2874,8 +2863,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "decrypt w snapshots",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -2897,8 +2886,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "deep recrypt",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -2931,15 +2920,15 @@ func TestEncryptDecryptVM(t *testing.T) {
 			},
 			isGeneratedKey: true,
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
 						},
 					}
 				})
-				Map.WithLock(ctx, ctx.Map.CryptoManager(), func() {
+				ctx.WithLock(ctx.Map.CryptoManager(), func() {
 					m := ctx.Map.CryptoManager()
 					m.KmipServers = append(m.KmipServers, types.KmipClusterInfo{
 						ClusterId: types.KeyProviderId{
@@ -2964,15 +2953,15 @@ func TestEncryptDecryptVM(t *testing.T) {
 			},
 			isGeneratedKey: true,
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "key",
 						ProviderId: &types.KeyProviderId{
 							Id: "key-provider",
 						},
 					}
 				})
-				Map.WithLock(ctx, ctx.Map.CryptoManager(), func() {
+				ctx.WithLock(ctx.Map.CryptoManager(), func() {
 					m := ctx.Map.CryptoManager()
 					m.KmipServers = append(m.KmipServers, types.KmipClusterInfo{
 						ClusterId: types.KeyProviderId{
@@ -2986,8 +2975,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "deep recrypt w same provider id",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -3030,8 +3019,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "deep recrypt w powered on",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -3062,8 +3051,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "deep recrypt w snapshots",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -3092,8 +3081,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "shallow recrypt",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -3126,15 +3115,15 @@ func TestEncryptDecryptVM(t *testing.T) {
 			},
 			isGeneratedKey: true,
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
 						},
 					}
 				})
-				Map.WithLock(ctx, ctx.Map.CryptoManager(), func() {
+				ctx.WithLock(ctx.Map.CryptoManager(), func() {
 					m := ctx.Map.CryptoManager()
 					m.KmipServers = append(m.KmipServers, types.KmipClusterInfo{
 						ClusterId: types.KeyProviderId{
@@ -3159,15 +3148,15 @@ func TestEncryptDecryptVM(t *testing.T) {
 			},
 			isGeneratedKey: true,
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "key",
 						ProviderId: &types.KeyProviderId{
 							Id: "key-provider",
 						},
 					}
 				})
-				Map.WithLock(ctx, ctx.Map.CryptoManager(), func() {
+				ctx.WithLock(ctx.Map.CryptoManager(), func() {
 					m := ctx.Map.CryptoManager()
 					m.KmipServers = append(m.KmipServers, types.KmipClusterInfo{
 						ClusterId: types.KeyProviderId{
@@ -3181,8 +3170,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "shallow recrypt w same provider id",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -3225,8 +3214,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "shallow recrypt w single snapshot chain",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -3260,8 +3249,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "shallow recrypt w snapshot tree",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -3318,8 +3307,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "noop",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -3341,8 +3330,8 @@ func TestEncryptDecryptVM(t *testing.T) {
 		{
 			name: "register",
 			initStateFn: func(ctx *Context, c *vim25.Client, vmRef types.ManagedObjectReference) error {
-				Map.WithLock(ctx, vmRef, func() {
-					Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
+				ctx.WithLock(vmRef, func() {
+					ctx.Map.Get(vmRef).(*VirtualMachine).Config.KeyId = &types.CryptoKeyId{
 						KeyId: "123",
 						ProviderId: &types.KeyProviderId{
 							Id: "abc",
@@ -3381,11 +3370,12 @@ func TestEncryptDecryptVM(t *testing.T) {
 			model.Host = 1
 
 			Test(func(ctx context.Context, c *vim25.Client) {
-				ref := Map.Any("VirtualMachine").Reference()
+				sctx := ctx.(*Context)
+				ref := sctx.Map.Any("VirtualMachine").Reference()
 				vm := object.NewVirtualMachine(c, ref)
 
 				if tc.initStateFn != nil {
-					if err := tc.initStateFn(SpoofContext(), c, ref); err != nil {
+					if err := tc.initStateFn(sctx, c, ref); err != nil {
 						t.Fatalf("initStateFn failed: %v", err)
 					}
 				}

--- a/simulator/vm_compatibility_checker.go
+++ b/simulator/vm_compatibility_checker.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -43,7 +31,7 @@ func resolveHostsAndPool(ctx *Context, vm, host, pool *types.ManagedObjectRefere
 		poolMo = ctx.Map.Get(*vmMo.ResourcePool).(*ResourcePool)
 	case host != nil:
 		h := ctx.Map.Get(*host).(*HostSystem)
-		parent := hostParent(&h.HostSystem).ResourcePool
+		parent := hostParent(ctx, &h.HostSystem).ResourcePool
 		poolMo = ctx.Map.Get(*parent).(*ResourcePool)
 	}
 

--- a/ssoadmin/client_test.go
+++ b/ssoadmin/client_test.go
@@ -38,7 +38,7 @@ func TestClient(t *testing.T) {
 			os.Setenv("GOVMOMI_ENVOY_SIDECAR_PORT", client.Client.URL().Port())
 			os.Setenv("GOVMOMI_ENVOY_SIDECAR_HOST", client.Client.URL().Hostname())
 
-			lsim.BreakLookupServiceURLs()
+			lsim.BreakLookupServiceURLs(ctx)
 
 			c, err := ssoadmin.NewClient(ctx, client)
 			require.NoError(t, err)

--- a/sts/client_test.go
+++ b/sts/client_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package sts_test
 
@@ -401,7 +389,7 @@ func TestNewClient(t *testing.T) {
 
 		model.Create()
 		simulator.Test(func(ctx context.Context, client *vim25.Client) {
-			lsim.BreakLookupServiceURLs()
+			lsim.BreakLookupServiceURLs(ctx)
 			// Map Envoy sidecar on the same port as the vcsim client.
 			os.Setenv("GOVMOMI_ENVOY_SIDECAR_PORT", client.Client.URL().Port())
 			os.Setenv("GOVMOMI_ENVOY_SIDECAR_HOST", client.Client.URL().Hostname())

--- a/vapi/cluster/cluster_test.go
+++ b/vapi/cluster/cluster_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2020 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package cluster_test
 
@@ -54,7 +42,7 @@ func TestClusterModules(t *testing.T) {
 			t.Errorf("expected 0 modules")
 		}
 
-		ccr := simulator.Map.Any("ClusterComputeResource")
+		ccr := simulator.Map(ctx).Any("ClusterComputeResource")
 
 		_, err = m.CreateModule(ctx, enoent)
 		if err == nil {
@@ -112,7 +100,7 @@ func TestClusterModuleMembers(t *testing.T) {
 			t.Error("expected error")
 		}
 
-		ccr := simulator.Map.Any("ClusterComputeResource")
+		ccr := simulator.Map(ctx).Any("ClusterComputeResource")
 
 		id, err := m.CreateModule(ctx, ccr)
 		if err != nil {

--- a/vapi/cluster/simulator/simulator.go
+++ b/vapi/cluster/simulator/simulator.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2020 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -36,7 +24,7 @@ import (
 
 func init() {
 	simulator.RegisterEndpoint(func(s *simulator.Service, r *simulator.Registry) {
-		New(s.Listen).Register(s, r)
+		New(r, s.Listen).Register(s, r)
 	})
 }
 
@@ -47,13 +35,15 @@ type module struct {
 
 // Handler implements the Cluster Modules API simulator
 type Handler struct {
+	Map     *simulator.Registry
 	Modules map[string]module
 	URL     *url.URL
 }
 
 // New creates a Handler instance
-func New(u *url.URL) *Handler {
+func New(r *simulator.Registry, u *url.URL) *Handler {
 	return &Handler{
+		Map:     r,
 		Modules: make(map[string]module),
 		URL:     u,
 	}
@@ -80,7 +70,7 @@ func (h *Handler) modules(w http.ResponseWriter, r *http.Request) {
 		var m internal.CreateModule
 		if vapi.Decode(r, w, &m) {
 			ref := types.ManagedObjectReference{Type: "ClusterComputeResource", Value: m.Spec.ID}
-			if simulator.Map.Get(ref) == nil {
+			if h.Map.Get(ref) == nil {
 				vapi.BadRequest(w, "com.vmware.vapi.std.errors.invalid_argument")
 				return
 			}

--- a/vapi/crypto/simulator/simulator.go
+++ b/vapi/crypto/simulator/simulator.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -172,7 +160,8 @@ func (h *Handler) providersID(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		m := h.Map.CryptoManager()
-		_ = m.UnregisterKmsCluster(simulator.SpoofContext(), &types.UnregisterKmsCluster{
+		ctx := &simulator.Context{Map: h.Map}
+		_ = m.UnregisterKmsCluster(ctx, &types.UnregisterKmsCluster{
 			This:      m.Self,
 			ClusterId: types.KeyProviderId{Id: id},
 		})

--- a/vapi/library/finder/path_test.go
+++ b/vapi/library/finder/path_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package finder_test
 
@@ -152,11 +140,12 @@ func TestResolveLibraryItemStorage(t *testing.T) {
 					fsType = string(types.HostFileSystemVolumeFileSystemTypeVsan)
 				}
 
-				simulator.Map.WithLock(
-					simulator.SpoofContext(),
+				sctx := ctx.(*simulator.Context)
+				sctx.Map.WithLock(
+					sctx,
 					ds.Reference(),
 					func() {
-						ds := simulator.Map.Get(ds.Reference()).(*simulator.Datastore)
+						ds := sctx.Map.Get(ds.Reference()).(*simulator.Datastore)
 						ds.Summary.Type = fsType
 						ds.Capability.TopLevelDirectoryCreateSupported = tc.topLevelDirectoryCreateSupported
 					})

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -193,7 +193,7 @@ func main() {
 			Registry *simulator.Registry `json:"registry"`
 			Model    *simulator.Model    `json:"model"`
 		}{
-			simulator.Map,
+			model.Service.Context.Map,
 			&count,
 		}
 	}))

--- a/vmdk/disk_info_test.go
+++ b/vmdk/disk_info_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package vmdk_test
 
@@ -417,10 +405,9 @@ func TestGetVirtualDiskInfoByUUID(t *testing.T) {
 
 	t.Run("fetch properties", func(t *testing.T) {
 		simulator.Test(func(ctx context.Context, c *vim25.Client) {
-
 			pc := &propertyCollectorWithFault{}
 			pc.Self = c.ServiceContent.PropertyCollector
-			simulator.Map.Put(pc)
+			simulator.Map(ctx).Put(pc)
 
 			finder := find.NewFinder(c, true)
 			datacenter, err := finder.DefaultDatacenter(ctx)

--- a/vslm/simulator/simulator.go
+++ b/vslm/simulator/simulator.go
@@ -336,7 +336,7 @@ func (m *VStorageObjectManager) VslmRegisterDisk(ctx *simulator.Context, req *ty
 	vctx := ctx.For(vim25.Path)
 	vsom := vctx.Map.VStorageObjectManager()
 
-	val := vsom.RegisterDisk(ctx, &vim.RegisterDisk{
+	val := vsom.RegisterDisk(vctx, &vim.RegisterDisk{
 		This: vsom.Self,
 		Path: req.Path,
 		Name: req.Name,


### PR DESCRIPTION
This package var has prevented multiple instances of vcsim running in parallel the same process.
Each simulator Model/Service instance now has its own Registry (Map) instance and Context.
The simulator.{Test,Run} functions are now passed the simulator.Context instance as the
context.Context callback param. 'simulator.Map' is now a helper function / shortcut to
reference the Map field of the Context instance.

BREAKING: simulator.Map package variable has been removed

BREAKING: simulator.SpoofContext function has been renamed to NewContext
