### PR TITLE
govc: Add datastore.cp disk format and adapter options

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -1310,6 +1310,8 @@ Examples:
   govc datastore.cp disks/disk1.vmdk -ds-target NFS-2 disks/disk2.vmdk
 
 Options:
+  -a=lsiLogic            Disk adapter
+  -d=thin                Disk format
   -dc-target=            Datacenter destination (defaults to -dc)
   -ds=                   Datastore [GOVC_DATASTORE]
   -ds-target=            Datastore destination (defaults to -ds)
@@ -1536,6 +1538,8 @@ Examples:
   govc datastore.mv -f my.vmx foo/foo.vmx
 
 Options:
+  -a=lsiLogic            Disk adapter
+  -d=thin                Disk format
   -dc-target=            Datacenter destination (defaults to -dc)
   -ds=                   Datastore [GOVC_DATASTORE]
   -ds-target=            Datastore destination (defaults to -ds)

--- a/govc/test/datastore.bats
+++ b/govc/test/datastore.bats
@@ -363,6 +363,9 @@ upload_file() {
     run govc datastore.rm -dc DC1 -ds LocalDS_1 "$clone"
     assert_success
   done
+
+  run govc datastore.cp -dc DC0 -ds LocalDS_0 -d preallocated "$vmdk" "$id/$id-thick.vmdk"
+  assert_success
 }
 
 @test "datastore.disk.info" {


### PR DESCRIPTION
Same '-a' and '-d' flags as datastore.disk.create

Fixes #3748

api: Add optional spec param to DatastoreFileManager.Copy