### PR TITLE
api: Rewrite lookup service URLs on DNS error

### DIFF
--- a/lookup/client.go
+++ b/lookup/client.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -41,6 +42,9 @@ type Client struct {
 	RoundTripper soap.RoundTripper
 
 	ServiceContent types.LookupServiceContent
+
+	// Rewrite when true changes EndpointURL Host to the VC connection's Host
+	Rewrite bool
 }
 
 // NewClient returns a client targeting the SSO Lookup Service API endpoint.
@@ -59,22 +63,35 @@ func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
 		}
 	}
 
-	sc := c.Client.NewServiceClient(path.String(), Namespace)
-	sc.Version = Version
-	client := &Client{Client: sc, RoundTripper: sc}
+	// 1st try: use the URL from OptionManager as-is, continue to 2nd try on DNS error
+	// 2nd try: use the URL from OptionManager, changing Host to vim25.Client's Host
+	var attempts []error
 
-	req := types.RetrieveServiceContent{
-		This: ServiceInstance,
+	for _, rewrite := range []bool{false, true} {
+		if rewrite {
+			path.Host = c.URL().Host
+		}
+
+		sc := c.Client.NewServiceClient(path.String(), Namespace)
+		sc.Version = Version
+		client := &Client{Client: sc, RoundTripper: sc, Rewrite: rewrite}
+
+		req := types.RetrieveServiceContent{
+			This: ServiceInstance,
+		}
+
+		res, err := methods.RetrieveServiceContent(ctx, client, &req)
+		if err != nil {
+			attempts = append(attempts, err)
+			continue
+		}
+
+		client.ServiceContent = res.Returnval
+
+		return client, nil
 	}
 
-	res, err := methods.RetrieveServiceContent(ctx, client, &req)
-	if err != nil {
-		return nil, err
-	}
-
-	client.ServiceContent = res.Returnval
-
-	return client, nil
+	return nil, errors.Join(attempts...)
 }
 
 // RoundTrip dispatches to the RoundTripper field.
@@ -124,10 +141,15 @@ func EndpointURL(ctx context.Context, c *vim25.Client, path string, filter *type
 			path = endpoint.Url
 
 			if u, err := url.Parse(path); err == nil {
-				// Set thumbprint only for endpoints on hosts outside this vCenter.
-				// Platform Services may live on multiple hosts.
-				if c.URL().Host != u.Host && c.Thumbprint(u.Host) == "" {
-					c.SetThumbprint(u.Host, endpointThumbprint(endpoint))
+				if lu.Rewrite {
+					u.Host = c.URL().Host
+					path = u.String()
+				} else {
+					// Set thumbprint only for endpoints on hosts outside this vCenter.
+					// Platform Services may live on multiple hosts.
+					if c.URL().Host != u.Host && c.Thumbprint(u.Host) == "" {
+						c.SetThumbprint(u.Host, endpointThumbprint(endpoint))
+					}
 				}
 			}
 		}

--- a/lookup/simulator/simulator.go
+++ b/lookup/simulator/simulator.go
@@ -186,3 +186,19 @@ func BreakLookupServiceURLs(ctx context.Context) {
 		}
 	}
 }
+
+// UnresolveLookupServiceURLs makes the path of all lookup service urls invalid
+func UnresolveLookupServiceURLs(ctx context.Context) {
+	setting := simulator.Map(ctx).OptionManager().Setting
+
+	for _, s := range setting {
+		o := s.GetOptionValue()
+		if strings.HasSuffix(o.Key, ".uri") {
+			val := o.Value.(string)
+			u, _ := url.Parse(val)
+			port := u.Port()
+			u.Host = "fake-name-will-not-dns-resolve:" + port
+			o.Value = u.String()
+		}
+	}
+}

--- a/ssoadmin/client_test.go
+++ b/ssoadmin/client_test.go
@@ -30,6 +30,16 @@ func TestClient(t *testing.T) {
 			verifyClient(t, ctx, c)
 		})
 	})
+	t.Run("With DNS errors, lookup client should rewrite URLs to VC's Host", func(t *testing.T) {
+		simulator.Test(func(ctx context.Context, client *vim25.Client) {
+			lsim.UnresolveLookupServiceURLs(ctx)
+
+			c, err := ssoadmin.NewClient(ctx, client)
+			require.NoError(t, err)
+
+			verifyClient(t, ctx, c)
+		})
+	})
 	t.Run("With Envoy sidecar and a malfunctioning lookup service, ssoadmin client creation should still succeed", func(t *testing.T) {
 		model := simulator.VPX()
 		model.Create()


### PR DESCRIPTION
If a vCenter's hostname is not in DNS (outside of VC's /etc/hosts), then lookup service URLs may fail to resolve. In this case, rewrite the URLs to use the same Host used for the vim25.Client's connection.
