### PR TITLE
chore(gh): update linting workflow

### DIFF
--- a/.github/workflows/govmomi-go-lint.yaml
+++ b/.github/workflows/govmomi-go-lint.yaml
@@ -1,25 +1,13 @@
-#  Copyright (c) 2021 VMware, Inc. All Rights Reserved.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#  http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
 name: Code Style
+
+permissions:
+  contents: read
 
 on:
   push:
-    branches: [ 'main' ]
-
+    branches: main
   pull_request:
-    branches: [ 'main' ]
+    branches: main
 
 jobs:
   lint:
@@ -28,13 +16,13 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - name: Check Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Setup Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: 1.22
+          go-version-file: go.mod
         id: go
 
       - name: Go Lint
@@ -52,16 +40,16 @@ jobs:
         # Map between extension and human-readable name.
         include:
         - extension: go
-          language: Go
+          language: go
 
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - name: Check Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Setup Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: 1.22
+          go-version-file: go.mod
         id: go
 
       - name: Install Tools
@@ -80,7 +68,7 @@ jobs:
           echo "${TEMP_PATH}" >> "$GITHUB_PATH"
 
       - id: boilerplate_txt
-        uses: andstor/file-existence-action@v3
+        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
         with:
           files: ./hack/boilerplate/boilerplate.${{ matrix.extension }}.txt
 


### PR DESCRIPTION
## Description

Updates to linting workflow:

- Limits workflow permissions.
- Removes superfluous quotes.
- Simplifies single branch reference.
- References `go.mod` for the Go version.
