### PR TITLE
chore: bump Go versions

### DIFF
--- a/.github/workflows/govmomi-build.yaml
+++ b/.github/workflows/govmomi-build.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
 
       - name: Restore Go cache
         uses: actions/cache@v4
@@ -54,9 +54,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.22-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.23-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.22-
+            ${{ runner.os }}-go-1.23-
 
       - name: Create CHANGELOG
         env:

--- a/.github/workflows/govmomi-go-lint.yaml
+++ b/.github/workflows/govmomi-go-lint.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
         id: go
 
       - name: Go Lint
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
         id: go
 
       - name: Install Tools

--- a/.github/workflows/govmomi-go-tests.yaml
+++ b/.github/workflows/govmomi-go-tests.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Run Unit Tests
     strategy:
       matrix:
-        go-version: ["1.22", "1.23"]
+        go-version: ["1.23", "1.24"]
         platform: ["ubuntu-20.04"]
       fail-fast: false
 

--- a/.github/workflows/govmomi-govc-tests.yaml
+++ b/.github/workflows/govmomi-govc-tests.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.22"]
+        go-version: ["1.23"]
         platform: ["ubuntu-20.04"]
         cmd: ["govc-test"]
         experimental: [false]
@@ -73,7 +73,7 @@ jobs:
     name: Verify govc docs are up2date
     strategy:
       matrix:
-        go-version: ["1.22"]
+        go-version: ["1.23"]
         platform: ["ubuntu-20.04"]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 3

--- a/.github/workflows/govmomi-release.yaml
+++ b/.github/workflows/govmomi-release.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Update version.go
         run: |


### PR DESCRIPTION
1.22 + 1.23 -> 1.23 + 1.24
