### PR TITLE
vcsim: support multiple VirtualSystemType in OvfManager.CreateImportSpec

### DIFF
--- a/simulator/ovf_manager.go
+++ b/simulator/ovf_manager.go
@@ -190,7 +190,8 @@ func (m *OvfManager) CreateImportSpec(ctx *Context, req *types.CreateImportSpec)
 
 	hw := env.VirtualSystem.VirtualHardware[0]
 	if vmx := hw.System.VirtualSystemType; vmx != nil {
-		spec.ConfigSpec.Version = *vmx
+		version := strings.Split(*vmx, ",")[0]
+		spec.ConfigSpec.Version = strings.TrimSpace(version)
 	}
 
 	ndisk := 0


### PR DESCRIPTION
Example ovf:
```console
% grep vmx- Operations-Appliance-9.0.0.0.24597071.ovf
        <vssd:VirtualSystemType>vmx-10,vmx-11</vssd:VirtualSystemType>
```

Without the change, ovf import will fail here: https://github.com/vmware/govmomi/blob/cc135ecc16a098f1d84266a873cf7f9170c1244e/simulator/virtual_machine.go#L1117-L1118