### PR TITLE
chore: update container images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,10 @@
 version: 2
 project_name: govmomi
 
+env:
+  - GO_VERSION=1.24
+  - ALPINE_VERSION=3.21
+
 builds:
   - id: govc
     no_main_check: true
@@ -111,6 +115,30 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.url=https://github.com/vmware/govmomi"
       - "--platform=linux/amd64"
+      - "--build-arg=GO_VERSION={{.Env.GO_VERSION}}"
+
+  - image_templates:
+      - "vmware/govc:{{ .Tag }}-runner"
+      - "vmware/govc:alpine-{{ .Tag }}-runner"
+      - "vmware/govc:{{ .ShortCommit }}-runner"
+      - "vmware/govc:alpine-{{ .ShortCommit }}-runner"
+      - "vmware/govc:latest-runner"
+      - "vmware/govc:alpine-latest-runner"
+    dockerfile: Dockerfile.govc.runner
+    ids:
+      - govc
+    extra_files:
+      - scripts/runner/entrypoint.sh
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.url=https://github.com/vmware/govmomi"
+      - "--platform=linux/amd64"
+      - "--build-arg=ALPINE_VERSION={{.Env.ALPINE_VERSION}}"
+
   - image_templates:
       - "vmware/vcsim:{{ .Tag }}"
       - "vmware/vcsim:{{ .ShortCommit }}"
@@ -126,3 +154,4 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.url=https://github.com/vmware/govmomi"
       - "--platform=linux/amd64"
+      - "--build-arg=GO_VERSION={{.Env.GO_VERSION}}"

--- a/Dockerfile.govc
+++ b/Dockerfile.govc
@@ -1,12 +1,14 @@
-# Create a builder container
-# Reference: https://hub.docker.com/_/golang/tags
-# Note: Official Docker images for Go use Debian.
+# © Broadcom. All Rights Reserved.
+# The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+# --- Builder Stage ---
+# Uses the official Go Docker image for the build.
+
 ARG GO_VERSION
-FROM golang:1.23.0 AS build
+FROM golang:${GO_VERSION} AS build
 WORKDIR /go/src/app
 
-# Create appuser to isolate potential vulnerabilities
-# Reference: https://stackoverflow.com/a/55757473/12429735
 ENV USER=appuser
 ENV UID=10001
 RUN adduser \
@@ -17,31 +19,23 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
-# Create a new tmp directory so no bad actors can manipulate it
 RUN mkdir /temporary-tmp-directory && chmod 777 /temporary-tmp-directory
 
-###############################################################################
-# Final stage
+# --- Final Stage ---
+
 FROM scratch
 
-# Allow container to use latest TLS certificates
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-# Copy over appuser to run as non-root
 COPY --from=build /etc/passwd /etc/passwd
 COPY --from=build /etc/group /etc/group
 
-# Copy over the /tmp directory for golang/os.TmpDir
 COPY --chown=appuser --from=build /temporary-tmp-directory /tmp
 
-# Copy application from external build
 COPY govc /govc
 
-# Run all commands as non-root
 USER appuser:appuser
 
-# session cache, etc
 ENV GOVMOMI_HOME=/tmp
 
-# Set CMD to application with container defaults
 CMD ["/govc"]

