### PR TITLE
govc: Support snapshot.export & nfc.lease.info

### DIFF
--- a/cli/vm/snapshot/export.go
+++ b/cli/vm/snapshot/export.go
@@ -1,0 +1,78 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package snapshot
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/cli"
+	"github.com/vmware/govmomi/cli/flags"
+)
+
+type export struct {
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("snapshot.export", &export{})
+}
+
+func (cmd *export) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *export) Usage() string {
+	return "NAME"
+}
+
+func (cmd *export) Description() string {
+	return `Export snapshot of VM with given NAME.
+
+NAME can be the snapshot name, tree path, or managed object ID.
+
+Examples:
+  govc snapshot.export -vm my-vm my-snapshot`
+}
+
+func (cmd *export) Process(ctx context.Context) error {
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *export) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	s, err := vm.FindSnapshot(ctx, f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	l, err := vm.ExportSnapshot(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	o, err := l.Properties(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(o)
+}

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -329,6 +329,7 @@ but appear via `govc $cmd -h`:
  - [session.ls](#sessionls)
  - [session.rm](#sessionrm)
  - [snapshot.create](#snapshotcreate)
+ - [snapshot.export](#snapshotexport)
  - [snapshot.remove](#snapshotremove)
  - [snapshot.revert](#snapshotrevert)
  - [snapshot.tree](#snapshottree)
@@ -5661,6 +5662,22 @@ Options:
   -d=                    Snapshot description
   -m=true                Include memory state
   -q=false               Quiesce guest file system
+  -vm=                   Virtual machine [GOVC_VM]
+```
+
+## snapshot.export
+
+```
+Usage: govc snapshot.export [OPTIONS] NAME
+
+Export snapshot of VM with given NAME.
+
+NAME can be the snapshot name, tree path, or managed object ID.
+
+Examples:
+  govc snapshot.export -vm my-vm my-snapshot
+
+Options:
   -vm=                   Virtual machine [GOVC_VM]
 ```
 

--- a/govc/test/snapshot.bats
+++ b/govc/test/snapshot.bats
@@ -16,7 +16,13 @@ test_vm_snapshot() {
   run govc snapshot.revert -vm "$vm"
   assert_failure
 
+  run govc snapshot.export -vm "$vm" "$id"
+  assert_failure
+
   run govc snapshot.create -vm "$vm" "$id"
+  assert_success
+
+  run govc snapshot.export -vm "$vm" "$id"
   assert_success
 
   run govc snapshot.revert -vm "$vm" enoent

--- a/nfc/lease.go
+++ b/nfc/lease.go
@@ -87,6 +87,29 @@ func (l *Lease) Progress(ctx context.Context, percent int32) error {
 	return nil
 }
 
+// Properties returns a mo.HttpNfcLease with the specified properties.
+// If no properties are requested, all properties are returned.
+func (l *Lease) Properties(
+	ctx context.Context,
+	props ...string) (mo.HttpNfcLease, error) {
+
+	if len(props) == 0 {
+		props = []string{
+			"initializeProgress",
+			"transferProgress",
+			"mode",
+			"capabilities",
+			"info",
+			"state",
+			"error",
+		}
+	}
+
+	var o mo.HttpNfcLease
+	pc := property.DefaultCollector(l.c)
+	return o, pc.RetrieveOne(ctx, l.Reference(), props, &o)
+}
+
 type LeaseInfo struct {
 	types.HttpNfcLeaseInfo
 

--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -6,6 +6,7 @@ package simulator
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 
@@ -159,6 +160,64 @@ func (v *VirtualMachineSnapshot) RevertToSnapshotTask(ctx *Context, req *types.R
 	return &methods.RevertToSnapshot_TaskBody{
 		Res: &types.RevertToSnapshot_TaskResponse{
 			Returnval: task.Run(ctx),
+		},
+	}
+}
+
+func (v *VirtualMachineSnapshot) ExportSnapshot(ctx *Context, req *types.ExportSnapshot) soap.HasFault {
+
+	vm := ctx.Map.Get(v.Vm).(*VirtualMachine)
+
+	lease := newHttpNfcLease(ctx)
+	lease.InitializeProgress = 100
+	lease.TransferProgress = 0
+	lease.Mode = string(types.HttpNfcLeaseModePushOrGet)
+	lease.Capabilities = types.HttpNfcLeaseCapabilities{
+		CorsSupported:     true,
+		PullModeSupported: true,
+	}
+
+	device := object.VirtualDeviceList(v.Config.Hardware.Device)
+	ndevice := make(map[string]int)
+	var urls []types.HttpNfcLeaseDeviceUrl
+
+	for _, d := range device {
+		info, ok := d.GetVirtualDevice().Backing.(types.BaseVirtualDeviceFileBackingInfo)
+		if !ok {
+			continue
+		}
+		var file object.DatastorePath
+		file.FromString(info.GetVirtualDeviceFileBackingInfo().FileName)
+		name := path.Base(file.Path)
+		ds := vm.findDatastore(ctx, file.Datastore)
+		lease.files[name] = ds.resolve(ctx, file.Path)
+
+		_, disk := d.(*types.VirtualDisk)
+		kind := device.Type(d)
+		n := ndevice[kind]
+		ndevice[kind]++
+
+		urls = append(urls, types.HttpNfcLeaseDeviceUrl{
+			Key:       fmt.Sprintf("/%s/%s:%d", vm.Self.Value, kind, n),
+			ImportKey: fmt.Sprintf("/%s/%s:%d", vm.Name, kind, n),
+			Url: (&url.URL{
+				Scheme: "https",
+				Host:   "*",
+				Path:   nfcPrefix + path.Join(lease.Reference().Value, name),
+			}).String(),
+			SslThumbprint: "",
+			Disk:          types.NewBool(disk),
+			TargetId:      name,
+			DatastoreKey:  "",
+			FileSize:      0,
+		})
+	}
+
+	lease.ready(ctx, v.Vm, urls)
+
+	return &methods.ExportSnapshotBody{
+		Res: &types.ExportSnapshotResponse{
+			Returnval: lease.Reference(),
 		},
 	}
 }

--- a/vim25/mo/helpers.go
+++ b/vim25/mo/helpers.go
@@ -1,0 +1,59 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package mo
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+)
+
+// Write implements the cli package's Write(io.Writer) error interface for
+// emitting objects to the command line.
+func (l HttpNfcLease) Write(w io.Writer) error {
+
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "Lease:\t%s\n", l.Reference().String())
+	fmt.Fprintf(tw, "InitializeProgress:\t%d\n", l.InitializeProgress)
+	fmt.Fprintf(tw, "TransferProgress:\t%d\n", l.TransferProgress)
+	fmt.Fprintf(tw, "Mode:\t%s\n", l.Mode)
+	fmt.Fprintf(tw, "State:\t%s\n", l.State)
+	fmt.Fprintf(tw, "Capabilities:\n")
+	fmt.Fprintf(tw, "  CorsSupported:\t%v\n", l.Capabilities.CorsSupported)
+	fmt.Fprintf(tw, "  PullModeSupported:\t%v\n", l.Capabilities.PullModeSupported)
+
+	if info := l.Info; info != nil {
+		fmt.Fprintf(tw, "Info:\n")
+		fmt.Fprintf(tw, "  Entity:\t%s\n", info.Entity.String())
+
+		timeout := time.Second * time.Duration(info.LeaseTimeout)
+		fmt.Fprintf(tw, "  Timeout:\t%s\n", timeout)
+
+		fmt.Fprintf(tw, "  TotalDiskCapacityInKB:\t%d\n", info.TotalDiskCapacityInKB)
+
+		fmt.Fprintf(tw, "  URLs:\n")
+		for i := range info.DeviceUrl {
+			du := info.DeviceUrl[i]
+			fmt.Fprintf(tw, "    Datastore:\t%s\n", du.DatastoreKey)
+			fmt.Fprintf(tw, "    DeviceKey:\t%s\n", du.Key)
+			isDisk := false
+			if du.Disk != nil {
+				isDisk = *du.Disk
+			}
+			fmt.Fprintf(tw, "    IsDisk:\t%v\n", isDisk)
+			fmt.Fprintf(tw, "    SSLThumbprint:\t%s\n", du.SslThumbprint)
+			fmt.Fprintf(tw, "    Target:\t%s\n", du.TargetId)
+			fmt.Fprintf(tw, "    URL:\t%s\n", du.Url)
+		}
+	}
+
+	if err := l.Error; err != nil {
+		fmt.Fprintf(tw, "Error:\t%s\n", err.LocalizedMessage)
+	}
+
+	return tw.Flush()
+}


### PR DESCRIPTION

## Description

This patch adds support for exporting a VM snapshot with govc as well as printing information about an HTTP NFC lease with govc.

Closes: `NA`

## How Has This Been Tested?

* Two tests were added in `snapshot.bats` for exporting a snapshot.
* The following was run against a real vCenter instance:

  * Export a snapshot

    ```shell
    govc snapshot.export -vm vm-1 root                                                                           
    ```

    ```shell
    Lease:               HttpNfcLease:session[52f12f02-e8d2-cc50-3d28-43fc1c4e2073]52894ef4-885f-254d-1cfa-3e1e12bade78
    InitializeProgress:  100
    TransferProgress:    0
    Mode:                pushOrGet
    State:               ready
    Capabilities:
      CorsSupported:      true
      PullModeSupported:  true
    Info:
      Entity:                 VirtualMachine:vm-226
      Timeout:                5m0s
      TotalDiskCapacityInKB:  16777216
      URLs:
        Datastore:      https://1.2.3.4/nfc/523c8394-23fa-f001-b426-d1e54ac14189/
        DeviceKey:      /vm-226/ParaVirtualSCSIController0:0
        IsDisk:         true
        SSLThumbprint:  AA:BB:CC:DD
        Target:         disk-0.vmdk
        URL:            https://1.2.3.4/nfc/523c8394-23fa-f001-b426-d1e54ac14189/disk-0.vmdk
    ```

  * Print the lease information:

    ```shell
    govc object.collect -o 'HttpNfcLease:session[527cc13a-4bdc-e54c-2686-0254ec485f30]52794b36-03bb-84b2-7416-e6161201f6f2'
    ```

    ```shell
    Lease:               HttpNfcLease:session[527cc13a-4bdc-e54c-2686-0254ec485f30]52794b36-03bb-84b2-7416-e6161201f6f2
    InitializeProgress:  100
    TransferProgress:    0
    Mode:                pushOrGet
    State:               ready
    Capabilities:
      CorsSupported:      true
      PullModeSupported:  true
    Info:
      Entity:                 VirtualMachine:vm-226
      Timeout:                5m0s
      TotalDiskCapacityInKB:  16777216
      URLs:
        Datastore:      https://1.2.3.4/nfc/52b6da41-c3b5-999f-0b77-6e9d9e28cb46/
        DeviceKey:      /vm-226/ParaVirtualSCSIController0:0
        IsDisk:         true
        SSLThumbprint:  AA:BB:CC
        Target:         disk-0.vmdk
        URL:            https://1.2.3.4/nfc/52b6da41-c3b5-999f-0b77-6e9d9e28cb46/disk-0.vmdk
    ```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
