### PR TITLE
chore: gofmt -w -r 'interface{} -> any' .

### DIFF
--- a/cli/about/command.go
+++ b/cli/about/command.go
@@ -105,7 +105,7 @@ func (r *infoResult) Write(w io.Writer) error {
 	return tw.Flush()
 }
 
-func (r *infoResult) Dump() interface{} {
+func (r *infoResult) Dump() any {
 	if r.Content != nil {
 		return r.Content
 	}

--- a/cli/disk/ls.go
+++ b/cli/disk/ls.go
@@ -189,7 +189,7 @@ func (r *lsResult) Write(w io.Writer) error {
 	return tw.Flush()
 }
 
-func (r *lsResult) Dump() interface{} {
+func (r *lsResult) Dump() any {
 	return r.Objects
 }
 

--- a/cli/disk/metadata/ls.go
+++ b/cli/disk/metadata/ls.go
@@ -70,7 +70,7 @@ func (r lsResult) Write(w io.Writer) error {
 	return tw.Flush()
 }
 
-func (r lsResult) Dump() interface{} {
+func (r lsResult) Dump() any {
 	return []types.KeyValue(r)
 }
 

--- a/cli/disk/snapshot/ls.go
+++ b/cli/disk/snapshot/ls.go
@@ -66,7 +66,7 @@ func (r *lsResult) Write(w io.Writer) error {
 	return tw.Flush()
 }
 
-func (r *lsResult) Dump() interface{} {
+func (r *lsResult) Dump() any {
 	return r.Info
 }
 

--- a/cli/esx/executor.go
+++ b/cli/esx/executor.go
@@ -150,7 +150,7 @@ func (e *Executor) NewRequest(ctx context.Context, args []string) (*internal.Exe
 	return &sreq, info, nil
 }
 
-func (e *Executor) Execute(ctx context.Context, req *internal.ExecuteSoapRequest, res interface{}) error {
+func (e *Executor) Execute(ctx context.Context, req *internal.ExecuteSoapRequest, res any) error {
 	req.This = e.mme.ManagedObjectReference
 	req.Version = "urn:vim25/5.0"
 

--- a/cli/events/command.go
+++ b/cli/events/command.go
@@ -142,7 +142,7 @@ type record struct {
 }
 
 // Dump the raw Event rather than the record struct.
-func (r *record) Dump() interface{} {
+func (r *record) Dump() any {
 	return r.event
 }
 

--- a/cli/flags/debug.go
+++ b/cli/flags/debug.go
@@ -360,7 +360,7 @@ func (v *verbose) objectContent(content []types.ObjectContent) []string {
 	return s
 }
 
-func (v *verbose) prettyPrint(val interface{}) string {
+func (v *verbose) prettyPrint(val any) string {
 	p := pretty.Sprintf("%# v\n", val)
 	var res []string
 	scanner := bufio.NewScanner(strings.NewReader(p))
@@ -435,7 +435,7 @@ func (v *verbose) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
 
 	vres := reflect.ValueOf(res).Elem().FieldByName("Res").Elem()
 	ret := vres.FieldByName("Returnval")
-	var s interface{} = "void"
+	var s any = "void"
 
 	if ret.IsValid() {
 		switch x := ret.Interface().(type) {

--- a/cli/flags/int32.go
+++ b/cli/flags/int32.go
@@ -20,7 +20,7 @@ func (i *int32Value) Set(s string) error {
 	return err
 }
 
-func (i *int32Value) Get() interface{} {
+func (i *int32Value) Get() any {
 	return int32(*i)
 }
 
@@ -44,7 +44,7 @@ func (i *int32ptrValue) Set(s string) error {
 	return err
 }
 
-func (i *int32ptrValue) Get() interface{} {
+func (i *int32ptrValue) Get() any {
 	if i.val == nil || *i.val == nil {
 		return nil
 	}

--- a/cli/flags/int64.go
+++ b/cli/flags/int64.go
@@ -20,7 +20,7 @@ func (i *int64Value) Set(s string) error {
 	return err
 }
 
-func (i *int64Value) Get() interface{} {
+func (i *int64Value) Get() any {
 	return int64(*i)
 }
 
@@ -44,7 +44,7 @@ func (i *int64ptrValue) Set(s string) error {
 	return err
 }
 
-func (i *int64ptrValue) Get() interface{} {
+func (i *int64ptrValue) Get() any {
 	if i.val == nil || *i.val == nil {
 		return nil
 	}

--- a/cli/flags/optional_bool.go
+++ b/cli/flags/optional_bool.go
@@ -20,7 +20,7 @@ func (b *optionalBool) Set(s string) error {
 	return err
 }
 
-func (b *optionalBool) Get() interface{} {
+func (b *optionalBool) Get() any {
 	if *b.val == nil {
 		return nil
 	}

--- a/cli/flags/optional_string.go
+++ b/cli/flags/optional_string.go
@@ -17,7 +17,7 @@ func (s *optionalString) Set(input string) error {
 	return nil
 }
 
-func (s *optionalString) Get() interface{} {
+func (s *optionalString) Get() any {
 	if *s.val == nil {
 		return nil
 	}

--- a/cli/flags/output.go
+++ b/cli/flags/output.go
@@ -117,9 +117,9 @@ func (flag *OutputFlag) All() bool {
 	return flag.JSON || flag.XML || flag.Dump
 }
 
-func dumpValue(val interface{}) interface{} {
+func dumpValue(val any) any {
 	type dumper interface {
-		Dump() interface{}
+		Dump() any
 	}
 
 	if d, ok := val.(dumper); ok {
@@ -159,7 +159,7 @@ func (*outputAny) Write(io.Writer) error {
 	return nil
 }
 
-func (a *outputAny) Dump() interface{} {
+func (a *outputAny) Dump() any {
 	return a.Value
 }
 
@@ -251,7 +251,7 @@ func (e errorOutput) Write(w io.Writer) error {
 	return nil
 }
 
-func (e errorOutput) Dump() interface{} {
+func (e errorOutput) Dump() any {
 	if f, ok := e.error.(task.Error); ok {
 		return f.LocalizedMethodFault
 	}

--- a/cli/folder/place.go
+++ b/cli/folder/place.go
@@ -224,7 +224,7 @@ type placementResult struct {
 	vm        *flags.VirtualMachineFlag
 }
 
-func (res *placementResult) Dump() interface{} {
+func (res *placementResult) Dump() any {
 	return res.Result
 }
 

--- a/cli/host/esxcli/esxcli.go
+++ b/cli/host/esxcli/esxcli.go
@@ -150,7 +150,7 @@ type result struct {
 	cmd *esxcli
 }
 
-func (r *result) Dump() interface{} {
+func (r *result) Dump() any {
 	return r.Response
 }
 

--- a/cli/host/esxcli/model.go
+++ b/cli/host/esxcli/model.go
@@ -77,7 +77,7 @@ type modelInfo struct {
 	Instances   []internal.DynamicTypeMgrMoInstance
 }
 
-func (r modelInfo) Dump() interface{} {
+func (r modelInfo) Dump() any {
 	if len(r.CommandInfo) != 0 {
 		return r.CommandInfo
 	}

--- a/cli/library/info.go
+++ b/cli/library/info.go
@@ -92,8 +92,8 @@ func (r infoResultsWriter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.Result)
 }
 
-func (r infoResultsWriter) Dump() interface{} {
-	res := make([]interface{}, len(r.Result))
+func (r infoResultsWriter) Dump() any {
+	res := make([]any, len(r.Result))
 	for i := range r.Result {
 		res[i] = r.Result[0].GetResult()
 	}

--- a/cli/library/policy/ls.go
+++ b/cli/library/policy/ls.go
@@ -74,7 +74,7 @@ func (r lsResultsWriter) Write(w io.Writer) error {
 	return tw.Flush()
 }
 
-func (r lsResultsWriter) Dump() interface{} {
+func (r lsResultsWriter) Dump() any {
 	return r.Policies
 }
 

--- a/cli/library/trust/info.go
+++ b/cli/library/trust/info.go
@@ -62,7 +62,7 @@ func (r infoResultsWriter) Write(w io.Writer) error {
 	return info.Write(w)
 }
 
-func (r infoResultsWriter) Dump() interface{} {
+func (r infoResultsWriter) Dump() any {
 	return r.TrustedCertificateInfo
 }
 

--- a/cli/library/trust/ls.go
+++ b/cli/library/trust/ls.go
@@ -71,7 +71,7 @@ func (r lsResultsWriter) Write(w io.Writer) error {
 	return tw.Flush()
 }
 
-func (r lsResultsWriter) Dump() interface{} {
+func (r lsResultsWriter) Dump() any {
 	return r.TrustedCertificates
 }
 

--- a/cli/namespace/cluster/ls.go
+++ b/cli/namespace/cluster/ls.go
@@ -100,7 +100,7 @@ func (r *lsWriter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.Cluster)
 }
 
-func (r *lsWriter) Dump() interface{} {
+func (r *lsWriter) Dump() any {
 	return r.Cluster
 }
 

--- a/cli/namespace/service/info.go
+++ b/cli/namespace/service/info.go
@@ -70,7 +70,7 @@ func (r *infoWriter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.Service)
 }
 
-func (r *infoWriter) Dump() interface{} {
+func (r *infoWriter) Dump() any {
 	return r.Service
 }
 

--- a/cli/namespace/service/ls.go
+++ b/cli/namespace/service/ls.go
@@ -77,7 +77,7 @@ func (r *lsWriter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.Service)
 }
 
-func (r *lsWriter) Dump() interface{} {
+func (r *lsWriter) Dump() any {
 	return r.Service
 }
 

--- a/cli/namespace/service/version/info.go
+++ b/cli/namespace/service/version/info.go
@@ -71,7 +71,7 @@ func (r *infoWriter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.Service)
 }
 
-func (r *infoWriter) Dump() interface{} {
+func (r *infoWriter) Dump() any {
 	return r.Service
 }
 

--- a/cli/namespace/service/version/ls.go
+++ b/cli/namespace/service/version/ls.go
@@ -83,7 +83,7 @@ func (r *lsWriter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.Versions)
 }
 
-func (r *lsWriter) Dump() interface{} {
+func (r *lsWriter) Dump() any {
 	return r.Versions
 }
 

--- a/cli/object/collect.go
+++ b/cli/object/collect.go
@@ -238,7 +238,7 @@ func (pc *change) Write(w io.Writer) error {
 	return tw.Flush()
 }
 
-func (pc *change) Dump() interface{} {
+func (pc *change) Dump() any {
 	if pc.cmd.simple && len(pc.Update.ChangeSet) == 1 {
 		val := pc.Update.ChangeSet[0].Val
 		if val != nil {
@@ -287,7 +287,7 @@ type dumpFilter struct {
 	types.CreateFilter
 }
 
-func (f *dumpFilter) Dump() interface{} {
+func (f *dumpFilter) Dump() any {
 	return f.CreateFilter
 }
 
@@ -297,10 +297,10 @@ func (f *dumpFilter) Write(w io.Writer) error {
 }
 
 type dumpEntity struct {
-	entity interface{}
+	entity any
 }
 
-func (e *dumpEntity) Dump() interface{} {
+func (e *dumpEntity) Dump() any {
 	return e.entity
 }
 

--- a/cli/object/find.go
+++ b/cli/object/find.go
@@ -184,7 +184,7 @@ func (r findResult) Write(w io.Writer) error {
 	return nil
 }
 
-func (r findResult) Dump() interface{} {
+func (r findResult) Dump() any {
 	return []string(r)
 }
 

--- a/cli/object/save.go
+++ b/cli/object/save.go
@@ -73,7 +73,7 @@ Examples:
 }
 
 // write encodes data to file name
-func (cmd *save) write(name string, data interface{}) error {
+func (cmd *save) write(name string, data any) error {
 	f, err := os.Create(filepath.Join(cmd.dir, name) + ".xml")
 	if err != nil {
 		return err
@@ -92,7 +92,7 @@ func (cmd *save) write(name string, data interface{}) error {
 
 type saveMethod struct {
 	Name string
-	Data interface{}
+	Data any
 }
 
 func saveDVS(ctx context.Context, c *vim25.Client, ref types.ManagedObjectReference) ([]saveMethod, error) {

--- a/cli/object/tree.go
+++ b/cli/object/tree.go
@@ -285,6 +285,6 @@ func (f fileInfo) ModTime() time.Time {
 func (f fileInfo) IsDir() bool {
 	return f.mode&os.ModeDir == os.ModeDir
 }
-func (f fileInfo) Sys() interface{} {
+func (f fileInfo) Sys() any {
 	return nil
 }

--- a/cli/sso/group/ls.go
+++ b/cli/sso/group/ls.go
@@ -61,7 +61,7 @@ func (cmd *ls) Process(ctx context.Context) error {
 
 type groupResult []types.AdminGroup
 
-func (r groupResult) Dump() interface{} {
+func (r groupResult) Dump() any {
 	return []types.AdminGroup(r)
 }
 

--- a/cli/sso/lpp/info.go
+++ b/cli/sso/lpp/info.go
@@ -82,7 +82,7 @@ func (r *lppInfo) Write(w io.Writer) error {
 	return nil
 }
 
-func (r *lppInfo) Dump() interface{} {
+func (r *lppInfo) Dump() any {
 	return r.LocalPasswordPolicy
 }
 

--- a/cli/sso/service/ls.go
+++ b/cli/sso/service/ls.go
@@ -71,7 +71,7 @@ func (cmd *ls) Process(ctx context.Context) error {
 
 type infoResult []types.LookupServiceRegistrationInfo
 
-func (r infoResult) Dump() interface{} {
+func (r infoResult) Dump() any {
 	return []types.LookupServiceRegistrationInfo(r)
 }
 
@@ -87,7 +87,7 @@ func (r infoResult) Write(w io.Writer) error {
 
 type infoResultLong []types.LookupServiceRegistrationInfo
 
-func (r infoResultLong) Dump() interface{} {
+func (r infoResultLong) Dump() any {
 	return []types.LookupServiceRegistrationInfo(r)
 }
 
@@ -107,7 +107,7 @@ func (r infoResultLong) Write(w io.Writer) error {
 
 type infoResultURL []types.LookupServiceRegistrationInfo
 
-func (r infoResultURL) Dump() interface{} {
+func (r infoResultURL) Dump() any {
 	return []types.LookupServiceRegistrationInfo(r)
 }
 

--- a/cli/sso/user/id.go
+++ b/cli/sso/user/id.go
@@ -69,7 +69,7 @@ func (r *userID) Write(w io.Writer) error {
 	return nil
 }
 
-func (r *userID) Dump() interface{} {
+func (r *userID) Dump() any {
 	return struct {
 		User  *types.AdminUser
 		Group []types.PrincipalId

--- a/cli/sso/user/ls.go
+++ b/cli/sso/user/ls.go
@@ -60,7 +60,7 @@ func (cmd *ls) Process(ctx context.Context) error {
 
 type userResult []types.AdminUser
 
-func (r userResult) Dump() interface{} {
+func (r userResult) Dump() any {
 	return []types.AdminUser(r)
 }
 
@@ -74,7 +74,7 @@ func (r userResult) Write(w io.Writer) error {
 
 type solutionResult []types.AdminSolutionUser
 
-func (r solutionResult) Dump() interface{} {
+func (r solutionResult) Dump() any {
 	return []types.AdminSolutionUser(r)
 }
 
@@ -88,7 +88,7 @@ func (r solutionResult) Write(w io.Writer) error {
 
 type personResult []types.AdminPersonUser
 
-func (r personResult) Dump() interface{} {
+func (r personResult) Dump() any {
 	return []types.AdminPersonUser(r)
 }
 

--- a/cli/vm/create.go
+++ b/cli/vm/create.go
@@ -337,7 +337,7 @@ type place struct {
 	cmd *create
 }
 
-func (p *place) Dump() interface{} {
+func (p *place) Dump() any {
 	return p.Recommendations
 }
 

--- a/cli/vm/info.go
+++ b/cli/vm/info.go
@@ -185,7 +185,7 @@ func (r *infoResult) collectReferences(pc *property.Collector, ctx context.Conte
 	// Note that we cannot use a []mo.ManagedEntity here, since mo.Network has its own 'Name' field,
 	// the mo.Network.ManagedEntity.Name field will not be set.
 	vrefs := map[string]*struct {
-		dest interface{}
+		dest any
 		refs []types.ManagedObjectReference
 		save func()
 	}{

--- a/cli/vm/option/info.go
+++ b/cli/vm/option/info.go
@@ -106,6 +106,6 @@ func (r *infoResult) Write(w io.Writer) error {
 	return tw.Flush()
 }
 
-func (r *infoResult) Dump() interface{} {
+func (r *infoResult) Dump() any {
 	return r.VirtualMachineConfigOption
 }

--- a/cli/vm/option/ls.go
+++ b/cli/vm/option/ls.go
@@ -64,7 +64,7 @@ func (r *lsResult) Write(w io.Writer) error {
 	return tw.Flush()
 }
 
-func (r *lsResult) Dump() interface{} {
+func (r *lsResult) Dump() any {
 	return r.opts
 }
 

--- a/cli/vm/target/capabilities.go
+++ b/cli/vm/target/capabilities.go
@@ -89,6 +89,6 @@ func (r *caplsResult) Write(w io.Writer) error {
 	return tw.Flush()
 }
 
-func (r *caplsResult) Dump() interface{} {
+func (r *caplsResult) Dump() any {
 	return r.HostCapability
 }

--- a/cli/vm/target/info.go
+++ b/cli/vm/target/info.go
@@ -128,6 +128,6 @@ func (r *infoResult) Write(w io.Writer) error {
 	return tw.Flush()
 }
 
-func (r *infoResult) Dump() interface{} {
+func (r *infoResult) Dump() any {
 	return r.ConfigTarget
 }

--- a/client.go
+++ b/client.go
@@ -104,12 +104,12 @@ func (c *Client) PropertyCollector() *property.Collector {
 }
 
 // RetrieveOne dispatches to the Retrieve function on the default property collector.
-func (c *Client) RetrieveOne(ctx context.Context, obj types.ManagedObjectReference, p []string, dst interface{}) error {
+func (c *Client) RetrieveOne(ctx context.Context, obj types.ManagedObjectReference, p []string, dst any) error {
 	return c.PropertyCollector().RetrieveOne(ctx, obj, p, dst)
 }
 
 // Retrieve dispatches to the Retrieve function on the default property collector.
-func (c *Client) Retrieve(ctx context.Context, objs []types.ManagedObjectReference, p []string, dst interface{}) error {
+func (c *Client) Retrieve(ctx context.Context, objs []types.ManagedObjectReference, p []string, dst any) error {
 	return c.PropertyCollector().Retrieve(ctx, objs, p, dst)
 }
 

--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -385,7 +385,7 @@ func TestClient(t *testing.T) {
 		t.Fatalf("Failed to create snapshots: fault=%+v", createSnapshotsOperationRes.Fault)
 	}
 
-	snapshotCreateResult := interface{}(createSnapshotsTaskResult).(*cnstypes.CnsSnapshotCreateResult)
+	snapshotCreateResult := any(createSnapshotsTaskResult).(*cnstypes.CnsSnapshotCreateResult)
 	snapshotId := snapshotCreateResult.Snapshot.SnapshotId.Id
 	snapshotCreateTime := snapshotCreateResult.Snapshot.CreateTime
 	t.Logf("snapshotCreateResult: %+v", pretty.Sprint(snapshotCreateResult))
@@ -544,7 +544,7 @@ func TestClient(t *testing.T) {
 		t.Fatalf("Failed to delete snapshots: fault=%+v", deleteSnapshotsOperationRes.Fault)
 	}
 
-	snapshotDeleteResult := interface{}(deleteSnapshotsTaskResult).(*cnstypes.CnsSnapshotDeleteResult)
+	snapshotDeleteResult := any(deleteSnapshotsTaskResult).(*cnstypes.CnsSnapshotDeleteResult)
 	t.Logf("snapshotDeleteResult: %+v", pretty.Sprint(snapshotCreateResult))
 	t.Logf("DeleteSnapshots: Snapshot deleted successfully. volumeId: %q, snapshot id %q, opId: %q", volumeId, snapshotDeleteResult.SnapshotId, deleteSnapshotsTaskInfo.ActivationId)
 
@@ -908,7 +908,7 @@ func TestClient(t *testing.T) {
 	if attachVolumeOperationRes.Fault != nil {
 		t.Fatalf("Failed to attach volume: fault=%+v", attachVolumeOperationRes.Fault)
 	}
-	diskUUID := interface{}(attachTaskResult).(*cnstypes.CnsVolumeAttachResult).DiskUUID
+	diskUUID := any(attachTaskResult).(*cnstypes.CnsVolumeAttachResult).DiskUUID
 	t.Logf("Volume attached sucessfully. Disk UUID: %s", diskUUID)
 
 	// Re-Attach same volume to the same node and expect ResourceInUse fault

--- a/cns/cns_util.go
+++ b/cns/cns_util.go
@@ -84,7 +84,7 @@ func dropUnknownCreateSpecElements(c *Client, createSpecList []cnstypes.CnsVolum
 			createSpec.Metadata.ContainerClusterArray = nil
 			var updatedEntityMetadata []cnstypes.BaseCnsEntityMetadata
 			for _, entityMetadata := range createSpec.Metadata.EntityMetadata {
-				k8sEntityMetadata := interface{}(entityMetadata).(*cnstypes.CnsKubernetesEntityMetadata)
+				k8sEntityMetadata := any(entityMetadata).(*cnstypes.CnsKubernetesEntityMetadata)
 				k8sEntityMetadata.ClusterID = ""
 				k8sEntityMetadata.ReferredEntity = nil
 				updatedEntityMetadata = append(updatedEntityMetadata, cnstypes.BaseCnsEntityMetadata(k8sEntityMetadata))
@@ -141,7 +141,7 @@ func dropUnknownVolumeMetadataUpdateSpecElements(c *Client, updateSpecList []cns
 			updateSpec.Metadata.ContainerCluster.ClusterDistribution = ""
 			var updatedEntityMetadata []cnstypes.BaseCnsEntityMetadata
 			for _, entityMetadata := range updateSpec.Metadata.EntityMetadata {
-				k8sEntityMetadata := interface{}(entityMetadata).(*cnstypes.CnsKubernetesEntityMetadata)
+				k8sEntityMetadata := any(entityMetadata).(*cnstypes.CnsKubernetesEntityMetadata)
 				k8sEntityMetadata.ClusterID = ""
 				k8sEntityMetadata.ReferredEntity = nil
 				updatedEntityMetadata = append(updatedEntityMetadata, cnstypes.BaseCnsEntityMetadata(k8sEntityMetadata))

--- a/cns/simulator/simulator_test.go
+++ b/cns/simulator/simulator_test.go
@@ -437,7 +437,7 @@ func TestSimulator(t *testing.T) {
 		t.Fatalf("Failed to create snapshots: fault=%+v", createSnapshotsOperationRes.Fault)
 	}
 
-	snapshotCreateResult := interface{}(createSnapshotsTaskResult).(*cnstypes.CnsSnapshotCreateResult)
+	snapshotCreateResult := any(createSnapshotsTaskResult).(*cnstypes.CnsSnapshotCreateResult)
 	snapshotId := snapshotCreateResult.Snapshot.SnapshotId.Id
 	t.Logf("snapshotCreateResult %+v", snapshotCreateResult)
 
@@ -555,7 +555,7 @@ func TestSimulator(t *testing.T) {
 		t.Fatalf("Failed to delete snapshots: fault=%+v", deleteSnapshotsOperationRes.Fault)
 	}
 
-	snapshotDeleteResult := interface{}(deleteSnapshotsTaskResult).(*cnstypes.CnsSnapshotDeleteResult)
+	snapshotDeleteResult := any(deleteSnapshotsTaskResult).(*cnstypes.CnsSnapshotDeleteResult)
 	t.Logf("snapshotDeleteResult %+v", snapshotDeleteResult)
 
 	// Delete

--- a/eam/object/agency_test.go
+++ b/eam/object/agency_test.go
@@ -172,7 +172,7 @@ func TestAgency(t *testing.T) {
 	}
 
 	testRuntimeGoalState := func(t *testing.T) {
-		validateExpectedGoalState := func(expGoalState interface{}) error {
+		validateExpectedGoalState := func(expGoalState any) error {
 			runtime, err := agency.Runtime(client.ctx)
 			if err != nil {
 				return err

--- a/history/collector.go
+++ b/history/collector.go
@@ -37,7 +37,7 @@ func (c Collector) Client() *vim25.Client {
 
 // Properties wraps property.DefaultCollector().RetrieveOne() and returns
 // properties for the specified managed object reference
-func (c Collector) Properties(ctx context.Context, r types.ManagedObjectReference, ps []string, dst interface{}) error {
+func (c Collector) Properties(ctx context.Context, r types.ManagedObjectReference, ps []string, dst any) error {
 	return property.DefaultCollector(c.c).RetrieveOne(ctx, r, ps, dst)
 }
 

--- a/list/lister.go
+++ b/list/lister.go
@@ -104,7 +104,7 @@ type Lister struct {
 	All       bool
 }
 
-func (l Lister) retrieveProperties(ctx context.Context, req types.RetrieveProperties, dst *[]interface{}) error {
+func (l Lister) retrieveProperties(ctx context.Context, req types.RetrieveProperties, dst *[]any) error {
 	res, err := l.Collector.RetrieveProperties(ctx, req)
 	if err != nil {
 		return err
@@ -215,7 +215,7 @@ func (l Lister) ListFolder(ctx context.Context) ([]Element, error) {
 		SpecSet: []types.PropertyFilterSpec{spec},
 	}
 
-	var dst []interface{}
+	var dst []any
 
 	err := l.retrieveProperties(ctx, req, &dst)
 	if err != nil {
@@ -273,7 +273,7 @@ func (l Lister) ListDatacenter(ctx context.Context) ([]Element, error) {
 		},
 	}
 
-	var dst []interface{}
+	var dst []any
 
 	err := l.retrieveProperties(ctx, req, &dst)
 	if err != nil {
@@ -340,7 +340,7 @@ func (l Lister) ListComputeResource(ctx context.Context) ([]Element, error) {
 		},
 	}
 
-	var dst []interface{}
+	var dst []any
 
 	err := l.retrieveProperties(ctx, req, &dst)
 	if err != nil {
@@ -403,7 +403,7 @@ func (l Lister) ListResourcePool(ctx context.Context) ([]Element, error) {
 		},
 	}
 
-	var dst []interface{}
+	var dst []any
 
 	err := l.retrieveProperties(ctx, req, &dst)
 	if err != nil {
@@ -470,7 +470,7 @@ func (l Lister) ListHostSystem(ctx context.Context) ([]Element, error) {
 		},
 	}
 
-	var dst []interface{}
+	var dst []any
 
 	err := l.retrieveProperties(ctx, req, &dst)
 	if err != nil {
@@ -533,7 +533,7 @@ func (l Lister) ListDistributedVirtualSwitch(ctx context.Context) ([]Element, er
 		},
 	}
 
-	var dst []interface{}
+	var dst []any
 
 	err := l.retrieveProperties(ctx, req, &dst)
 	if err != nil {
@@ -598,7 +598,7 @@ func (l Lister) ListVirtualApp(ctx context.Context) ([]Element, error) {
 		},
 	}
 
-	var dst []interface{}
+	var dst []any
 
 	err := l.retrieveProperties(ctx, req, &dst)
 	if err != nil {

--- a/object/authorization_manager_internal.go
+++ b/object/authorization_manager_internal.go
@@ -26,7 +26,7 @@ type disableMethodsRequest struct {
 
 type disableMethodsBody struct {
 	Req *disableMethodsRequest `xml:"urn:internalvim25 DisableMethods,omitempty"`
-	Res interface{}            `xml:"urn:vim25 DisableMethodsResponse,omitempty"`
+	Res any                    `xml:"urn:vim25 DisableMethodsResponse,omitempty"`
 	Err *soap.Fault            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
 }
 
@@ -54,7 +54,7 @@ type enableMethodsRequest struct {
 
 type enableMethodsBody struct {
 	Req *enableMethodsRequest `xml:"urn:internalvim25 EnableMethods,omitempty"`
-	Res interface{}           `xml:"urn:vim25 EnableMethodsResponse,omitempty"`
+	Res any                   `xml:"urn:vim25 EnableMethodsResponse,omitempty"`
 	Err *soap.Fault           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
 }
 

--- a/object/common.go
+++ b/object/common.go
@@ -83,7 +83,7 @@ func (c Common) ObjectName(ctx context.Context) (string, error) {
 }
 
 // Properties is a wrapper for property.DefaultCollector().RetrieveOne()
-func (c Common) Properties(ctx context.Context, r types.ManagedObjectReference, ps []string, dst interface{}) error {
+func (c Common) Properties(ctx context.Context, r types.ManagedObjectReference, ps []string, dst any) error {
 	return property.DefaultCollector(c.c).RetrieveOne(ctx, r, ps, dst)
 }
 

--- a/object/datastore_file.go
+++ b/object/datastore_file.go
@@ -141,7 +141,7 @@ func (s *fileStat) IsDir() bool {
 	return false
 }
 
-func (s *fileStat) Sys() interface{} {
+func (s *fileStat) Sys() any {
 	return s.header
 }
 

--- a/object/host_system.go
+++ b/object/host_system.go
@@ -39,7 +39,7 @@ func (h HostSystem) ResourcePool(ctx context.Context) (*ResourcePool, error) {
 	}
 
 	var mcr *mo.ComputeResource
-	var parent interface{}
+	var parent any
 
 	switch mh.Parent.Type {
 	case "ComputeResource":

--- a/property/collector.go
+++ b/property/collector.go
@@ -161,7 +161,7 @@ func (p *Collector) RetrieveProperties(
 // the properties slice is nil, all properties are loaded.
 // Note that pointer types are optional fields that may be left as a nil value.
 // The caller should check such fields for a nil value before dereferencing.
-func (p *Collector) Retrieve(ctx context.Context, objs []types.ManagedObjectReference, ps []string, dst interface{}) error {
+func (p *Collector) Retrieve(ctx context.Context, objs []types.ManagedObjectReference, ps []string, dst any) error {
 	if len(objs) == 0 {
 		return errors.New("object references is empty")
 	}
@@ -221,7 +221,7 @@ func (p *Collector) RetrieveWithFilter(
 	ctx context.Context,
 	objs []types.ManagedObjectReference,
 	ps []string,
-	dst interface{},
+	dst any,
 	filter Match) error {
 
 	if len(filter) == 0 {
@@ -245,7 +245,7 @@ func (p *Collector) RetrieveWithFilter(
 }
 
 // RetrieveOne calls Retrieve with a single managed object reference via Collector.Retrieve().
-func (p *Collector) RetrieveOne(ctx context.Context, obj types.ManagedObjectReference, ps []string, dst interface{}) error {
+func (p *Collector) RetrieveOne(ctx context.Context, obj types.ManagedObjectReference, ps []string, dst any) error {
 	var objs = []types.ManagedObjectReference{obj}
 	return p.Retrieve(ctx, objs, ps, dst)
 }

--- a/simulator/esxcli.go
+++ b/simulator/esxcli.go
@@ -367,7 +367,7 @@ func (m *ManagedMethodExecuter) VimEsxCLISystemStatsUptimeGet(_ *Context, _ esxc
 	return &esxcli.Response{Kind: "long", String: uptime}, nil
 }
 
-func (_ *ManagedMethodExecuter) toXML(v interface{}) string {
+func (_ *ManagedMethodExecuter) toXML(v any) string {
 	var out bytes.Buffer
 
 	err := xml.NewEncoder(&out).Encode(v)

--- a/simulator/folder_test.go
+++ b/simulator/folder_test.go
@@ -339,7 +339,7 @@ func TestRegisterVm(t *testing.T) {
 		}
 
 		steps := []struct {
-			e interface{}
+			e any
 			f func()
 		}{
 			{
@@ -403,7 +403,7 @@ func TestRegisterVm(t *testing.T) {
 		_ = onTask.Wait(ctx)
 
 		steps = []struct {
-			e interface{}
+			e any
 			f func()
 		}{
 			{

--- a/simulator/internal/object_lock.go
+++ b/simulator/internal/object_lock.go
@@ -12,7 +12,7 @@ import (
 // SharedLockingContext is used to identify when locks can be shared. In
 // practice, simulator code uses the simulator.Context for a request, but in
 // principle this could be anything.
-type SharedLockingContext interface{}
+type SharedLockingContext any
 
 // ObjectLock implements a basic "reference-counted" mutex, where a single
 // SharedLockingContext can "share" the lock across code paths or child tasks.

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -353,7 +353,7 @@ func (m *Model) resolveReferences(ctx *Context) error {
 	return nil
 }
 
-func (m *Model) decode(path string, data interface{}) error {
+func (m *Model) decode(path string, data any) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err

--- a/simulator/object.go
+++ b/simulator/object.go
@@ -53,7 +53,7 @@ func sha1UUID(s string) uuid.UUID {
 }
 
 // deepCopy uses xml encode/decode to copy src to dst
-func deepCopy(src, dst interface{}) {
+func deepCopy(src, dst any) {
 	b, err := xml.Marshal(src)
 	if err != nil {
 		panic(err)

--- a/simulator/property_collector.go
+++ b/simulator/property_collector.go
@@ -106,7 +106,7 @@ func getManagedObject(obj mo.Reference) reflect.Value {
 }
 
 // wrapValue converts slice types to the appropriate ArrayOf type used in property collector responses.
-func wrapValue(rval reflect.Value, rtype reflect.Type) interface{} {
+func wrapValue(rval reflect.Value, rtype reflect.Type) any {
 	pval := rval.Interface()
 
 	if rval.Kind() == reflect.Slice {
@@ -150,7 +150,7 @@ func wrapValue(rval reflect.Value, rtype reflect.Type) interface{} {
 	return pval
 }
 
-func fieldValueInterface(f reflect.StructField, rval reflect.Value, keyed ...bool) interface{} {
+func fieldValueInterface(f reflect.StructField, rval reflect.Value, keyed ...bool) any {
 	if rval.Kind() == reflect.Ptr {
 		rval = rval.Elem()
 	}
@@ -162,8 +162,8 @@ func fieldValueInterface(f reflect.StructField, rval reflect.Value, keyed ...boo
 	return wrapValue(rval, f.Type)
 }
 
-func fieldValue(rval reflect.Value, p string, keyed ...bool) (interface{}, error) {
-	var value interface{}
+func fieldValue(rval reflect.Value, p string, keyed ...bool) (any, error) {
+	var value any
 	fields := strings.Split(p, ".")
 
 	for i, name := range fields {
@@ -211,7 +211,7 @@ func fieldValue(rval reflect.Value, p string, keyed ...bool) (interface{}, error
 	return value, nil
 }
 
-func fieldValueKey(rval reflect.Value, p mo.Field) (interface{}, error) {
+func fieldValueKey(rval reflect.Value, p mo.Field) (any, error) {
 	if rval.Kind() != reflect.Slice {
 		return nil, errInvalidField
 	}
@@ -260,7 +260,7 @@ func fieldValueKey(rval reflect.Value, p mo.Field) (interface{}, error) {
 	return nil, nil
 }
 
-func fieldValueIndex(rval reflect.Value, p mo.Field) (interface{}, error) {
+func fieldValueIndex(rval reflect.Value, p mo.Field) (any, error) {
 	val, err := fieldValueKey(rval, p)
 	if err != nil || val == nil || p.Item == "" {
 		return val, err
@@ -269,7 +269,7 @@ func fieldValueIndex(rval reflect.Value, p mo.Field) (interface{}, error) {
 	return fieldValue(reflect.ValueOf(val), p.Item)
 }
 
-func fieldRefs(f interface{}) []types.ManagedObjectReference {
+func fieldRefs(f any) []types.ManagedObjectReference {
 	switch fv := f.(type) {
 	case types.ManagedObjectReference:
 		return []types.ManagedObjectReference{fv}
@@ -384,7 +384,7 @@ func (rr *retrieveResult) collectFields(ctx *Context, rval reflect.Value, fields
 		}
 		seen[name] = true
 
-		var val interface{}
+		var val any
 		var err error
 		var field mo.Field
 		if field.FromString(name) {

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -119,7 +119,7 @@ func Fault(msg string, fault types.BaseMethodFault) *soap.Fault {
 	return f
 }
 
-func tracef(format string, v ...interface{}) {
+func tracef(format string, v ...any) {
 	if Trace {
 		log.Printf(format, v...)
 	}
@@ -268,12 +268,12 @@ func (s *Service) RoundTrip(ctx context.Context, request, response soap.HasFault
 // and additional namespace attributes required by some client libraries.
 // Go still has issues decoding with such a namespace, but encoding is ok.
 type soapEnvelope struct {
-	XMLName xml.Name    `xml:"soapenv:Envelope"`
-	Enc     string      `xml:"xmlns:soapenc,attr"`
-	Env     string      `xml:"xmlns:soapenv,attr"`
-	XSD     string      `xml:"xmlns:xsd,attr"`
-	XSI     string      `xml:"xmlns:xsi,attr"`
-	Body    interface{} `xml:"soapenv:Body"`
+	XMLName xml.Name `xml:"soapenv:Envelope"`
+	Enc     string   `xml:"xmlns:soapenc,attr"`
+	Env     string   `xml:"xmlns:soapenv,attr"`
+	XSD     string   `xml:"xmlns:xsd,attr"`
+	XSI     string   `xml:"xmlns:xsi,attr"`
+	Body    any      `xml:"soapenv:Body"`
 }
 
 type faultDetail struct {
@@ -498,7 +498,7 @@ func (s *Service) ServeSDK(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var res soap.HasFault
-	var soapBody interface{}
+	var soapBody any
 
 	method, err := UnmarshalBody(ctx.Map.typeFunc, body)
 	if err != nil {
@@ -925,7 +925,7 @@ func (e *Element) decoder() *xml.Decoder {
 	return decoder
 }
 
-func (e *Element) Decode(val interface{}) error {
+func (e *Element) Decode(val any) error {
 	return e.decoder().DecodeElement(val, &e.start)
 }
 

--- a/simulator/simulator_test.go
+++ b/simulator/simulator_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestUnmarshal(t *testing.T) {
 	requests := []struct {
-		body interface{}
+		body any
 		data string
 	}{
 		{

--- a/simulator/task.go
+++ b/simulator/task.go
@@ -122,7 +122,7 @@ func (t *Task) Run(ctx *Context) types.ManagedObjectReference {
 		unlock()
 
 		state := types.TaskInfoStateSuccess
-		var fault interface{}
+		var fault any
 		if err != nil {
 			state = types.TaskInfoStateError
 			fault = types.LocalizedMethodFault{

--- a/simulator/virtual_disk_manager.go
+++ b/simulator/virtual_disk_manager.go
@@ -71,7 +71,7 @@ func vdmCreateVirtualDisk(ctx *Context, op types.VirtualDeviceConfigSpecFileOper
 		}
 
 		if req.Spec != nil {
-			var spec interface{} = req.Spec
+			var spec any = req.Spec
 			fileBackedSpec, ok := spec.(*types.FileBackedVirtualDiskSpec)
 
 			if !ok {

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1097,7 +1097,7 @@ func (vm *VirtualMachine) createFile(ctx *Context, spec string, name string, reg
 
 // Rather than keep an fd open for each VM, open/close the log for each messages.
 // This is ok for now as we do not do any heavy VM logging.
-func (vm *VirtualMachine) logPrintf(format string, v ...interface{}) {
+func (vm *VirtualMachine) logPrintf(format string, v ...any) {
 	f, err := os.OpenFile(vm.log, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0)
 	if err != nil {
 		log.Println(err)

--- a/sts/internal/types.go
+++ b/sts/internal/types.go
@@ -527,7 +527,7 @@ type RequestSecurityToken struct {
 	RenewTarget        *Target   `xml:",omitempty"`
 }
 
-func Unmarshal(data []byte, v interface{}) error {
+func Unmarshal(data []byte, v any) error {
 	dec := xml.NewDecoder(bytes.NewReader(data))
 	dec.TypeFunc = types.TypeFunc()
 	return dec.Decode(v)
@@ -658,7 +658,7 @@ func Renew(ctx context.Context, r soap.RoundTripper, req *RequestSecurityToken) 
 }
 
 // Marshal panics if xml.Marshal returns an error
-func Marshal(val interface{}) string {
+func Marshal(val any) string {
 	b, err := xml.Marshal(val)
 	if err != nil {
 		panic(err)
@@ -669,7 +669,7 @@ func Marshal(val interface{}) string {
 // mkns prepends the given namespace to xml.Name.Local and returns obj encoded as xml.
 // Note that the namespace is required when encoding, but the namespace prefix must not be
 // present when decoding as Go's decoding does not handle namespace prefix.
-func mkns(ns string, obj interface{}, name ...*xml.Name) string {
+func mkns(ns string, obj any, name ...*xml.Name) string {
 	ns += ":"
 	for i := range name {
 		name[i].Space = ""

--- a/toolbox/guest_info.go
+++ b/toolbox/guest_info.go
@@ -75,7 +75,7 @@ type GuestNicInfo struct {
 	V3      *NicInfoV3 `xdr:"optional"`
 }
 
-func EncodeXDR(val interface{}) ([]byte, error) {
+func EncodeXDR(val any) ([]byte, error) {
 	var buf bytes.Buffer
 
 	_, err := xdr.Marshal(&buf, val)
@@ -86,7 +86,7 @@ func EncodeXDR(val interface{}) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func DecodeXDR(buf []byte, val interface{}) error {
+func DecodeXDR(buf []byte, val any) error {
 	r := bytes.NewReader(buf)
 	_, err := xdr.Unmarshal(r, val)
 	return err

--- a/toolbox/hgfs/archive.go
+++ b/toolbox/hgfs/archive.go
@@ -103,7 +103,7 @@ func (a *archive) IsDir() bool {
 }
 
 // Sys implementation of the os.FileInfo interface method.
-func (a *archive) Sys() interface{} {
+func (a *archive) Sys() any {
 	return nil
 }
 

--- a/toolbox/hgfs/encoding.go
+++ b/toolbox/hgfs/encoding.go
@@ -11,7 +11,7 @@ import (
 )
 
 // MarshalBinary is a wrapper around binary.Write
-func MarshalBinary(fields ...interface{}) ([]byte, error) {
+func MarshalBinary(fields ...any) ([]byte, error) {
 	buf := new(bytes.Buffer)
 
 	for _, p := range fields {
@@ -39,7 +39,7 @@ func MarshalBinary(fields ...interface{}) ([]byte, error) {
 }
 
 // UnmarshalBinary is a wrapper around binary.Read
-func UnmarshalBinary(data []byte, fields ...interface{}) error {
+func UnmarshalBinary(data []byte, fields ...any) error {
 	buf := bytes.NewBuffer(data)
 
 	for _, p := range fields {

--- a/toolbox/hgfs/protocol.go
+++ b/toolbox/hgfs/protocol.go
@@ -248,7 +248,7 @@ type Packet struct {
 }
 
 // Reply composes a new Packet with the given payload or error
-func (r *Packet) Reply(payload interface{}, err error) ([]byte, error) {
+func (r *Packet) Reply(payload any, err error) ([]byte, error) {
 	p := new(Packet)
 
 	status := uint32(StatusSuccess)
@@ -400,7 +400,7 @@ type ReplyCreateSessionV4 struct {
 func (r *ReplyCreateSessionV4) MarshalBinary() ([]byte, error) {
 	buf := new(bytes.Buffer)
 
-	fields := []interface{}{
+	fields := []any{
 		&r.SessionID,
 		&r.NumCapabilities,
 		&r.MaxPacketSize,
@@ -430,7 +430,7 @@ func (r *ReplyCreateSessionV4) MarshalBinary() ([]byte, error) {
 func (r *ReplyCreateSessionV4) UnmarshalBinary(data []byte) error {
 	buf := bytes.NewBuffer(data)
 
-	fields := []interface{}{
+	fields := []any{
 		&r.SessionID,
 		&r.NumCapabilities,
 		&r.MaxPacketSize,
@@ -548,7 +548,7 @@ func (f *FileNameV3) MarshalBinary() ([]byte, error) {
 func (f *FileNameV3) UnmarshalBinary(data []byte) error {
 	buf := bytes.NewBuffer(data)
 
-	fields := []interface{}{
+	fields := []any{
 		&f.Length, &f.Flags, &f.CaseType, &f.ID,
 	}
 

--- a/toolbox/hgfs/protocol_test.go
+++ b/toolbox/hgfs/protocol_test.go
@@ -32,7 +32,7 @@ func TestProtocolEncoding(t *testing.T) {
 	// govc guest.upload /etc/hosts /tmp/hosts
 	tests := []struct {
 		pkt string
-		dec interface{}
+		dec any
 	}{
 		{
 			"AQAAAP8AAABMAAAANAAAAAAAAIApAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+AAAAAAAAAAAAAAAAAAAAAAAAA==",

--- a/toolbox/hgfs/server.go
+++ b/toolbox/hgfs/server.go
@@ -31,7 +31,7 @@ var (
 type Server struct {
 	Capabilities []Capability
 
-	handlers map[int32]func(*Packet) (interface{}, error)
+	handlers map[int32]func(*Packet) (any, error)
 	schemes  map[string]FileHandler
 	sessions map[uint64]*session
 	mu       sync.Mutex
@@ -54,7 +54,7 @@ func NewServer() *Server {
 		chown:    os.Chown,
 	}
 
-	s.handlers = map[int32]func(*Packet) (interface{}, error){
+	s.handlers = map[int32]func(*Packet) (any, error){
 		OpCreateSessionV4:  s.CreateSessionV4,
 		OpDestroySessionV4: s.DestroySessionV4,
 		OpGetattrV2:        s.GetattrV2,
@@ -95,7 +95,7 @@ func (s *Server) Dispatch(packet []byte) ([]byte, error) {
 		fmt.Fprintf(os.Stderr, "[hgfs] request  %#v\n", req.Header)
 	}
 
-	var res interface{}
+	var res any
 
 	handler, ok := s.handlers[req.Op]
 	if ok {
@@ -256,7 +256,7 @@ func (s *Server) removeSession(id uint64) bool {
 const maxSessions = 24
 
 // CreateSessionV4 handls OpCreateSessionV4 requests
-func (s *Server) CreateSessionV4(p *Packet) (interface{}, error) {
+func (s *Server) CreateSessionV4(p *Packet) (any, error) {
 	const SessionMaxPacketSizeValid = 0x1
 
 	req := new(RequestCreateSessionV4)
@@ -285,7 +285,7 @@ func (s *Server) CreateSessionV4(p *Packet) (interface{}, error) {
 }
 
 // DestroySessionV4 handls OpDestroySessionV4 requests
-func (s *Server) DestroySessionV4(p *Packet) (interface{}, error) {
+func (s *Server) DestroySessionV4(p *Packet) (any, error) {
 	if s.removeSession(p.SessionID) {
 		return &ReplyDestroySessionV4{}, nil
 	}
@@ -312,7 +312,7 @@ func (a *AttrV2) Stat(info os.FileInfo) {
 }
 
 // GetattrV2 handles OpGetattrV2 requests
-func (s *Server) GetattrV2(p *Packet) (interface{}, error) {
+func (s *Server) GetattrV2(p *Packet) (any, error) {
 	res := &ReplyGetattrV2{}
 
 	req := new(RequestGetattrV2)
@@ -333,7 +333,7 @@ func (s *Server) GetattrV2(p *Packet) (interface{}, error) {
 }
 
 // SetattrV2 handles OpSetattrV2 requests
-func (s *Server) SetattrV2(p *Packet) (interface{}, error) {
+func (s *Server) SetattrV2(p *Packet) (any, error) {
 	res := &ReplySetattrV2{}
 
 	req := new(RequestSetattrV2)
@@ -394,7 +394,7 @@ func (s *Server) newHandle() uint32 {
 }
 
 // Open handles OpOpen requests
-func (s *Server) Open(p *Packet) (interface{}, error) {
+func (s *Server) Open(p *Packet) (any, error) {
 	req := new(RequestOpen)
 	err := UnmarshalBinary(p.Payload, req)
 	if err != nil {
@@ -433,7 +433,7 @@ func (s *Server) Open(p *Packet) (interface{}, error) {
 }
 
 // Close handles OpClose requests
-func (s *Server) Close(p *Packet) (interface{}, error) {
+func (s *Server) Close(p *Packet) (any, error) {
 	req := new(RequestClose)
 	err := UnmarshalBinary(p.Payload, req)
 	if err != nil {
@@ -462,7 +462,7 @@ func (s *Server) Close(p *Packet) (interface{}, error) {
 }
 
 // OpenV3 handles OpOpenV3 requests
-func (s *Server) OpenV3(p *Packet) (interface{}, error) {
+func (s *Server) OpenV3(p *Packet) (any, error) {
 	req := new(RequestOpenV3)
 	err := UnmarshalBinary(p.Payload, req)
 	if err != nil {
@@ -500,7 +500,7 @@ func (s *Server) OpenV3(p *Packet) (interface{}, error) {
 }
 
 // ReadV3 handles OpReadV3 requests
-func (s *Server) ReadV3(p *Packet) (interface{}, error) {
+func (s *Server) ReadV3(p *Packet) (any, error) {
 	req := new(RequestReadV3)
 	err := UnmarshalBinary(p.Payload, req)
 	if err != nil {
@@ -540,7 +540,7 @@ func (s *Server) ReadV3(p *Packet) (interface{}, error) {
 }
 
 // WriteV3 handles OpWriteV3 requests
-func (s *Server) WriteV3(p *Packet) (interface{}, error) {
+func (s *Server) WriteV3(p *Packet) (any, error) {
 	req := new(RequestWriteV3)
 	err := UnmarshalBinary(p.Payload, req)
 	if err != nil {

--- a/toolbox/hgfs/server_test.go
+++ b/toolbox/hgfs/server_test.go
@@ -25,7 +25,7 @@ func NewClient() *Client {
 	}
 }
 
-func (c *Client) Dispatch(op int32, req interface{}, res interface{}) *Packet {
+func (c *Client) Dispatch(op int32, req any, res any) *Packet {
 	var err error
 	p := new(Packet)
 	p.Payload, err = MarshalBinary(req)

--- a/toolbox/process/process.go
+++ b/toolbox/process/process.go
@@ -142,7 +142,7 @@ func (a *File) IsDir() bool {
 }
 
 // Sys implementation of the os.FileInfo interface method.
-func (a *File) Sys() interface{} {
+func (a *File) Sys() any {
 	return nil
 }
 
@@ -212,7 +212,7 @@ func NewManager() *Manager {
 		expire:  time.Minute * 5,
 		entries: make(map[int64]*Process),
 		pids: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				return atomic.AddInt64(&pid, 1)
 			},
 		},

--- a/vapi/appliance/simulator/simulator.go
+++ b/vapi/appliance/simulator/simulator.go
@@ -57,12 +57,12 @@ func (h *Handler) Register(s *simulator.Service, r *simulator.Registry) {
 	s.HandleFunc(shutdown.Path, h.shutdown)
 }
 
-func (h *Handler) decode(r *http.Request, w http.ResponseWriter, val interface{}) bool {
+func (h *Handler) decode(r *http.Request, w http.ResponseWriter, val any) bool {
 	return Decode(r, w, val)
 }
 
 // Decode decodes the request Body into val, returns true on success, otherwise false.
-func Decode(request *http.Request, writer http.ResponseWriter, val interface{}) bool {
+func Decode(request *http.Request, writer http.ResponseWriter, val any) bool {
 	defer request.Body.Close()
 	err := json.NewDecoder(request.Body).Decode(val)
 	if err != nil {

--- a/vapi/cis/tasks/tasks.go
+++ b/vapi/cis/tasks/tasks.go
@@ -61,9 +61,9 @@ func (c *Manager) WaitForCompletion(ctx context.Context, taskId string) (string,
 	}
 }
 
-func (c *Manager) getTaskInfo(taskId string) (map[string]interface{}, error) {
+func (c *Manager) getTaskInfo(taskId string) (map[string]any, error) {
 	path := c.Resource(TasksPath).WithSubpath(taskId)
 	req := path.Request(http.MethodGet)
-	var res map[string]interface{}
+	var res map[string]any
 	return res, c.Do(context.Background(), req, &res)
 }

--- a/vapi/esx/settings/depots/depots.go
+++ b/vapi/esx/settings/depots/depots.go
@@ -91,13 +91,13 @@ type ComponentVersion struct {
 // SettingsDepotsMetadataInfo is a partial type mapping for
 // https://developer.vmware.com/apis/vsphere-automation/latest/esx/data-structures/Settings/Depots/MetadataInfo/
 type SettingsDepotsMetadataInfo struct {
-	Addons                map[string]interface{}                    `json:"addons,omitempty"`
-	BaseImages            []interface{}                             `json:"base_images,omitempty"`
+	Addons                map[string]any                            `json:"addons,omitempty"`
+	BaseImages            []any                                     `json:"base_images,omitempty"`
 	FileName              string                                    `json:"file_name"`
-	HardwareSupport       map[string]interface{}                    `json:"hardware_support,omitempty"`
+	HardwareSupport       map[string]any                            `json:"hardware_support,omitempty"`
 	IndependentComponents map[string]SettingsDepotsComponentSummary `json:"independent_components,omitempty"`
-	Solutions             map[string]interface{}                    `json:"solutions,omitempty"`
-	Updates               map[string]interface{}                    `json:"updates,omitempty"`
+	Solutions             map[string]any                            `json:"solutions,omitempty"`
+	Updates               map[string]any                            `json:"updates,omitempty"`
 }
 
 // SettingsDepotsOfflineContentInfo is a type mapping for

--- a/vapi/library/finder/finder.go
+++ b/vapi/library/finder/finder.go
@@ -117,15 +117,15 @@ type FindResult interface {
 	GetName() string
 
 	// GetResult gets the underlying library object.
-	GetResult() interface{}
+	GetResult() any
 }
 
 type findResult struct {
-	result interface{}
+	result any
 	parent FindResult
 }
 
-func (f findResult) GetResult() interface{} {
+func (f findResult) GetResult() any {
 	return f.result
 }
 func (f findResult) GetParent() FindResult {

--- a/vapi/namespace/namespace.go
+++ b/vapi/namespace/namespace.go
@@ -436,7 +436,7 @@ type DefaultImageRegistry struct {
 // EnableCluster enables vSphere Namespaces on the specified cluster, using the given spec.
 // See https://developer.vmware.com/apis/vsphere-automation/latest/vcenter/api/vcenter/namespace-management/clusters/clusteractionenable/post/
 func (c *Manager) EnableCluster(ctx context.Context, id string, spec *EnableClusterSpec) error {
-	var response interface{}
+	var response any
 	url := c.Resource(path.Join(internal.NamespaceClusterPath, id)).WithParam("action", "enable")
 	fmt.Fprint(os.Stdout, spec)
 	err := c.Do(ctx, url.Request(http.MethodPost, spec), response)
@@ -445,7 +445,7 @@ func (c *Manager) EnableCluster(ctx context.Context, id string, spec *EnableClus
 
 // EnableCluster enables vSphere Namespaces on the specified cluster, using the given spec.
 func (c *Manager) DisableCluster(ctx context.Context, id string) error {
-	var response interface{}
+	var response any
 	url := c.Resource(path.Join(internal.NamespaceClusterPath, id)).WithParam("action", "disable")
 	err := c.Do(ctx, url.Request(http.MethodPost), response)
 	return err
@@ -659,8 +659,8 @@ type NamespacesInstanceSummary struct {
 }
 
 type LocalizableMessage struct {
-	Details  interface{} `json:"details"`
-	Severity string      `json:"severity"`
+	Details  any    `json:"details"`
+	Severity string `json:"severity"`
 }
 
 // NamespacesInstanceInfo https://developer.vmware.com/apis/vsphere-automation/v7.0U3/vcenter/data-structures/Namespaces/Instances/Info/

--- a/vapi/rest/client.go
+++ b/vapi/rest/client.go
@@ -160,7 +160,7 @@ type RawResponse struct {
 }
 
 // Do sends the http.Request, decoding resBody if provided.
-func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{}) error {
+func (c *Client) Do(ctx context.Context, req *http.Request, resBody any) error {
 	switch req.Method {
 	case http.MethodPost, http.MethodPatch, http.MethodPut:
 		req.Header.Set("Content-Type", "application/json")
@@ -226,7 +226,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 			}
 			// Responses from the /rest endpoint are wrapped in this structure
 			val := struct {
-				Value interface{} `json:"value,omitempty"`
+				Value any `json:"value,omitempty"`
 			}{
 				resBody,
 			}

--- a/vapi/rest/resource.go
+++ b/vapi/rest/resource.go
@@ -77,7 +77,7 @@ func (r *Resource) WithPathEncodedParam(name string, value string) *Resource {
 
 // Request returns a new http.Request for the given method.
 // An optional body can be provided for POST and PATCH methods.
-func (r *Resource) Request(method string, body ...interface{}) *http.Request {
+func (r *Resource) Request(method string, body ...any) *http.Request {
 	rdr := io.MultiReader() // empty body by default
 	if len(body) != 0 {
 		rdr = encode(body[0])
@@ -98,7 +98,7 @@ func (e errorReader) Read([]byte) (int, error) {
 }
 
 // encode body as JSON, deferring any errors until io.Reader is used.
-func encode(body interface{}) io.Reader {
+func encode(body any) io.Reader {
 	var b bytes.Buffer
 	err := json.NewEncoder(&b).Encode(body)
 	if err != nil {

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -373,7 +373,7 @@ func (s *handler) DetachTag(id vim.ManagedObjectReference, tag vim.VslmTagEntry)
 
 // StatusOK responds with http.StatusOK and encodes val, if specified, to JSON
 // For use with "/api" endpoints.
-func StatusOK(w http.ResponseWriter, val ...interface{}) {
+func StatusOK(w http.ResponseWriter, val ...any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if len(val) == 0 {
@@ -389,14 +389,14 @@ func StatusOK(w http.ResponseWriter, val ...interface{}) {
 
 // OK responds with http.StatusOK and encodes val, if specified, to JSON
 // For use with "/rest" endpoints where the response is a "value" wrapped structure.
-func OK(w http.ResponseWriter, val ...interface{}) {
+func OK(w http.ResponseWriter, val ...any) {
 	if len(val) == 0 {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
 	s := struct {
-		Value interface{} `json:"value,omitempty"`
+		Value any `json:"value,omitempty"`
 	}{
 		val[0],
 	}
@@ -495,13 +495,13 @@ func (s *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.ServeMux.ServeHTTP(w, r)
 }
 
-func (s *handler) decode(r *http.Request, w http.ResponseWriter, val interface{}) bool {
+func (s *handler) decode(r *http.Request, w http.ResponseWriter, val any) bool {
 	return Decode(r, w, val)
 }
 
 // Decode the request Body into val.
 // Returns true on success, otherwise false and sends the http.StatusBadRequest response.
-func Decode(r *http.Request, w http.ResponseWriter, val interface{}) bool {
+func Decode(r *http.Request, w http.ResponseWriter, val any) bool {
 	defer r.Body.Close()
 	err := json.NewDecoder(r.Body).Decode(val)
 	if err != nil {

--- a/vapi/vcenter/consumptiondomains/simulator/simulator.go
+++ b/vapi/vcenter/consumptiondomains/simulator/simulator.go
@@ -143,7 +143,7 @@ func (h *Handler) associations(w http.ResponseWriter, r *http.Request) {
 			if d, ok := h.data[zoneId]; ok {
 				associations := append(d.Associations, clusterIds...)
 				d.Associations = associations
-				res := make(map[string]interface{})
+				res := make(map[string]any)
 				res["success"] = true
 				vapi.StatusOK(w, res)
 				return

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -186,7 +186,7 @@ func main() {
 		}
 	}
 
-	expvar.Publish("vcsim", expvar.Func(func() interface{} {
+	expvar.Publish("vcsim", expvar.Func(func() any {
 		count := model.Count()
 
 		return struct {

--- a/view/container_view.go
+++ b/view/container_view.go
@@ -24,7 +24,7 @@ func NewContainerView(c *vim25.Client, ref types.ManagedObjectReference) *Contai
 }
 
 // Retrieve populates dst as property.Collector.Retrieve does, for all entities in the view of types specified by kind.
-func (v ContainerView) Retrieve(ctx context.Context, kind []string, ps []string, dst interface{}, pspec ...types.PropertySpec) error {
+func (v ContainerView) Retrieve(ctx context.Context, kind []string, ps []string, dst any, pspec ...types.PropertySpec) error {
 	pc := property.DefaultCollector(v.Client())
 
 	ospec := types.ObjectSpec{
@@ -79,7 +79,7 @@ func (v ContainerView) Retrieve(ctx context.Context, kind []string, ps []string,
 }
 
 // RetrieveWithFilter populates dst as Retrieve does, but only for entities matching the given filter.
-func (v ContainerView) RetrieveWithFilter(ctx context.Context, kind []string, ps []string, dst interface{}, filter property.Match) error {
+func (v ContainerView) RetrieveWithFilter(ctx context.Context, kind []string, ps []string, dst any, filter property.Match) error {
 	if len(filter) == 0 {
 		return v.Retrieve(ctx, kind, ps, dst)
 	}

--- a/vim25/mo/ancestors.go
+++ b/vim25/mo/ancestors.go
@@ -61,7 +61,7 @@ func Ancestors(ctx context.Context, rt soap.RoundTripper, pc, obj types.ManagedO
 		},
 	}
 
-	var ifaces []interface{}
+	var ifaces []any
 	err := RetrievePropertiesForRequest(ctx, rt, req, &ifaces)
 	if err != nil {
 		return nil, err

--- a/vim25/mo/retrieve.go
+++ b/vim25/mo/retrieve.go
@@ -39,7 +39,7 @@ func ignoreMissingProperty(ref types.ManagedObjectReference, p types.MissingProp
 // it returns the first fault it finds there as error. If the 'MissingSet'
 // field is empty, it returns a pointer to a reflect.Value. It handles contain
 // nested properties, such as 'guest.ipAddress' or 'config.hardware'.
-func ObjectContentToType(o types.ObjectContent, ptr ...bool) (interface{}, error) {
+func ObjectContentToType(o types.ObjectContent, ptr ...bool) (any, error) {
 	// Expect no properties in the missing set
 	for _, p := range o.MissingSet {
 		if ignoreMissingProperty(o.Obj, p) {
@@ -86,7 +86,7 @@ func ApplyPropertyChange(obj Reference, changes []types.PropertyChange) {
 
 // LoadObjectContent converts the response of a call to
 // RetrieveProperties{Ex} to one or more managed objects.
-func LoadObjectContent(content []types.ObjectContent, dst interface{}) error {
+func LoadObjectContent(content []types.ObjectContent, dst any) error {
 	rt := reflect.TypeOf(dst)
 	if rt == nil || rt.Kind() != reflect.Ptr {
 		panic("need pointer")
@@ -187,7 +187,7 @@ func RetrievePropertiesEx(ctx context.Context, r soap.RoundTripper, req types.Re
 // RetrievePropertiesForRequest calls the RetrieveProperties method with the
 // specified request and decodes the response struct into the value pointed to
 // by dst.
-func RetrievePropertiesForRequest(ctx context.Context, r soap.RoundTripper, req types.RetrieveProperties, dst interface{}) error {
+func RetrievePropertiesForRequest(ctx context.Context, r soap.RoundTripper, req types.RetrieveProperties, dst any) error {
 	objects, err := RetrievePropertiesEx(ctx, r, types.RetrievePropertiesEx{
 		This:    req.This,
 		SpecSet: req.SpecSet,
@@ -201,7 +201,7 @@ func RetrievePropertiesForRequest(ctx context.Context, r soap.RoundTripper, req 
 
 // RetrieveProperties retrieves the properties of the managed object specified
 // as obj and decodes the response struct into the value pointed to by dst.
-func RetrieveProperties(ctx context.Context, r soap.RoundTripper, pc, obj types.ManagedObjectReference, dst interface{}) error {
+func RetrieveProperties(ctx context.Context, r soap.RoundTripper, pc, obj types.ManagedObjectReference, dst any) error {
 	req := types.RetrieveProperties{
 		This: pc,
 		SpecSet: []types.PropertyFilterSpec{
@@ -230,7 +230,7 @@ var morType = reflect.TypeOf((*types.ManagedObjectReference)(nil)).Elem()
 // References returns all non-nil moref field values in the given struct.
 // Only Anonymous struct fields are followed by default. The optional follow
 // param will follow any struct fields when true.
-func References(s interface{}, follow ...bool) []types.ManagedObjectReference {
+func References(s any, follow ...bool) []types.ManagedObjectReference {
 	var refs []types.ManagedObjectReference
 	rval := reflect.ValueOf(s)
 	rtype := rval.Type()

--- a/vim25/soap/json_client.go
+++ b/vim25/soap/json_client.go
@@ -44,7 +44,7 @@ func (c *Client) jsonRoundTrip(ctx context.Context, req, res HasFault) error {
 }
 
 // Invoke calls a managed object method
-func (c *Client) invoke(ctx context.Context, this types.ManagedObjectReference, method string, params interface{}, res HasFault) error {
+func (c *Client) invoke(ctx context.Context, this types.ManagedObjectReference, method string, params any, res HasFault) error {
 	buffer := bytes.Buffer{}
 	if params != nil {
 		marshaller := types.NewJSONEncoder(&buffer)
@@ -77,7 +77,7 @@ func (c *Client) invoke(ctx context.Context, this types.ManagedObjectReference, 
 // unmarshaler checks for errors and tries to load the response body in the
 // result structure. It is assumed that result is pointer to a data structure or
 // interface{}.
-func (c *Client) responseUnmarshaler(result interface{}) func(resp *http.Response) error {
+func (c *Client) responseUnmarshaler(result any) func(resp *http.Response) error {
 	return func(resp *http.Response) error {
 		if resp.StatusCode == http.StatusNoContent ||
 			(!isError(resp.StatusCode) && resp.ContentLength == 0) {
@@ -93,7 +93,7 @@ func (c *Client) responseUnmarshaler(result interface{}) func(resp *http.Respons
 			if e != nil {
 				return e
 			}
-			var serverErr interface{}
+			var serverErr any
 			dec := types.NewJSONDecoder(bytes.NewReader(bodyBytes))
 			e = dec.Decode(&serverErr)
 			if e != nil {
@@ -180,7 +180,7 @@ func (c *Client) getPathForName(this types.ManagedObjectReference, name string) 
 // defined in methods.go. It is expected to have "Req" field that is a non-null
 // pointer to a struct. The struct simple type name is the method name. The
 // struct "This" member is the this MoRef value.
-func unpackSOAPRequest(req HasFault) (this types.ManagedObjectReference, method string, params interface{}, err error) {
+func unpackSOAPRequest(req HasFault) (this types.ManagedObjectReference, method string, params any, err error) {
 	reqBodyPtr := reflect.ValueOf(req)
 	if reqBodyPtr.Kind() != reflect.Ptr {
 		err = fmt.Errorf("Expected pointer to request body as input. %w", errInputError)
@@ -220,7 +220,7 @@ func unpackSOAPRequest(req HasFault) (this types.ManagedObjectReference, method 
 
 // getSOAPResultPtr extract a pointer to the result data structure using go
 // reflection from a SOAP data structure used for marshalling.
-func getSOAPResultPtr(result HasFault) (res interface{}, err error) {
+func getSOAPResultPtr(result HasFault) (res any, err error) {
 	resBodyPtr := reflect.ValueOf(result)
 	if resBodyPtr.Kind() != reflect.Ptr {
 		err = fmt.Errorf("Expected pointer to result body as input. %w", errInputError)

--- a/vim25/soap/json_client_test.go
+++ b/vim25/soap/json_client_test.go
@@ -87,7 +87,7 @@ func TestErrorUnmarshal(t *testing.T) {
 	c := NewClient(addr, true)
 	c.Namespace = "urn:vim25"
 
-	var result interface{}
+	var result any
 	unmarshaler := c.responseUnmarshaler(&result)
 
 	err := unmarshaler(resp)
@@ -152,7 +152,7 @@ func TestSuccessUnmarshal(t *testing.T) {
 	c := NewClient(addr, true)
 	c.Namespace = "urn:vim25"
 
-	var result interface{}
+	var result any
 	unmarshaler := c.responseUnmarshaler(&result)
 
 	err := unmarshaler(resp)

--- a/vim25/soap/soap.go
+++ b/vim25/soap/soap.go
@@ -20,13 +20,13 @@ type Header struct {
 	Action   string         `xml:"-"`                         // Action is the 'SOAPAction' HTTP header value. Defaults to "Client.Namespace/Client.Version".
 	Cookie   *HeaderElement `xml:"vcSessionCookie,omitempty"` // Cookie is a vCenter session cookie that can be used with other SDK endpoints (e.g. pbm, vslm).
 	ID       string         `xml:"operationID,omitempty"`     // ID is the operationID used by ESX/vCenter logging for correlation.
-	Security interface{}    `xml:",omitempty"`                // Security is used for SAML token authentication and request signing.
+	Security any            `xml:",omitempty"`                // Security is used for SAML token authentication and request signing.
 }
 
 type Envelope struct {
 	XMLName xml.Name `xml:"http://schemas.xmlsoap.org/soap/envelope/ Envelope"`
 	Header  *Header  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Header,omitempty"`
-	Body    interface{}
+	Body    any
 }
 
 type Fault struct {

--- a/vim25/types/base.go
+++ b/vim25/types/base.go
@@ -4,4 +4,4 @@
 
 package types
 
-type AnyType interface{}
+type AnyType any

--- a/vim25/types/base_test.go
+++ b/vim25/types/base_test.go
@@ -21,7 +21,7 @@ func TestAnyType(t *testing.T) {
 
 	tests := []struct {
 		Input []byte
-		Value interface{}
+		Value any
 	}{
 		{
 			Input: x(`<name xsi:type="xsd:string">test</name>`),
@@ -35,7 +35,7 @@ func TestAnyType(t *testing.T) {
 
 	for _, test := range tests {
 		var r struct {
-			A interface{} `xml:"name,typeattr"`
+			A any `xml:"name,typeattr"`
 		}
 
 		dec := xml.NewDecoder(bytes.NewReader(test.Input))

--- a/vim25/types/json_bench_test.go
+++ b/vim25/types/json_bench_test.go
@@ -50,7 +50,7 @@ func BenchmarkDecodeVirtualMachineConfigInfo(b *testing.B) {
 					json.DiscriminatorToTypeFunc(TypeFunc()),
 				)
 
-				var obj interface{}
+				var obj any
 				if err := dec.Decode(&obj); err != nil {
 					b.Fatal(err)
 				}

--- a/vim25/types/json_test.go
+++ b/vim25/types/json_test.go
@@ -19,7 +19,7 @@ import (
 var serializationTests = []struct {
 	name      string
 	file      string
-	data      interface{}
+	data      any
 	goType    reflect.Type
 	expDecErr string
 }{

--- a/vsan/types/base.go
+++ b/vsan/types/base.go
@@ -4,4 +4,4 @@
 
 package types
 
-type AnyType interface{}
+type AnyType any


### PR DESCRIPTION
Excludes Go stdlib forks vim25/{json,xml} , which should be synced separately w/ upstream.