--- a/Dockerfile.govc.runner
+++ b/Dockerfile.govc.runner
@@ -1,0 +1,37 @@
+# © Broadcom. All Rights Reserved.
+# The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG ALPINE_VERSION
+FROM alpine:${ALPINE_VERSION}
+
+ENV USER=appuser
+ENV UID=10001
+
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    "${USER}" && \
+    mkdir -p /home/${USER} /tmp && \
+    chown -R "${USER}:${USER}" /home/${USER} /tmp && \
+    apk --no-cache add --no-check-certificate ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/cache/apk/*
+
+COPY govc /usr/local/bin/govc
+RUN chmod +x /usr/local/bin/govc
+
+COPY scripts/runner/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+USER "${USER}"
+
+ENV GOVMOMI_HOME=/tmp
+ENV PATH="$PATH:/usr/local/bin"
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+WORKDIR /home/${USER}

--- a/Dockerfile.vcsim
+++ b/Dockerfile.vcsim
@@ -1,49 +1,42 @@
-# Create a builder container
-# Reference: https://hub.docker.com/_/golang/tags
-# Note: Official Docker images for Go use Debian.
+# © Broadcom. All Rights Reserved.
+# The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+# --- Builder Stage ---
+# Uses the official Go Docker image to for the build.
+
 ARG GO_VERSION
-FROM golang:1.23.0 AS build
+FROM golang:${GO_VERSION} AS build
 WORKDIR /go/src/app
 
-# Create appuser to isolate potential vulnerabilities
-# Reference: https://stackoverflow.com/a/55757473/12429735
 ENV USER=appuser
 ENV UID=10001
 RUN adduser \
     --disabled-password \
     --gecos "" \
-    --home "/nonexistent" \
     --shell "/sbin/nologin" \
     --no-create-home \
     --uid "${UID}" \
     "${USER}"
 
-# Create a new tmp directory so no bad actors can manipulate it
 RUN mkdir /temporary-tmp-directory && chmod 777 /temporary-tmp-directory
 
-###############################################################################
-# Final stage
+# --- Final Stage ---
 FROM scratch
 
-# Run all commands as non-root
 USER appuser:appuser
 
-# Allow container to use latest TLS certificates
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-# Copy over appuser to run as non-root
 COPY --from=build /etc/passwd /etc/passwd
 COPY --from=build /etc/group /etc/group
 
-# Copy over the /tmp directory for golang/os.TmpDir
 COPY --chown=appuser --from=build /temporary-tmp-directory /tmp
 
-# Expose application port
 EXPOSE 8989
 
-# Copy application from external build
 COPY vcsim /vcsim
 
-# Set entrypoint to application with container defaults
 ENTRYPOINT [ "/vcsim" ]
+
 CMD ["-l", "0.0.0.0:8989"]

--- a/govc/README.md
+++ b/govc/README.md
@@ -9,16 +9,20 @@ It also acts as a [test harness](test) for the `govmomi` APIs and provides worki
 
 ### Docker
 
-The official `govc` [Docker images](https://hub.docker.com/r/vmware/govc) are built from this [Dockerfile](../Dockerfile.govc).
+The official `govc` [Docker image](https://hub.docker.com/r/vmware/govc) is built from the [Dockerfile](../Dockerfile.govc).
+
+A separate `govc` runner image is also available, built from [Dockerfile.govc.runner](../Dockerfile.govc.runner),
+which provides a minimal Alpine-based image allowing both `govc` and shell commands to be run.
 
 ### Binaries
+
 You can find prebuilt `govc` binaries on the [releases page](https://github.com/vmware/govmomi/releases).
 
 You can download and install a binary locally like this:
 
 ```bash
-# extract govc binary to /usr/local/bin
-# note: the "tar" command must run with root permissions
+# Extract govc binary to /usr/local/bin.
+# Note: The "tar" command must run with root permissions.
 curl -L -o - "https://github.com/vmware/govmomi/releases/latest/download/govc_$(uname -s)_$(uname -m).tar.gz" | tar -C /usr/local/bin -xvzf - govc
 ```
 
@@ -26,23 +30,21 @@ curl -L -o - "https://github.com/vmware/govmomi/releases/latest/download/govc_$(
 
 #### Install via `go install`
 
-To build `govc` from source, first install the [Go
-toolchain](https://golang.org/dl/). You can then install the latest `govc` from
-Github using:
+To build `govc` from source, first install the [Go toolchain](https://golang.org/dl/). You can then
+install the latest `govc` from GitHub using:
 
 ```bash
 cd $(mktemp -d) && git clone github.com/vmware/govmomi . && go -C govc install
 ```
 
-**Note:** To inject build variables (see details
-[below](#install-via-goreleaser)) used by `govc version [-l]`, `GOFLAGS` can be
-defined and are honored by `go get`.
+**Note:** To inject build variables (see details [below](#install-via-goreleaser)) used by `govc version [-l]`,
+`GOFLAGS` can be defined and are honored by `go get`.
 
-⚠️ Make sure `$GOPATH/bin` is in your `PATH` to use the version installed from
+> [!tip] Make sure `$GOPATH/bin` is in your `PATH` to use the version installed from
 source.
 
-If you've made local modifications to the repository, you can install with the
-following command from inside the `./govc` package:
+If you've made local modifications to the repository, you can install with the following command
+from inside the `./govc` package:
 
 ```bash
 go install .
@@ -56,73 +58,67 @@ go -C govc install
 
 #### Install via `goreleaser`
 
-You can also build `govc` following our release process using `goreleaser`
-(requires [Go toolchain](https://golang.org/dl/)). This will ensure that build
-time variables are correctly injected. Build (linker) flags and injection are
-defined in [.goreleaser.yaml](./../.goreleaser.yml) and automatically set as
-`GOFLAGS` when building with `goreleaser`.
+You can also build `govc` following our release process using `goreleaser` (requires [Go toolchain](https://golang.org/dl/)).
 
-Install `goreleaser` as per the installation
-[instructions](https://goreleaser.com/install/), then:
+This will ensure that build time variables are correctly injected. Build (linker) flags and
+injection are defined in [.goreleaser.yaml](./../.goreleaser.yml) and automatically set as `GOFLAGS`
+when building with `goreleaser`.
+
+Install `goreleaser` as per the installation [instructions](https://goreleaser.com/install/), then:
 
 ```bash
 git clone https://github.com/vmware/govmomi.git
 cd govmomi
 
-# pick a tag (>=v0.25.0)
-RELEASE=v0.25.0
+# pick a tag (>=v0.50.0)
+RELEASE=v0.50.0
 
 git checkout ${RELEASE}
 
-# build for the host OS/ARCH, otherwise omit --single-target
-# binaries are placed in respective subdirectories in ./dist/
+# Build for the host OS/ARCH, otherwise omit --single-target
+# Binaries are placed in respective subdirectories in ./dist/
 goreleaser build --clean --single-target
 ```
 
 ## Usage
 
-For the complete list of commands and flags, refer to the [USAGE](USAGE.md) document.
+For the complete list of commands and flags, refer to the [USAGE](USAGE.md) documentation.
 
 Common flags include:
 
-* `-u`: ESXi or vCenter URL (ex: `user:pass@host`)
+* `-u`: ESX or vCenter URL (*e.g.*, `user:pass@host`)
 * `-debug`: Trace requests and responses (to `~/.govmomi/debug`)
 
-Managed entities can be referred to by their absolute path or by their relative
-path. For example, when specifying a datastore to use for a subcommand, you can
-either specify it as `/mydatacenter/datastore/mydatastore`, or as
-`mydatastore`. If you're not sure about the name of the datastore, or even the
-full path to the datastore, you can specify a pattern to match. Both
-`/*center/*/my*` (absolute) and `my*store` (relative) will resolve to the same
-datastore, given there are no other datastores that match those globs.
+Managed entities can be referred to by their absolute path or by their relative path. For example,
+when specifying a datastore to use for a subcommand, you can either specify it as
+`/mydatacenter/datastore/mydatastore`, or as `mydatastore`. If you're not sure about the name of the
+datastore, or even the full path to the datastore, you can specify a pattern to match. Both
+`/*center/*/my*` (absolute) and `my*store` (relative) will resolve to the same datastore, given
+there are no other datastores that match those globs.
 
-The relative path in this example can only be used if the command can
-umambigously resolve a datacenter to use as origin for the query. If no
-datacenter is specified, `govc` defaults to the only datacenter, if there is
-only one. The datacenter itself can be specified as a pattern as well, enabling
-the following arguments: `-dc='my*' -ds='*store'`. The datastore pattern is
-looked up and matched relative to the datacenter which itself is specified as a
-pattern.
+The relative path in this example can only be used if the command can unambiguously resolve a
+datacenter to use as origin for the query. If no datacenter is specified, `govc` defaults to the
+only datacenter, if there is only one. The datacenter itself can be specified as a pattern as well,
+enabling the following arguments: `-dc='my*' -ds='*store'`. The datastore pattern is looked up and
+matched relative to the datacenter which itself is specified as a pattern.
 
-Besides specifying managed entities as arguments, they can also be specified
-using environment variables. The following environment variables are used by
-`govc` to set defaults:
+Besides specifying managed entities as arguments, they can also be specified using environment
+variables. The following environment variables are used by `govc` to set defaults:
 
-* `GOVC_URL`: URL of ESXi or vCenter instance to connect to.
+* `GOVC_URL`: URL of ESX or vCenter instance to connect to.
 
-    The URL scheme defaults to `https` and the URL path defaults to `/sdk`.
-    This means that specifying `user:pass@host` is equivalent to
-    `https://user:pass@host/sdk`.
+    The URL scheme defaults to `https` and the URL path defaults to `/sdk`. This means that
+    specifying `user:pass@host` is equivalent to `https://user:pass@host/sdk`.
 
     If username or password includes special characters like `\`, `#` or `:` you can use
     `GOVC_USERNAME` and `GOVC_PASSWORD` to have a simple `GOVC_URL`
 
