### PR TITLE
fix: vcsim: Avoid panic in QueryAvailablePerfMetric if VM has no Datastore

### DIFF
--- a/simulator/performance_manager.go
+++ b/simulator/performance_manager.go
@@ -109,7 +109,9 @@ func (p *PerformanceManager) buildAvailablePerfMetricsQueryResponse(ids []types.
 				r.Returnval = append(r.Returnval, types.PerfMetricId{CounterId: id.CounterId, Instance: strconv.Itoa(i)})
 			}
 		case "$physDisk":
-			r.Returnval = append(r.Returnval, types.PerfMetricId{CounterId: id.CounterId, Instance: datastoreURL})
+			if datastoreURL != "" {
+				r.Returnval = append(r.Returnval, types.PerfMetricId{CounterId: id.CounterId, Instance: datastoreURL})
+			}
 		case "$file":
 			r.Returnval = append(r.Returnval, types.PerfMetricId{CounterId: id.CounterId, Instance: "DISKFILE"})
 			r.Returnval = append(r.Returnval, types.PerfMetricId{CounterId: id.CounterId, Instance: "DELTAFILE"})
@@ -128,7 +130,11 @@ func (p *PerformanceManager) queryAvailablePerfMetric(ctx *Context, entity types
 	switch entity.Type {
 	case "VirtualMachine":
 		vm := ctx.Map.Get(entity).(*VirtualMachine)
-		return p.buildAvailablePerfMetricsQueryResponse(p.vmMetrics, int(vm.Summary.Config.NumCpu), vm.Datastore[0].Value)
+		ds := ""
+		if len(vm.Datastore) != 0 {
+			ds = vm.Datastore[0].Value
+		}
+		return p.buildAvailablePerfMetricsQueryResponse(p.vmMetrics, int(vm.Summary.Config.NumCpu), ds)
 	case "HostSystem":
 		host := ctx.Map.Get(entity).(*HostSystem)
 		return p.buildAvailablePerfMetricsQueryResponse(p.hostMetrics, int(host.Hardware.CpuInfo.NumCpuThreads), host.Datastore[0].Value)

--- a/simulator/performance_manager_test.go
+++ b/simulator/performance_manager_test.go
@@ -174,6 +174,15 @@ func TestQueryAvailablePerfMetric(t *testing.T) {
 		}
 	}
 
+	vm.Datastore = nil // e.g. vCLS VMs have no Datastore
+	if info, err := p.AvailableMetric(ctx, vm.Reference(), 20); err != nil {
+		t.Fatal(err)
+	} else {
+		if len(info) == 0 {
+			t.Fatal("Expected non-empty list of vm")
+		}
+	}
+
 	host := ctx.Map.Any("HostSystem").(*HostSystem)
 	if info, err := p.AvailableMetric(ctx, host.Reference(), 20); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This is the case for vCLS VMs at least:
```console
> % govc collect -type m /DC/vm/vCLS name datastore
> VirtualMachine:vm-3007  name       string                          vCLS-4c4c4544-0038-3610-8057-b1c04f514a33
> VirtualMachine:vm-3007  datastore  []types.ManagedObjectReference  
> VirtualMachine:vm-3014  name       string                          vCLS-4c4c4544-0031-3310-8057-b4c04f514a33
> VirtualMachine:vm-3014  datastore  []types.ManagedObjectReference  
```