### PR TITLE
chore(gh): update to `ubuntu-latest` runner

### DIFF
--- a/.github/workflows/govmomi-build.yaml
+++ b/.github/workflows/govmomi-build.yaml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   artifacts:
     name: Build Snapshot Release (no upload)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/govmomi-check-wip.yaml
+++ b/.github/workflows/govmomi-check-wip.yaml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   wip:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check WIP in PR Title
         uses: embano1/wip@v2

--- a/.github/workflows/govmomi-go-lint.yaml
+++ b/.github/workflows/govmomi-go-lint.yaml
@@ -24,7 +24,7 @@ on:
 jobs:
   lint:
     name: Lint Files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/govmomi-go-tests.yaml
+++ b/.github/workflows/govmomi-go-tests.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.22", "1.23"]
-        platform: ["ubuntu-20.04"]
+        platform: ["ubuntu-latest"]
       fail-fast: false
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/govmomi-govc-tests.yaml
+++ b/.github/workflows/govmomi-govc-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: ["1.22"]
-        platform: ["ubuntu-20.04"]
+        platform: ["ubuntu-latest"]
         cmd: ["govc-test"]
         experimental: [false]
         timeout: [20]
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.22"]
-        platform: ["ubuntu-20.04"]
+        platform: ["ubuntu-latest"]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 3
     steps:

--- a/.github/workflows/govmomi-release.yaml
+++ b/.github/workflows/govmomi-release.yaml
@@ -31,7 +31,7 @@ on:
 jobs:
   release:
     name: Create Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     outputs:
       latesttag: ${{ steps.tag.outputs.islatest }}
@@ -152,7 +152,7 @@ jobs:
   pull-request:
     needs: release
     name: Create CHANGELOG.md PR
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     continue-on-error: true
     # only update CHANGELOG for latest semver tag
     if: ${{ !inputs.dryrun && needs.release.outputs.latesttag == 'true' }}

--- a/.github/workflows/govmomi-stale.yaml
+++ b/.github/workflows/govmomi-stale.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: "actions/stale@v9"

--- a/.github/workflows/issue-greeting.yaml
+++ b/.github/workflows/issue-greeting.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   greeting:
     name: Send Greeting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # only send message to users not (yet) associated with repo
     # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
     if: github.event.issue.author_association == 'NONE'

--- a/.github/workflows/verify-docker-login.yaml
+++ b/.github/workflows/verify-docker-login.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   login:
     name: Verify Docker Login
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 3
 
     steps:


### PR DESCRIPTION
## Description

Updates the use of all instances of `ubuntu-20.04` to  `ubuntu-latest`.

The 20.04 runner image was deprecated on 2025-02-01 and will be fully unsupported by 2025-04-01.

[Reference](https://github.com/actions/runner-images/issues/11101)