### PR TITLE
vcsim: Avoid panic if VM NIC is removed after CustomizeVM

### DIFF
--- a/simulator/esx/event_manager.go
+++ b/simulator/esx/event_manager.go
@@ -240,6 +240,12 @@ var EventInfo = []types.EventDescriptionEventDetail{
 		FullFormat:  "Customization of VM {{.Vm.Name}} succeeded",
 	},
 	{
+		Key:         "CustomizationNetworkSetupFailed",
+		Description: "Cannot complete customization network setup",
+		Category:    "error",
+		FullFormat:  "An error occurred while setting up network properties of the guest OS",
+	},
+	{
 		Key:         "DrsVmMigratedEvent",
 		Description: "DRS VM migrated",
 		Category:    "info",

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -2580,6 +2580,19 @@ func (vm *VirtualMachine) customize(ctx *Context) {
 		{Name: "config.tools.pendingCustomization", Val: ""},
 	}
 
+	if len(vm.Guest.Net) != len(vm.imc.NicSettingMap) {
+		ctx.postEvent(&types.CustomizationNetworkSetupFailed{
+			CustomizationFailed: types.CustomizationFailed{
+				CustomizationEvent: event,
+				Reason:             "NicSettingMismatch",
+			},
+		})
+
+		vm.imc = nil
+		ctx.Update(vm, changes)
+		return
+	}
+
 	hostname := ""
 	address := ""
 


### PR DESCRIPTION
CustomizeVM_Task returns NicSettingMismatch if NumberOfNicsInVM != 0 NumberOfNicsInSpec. However, a NIC can be removed via ReconfigVM_Task before powering on a VM, which results in panic due to index-out-of-range.
If there is a mismatch at poweron, emit a CustomizationNetworkSetupFailed as real vCenter does.
