### PR TITLE
vcsim: add vsan Datastore support

### DIFF
--- a/govc/test/cli.bats
+++ b/govc/test/cli.bats
@@ -174,7 +174,7 @@ load test_helper
 }
 
 @test "govc format error" {
-  vcsim_env
+  vcsim_env -host 1
 
   vm=DC0_H0_VM0
 
@@ -192,7 +192,7 @@ load test_helper
   assert_failure
   gofmt <<<"$output"
 
-  run govc datastore.create -type local -name vsanDatastore -path "$BATS_TMPDIR" DC0_C0_H0
+  run govc cluster.change -vsan-enabled DC0_C0
   assert_success
 
   run govc vm.create -ds vsanDatastore "$(new_id)"

--- a/simulator/datastore_namespace_manager.go
+++ b/simulator/datastore_namespace_manager.go
@@ -35,9 +35,12 @@ func (m *DatastoreNamespaceManager) ConvertNamespacePathToUuidPath(ctx *Context,
 	}
 
 	var ds *Datastore
+	ns := ""
+
 	for _, ref := range dc.Datastore {
 		ds = ctx.Map.Get(ref).(*Datastore)
-		if strings.HasPrefix(req.NamespaceUrl, ds.Summary.Url) {
+		ns = strings.TrimPrefix(req.NamespaceUrl, ds.Summary.Url)
+		if ns != req.NamespaceUrl {
 			break
 		}
 		ds = nil
@@ -54,7 +57,7 @@ func (m *DatastoreNamespaceManager) ConvertNamespacePathToUuidPath(ctx *Context,
 	}
 
 	body.Res = &types.ConvertNamespacePathToUuidPathResponse{
-		Returnval: req.NamespaceUrl,
+		Returnval: ds.resolve(ctx, ns),
 	}
 
 	return body
@@ -101,10 +104,8 @@ func (m *DatastoreNamespaceManager) CreateDirectory(ctx *Context, req *types.Cre
 	if fault.Fault() != nil {
 		body.Fault_ = fault.Fault()
 	} else {
-		dir := ds.Info.GetDatastoreInfo().Url
-
 		body.Res = &types.CreateDirectoryResponse{
-			Returnval: path.Join(dir, req.DisplayName),
+			Returnval: ds.resolve(ctx, req.DisplayName),
 		}
 	}
 

--- a/simulator/datastore_test.go
+++ b/simulator/datastore_test.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017-2023 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -86,7 +74,7 @@ func TestRefreshDatastore(t *testing.T) {
 			},
 		}
 
-		r := ds.RefreshDatastore(nil)
+		r := ds.RefreshDatastore(NewContext(), nil)
 		res, ok := r.(*methods.RefreshDatastoreBody)
 		if !ok {
 			t.Fatalf("Unexpected response type: %T", r)

--- a/simulator/file_manager.go
+++ b/simulator/file_manager.go
@@ -7,7 +7,6 @@ package simulator
 import (
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/vmware/govmomi/simulator/esx"
@@ -54,7 +53,7 @@ func (f *FileManager) findDatastore(ctx *Context, ref mo.Reference, name string)
 	return nil, &types.InvalidDatastore{Name: name}
 }
 
-func (f *FileManager) resolve(ctx *Context, dc *types.ManagedObjectReference, name string) (string, types.BaseMethodFault) {
+func (f *FileManager) resolve(ctx *Context, dc *types.ManagedObjectReference, name string, remove ...bool) (string, types.BaseMethodFault) {
 	p, fault := parseDatastorePath(name)
 	if fault != nil {
 		return "", fault
@@ -75,9 +74,7 @@ func (f *FileManager) resolve(ctx *Context, dc *types.ManagedObjectReference, na
 		return "", fault
 	}
 
-	dir := ds.Info.GetDatastoreInfo().Url
-
-	return path.Join(dir, p.Path), nil
+	return ds.resolve(ctx, p.Path, remove...), nil
 }
 
 func (f *FileManager) fault(name string, err error, fault types.BaseFileFault) types.BaseMethodFault {
@@ -94,7 +91,7 @@ func (f *FileManager) fault(name string, err error, fault types.BaseFileFault) t
 }
 
 func (f *FileManager) deleteDatastoreFile(ctx *Context, req *types.DeleteDatastoreFile_Task) types.BaseMethodFault {
-	file, fault := f.resolve(ctx, req.Datacenter, req.Name)
+	file, fault := f.resolve(ctx, req.Datacenter, req.Name, true)
 	if fault != nil {
 		return fault
 	}

--- a/simulator/option_manager.go
+++ b/simulator/option_manager.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package simulator
 
@@ -75,6 +63,10 @@ func (m *OptionManager) init(r *Registry) {
 			m.Setting = esx.Setting
 		}
 	}
+}
+
+func (m *OptionManager) model(model *Model) error {
+	return model.createRootTempDir(m)
 }
 
 func (m *OptionManager) QueryOptions(req *types.QueryOptions) soap.HasFault {

--- a/simulator/resource_pool.go
+++ b/simulator/resource_pool.go
@@ -279,7 +279,7 @@ func (p *ResourcePool) ImportVApp(ctx *Context, req *types.ImportVApp) soap.HasF
 			file.FromString(info.GetVirtualDeviceFileBackingInfo().FileName)
 			name := path.Base(file.Path)
 			ds := vm.findDatastore(ctx, file.Datastore)
-			lease.files[name] = path.Join(ds.Info.GetDatastoreInfo().Url, file.Path)
+			lease.files[name] = ds.resolve(ctx, file.Path)
 
 			_, disk := d.(*types.VirtualDisk)
 			kind := device.Type(d)

--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -83,7 +83,7 @@ func (v *VirtualMachineSnapshot) removeSnapshotFiles(ctx *Context) types.BaseMet
 
 					host := ctx.Map.Get(*vm.Runtime.Host).(*HostSystem)
 					datastore := ctx.Map.FindByName(p.Datastore, host.Datastore).(*Datastore)
-					dFilePath := path.Join(datastore.Info.GetDatastoreInfo().Url, p.Path)
+					dFilePath := datastore.resolve(ctx, p.Path)
 
 					_ = os.Remove(dFilePath)
 				}

--- a/simulator/vstorage_object_manager.go
+++ b/simulator/vstorage_object_manager.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -146,10 +145,9 @@ func (m *VcenterVStorageObjectManager) RegisterDisk(ctx *Context, req *types.Reg
 		return invalid()
 	}
 
-	st, err := os.Stat(filepath.Join(ds.Info.GetDatastoreInfo().Url, u.Path))
+	st, err := os.Stat(ds.resolve(ctx, u.Path))
 	if err != nil {
 		return invalid()
-
 	}
 	if st.IsDir() {
 		return invalid()
@@ -199,7 +197,7 @@ func (m *VcenterVStorageObjectManager) createObject(ctx *Context, req *types.Cre
 	if !ok {
 		objects = make(map[types.ID]*VStorageObject)
 		m.objects[ds.Self] = objects
-		_ = os.MkdirAll(filepath.Join(ds.Info.GetDatastoreInfo().Url, dir), 0750)
+		_ = os.MkdirAll(ds.resolve(ctx, dir), 0750)
 	}
 
 	id := uuid.New().String()

--- a/units/size.go
+++ b/units/size.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package units
 

--- a/vslm/simulator/simulator.go
+++ b/vslm/simulator/simulator.go
@@ -746,6 +746,8 @@ func (*VslmTask) task(ctx *simulator.Context, ref vim.ManagedObjectReference) (v
 	ref.Type = "Task"
 
 	if task, ok := ctx.Map.Get(ref).(*simulator.Task); ok {
+		unlock := ctx.Map.AcquireLock(ctx, ref)
+		defer unlock()
 		return task.Info, nil
 	}
 


### PR DESCRIPTION
- Use a single top-level TempDir for a vcsim Model instance. Make this path available via OptionManager. This top-level can be used internally as backing for vSAN Datastores.

- Split FileManager.resolve logic into Datastore.resolve and use that method everywhere for resolving a Datastore relative path to local file system absolute path. This is where top-level vSAN friendlyName is now translated to vSAN object UUID.

- ReconfigureComputeResource_Task will now create a vsanDatastore when spec.VsanConfig.Enabled == true. This Datastore will be added to existing hosts in the cluster, and any hosts later added to the cluster.

- HostDatastoreBrowser search methods now populate the FriendlyName field for vSAN Datastores.

- The tests added to datastore.bats cover these cases using existing govc commands.
