### PR TITLE
govc: Add vm.policy.ls command

### DIFF
--- a/cli/vm/policy/ls.go
+++ b/cli/vm/policy/ls.go
@@ -1,0 +1,142 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/vmware/govmomi/cli"
+	"github.com/vmware/govmomi/cli/flags"
+	"github.com/vmware/govmomi/pbm/types"
+	vim "github.com/vmware/govmomi/vim25/types"
+)
+
+type ls struct {
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("vm.policy.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *ls) Description() string {
+	return `List VM storage policies.
+
+Examples:
+  govc vm.policy.ls -vm $name
+  govc vm.policy.ls -vm $name -json`
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	c, err := cmd.PbmClient()
+	if err != nil {
+		return err
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	m, err := c.ProfileMap(ctx)
+	if err != nil {
+		return err
+	}
+
+	ref := vm.Reference().Value
+
+	res := []Entity{{
+		Name: "VM home",
+		ID: types.PbmServerObjectRef{
+			ObjectType: string(types.PbmObjectTypeVirtualMachine),
+			Key:        ref,
+		},
+	}}
+
+	for _, disk := range devices.SelectByType((*vim.VirtualDisk)(nil)) {
+		key := disk.GetVirtualDevice().Key
+
+		entity := Entity{
+			Name: devices.Name(disk),
+			ID: types.PbmServerObjectRef{
+				ObjectType: string(types.PbmObjectTypeVirtualDiskId),
+				Key:        fmt.Sprintf("%s:%d", ref, key),
+			},
+		}
+
+		res = append(res, entity)
+	}
+
+	for i := range res {
+		entity := &res[i]
+		entity.PolicyName = "None"
+
+		ids, err := c.QueryAssociatedProfile(ctx, entity.ID)
+		if err != nil {
+			return err
+		}
+
+		if len(ids) != 0 {
+			entity.PolicyID = ids[0].UniqueId
+			entity.PolicyName = m.Name[entity.PolicyID].GetPbmProfile().Name
+
+			res, err := c.FetchComplianceResult(ctx, []types.PbmServerObjectRef{entity.ID})
+			if err != nil {
+				return err
+			}
+
+			entity.Compliance = &res[0]
+		}
+	}
+
+	return cmd.WriteResult(List(res))
+}
+
+type Entity struct {
+	Name       string                     `json:"name"`
+	ID         types.PbmServerObjectRef   `json:"id"`
+	PolicyID   string                     `json:"policyID"`
+	PolicyName string                     `json:"policyName"`
+	Compliance *types.PbmComplianceResult `json:"compliance"`
+}
+
+type List []Entity
+
+func (r List) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, disk := range r {
+		status := ""
+		checked := ""
+
+		if c := disk.Compliance; c != nil {
+			status = disk.Compliance.ComplianceStatus
+			checked = c.CheckTime.Format(time.ANSIC)
+		}
+
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", disk.Name, disk.PolicyName, status, checked)
+	}
+
+	return tw.Flush()
+}

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -421,6 +421,7 @@ but appear via `govc $cmd -h`:
  - [vm.network.change](#vmnetworkchange)
  - [vm.option.info](#vmoptioninfo)
  - [vm.option.ls](#vmoptionls)
+ - [vm.policy.ls](#vmpolicyls)
  - [vm.power](#vmpower)
  - [vm.question](#vmquestion)
  - [vm.rdm.attach](#vmrdmattach)
@@ -7469,6 +7470,21 @@ Examples:
 Options:
   -cluster=              Cluster [GOVC_CLUSTER]
   -host=                 Host system [GOVC_HOST]
+  -vm=                   Virtual machine [GOVC_VM]
+```
+
+## vm.policy.ls
+
+```
+Usage: govc vm.policy.ls [OPTIONS]
+
+List VM storage policies.
+
+Examples:
+  govc vm.policy.ls -vm $name
+  govc vm.policy.ls -vm $name -json
+
+Options:
   -vm=                   Virtual machine [GOVC_VM]
 ```
 

--- a/govc/main.go
+++ b/govc/main.go
@@ -114,6 +114,7 @@ import (
 	_ "github.com/vmware/govmomi/cli/vm/guest"
 	_ "github.com/vmware/govmomi/cli/vm/network"
 	_ "github.com/vmware/govmomi/cli/vm/option"
+	_ "github.com/vmware/govmomi/cli/vm/policy"
 	_ "github.com/vmware/govmomi/cli/vm/rdm"
 	_ "github.com/vmware/govmomi/cli/vm/snapshot"
 	_ "github.com/vmware/govmomi/cli/vm/target"

--- a/govc/test/storage.bats
+++ b/govc/test/storage.bats
@@ -63,3 +63,13 @@ load test_helper
   run govc storage.policy.info MyCombinedPolicy
   assert_success
 }
+
+@test "vm.policy.ls" {
+  vcsim_env
+
+  run govc vm.policy.ls -vm DC0_H0_VM0
+  assert_success
+
+  run govc vm.policy.ls -vm DC0_H0_VM0 -json
+  assert_success
+}


### PR DESCRIPTION
See discussion #3727

Example output:
```console
% govc vm.policy.ls -vm $vm
VM home      wcpglobal_storage_profile  compliant  Fri Mar 28 16:42:19 2025
disk-1000-0  wcpglobal_storage_profile  compliant  Fri Mar 28 16:42:19 2025
disk-1000-1  wcpglobal_storage_profile  compliant  Wed Mar 26 17:08:54 2025
```