-    When using govc against VMware Workstation, GOVC_URL can be set to "localhost"
-    without a user or pass, in which case local ticket based authentication is used.
+    When using govc against VMware Workstation, `GOVC_URL` can be set to "localhost" without a user
+    or pass, in which case local ticket based authentication is used.
 
-* `GOVC_USERNAME`: USERNAME to use if not specified in GOVC_URL.
+* `GOVC_USERNAME`: Username to use if not specified in `GOVC_URL`.
 
-* `GOVC_PASSWORD`: PASSWORD to use if not specified in GOVC_URL.
+* `GOVC_PASSWORD`: Password to use if not specified in `GOVC_URL`.
 
 * `GOVC_TLS_CA_CERTS`: Override system root certificate authorities.
 
@@ -135,7 +131,7 @@ using environment variables. The following environment variables are used by
 * `GOVC_TLS_KNOWN_HOSTS`: File(s) for thumbprint based certificate verification.
 
     Thumbprint based verification can be used in addition to or as an alternative to
-    `GOVC_TLS_CA_CERTS` for self-signed certificates.  Example:
+    `GOVC_TLS_CA_CERTS` for self-signed certificates.
 
     ```bash
     export GOVC_TLS_KNOWN_HOSTS=~/.govc_known_hosts
@@ -148,70 +144,76 @@ using environment variables. The following environment variables are used by
 * `GOVC_INSECURE`: Disable certificate verification.
 
     This option sets Go's `tls.Config.InsecureSkipVerify` flag and is false by default.
-    Quoting https://golang.org/pkg/crypto/tls/#Config:
-    > `InsecureSkipVerify` controls whether a client verifies the
-    > server's certificate chain and host name.
+
+    >[!NOTE]
+    > `InsecureSkipVerify` controls whether a client verifies the server's certificate chain and
+    > host name.
     >
-    > If `InsecureSkipVerify` is true, TLS accepts any certificate
-    > presented by the server and any host name in that certificate.
+    > If `InsecureSkipVerify` is `true`, TLS accepts any certificate presented by the server and any
+    > host name in that certificate.
     >
-    > In this mode, TLS is susceptible to man-in-the-middle attacks.
-    > This should be used only for testing.
+    > In this mode, TLS is susceptible to man-in-the-middle attacks. This should be used only for
+    > testing.
+    >
+    > [Reference](https://pkg.go.dev/crypto/tls#Config)
 
-* `GOVC_DATACENTER`
+* `GOVC_DATACENTER`: Name of the datacenter to use as default.
 
-* `GOVC_DATASTORE`
+* `GOVC_DATASTORE`: Name of the datastore to use as default.
 
-* `GOVC_NETWORK`
+* `GOVC_NETWORK`: Name of the network to use as default.
 
-* `GOVC_RESOURCE_POOL`
+* `GOVC_RESOURCE_POOL`: Name of the resource pool to use as default.
 
-* `GOVC_HOST`
+* `GOVC_HOST`: Name of the host system to use as default.
 
-* `GOVC_GUEST_LOGIN`: Guest credentials for guest operations
+* `GOVC_GUEST_LOGIN`: Guest credentials for guest operations.
 
-* `GOVC_VIM_NAMESPACE`: Vim namespace defaults to `urn:vim25`
+* `GOVC_VIM_NAMESPACE`: Vim namespace. Defaults to `urn:vim25`.
 
-* `GOVC_VIM_VERSION`: Vim version defaults to `6.0`
+* `GOVC_VIM_VERSION`: Vim version. Defaults to `6.0`.
 
-* `GOVC_VI_JSON`: Uses JSON transport instead of SOAP (Experimental; Usable only
-for vim25 APIs in vCenter 8.0u1)
+* `GOVC_VI_JSON`: Uses JSON transport instead of SOAP. (Experimental; usable only for vim25 APIs in vCenter 8.0u1)
 
 ## Troubleshooting
 
 ### Verbose Flag
 
-The `-verbose` flag writes request and response data to stderr, in a format more compact than the `-trace` or `-debug` flags.
-The output includes the request method name with abbreviated input parameters. The response data is more detailed and may include
-structures formatted as Go code, such as Task property updates.  The value of some properties will the `govc` `object.collect`
-command that can be used to view the actual value.
+The `-verbose` flag writes request and response data to stderr, in a format more compact than the
+`-trace` or `-debug` flags.
+
+The output includes the request method name with abbreviated input parameters. The response data is
+more detailed and may include structures formatted as Go code, such as Task property updates. The
+value of some properties will the `govc` `object.collect` command that can be used to view the
+actual value.
 
 ### Trace flag
 
-The `-trace` flag writes HTTP request and response data to stderr.
-XML bodies are formatted using `xmlstarlet` if installed and JSON bodies using `jq` if installed.
-Formatting can be disabled via `export GOVC_DEBUG_FORMAT=false`.
+The `-trace` flag writes HTTP request and response data to stderr. XML bodies are formatted using
+`xmlstarlet` if installed and JSON bodies using `jq` if installed. Formatting can be disabled via
+`export GOVC_DEBUG_FORMAT=false`.
 
 If both `-trace` and `-verbose` flags are specified, request and response data is formatted as Go code.
 
 ### Debug Flag
 
-The`-debug` flag traces vSphere API calls similar to the `-trace` flag, but saves to files rather than stderr.
-When the `-debug` flag is specified, the default behavior is to put the output in `~/.govmomi/debug/<run timestamp>`.
-In that directory will be four (4) files per API call.
+The`-debug` flag traces vSphere API calls similar to the `-trace` flag, but saves to files rather
+than stderr. When the `-debug` flag is specified, the default behavior is to put the output in
+`~/.govmomi/debug/<run timestamp>`. In that directory will be four (4) files per API call.
 
 ```bash
 1-0001.req.headers #headers from the request sent to the API
 1-0001.req.xml #body content from request sent to the API
 1-0001.res.headers #headers from the response from the API
