### PR TITLE
govc: Add import.ova -net flag

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -3772,6 +3772,7 @@ Options:
   -lease=false           Output NFC Lease only
   -m=false               Verify checksum of uploaded files against manifest (.mf)
   -name=                 Name to use for new entity
+  -net=                  Network
   -options=              Options spec file path for VM deployment
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
 ```
@@ -3789,6 +3790,7 @@ Options:
   -lease=false           Output NFC Lease only
   -m=false               Verify checksum of uploaded files against manifest (.mf)
   -name=                 Name to use for new entity
+  -net=                  Network
   -options=              Options spec file path for VM deployment
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
 ```

--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -216,6 +216,12 @@ load test_helper
   run govc import.ovf -options - "$ovf" <<<"$options"
   assert_success # using raw MO id
   grep "invalid NetworkMapping.Name" <<<"$output"
+
+  run govc import.ovf -name netflag -net enoent "$ovf"
+  assert_failure
+
+  run govc import.ovf -name netflag -net "VM Network" "$ovf"
+  assert_success
 }
 
 @test "import invalid disk provisioning" {

--- a/ovf/importer/importer.go
+++ b/ovf/importer/importer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vmware/govmomi/nfc"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/ovf"
+	"github.com/vmware/govmomi/task"
 	"github.com/vmware/govmomi/vapi/library"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/progress"
@@ -118,7 +119,7 @@ func (imp *Importer) ImportVApp(ctx context.Context, fpath string, opts Options)
 		return nil, nil, err
 	}
 	if spec.Error != nil {
-		return nil, nil, errors.New(spec.Error[0].LocalizedMessage)
+		return nil, nil, &task.Error{LocalizedMethodFault: &spec.Error[0]}
 	}
 	if spec.Warning != nil {
 		for _, w := range spec.Warning {


### PR DESCRIPTION
Network can already be set via -options, but this simplifies the common case.

Added a hint to specify network (See also: #1561), example when not specified:
```console
% govc import.ovf foo.ovf
govc: Host did not have any virtual network defined. (specify Network with '-net' or '-options')
```

Fixes #3679
