### PR TITLE
chore: update `.goreleaser.yml` to v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 ---
+version: 2
 project_name: govmomi
 
 builds:
@@ -37,7 +38,9 @@ builds:
 
 nfpms:
   - package_name: govmomi
-    builds:
+    vendor: Broadcom
+    license: Apache 2.0
+    ids:
       - govc
       - vcsim
     homepage: https://github.com/vmware/govmomi
@@ -49,7 +52,7 @@ nfpms:
 
 archives:
   - id: govcbuild
-    builds:
+    ids:
       - govc
     name_template: >-
       govc_
@@ -59,14 +62,14 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
     format_overrides: &overrides
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files: &extrafiles
       - CHANGELOG.md
       - LICENSE.txt
       - README.md
-
   - id: vcsimbuild
-    builds:
+    ids:
       - vcsim
     name_template: >-
       vcsim_
@@ -78,7 +81,7 @@ archives:
     files: *extrafiles
 
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> Holding this one in draft until after the next release. 

- Updates  `.goreleaser.yml` to v2 configuration and addresses deprecations.
- Adds `vendor` and `license` to `nfpms` configuration.

Before:

```shell
➜ goreleaser check .goreleaser.yml
  • only  version: 2  configuration files are supported, yours is  version: 0 , please update your configuration
  ⨯ command failed                                   error=only  version: 2  configuration files are supported, yours is  version: 0 , please update your configuration
```

```shell
➜ goreleaser check .goreleaser.yml
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
  • DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
  • DEPRECATED:  archives.builds  should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
  • DEPRECATED:  nfpms.builds  should not be used anymore, check https://goreleaser.com/deprecations#nfpmsbuilds for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

After:

```shell
govmomi on  chore/update-goreleaser-v2 via 🐹 v1.24.1 
➜ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

### References

[GoReleaser Deprecation Notices](https://goreleaser.com/deprecations/)

Closes #3734