### PR TITLE
chore(gh): update greeting workflow

### DIFF
--- a/.github/workflows/issue-greeting.yaml
+++ b/.github/workflows/issue-greeting.yaml
@@ -1,47 +1,35 @@
-#  Copyright (c) 2021 VMware, Inc. All Rights Reserved.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#  http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
 name: Greeting
+
+permissions:
+  issues: write
+  contents: read
 
 on:
   issues:
-    types: ["opened"]
+    types: opened
 
 jobs:
   greeting:
     name: Send Greeting
     runs-on: ubuntu-latest
-    # only send message to users not (yet) associated with repo
-    # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
     if: github.event.issue.author_association == 'NONE'
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
 
-      - name: Render template
+      - name: Render Template
         id: template
-        uses: chuhlomin/render-template@v1.10
+        uses: chuhlomin/render-template@807354a04d9300c9c2ac177c0aa41556c92b3f75 # v1.10
         with:
           template: .github/comment-template.md
           vars: |
             author: ${{ github.actor }}
 
-      - name: Create comment
-        uses: peter-evans/create-or-update-comment@v4
+      - name: Create Comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.1.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: ${{ steps.template.outputs.result }}


### PR DESCRIPTION
## Description

Updates the GitHub Actions workflow for issue greetings. 

The changes include updating permissions, simplifying the event type specification, and pinning action versions for stability.

* [`.github/workflows/issue-greeting.yaml`](diffhunk://#diff-5a1833d14853c34a2a49ab440bbfcdc292d4c01fe4ae3ba5f05659c82fbf6537L1-R32): Added specific permissions for issues and contents.
* [`.github/workflows/issue-greeting.yaml`](diffhunk://#diff-5a1833d14853c34a2a49ab440bbfcdc292d4c01fe4ae3ba5f05659c82fbf6537L1-R32): Simplified the event type specification from `["opened"]` to `opened`.
* [`.github/workflows/issue-greeting.yaml`](diffhunk://#diff-5a1833d14853c34a2a49ab440bbfcdc292d4c01fe4ae3ba5f05659c82fbf6537L1-R32): Pinned action versions for `checkout`, `render-template`, and `create-or-update-comment` to specific commit SHAs for stability.
