### PR TITLE
docs: remove legacy docs links

### DIFF
--- a/scripts/vcsa/create-esxi-vm.sh
+++ b/scripts/vcsa/create-esxi-vm.sh
@@ -20,7 +20,7 @@ EOF
 
 disk=48
 mem=16
-# 6.7 U3 https://docs.vmware.com/en/VMware-vSphere/6.7/rn/vsphere-esxi-vcenter-server-67-release-notes.html
+# 6.7 U3
 iso=VMware-VMvisor-6.7.0-14320388.x86_64.iso
 
 while getopts d:hi:m:s flag

--- a/scripts/vcsa/create-vcsa-vm.sh
+++ b/scripts/vcsa/create-vcsa-vm.sh
@@ -15,7 +15,7 @@ export GOVC_INSECURE=1
 
 name=vcsa
 
-# 6.7 U3 https://docs.vmware.com/en/VMware-vSphere/6.7/rn/vsphere-esxi-vcenter-server-67-release-notes.html
+# 6.7 U3
 ova=VMware-vCenter-Server-Appliance-6.7.0.40000-14367737_OVF10.ova
 
 while getopts a:i:n: flag


### PR DESCRIPTION
## Description

Removes legacy links to `docs.vmware.com` in scripts.
