### PR TITLE
chore(gh): update dependabot for ruby dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
   directory: "/"
   schedule:
       interval: "daily"
+- package-ecosystem: "bundler"
+  directory: "/gen"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
## Description

Updates the Dependabot configuration to also check for updates to Ruby dependencies in the `/gen` directory using `bundler` (Ruby's dependency manager).
