### PR TITLE
toolbox: fix codeql go/zipslip

### DIFF
--- a/toolbox/hgfs/archive.go
+++ b/toolbox/hgfs/archive.go
@@ -238,6 +238,12 @@ func archiveRead(u *url.URL, tr *tar.Reader) error {
 			return err
 		}
 
+		// validate to prevent directory traversal
+		if strings.Contains(header.Name, "..") {
+			log.Printf("skipping invalid entry with '..' in name: %s", header.Name)
+			continue
+		}
+
 		name := filepath.Join(u.Path, header.Name)
 		mode := os.FileMode(header.Mode)
 


### PR DESCRIPTION
## Description

Updates the `archiveRead` function in the `toolbox/hgfs/archive.go` file. The change adds validation to prevent directory traversal attacks.

* [`toolbox/hgfs/archive.go`](diffhunk://#diff-dd810031b8da2e54219d302bddd91bbe1b4e9192ac40c268c56477527c423194R241-R246): Added a check to skip entries containing '..' in their names to prevent directory traversal vulnerabilities.

[Reference](https://cwe.mitre.org/data/definitions/22.html)


