### PR TITLE
vcsim: Add VirtualMachine.PromoteDisks_Task method

### DIFF
--- a/cli/vm/disk/promote.go
+++ b/cli/vm/disk/promote.go
@@ -1,0 +1,88 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package disk
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/cli"
+	"github.com/vmware/govmomi/cli/device"
+	"github.com/vmware/govmomi/cli/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type promote struct {
+	*flags.VirtualMachineFlag
+
+	unlink bool
+}
+
+func init() {
+	cli.Register("vm.disk.promote", &promote{})
+}
+
+func (cmd *promote) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.unlink, "unlink", true, "Unlink")
+}
+
+func (cmd *promote) Usage() string {
+	return "DISK..."
+}
+
+func (cmd *promote) Description() string {
+	return `Promote VM disk.
+
+Examples:
+  govc device.info -vm $name disk-*
+  govc vm.disk.promote -vm $name disk-1000-0
+  govc vm.disk.promote -vm $name disk-*`
+}
+
+func (cmd *promote) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	devices = devices.SelectByType((*types.VirtualDisk)(nil))
+
+	devices, err = device.Match(devices, f.Args())
+	if err != nil {
+		return err
+	}
+
+	disks := make([]types.VirtualDisk, len(devices))
+	for i := range devices {
+		disks[i] = *(devices[i].(*types.VirtualDisk))
+	}
+
+	task, err := vm.PromoteDisks(ctx, cmd.unlink, disks)
+	if err != nil {
+		return err
+	}
+
+	logger := cmd.ProgressLogger("Promoting disks...")
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
+}

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -3809,10 +3809,20 @@ Options:
 ```
 Usage: govc import.vmdk [OPTIONS] PATH_TO_VMDK [REMOTE_DIRECTORY]
 
+Import vmdk to datastore.
+
+The local vmdk must be in streamOptimized format.
+
+Examples:
+  govc import.vmdk my.vmdk
+  govc import.vmdk -i my.vmdk # output vmdk info only
+  govc import.vmdk -json -i my.vmdk | jq .capacity | xargs numfmt --to=iec --suffix=B --format="%.1f"
+
 Options:
   -ds=                   Datastore [GOVC_DATASTORE]
   -folder=               Inventory folder [GOVC_FOLDER]
   -force=false           Overwrite existing disk
+  -i=false               Output vmdk info only
   -pool=                 Resource pool [GOVC_RESOURCE_POOL]
 ```
 

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -409,6 +409,7 @@ but appear via `govc $cmd -h`:
  - [vm.disk.attach](#vmdiskattach)
  - [vm.disk.change](#vmdiskchange)
  - [vm.disk.create](#vmdiskcreate)
+ - [vm.disk.promote](#vmdiskpromote)
  - [vm.guest.tools](#vmguesttools)
  - [vm.info](#vminfo)
  - [vm.instantclone](#vminstantclone)
@@ -7198,6 +7199,23 @@ Options:
   -sharing=              Sharing (sharingNone|sharingMultiWriter)
   -size=10.0GB           Size of new disk
   -thick=false           Thick provision new disk
+  -vm=                   Virtual machine [GOVC_VM]
+```
+
+## vm.disk.promote
+
+```
+Usage: govc vm.disk.promote [OPTIONS] DISK...
+
+Promote VM disk.
+
+Examples:
+  govc device.info -vm $name disk-*
+  govc vm.disk.promote -vm $name disk-1000-0
+  govc vm.disk.promote -vm $name disk-*
+
+Options:
+  -unlink=true           Unlink
   -vm=                   Virtual machine [GOVC_VM]
 ```
 

--- a/govc/emacs/govc.el
+++ b/govc/emacs/govc.el
@@ -1137,7 +1137,7 @@ Optionally filter by FILTER and inherit SESSION."
 
 (defun govc-datastore-ls-entries ()
   "Wrapper for govc datastore.ls."
-  (let* ((data (govc-json "datastore.ls" "-l" "-p" govc-filter))
+  (let* ((data (govc-json "datastore.ls" (if current-prefix-arg "-a") "-l" "-p" govc-filter))
          (file (plist-get (elt data 0) :file)))
     (-map (lambda (ent)
             (let ((name (plist-get ent :path))
@@ -1164,7 +1164,7 @@ Optionally filter by FILTER and inherit SESSION."
   (interactive)
   (let ((id (tabulated-list-get-id)))
     (if current-prefix-arg
-        (govc-shell-command (list "datastore.ls" "-l" "-p" "-R" id))
+        (govc-shell-command (list "datastore.ls" (if current-prefix-arg "-a") "-l" "-p" "-R" id))
       (if (s-ends-with? "/" id)
           (progn (setq govc-filter id)
                  (tabulated-list-revert))

--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -168,6 +168,23 @@ load test_helper
   assert_success # exists, but -force was used
 }
 
+@test "import.vmdk -i" {
+  # ClientFlag.Process errors otherwise, but not using client with -i flag
+  export GOVC_URL="unused"
+
+  run govc import.vmdk -i "$GOVC_IMAGES/${TTYLINUX_NAME}.ovf"
+  assert_failure
+
+  run govc import.vmdk -i "$GOVC_TEST_VMDK_SRC"
+  assert_success
+
+  run govc import.vmdk -json -i "$GOVC_TEST_VMDK_SRC"
+  assert_success
+
+  run jq . <<<"$output"
+  assert_success
+}
+
 @test "import duplicate dvpg names" {
   vcsim_env
 

--- a/object/virtual_machine.go
+++ b/object/virtual_machine.go
@@ -1078,3 +1078,18 @@ func (v *VirtualMachine) ExportSnapshot(ctx context.Context, snapshot *types.Man
 	}
 	return nfc.NewLease(v.c, resp.Returnval), nil
 }
+
+func (v *VirtualMachine) PromoteDisks(ctx context.Context, unlink bool, disks []types.VirtualDisk) (*Task, error) {
+	req := types.PromoteDisks_Task{
+		This:   v.Reference(),
+		Unlink: unlink,
+		Disks:  disks,
+	}
+
+	res, err := methods.PromoteDisks_Task(ctx, v.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(v.Client(), res.Returnval), nil
+}

--- a/simulator/http_nfc_lease.go
+++ b/simulator/http_nfc_lease.go
@@ -59,12 +59,14 @@ func ServeNFC(w http.ResponseWriter, r *http.Request) {
 	}
 
 	status := http.StatusOK
-	var dst hash.Hash
+	var sum hash.Hash
+	var dst io.Writer = w
 	var src io.ReadCloser
 
 	switch r.Method {
 	case http.MethodPut, http.MethodPost:
-		dst = sha1.New()
+		sum = sha1.New()
+		dst = sum
 		src = r.Body
 	case http.MethodGet:
 		f, err := os.Open(file)
@@ -79,9 +81,9 @@ func ServeNFC(w http.ResponseWriter, r *http.Request) {
 
 	n, err := io.Copy(dst, src)
 	_ = src.Close()
-	if dst != nil {
+	if sum != nil {
 		lease.metadata[name] = metadata{
-			sha1: dst.Sum(nil),
+			sha1: sum.Sum(nil),
 			size: n,
 		}
 	}

--- a/simulator/session_manager.go
+++ b/simulator/session_manager.go
@@ -196,6 +196,9 @@ func (s *SessionManager) Logout(ctx *Context, _ *types.Logout) soap.HasFault {
 	s.delSession(session.Key)
 	pc := ctx.Map.content().PropertyCollector
 
+	ctx.Session.Registry.m.Lock()
+	defer ctx.Session.Registry.m.Unlock()
+
 	for ref, obj := range ctx.Session.Registry.objects {
 		if ref == pc {
 			continue // don't unregister the PropertyCollector singleton

--- a/simulator/vstorage_object_manager.go
+++ b/simulator/vstorage_object_manager.go
@@ -234,6 +234,7 @@ func (m *VcenterVStorageObjectManager) createObject(ctx *Context, req *types.Cre
 		err := vdmCreateVirtualDisk(ctx, types.VirtualDeviceConfigSpecFileOperationCreate, &types.CreateVirtualDisk_Task{
 			Datacenter: &dc.Self,
 			Name:       path.String(),
+			Spec:       &types.FileBackedVirtualDiskSpec{CapacityKb: req.Spec.CapacityInMB * 1024},
 		})
 		if err != nil {
 			return nil, err

--- a/vapi/library/example_test.go
+++ b/vapi/library/example_test.go
@@ -241,12 +241,12 @@ func ExampleManager_CreateLibrary_subscribed() {
 	//   created library item my-image
 	//     uploaded library item file ttylinux-pc_i486-16.1.ovf, cached=true, size=5005
 	//     uploaded library item file ttylinux-pc_i486-16.1.mf, cached=true, size=159
-	//     uploaded library item file ttylinux-pc_i486-16.1-disk1.vmdk, cached=true, size=1048576
+	//     uploaded library item file ttylinux-pc_i486-16.1-disk1.vmdk, cached=true, size=1047552
 	// created library my-sub-lib
 	//   got subscribed library item my-image
 	//     library item file ttylinux-pc_i486-16.1.ovf, cached=true, size=5005
 	//     library item file ttylinux-pc_i486-16.1.mf, cached=true, size=159
-	//     library item file ttylinux-pc_i486-16.1-disk1.vmdk, cached=true, size=1048576
+	//     library item file ttylinux-pc_i486-16.1-disk1.vmdk, cached=true, size=1047552
 }
 
 func ExampleManager_CreateLibrary_subscribed_ondemand() {
@@ -449,7 +449,7 @@ func ExampleManager_CreateLibrary_subscribed_ondemand() {
 	//   created library item my-image
 	//     uploaded library item file ttylinux-pc_i486-16.1.ovf, cached=true, size=5005
 	//     uploaded library item file ttylinux-pc_i486-16.1.mf, cached=true, size=159
-	//     uploaded library item file ttylinux-pc_i486-16.1-disk1.vmdk, cached=true, size=1048576
+	//     uploaded library item file ttylinux-pc_i486-16.1-disk1.vmdk, cached=true, size=1047552
 	// created library my-sub-lib
 	//   got subscribed library item my-image
 	//     library item file ttylinux-pc_i486-16.1.ovf, cached=true, size=5005
@@ -458,5 +458,5 @@ func ExampleManager_CreateLibrary_subscribed_ondemand() {
 	//   sync'd (force=true) subscribed library item my-image
 	//     library item file ttylinux-pc_i486-16.1.ovf, cached=true, size=5005
 	//     library item file ttylinux-pc_i486-16.1.mf, cached=true, size=159
-	//     library item file ttylinux-pc_i486-16.1-disk1.vmdk, cached=true, size=1048576
+	//     library item file ttylinux-pc_i486-16.1-disk1.vmdk, cached=true, size=1047552
 }

--- a/vmdk/import_test.go
+++ b/vmdk/import_test.go
@@ -5,9 +5,11 @@
 package vmdk_test
 
 import (
+	"io"
 	"os"
 	"testing"
 
+	"github.com/vmware/govmomi/units"
 	"github.com/vmware/govmomi/vmdk"
 )
 
@@ -20,9 +22,34 @@ func TestDiskInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	w := io.Discard
+	if testing.Verbose() {
+		w = os.Stderr
+	}
+
+	if err := di.Descriptor.Write(w); err != nil {
+		t.Error(err)
+	}
+
+	cap := di.Descriptor.Capacity()
+	hdr := di.Capacity
+	if cap != hdr {
+		t.Errorf("descriptor capacity %d != header capacity %d", cap, hdr)
+	}
+
+	scap := units.ByteSize(di.Capacity).String()
+	if scap != "30.0MB" {
+		t.Errorf("capacity=%s", scap)
+	}
+
 	_, err = di.OVF()
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	di, err = vmdk.Stat("../govc/test/images/ttylinux-pc_i486-16.1.ovf")
+	if err != vmdk.ErrInvalidFormat {
+		t.Fatalf("error=%s", err)
 	}
 }
 


### PR DESCRIPTION
- govc: Add vm.disk.promote command

- api: Add object.VirtualMachine.PromoteDisks method

- vcsim: Use vmdk.Descriptor for vmdk file metadata

- govc: Add import.vmdk '-i' flag to output vmdk info only

- api: Extend vmdk.Info to include Descriptor

- fix: vcsim: Avoid possible race in SessionManager.Logout
