### PR TITLE
vcsim: Avoid use of sha1 for stable UUIDs (OIDs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,11 @@ go-test: ## Runs go unit tests with race detector enabled
   -v $(TEST_OPTS) \
   ./...
 
+.PHONY: go-fips140-test
+go-fips140-test: ## Test simulator can be used with fips140=only
+	GODEBUG=fips140=only $(GO) test ./property
+
+go-test: ## Runs go unit tests with race detector enabled
 .PHONY: govc-test
 govc-test: install
 govc-test: ## Runs govc bats tests
@@ -159,4 +164,4 @@ govc-test: ## Runs govc bats tests
 	(cd govc/test && ./vendor/github.com/bats-core/bats-core/bin/bats -t .)
 
 .PHONY: test
-test: go-test govc-test	## Runs go-test and govc-test
+test: go-test go-fips140-test govc-test	## Runs go-test and govc-test

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -212,13 +212,13 @@ EOF
 
   # VM uuids are stable, based on path to .vmx
   run govc object.collect -s vm/DC0_H0_VM0 config.uuid config.instanceUuid
-  assert_success "$(printf "265104de-1472-547c-b873-6dc7883fb6cb\nb4689bed-97f0-5bcd-8a4c-07477cc8f06f")"
+  assert_success "$(printf "63d40cc5-9cba-5cc1-884a-f7f19070ecea\nb170c191-7587-5f8e-9a15-08c6a0a11ca5")"
 
   dups=$(govc object.collect -s -type m / config.uuid | sort | uniq -d | wc -l)
   assert_equal 0 "$dups"
 
   run govc object.collect -s host/DC0_H0/DC0_H0 summary.hardware.uuid
-  assert_success dcf7fb3c-4a1c-5a05-b730-5e09f3704e2f
+  assert_success efc5827c-ee19-5d35-84ef-a77d6ea6ee4c
 
   dups=$(govc object.collect -s -type m / summary.hardware.uuid | sort | uniq -d | wc -l)
   assert_equal 0 "$dups"

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -6,6 +6,7 @@ package internal
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -16,6 +17,8 @@ import (
 	"path"
 	"slices"
 	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -167,4 +170,9 @@ func (arg ReflectManagedMethodExecuterSoapArgument) Value() []string {
 
 func EsxcliName(name string) string {
 	return strings.ReplaceAll(strings.Title(name), ".", "")
+}
+
+// OID returns a stable UUID based on input s
+func OID(s string) uuid.UUID {
+	return uuid.NewHash(sha256.New(), uuid.NameSpaceOID, []byte(s), 5)
 }

--- a/simulator/object.go
+++ b/simulator/object.go
@@ -7,8 +7,7 @@ package simulator
 import (
 	"bytes"
 
-	"github.com/google/uuid"
-
+	"github.com/vmware/govmomi/internal"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
@@ -44,12 +43,7 @@ func SetCustomValue(ctx *Context, req *types.SetCustomValue) soap.HasFault {
 
 // newUUID returns a stable UUID string based on input s
 func newUUID(s string) string {
-	return sha1UUID(s).String()
-}
-
-// sha1UUID returns a stable UUID based on input s
-func sha1UUID(s string) uuid.UUID {
-	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(s))
+	return internal.OID(s).String()
 }
 
 // deepCopy uses xml encode/decode to copy src to dst

--- a/simulator/virtual_disk_manager.go
+++ b/simulator/virtual_disk_manager.go
@@ -10,8 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/uuid"
-
 	"github.com/vmware/govmomi/internal"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -246,7 +244,7 @@ func virtualDiskUUID(dc *types.ManagedObjectReference, file string) string {
 	if dc != nil {
 		file = dc.String() + file
 	}
-	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(file)).String()
+	return newUUID(file)
 }
 
 func (m *VirtualDiskManager) QueryVirtualDiskUuid(ctx *Context, req *types.QueryVirtualDiskUuid) soap.HasFault {

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -121,7 +121,7 @@ func NewVirtualMachine(ctx *Context, parent types.ManagedObjectReference, spec *
 	spec.Files.VmPathName = vmx.String()
 
 	dsPath := path.Dir(spec.Files.VmPathName)
-	vm.uid = sha1UUID(spec.Files.VmPathName)
+	vm.uid = internal.OID(spec.Files.VmPathName)
 
 	defaults := types.VirtualMachineConfigSpec{
 		NumCPUs:           1,

--- a/simulator/vpx/service_content.go
+++ b/simulator/vpx/service_content.go
@@ -7,6 +7,7 @@ package vpx
 import (
 	"github.com/google/uuid"
 
+	"github.com/vmware/govmomi/internal"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -29,7 +30,7 @@ var ServiceContent = types.ServiceContent{
 		ProductLineId:         "vpx",
 		ApiType:               "VirtualCenter",
 		ApiVersion:            "6.5",
-		InstanceUuid:          uuid.NewSHA1(uuid.NameSpaceOID, uuid.NodeID()).String(),
+		InstanceUuid:          internal.OID(string(uuid.NodeID())).String(),
 		LicenseProductName:    "VMware VirtualCenter Server",
 		LicenseProductVersion: "6.0",
 	},

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -397,10 +397,16 @@ func (c *Client) loadThumbprints(name string) error {
 	return scanner.Err()
 }
 
+var fips140 = strings.Contains(os.Getenv("GODEBUG"), "fips140=only")
+
 // ThumbprintSHA1 returns the thumbprint of the given cert in the same format used by the SDK and Client.SetThumbprint.
 //
 // See: SSLVerifyFault.Thumbprint, SessionManagerGenericServiceTicket.Thumbprint, HostConnectSpec.SslThumbprint
+// When GODEBUG contains "fips140=only", this function returns an empty string.
 func ThumbprintSHA1(cert *x509.Certificate) string {
+	if fips140 {
+		return ""
+	}
 	sum := sha1.Sum(cert.Raw)
 	hex := make([]string, len(sum))
 	for i, b := range sum {


### PR DESCRIPTION
api: soap.ThumbprintsSHA1 returns an empty string when GODEBUG contains "fips140=only"

Fixes #3766
