### PR TITLE
chore(deps): update bundler to v2 for dependabot

### DIFF
--- a/gen/Gemfile
+++ b/gen/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
-gem "nokogiri", ">= 1.11.0"
+gem "bundler", "~> 2.0"
+gem "nokogiri", ">= 1.18.6"
 gem "test-unit"
 gem "yaml"

--- a/gen/Gemfile.lock
+++ b/gen/Gemfile.lock
@@ -1,23 +1,24 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    mini_portile2 (2.8.6)
-    nokogiri (1.16.5)
+    mini_portile2 (2.8.8)
+    nokogiri (1.18.6)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    power_assert (0.4.1)
-    racc (1.7.3)
-    test-unit (3.2.3)
+    power_assert (2.0.5)
+    racc (1.8.1)
+    test-unit (3.6.7)
       power_assert
-    yaml (0.2.1)
+    yaml (0.4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  nokogiri (>= 1.11.0)
+  bundler (~> 2.0)
+  nokogiri (>= 1.18.6)
   test-unit
   yaml
 
 BUNDLED WITH
-   1.17.2
+   2.6.6


### PR DESCRIPTION
## Description

Updates bundler to v2 to support Dependabot.

Ref: 
- https://github.com/vmware/govmomi/security/dependabot/27
- https://github.com/vmware/govmomi/security/dependabot/25
- [bundler in /gen - Update #985577617 #352](https://github.com/vmware/govmomi/actions/runs/14034776848/job/39290201894)

```shell
govmomi/gen on  chore(deps)/bundler-v2 [!] via 💎 v3.4.2 via 🐹 v1.24.1 on 🐳 v26.1.3 (rancher-desktop) 
✦ ➜ bundle update                     
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Using racc 1.8.1 (was 1.7.3)
Using power_assert 2.0.5 (was 0.4.1)
Using yaml 0.4.0 (was 0.2.1)
Fetching mini_portile2 2.8.8 (was 2.8.6)
Using nokogiri 1.18.6 (x86_64-darwin) (was 1.16.5)
Using test-unit 3.6.7 (was 3.2.3)
Installing mini_portile2 2.8.8 (was 2.8.6)
Bundle updated!
```
