### PR TITLE
fix: vcsim -load Datastore summary.url property

### DIFF
--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -564,6 +564,10 @@ EOF
 
   run govc host.portgroup.add -host DC0_H0 -vswitch vSwitch0 bridge
   assert_success # issue #2016
+
+  # make sure we can write the save/load-ed Datastore
+  run govc import.ova "$GOVC_IMAGES/$TTYLINUX_NAME.ova"
+  assert_success
 }
 
 @test "vcsim trace file" {

--- a/simulator/datastore.go
+++ b/simulator/datastore.go
@@ -50,7 +50,18 @@ func (ds *Datastore) model(m *Model) error {
 		}
 
 		info.Url = dir
+	} else {
+		// rewrite local path from a saved vcsim instance
+		dir, err := m.createTempDir(path.Base(u.Path))
+		if err != nil {
+			return err
+		}
+
+		info.Url = dir
 	}
+
+	ds.Summary.Url = info.Url
+
 	return nil
 }
 


### PR DESCRIPTION
PR #3705 refactored Datastore access, part of which uses the Datastore summary.url property instead of info.url

Also fix the Datastore urls for local paths, such as govc object.save of a vcsim instance
