### PR TITLE
vcsim: Use the simulator's URL.Host in NFC lease URLs

### DIFF
--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -287,4 +287,31 @@ load test_helper
 
   run govc import.ova -ds $pod "$GOVC_IMAGES/$TTYLINUX_NAME.ova"
   assert_success
+
+  run govc import.ova -ds $pod -name test-url -lease -json "$GOVC_IMAGES/$TTYLINUX_NAME.ova"
+  assert_success
+
+  run jq -r .info.deviceUrl[].url <<<"$output"
+  assert_success
+
+  # Device URL.Host should be the same as vcsim's https://127.0.0.1:$port/nfc/.../disk-0.vmdk
+  run govc env -x -u "$output" GOVC_URL_HOST
+  assert_success "$(govc env -x GOVC_URL_HOST)"
+}
+
+@test "import esx" {
+  vcsim_env -esx
+
+  run govc import.ova "$GOVC_IMAGES/$TTYLINUX_NAME.ova"
+  assert_success
+
+  run govc import.ova -name test-url -lease -json "$GOVC_IMAGES/$TTYLINUX_NAME.ova"
+  assert_success
+
+  run jq -r .info.deviceUrl[].url <<<"$output"
+  assert_success
+
+  # Device URL.Host should be '*' https://*:$port/nfc/.../disk-0.vmdk
+  run govc env -x -u "$output" GOVC_URL_HOST
+  assert_success "*"
 }

--- a/simulator/http_nfc_lease.go
+++ b/simulator/http_nfc_lease.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -132,6 +133,22 @@ func newHttpNfcLease(ctx *Context) *HttpNfcLease {
 	nfcLease.Store(lease.Reference(), lease)
 
 	return lease
+}
+
+func leaseURL(ctx *Context) *url.URL {
+	opt := ctx.Map.OptionManager().find("vcsim.server.url")
+
+	u, _ := url.Parse(opt.Value.(string))
+
+	// See NfcLease.DeviceUrl doc:
+	//  If a "*" is returned the client must substitute "*" with the
+	//  hostname or IP address used when connecting to the server.
+	// This is the case when connecting directly to an ESX host.
+	if ctx.Map.IsESX() {
+		u.Host = "*"
+	}
+
+	return u
 }
 
 func (l *HttpNfcLease) HttpNfcLeaseComplete(ctx *Context, req *types.HttpNfcLeaseComplete) soap.HasFault {

--- a/simulator/resource_pool.go
+++ b/simulator/resource_pool.go
@@ -6,7 +6,6 @@ package simulator
 
 import (
 	"fmt"
-	"net/url"
 	"path"
 	"strings"
 
@@ -269,6 +268,7 @@ func (p *ResourcePool) ImportVApp(ctx *Context, req *types.ImportVApp) soap.HasF
 		device := object.VirtualDeviceList(vm.Config.Hardware.Device)
 		ndevice := make(map[string]int)
 		var urls []types.HttpNfcLeaseDeviceUrl
+		u := leaseURL(ctx)
 
 		for _, d := range device {
 			info, ok := d.GetVirtualDevice().Backing.(types.BaseVirtualDeviceFileBackingInfo)
@@ -286,14 +286,11 @@ func (p *ResourcePool) ImportVApp(ctx *Context, req *types.ImportVApp) soap.HasF
 			n := ndevice[kind]
 			ndevice[kind]++
 
+			u.Path = nfcPrefix + path.Join(ref.Value, name)
 			urls = append(urls, types.HttpNfcLeaseDeviceUrl{
-				Key:       fmt.Sprintf("/%s/%s:%d", vm.Self.Value, kind, n),
-				ImportKey: fmt.Sprintf("/%s/%s:%d", vm.Name, kind, n),
-				Url: (&url.URL{
-					Scheme: "https",
-					Host:   "*",
-					Path:   nfcPrefix + path.Join(ref.Value, name),
-				}).String(),
+				Key:           fmt.Sprintf("/%s/%s:%d", vm.Self.Value, kind, n),
+				ImportKey:     fmt.Sprintf("/%s/%s:%d", vm.Name, kind, n),
+				Url:           u.String(),
 				SslThumbprint: "",
 				Disk:          types.NewBool(disk),
 				TargetId:      name,

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -744,12 +744,12 @@ func (s *Service) NewServer() *Server {
 			}
 		}
 	}
-	m.Setting = append(m.Setting,
-		&types.OptionValue{
+	m.UpdateOptions(&types.UpdateOptions{
+		ChangedValue: []types.BaseOptionValue{&types.OptionValue{
 			Key:   "vcsim.server.url",
 			Value: u.String(),
-		},
-	)
+		}},
+	})
 
 	u.User = s.Listen.User
 	if u.User == nil {

--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -6,7 +6,6 @@ package simulator
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"path"
 
@@ -180,6 +179,7 @@ func (v *VirtualMachineSnapshot) ExportSnapshot(ctx *Context, req *types.ExportS
 	device := object.VirtualDeviceList(v.Config.Hardware.Device)
 	ndevice := make(map[string]int)
 	var urls []types.HttpNfcLeaseDeviceUrl
+	u := leaseURL(ctx)
 
 	for _, d := range device {
 		info, ok := d.GetVirtualDevice().Backing.(types.BaseVirtualDeviceFileBackingInfo)
@@ -197,14 +197,11 @@ func (v *VirtualMachineSnapshot) ExportSnapshot(ctx *Context, req *types.ExportS
 		n := ndevice[kind]
 		ndevice[kind]++
 
+		u.Path = nfcPrefix + path.Join(lease.Reference().Value, name)
 		urls = append(urls, types.HttpNfcLeaseDeviceUrl{
-			Key:       fmt.Sprintf("/%s/%s:%d", vm.Self.Value, kind, n),
-			ImportKey: fmt.Sprintf("/%s/%s:%d", vm.Name, kind, n),
-			Url: (&url.URL{
-				Scheme: "https",
-				Host:   "*",
-				Path:   nfcPrefix + path.Join(lease.Reference().Value, name),
-			}).String(),
+			Key:           fmt.Sprintf("/%s/%s:%d", vm.Self.Value, kind, n),
+			ImportKey:     fmt.Sprintf("/%s/%s:%d", vm.Name, kind, n),
+			Url:           u.String(),
 			SslThumbprint: "",
 			Disk:          types.NewBool(disk),
 			TargetId:      name,


### PR DESCRIPTION
Host should only be '*' when connecting directly to an ESX host.
