### PR TITLE
vcsim: fix integer type conversion

### DIFF
--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -255,7 +255,7 @@ func updateHostTemplate(ip string) error {
 	}
 	esx.HostSystem.Summary.ManagementServerIp = addr
 	if port != "0" { // server starts after the model is created, skipping auto-selected ports for now
-		n, err := strconv.Atoi(port)
+		n, err := strconv.ParseInt(port, 10, 32)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

Replace the use of `strconv.Atoi` with `strconv.ParseInt`, specifying the bit size as 32. This ensures that the parsed value is within the range of int32.

Ref: GHSA https://github.com/vmware/govmomi/security/code-scanning/20