### PR TITLE
api: use `crypto/rand` for nonce generation

### DIFF
--- a/sts/signer.go
+++ b/sts/signer.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package sts
 
@@ -28,7 +16,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	mrand "math/rand"
+	"math"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
@@ -261,7 +250,13 @@ func (s *Signer) SignRequest(req *http.Request) error {
 	})
 
 	if s.Certificate != nil {
-		nonce := fmt.Sprintf("%d:%d", time.Now().UnixNano()/1e6, mrand.Int())
+		randNum, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+		if err != nil {
+			return fmt.Errorf("sts: generating nonce: %w", err)
+		}
+
+		nonce := fmt.Sprintf("%d:%d", time.Now().UnixNano()/1e6, randNum.Int64())
+
 		var body []byte
 		if req.GetBody != nil {
 			r, rerr := req.GetBody()


### PR DESCRIPTION
## Description

* [`sts/signer.go`](diffhunk://#diff-8c0865d840bf0719e62b56c9bce965a2f828bc93946f5656339de5b4bb9fcc83L31-R20): Replaces `math/rand` with `crypto/rand` for nonce generation in the `SignRequest` function. This ensures that the generated nonces are more cryptographically secure.. [[1]](diffhunk://#diff-8c0865d840bf0719e62b56c9bce965a2f828bc93946f5656339de5b4bb9fcc83L31-R20) [[2]](diffhunk://#diff-8c0865d840bf0719e62b56c9bce965a2f828bc93946f5656339de5b4bb9fcc83L264-R259)