-1-0001.res.xml #body from the respnse from the API
+1-0001.res.xml #body from the response from the API
 ```
 
-In that filename the `0001` represents the an incremented call order and will increment for each time the SOAP client
-makes an API call.
+In that filename the `0001` represents the an incremented call order and will increment for each
+time the SOAP client makes an API call.
 
 To configure the debug output you can use two environment variables.
-* `GOVC_DEBUG_PATH`: defaults to ~/.govmomi/debug
+
+* `GOVC_DEBUG_PATH`: defaults to `~/.govmomi/debug`
 * `GOVC_DEBUG_PATH_RUN`: defaults to timestamp of the run
 
 The [debug-format](../scripts/debug-format.sh) script can be used to format the debug output similar to the `-trace` flag.
@@ -220,17 +222,14 @@ The [debug-format](../scripts/debug-format.sh) script can be used to format the 
 
 For troubleshooting and when filing issues, get build related details with:
 
-```console
-$ govc version -l
-Build Version: v0.25.0-next
-Build Commit: e86da96e
-Build Date: 2021-04-19T10:29:57Z
+```bash
+govc version -l
 ```
 
 #### stderr debug
 
-If you prefer debug output to be sent to stderr and seen while the command is running you can override the file behavior
-by setting the debug path to a dash: `export GOVC_DEBUG_PATH=-`
+If you prefer debug output to be sent to stderr and seen while the command is running you can
+override the file behavior by setting the debug path to a dash: `export GOVC_DEBUG_PATH=-`
 
 ### Environment variables
 
