### PR TITLE
vcsim: Use OptionManager to configure session timeout duration

### DIFF
--- a/cli/host/option/set.go
+++ b/cli/host/option/set.go
@@ -46,7 +46,8 @@ func (cmd *set) Description() string {
 
 Examples:
   govc host.option.set Config.HostAgent.plugins.solo.enableMob true
-  govc host.option.set Config.HostAgent.log.level verbose`
+  govc host.option.set Config.HostAgent.log.level verbose
+  govc host.option.set Config.HostAgent.vmacore.soap.sessionTimeout 90`
 }
 
 func (cmd *set) Run(ctx context.Context, f *flag.FlagSet) error {

--- a/cli/option/set.go
+++ b/cli/option/set.go
@@ -47,8 +47,11 @@ func (cmd *Set) Description() string {
 	return SetDescription + `
 
 Examples:
+  # Change log levels
   govc option.set log.level info
-  govc option.set logger.Vsan verbose`
+  govc option.set logger.Vsan verbose
+  # Increase vCenter session timeout to 90 minutes
+  govc option.set config.vmacore.soap.sessionTimeout 90`
 }
 
 func (cmd *Set) Update(ctx context.Context, f *flag.FlagSet, m *object.OptionManager) error {

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -3460,6 +3460,7 @@ Set option NAME to VALUE.
 Examples:
   govc host.option.set Config.HostAgent.plugins.solo.enableMob true
   govc host.option.set Config.HostAgent.log.level verbose
+  govc host.option.set Config.HostAgent.vmacore.soap.sessionTimeout 90
 
 Options:
   -host=                 Host system [GOVC_HOST]
@@ -5296,8 +5297,11 @@ Usage: govc option.set [OPTIONS] NAME VALUE
 Set option NAME to VALUE.
 
 Examples:
+  # Change log levels
   govc option.set log.level info
   govc option.set logger.Vsan verbose
+  # Increase vCenter session timeout to 90 minutes
+  govc option.set config.vmacore.soap.sessionTimeout 90
 
 Options:
 ```

--- a/simulator/option_manager.go
+++ b/simulator/option_manager.go
@@ -27,11 +27,6 @@ type OptionManager struct {
 	mirror *[]types.BaseOptionValue
 }
 
-func asOptionManager(ctx *Context, obj mo.Reference) (*OptionManager, bool) {
-	om, ok := ctx.Map.Get(obj.Reference()).(*OptionManager)
-	return om, ok
-}
-
 // NewOptionManager constructs the type. If mirror is non-nil it takes precedence over settings, and settings is ignored.
 // Args:
 //   - ref - used to set OptionManager.Self if non-nil

--- a/simulator/sim25/client.go
+++ b/simulator/sim25/client.go
@@ -1,0 +1,31 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package sim25
+
+import (
+	"context"
+	"time"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// SetSessionTimeout changes the default session timeout.
+func SetSessionTimeout(ctx context.Context, c *vim25.Client, timeout time.Duration) error {
+	// Note that real vCenter supports the same OptionValue Key, but only with a Value of whole seconds.
+	req := types.UpdateOptions{
+		This: *c.ServiceContent.Setting,
+		ChangedValue: []types.BaseOptionValue{
+			&types.OptionValue{
+				Key:   "config.vmacore.soap.sessionTimeout",
+				Value: timeout.String(),
+			},
+		},
+	}
+
+	_, err := methods.UpdateOptions(ctx, c, &req)
+	return err
+}

--- a/simulator/sim25/doc.go
+++ b/simulator/sim25/doc.go
@@ -1,0 +1,8 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package sim25 contains vim25.Client helpers intended for use with vcsim.
+*/
+package sim25


### PR DESCRIPTION
Use of SessionIdleTimeout package var can race.
Changing session timeout via OptionManager:
- Avoids races
- Works with clients other than Go
- Same method used by real vCenter

BREAKING: var `simulator.SessionIdleTimeout` has been removed.
Use `sim25.SetSessionTimeout` instead.

Example against real vCenter:
```console
% govc option.set config.vmacore.soap.sessionTimeout 42
```

Setting is persisted here:
```console
# grep sessionTimeout -B1 -A1 /etc/vmware-vpx/vpxd.cfg
    <soap>
      <sessionTimeout>42</sessionTimeout>
    </soap>
```