### PR TITLE
vcsim: Resolve NSX OpaqueBacking to the DistributedVirtualPortgroup

### DIFF
--- a/object/example_test.go
+++ b/object/example_test.go
@@ -514,8 +514,19 @@ func ExampleNetworkReference_EthernetCardBackingInfo() {
 			return err
 		}
 
+		// The NSX OpaqueNetwork backing should replaced with the DVPG.
+		dvpgNet, err := finder.Network(ctx, "DC0_NSXPG0")
+		if err != nil {
+			return err
+		}
+
+		dvpgBacking, err := dvpgNet.EthernetCardBackingInfo(ctx)
+		if err != nil {
+			return err
+		}
+
 		nics := list.SelectByType((*types.VirtualEthernetCard)(nil)) // All VM NICs (DC0_DVPG0 + DC0_NSX0)
-		match := list.SelectByBackingInfo(backing)                   // VM NIC with DC0_NSX0 backing
+		match := list.SelectByBackingInfo(dvpgBacking)               // VM NIC with DC0_NSX0 backing
 
 		fmt.Printf("%d of %d NICs match backing\n", len(match), len(nics))
 

--- a/simulator/model_test.go
+++ b/simulator/model_test.go
@@ -23,6 +23,7 @@ func compareModel(t *testing.T, m *Model) {
 	if pgs > 0 {
 		pgs++ // uplinks
 	}
+	pgs += m.OpaqueNetwork // pg for each opaque network
 
 	tests := []struct {
 		expect int


### PR DESCRIPTION
## Description

Real VC replaces the NSX OpaqueBacking with the DVPG found via the LogicalSwitchUuid so do the same in vcsim. For each OpaqueNetwork specified in the simulator model, create a corresponding NSX portgroup with the LogicalSwitchUuid so the each opaque backing can be resolved to a DPVG.

Closes: #(issue-number)

## How Has This Been Tested?

Tested against a slightly hacked version of vm-operator's vcsim test framework.

MR is draft atm until I can look at adding some govmoni tests

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