@@ -240,7 +239,7 @@ If you're using environment variables to set `GOVC_URL`, verify the values are s
 govc env
 ```
 
-### Connection issues
+### Connection Issues
 
 Check your proxy settings:
 
@@ -260,9 +259,8 @@ Changes to the CLI are subject to [semantic versioning](http://semver.org).
 
 Refer to the [CHANGELOG](../CHANGELOG.md) for version to version changes.
 
-When new `govc` commands or flags are added, the PATCH version will be
-incremented.  This enables you to require a minimum version from within a
-script, for example:
+When new `govc` commands or flags are added, the PATCH version will be incremented. This enables you
+to require a minimum version from within a script, for example:
 
 ```bash
 govc version -require 0.24
@@ -274,4 +272,4 @@ govc version -require 0.24
 
 ## Name
 
-Pronounced "go-v-c", short for "Go(lang) vCenter CLI".
+Pronounced "*go-v-c*", short for "Go(lang) vCenter CLI".

--- a/scripts/runner/entrypoint.sh
+++ b/scripts/runner/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# © Broadcom. All Rights Reserved.
+# The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+DEFAULT_COMMAND="govc"
+DEFAULT_ARGS="version"
+
+if [ "$#" -eq 0 ]; then
+    exec "$DEFAULT_COMMAND" $DEFAULT_ARGS
+fi
+
+if [ "$1" = "govc" ]; then
+    exec "$@"
+else
+    exec /bin/sh -c "$*"
+fi


