### PR TITLE
docs: update kb urls

### DIFF
--- a/find/finder.go
+++ b/find/finder.go
@@ -801,7 +801,7 @@ func (f *Finder) NetworkList(ctx context.Context, path string) ([]object.Network
 // With standard vSphere networking, Portgroups cannot have the same name within the same network folder.
 // With NSX, Portgroups can have the same name, even within the same Switch. In this case, using an inventory path
 // results in a MultipleFoundError. A MOID, switch UUID or segment ID can be used instead, as both are unique.
-// See also: https://kb.vmware.com/s/article/79872#Duplicate_names
+// See also: https://knowledge.broadcom.com/external/article?articleNumber=320145#Duplicate_names
 // Examples:
 // - Name:                "dvpg-1"
 // - Inventory Path:      "vds-1/dvpg-1"

--- a/session/manager.go
+++ b/session/manager.go
@@ -113,7 +113,6 @@ func (sm *Manager) Login(ctx context.Context, u *url.Userinfo) error {
 
 // LoginExtensionByCertificate uses the vCenter SDK tunnel to login using a client certificate.
 // The client certificate can be set using the soap.Client.SetCertificate method.
-// See: https://kb.vmware.com/s/article/2004305
 func (sm *Manager) LoginExtensionByCertificate(ctx context.Context, key string) error {
 	c := sm.client
 	u := c.URL()

--- a/vim25/types/esxi_version.go
+++ b/vim25/types/esxi_version.go
@@ -37,7 +37,7 @@ const (
 )
 
 // HardwareVersion returns the maximum hardware version supported by this
-// version of ESXi, per https://kb.vmware.com/s/article/1003746.
+// version of ESXi, per https://knowledge.broadcom.com/external/article?articleNumber=315655.
 func (ev ESXiVersion) HardwareVersion() HardwareVersion {
 	switch ev {
 	case ESXi2000:

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -17984,7 +17984,7 @@ type CustomizationAdapterMapping struct {
 	// In vSphere 7.0 series, the MAC addresses must be specified in the
 	// ascending order of pciSlotNumber, otherwise a MAC address mismatch error
 	// will be reported. For further details, see the
-	// https://kb.vmware.com/s/article/87648
+	// https://knowledge.broadcom.com/external/article?articleNumber=312120
 	MacAddress string `xml:"macAddress,omitempty" json:"macAddress,omitempty"`
 	// The IP settings for the associated virtual network adapter.
 	Adapter CustomizationIPSettings `xml:"adapter" json:"adapter"`
@@ -18463,7 +18463,7 @@ type CustomizationLinuxPrep struct {
 	// Area is a continent or ocean name, and Location is the city, island, or
 	// other regional designation.
 	//
-	// See the <a href="https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2145518"target="_blank">List of supported time zones for different vSphere versions in Linux/Unix systems</a>.
+	// See the <a href="https://knowledge.broadcom.com/external/article?articleNumber=320212"target="_blank">List of supported time zones for different vSphere versions in Linux/Unix systems</a>.
 	TimeZone string `xml:"timeZone,omitempty" json:"timeZone,omitempty"`
 	// Specifies whether the hardware clock is in UTC or local time.
 	//   - True when the hardware clock is in UTC.
@@ -18483,7 +18483,7 @@ type CustomizationLinuxPrep struct {
 	//
 	// Please set the compatible customization method to a supported string value
 	// e.g. "GOSC\_METHOD\_1".
-	// See <a href="https://kb.vmware.com/s/article/95903"target="_blank">Supported compatible customization method list</a>.
+	// See <a href="https://knowledge.broadcom.com/external/article?articleNumber=313164"target="_blank">Supported compatible customization method list</a>.
 	CompatibleCustomizationMethod string `xml:"compatibleCustomizationMethod,omitempty" json:"compatibleCustomizationMethod,omitempty" vim:"8.0.3.0"`
 }
 
@@ -18757,8 +18757,8 @@ type CustomizationSysprepText struct {
 
 	// Text for the `sysprep.xml` answer file.
 	//
-	// For additional details, see <a href="https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2151684"target="_blank">Using custom sysprep.xml for vCenter Guest Customization</a> and
-	// <a href="https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1029174"target="_blank">Specifying network settings in custom sysprep.xml</a>.
+	// For additional details, see <a href="https://knowledge.broadcom.com/external/article?articleNumber=336083"target="_blank">Using custom sysprep.xml for vCenter Guest Customization</a> and
+	// <a href="https://knowledge.broadcom.com/external/article?articleNumber=313515"target="_blank">Specifying network settings in custom sysprep.xml</a>.
 	Value string `xml:"value" json:"value"`
 }
 


### PR DESCRIPTION
## Description

Updates (or removes) `kb.vmware.com` URLs to replacement `support.broadcom.com` URLs as necessary.