### PR DESCRIPTION
## Description

- Updates the default container images to pass the `GO_VERSION` as a build argument for `FROM`.
- Adds a minimal Alpine-based image that can be used as runner image requested by the community.

> [!NOTE]
> The compressed size once published to Docker Hub will be ~39.6 MB. 

Closes: #2988

## How Has This Been Tested?

```shell
govmomi on  chore/update-container-images [✘!?] via 🐹 v1.24.2 on 🐳 v26.1.5 (rancher-desktop) 
✦3 ➜ goreleaser release --snapshot --clean                          
  • skipping announce, publish, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=016b3203e91bd17687f8c74fe8fb96c5f5331f3f branch=chore/update-container-images current_tag=v0.51.0-alpha.0 previous_tag=v0.50.0-alpha.0 dirty=true
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.51.0-alpha.0-next
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/vcsim_linux_arm64_v8.0/vcsim
    • building                                       binary=dist/govc_linux_amd64_v1/govc
    • building                                       binary=dist/govc_darwin_amd64_v1/govc
    • building                                       binary=dist/govc_windows_arm_6/govc.exe
    • building                                       binary=dist/govc_linux_arm64_v8.0/govc
    • building                                       binary=dist/govc_freebsd_amd64_v1/govc
    • building                                       binary=dist/govc_windows_amd64_v1/govc.exe
    • building                                       binary=dist/vcsim_linux_arm_6/vcsim
    • building                                       binary=dist/govc_linux_mips64le_hardfloat/govc
    • building                                       binary=dist/govc_freebsd_arm64_v8.0/govc
    • building                                       binary=dist/govc_linux_s390x/govc
    • building                                       binary=dist/govc_darwin_arm64_v8.0/govc
    • building                                       binary=dist/govc_freebsd_arm_6/govc
    • building                                       binary=dist/govc_linux_arm_6/govc
    • building                                       binary=dist/vcsim_linux_amd64_v1/vcsim
    • building                                       binary=dist/govc_windows_arm64_v8.0/govc.exe
    • building                                       binary=dist/vcsim_linux_mips64le_hardfloat/vcsim
    • building                                       binary=dist/vcsim_linux_s390x/vcsim
    • building                                       binary=dist/vcsim_darwin_amd64_v1/vcsim
    • building                                       binary=dist/vcsim_darwin_arm64_v8.0/vcsim
    • building                                       binary=dist/vcsim_windows_amd64_v1/vcsim.exe
    • building                                       binary=dist/vcsim_windows_arm_6/vcsim.exe
    • building                                       binary=dist/vcsim_windows_arm64_v8.0/vcsim.exe
    • building                                       binary=dist/vcsim_freebsd_amd64_v1/vcsim
    • building                                       binary=dist/vcsim_freebsd_arm_6/vcsim
    • building                                       binary=dist/vcsim_freebsd_arm64_v8.0/vcsim
    • took: 27s
  • archives
    • archiving                                      name=dist/govc_Freebsd_x86_64.tar.gz
    • archiving                                      name=dist/govc_Windows_arm.zip
    • archiving                                      name=dist/vcsim_Linux_s390x.tar.gz
    • archiving                                      name=dist/govc_Windows_x86_64.zip
    • archiving                                      name=dist/govc_Windows_arm64.zip
    • archiving                                      name=dist/govc_Linux_arm.tar.gz
    • archiving                                      name=dist/govc_Linux_mips64le.tar.gz
    • archiving                                      name=dist/govc_Linux_x86_64.tar.gz
    • archiving                                      name=dist/govc_Darwin_arm64.tar.gz
    • archiving                                      name=dist/govc_Linux_arm64.tar.gz
    • archiving                                      name=dist/govc_Linux_s390x.tar.gz
    • archiving                                      name=dist/govc_Darwin_x86_64.tar.gz
    • archiving                                      name=dist/govc_Freebsd_arm.tar.gz
    • archiving                                      name=dist/vcsim_Linux_arm64.tar.gz
    • archiving                                      name=dist/vcsim_Linux_x86_64.tar.gz
    • archiving                                      name=dist/govc_Freebsd_arm64.tar.gz
    • archiving                                      name=dist/vcsim_Darwin_x86_64.tar.gz
    • archiving                                      name=dist/vcsim_Windows_x86_64.zip
    • archiving                                      name=dist/vcsim_Freebsd_arm64.tar.gz
    • archiving                                      name=dist/vcsim_Freebsd_arm.tar.gz
    • archiving                                      name=dist/vcsim_Darwin_arm64.tar.gz
    • archiving                                      name=dist/vcsim_Linux_arm.tar.gz
    • archiving                                      name=dist/vcsim_Linux_mips64le.tar.gz
    • archiving                                      name=dist/vcsim_Windows_arm.zip
    • archiving                                      name=dist/vcsim_Freebsd_x86_64.tar.gz
    • archiving                                      name=dist/vcsim_Windows_arm64.zip
    • took: 36s
  • linux packages
    • creating                                       package=govmomi format=rpm arch=s390x file=dist/govmomi_v0.51.0-alpha.0-next_linux_s390x.rpm
    • creating                                       package=govmomi format=rpm arch=mips64lehardfloat file=dist/govmomi_v0.51.0-alpha.0-next_linux_mips64le_hardfloat.rpm
    • creating                                       package=govmomi format=rpm arch=arm6 file=dist/govmomi_v0.51.0-alpha.0-next_linux_armv6.rpm
    • creating                                       package=govmomi format=rpm arch=amd64v1 file=dist/govmomi_v0.51.0-alpha.0-next_linux_amd64.rpm
    • creating                                       package=govmomi format=rpm arch=arm64v8.0 file=dist/govmomi_v0.51.0-alpha.0-next_linux_arm64.rpm
  • calculating checksums
  • docker images
    • building docker image                          image=vmware/vcsim:v0.51.0-alpha.0
    • building docker image                          image=vmware/govc:v0.51.0-alpha.0
    • building docker image                          image=vmware/govc:v0.51.0-alpha.0-runner
    • took: 17s
  • writing artifacts metadata
  • release succeeded after 1m24s
  • thanks for using GoReleaser!

govmomi on  chore/update-container-images [?] via 🐹 v1.24.2 on 🐳 v26.1.5 (rancher-desktop) 
✦3 ➜ docker images | grep runner
vmware/govc                        016b3203-runner                 b9e90669e088   32 minutes ago      108MB
vmware/govc                        alpine-016b3203-runner          b9e90669e088   32 minutes ago      108MB
vmware/govc                        alpine-latest-runner            b9e90669e088   32 minutes ago      108MB
vmware/govc                        alpine-v0.51.0-alpha.0-runner   b9e90669e088   32 minutes ago      108MB
vmware/govc                        latest-runner                   b9e90669e088   32 minutes ago      108MB
vmware/govc                        v0.51.0-alpha.0-runner          b9e90669e088   32 minutes ago      108MB

govmomi on  chore/update-container-images [✘!?] via 🐹 v1.24.2 on 🐳 v26.1.5 (rancher-desktop) took 1m 25.0s 
✦3 ➜ docker run --rm -it vmware/govc:latest-runner
govc 0.51.0-alpha.0-next

govmomi on  chore/update-container-images [✘!?] via 🐹 v1.24.2 on 🐳 v26.1.5 (rancher-desktop) 
✦3 ➜ docker run --rm -it vmware/govc:latest-runner govc version
govc 0.51.0-alpha.0-next

govmomi on  chore/update-container-images [✘!?] via 🐹 v1.24.2 on 🐳 v26.1.5 (rancher-desktop) 
✦3 ➜ docker run --rm -it vmware/govc:latest-runner echo "hello world"
hello world
```