### PR TITLE
Add linkedClone creation support for CNS volumes

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -813,8 +813,9 @@ func init() {
 type CnsSnapshotVolumeSource struct {
 	CnsVolumeSource
 
-	VolumeId   CnsVolumeId   `xml:"volumeId,omitempty" json:"volumeId"`
-	SnapshotId CnsSnapshotId `xml:"snapshotId,omitempty" json:"snapshotId"`
+	VolumeId    CnsVolumeId   `xml:"volumeId,omitempty" json:"volumeId"`
+	SnapshotId  CnsSnapshotId `xml:"snapshotId,omitempty" json:"snapshotId"`
+	LinkedClone bool          `xml:"linkedClone,omitempty" json:"linkedClone"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

This change adds supports in govmomi to create LinkedClone volumes from CNS volumes.

Closes: #(issue-number)

## How Has This Been Tested?
Added tests, and executed against a VC with FCD_LINKED_CLONE_SUPPORT=enabled
```
  client_test.go:538: Creating linkedclone using the spec: types.CnsVolumeCreateSpec{
            DynamicData: types.DynamicData{},
            Name:        "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0-create-lc",
            VolumeType:  "BLOCK",
            Datastores:  {
                {Type:"Datastore", Value:"datastore-37", ServerGUID:""},
            },
            Metadata: types.CnsVolumeMetadata{
                DynamicData:      types.DynamicData{},
                ContainerCluster: types.CnsContainerCluster{
                    DynamicData:         types.DynamicData{},
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "OpenShift",
                    Delete:              false,
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    DynamicData:  types.DynamicData{},
                    CapacityInMb: 5120,
                },
                BackingDiskId:                  "",
                BackingDiskUrlPath:             "",
                BackingDiskObjectId:            "",
                AggregatedSnapshotCapacityInMb: 0,
                BackingDiskPath:                "",
            },
            Profile:      nil,
            CreateSpec:   nil,
            VolumeSource: &types.CnsSnapshotVolumeSource{
                CnsVolumeSource: types.CnsVolumeSource{},
                VolumeId:        types.CnsVolumeId{
                    DynamicData: types.DynamicData{},
                    Id:          "b15e6dfe-77e8-4244-af93-491f34f95856",
                },
                SnapshotId: types.CnsSnapshotId{
                    DynamicData: types.DynamicData{},
                    Id:          "a1864630-8641-4b05-84ed-783f8b5d0c72",
                },
                LinkedClone: true,
            },
        }
    client_test.go:564: createLinkedCloneResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:679a0762-203f-48f0-b0de-09eb04876d32} Fault:<nil>} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0-create-lc PlacementResults:[{Datastore:Datastore:datastore-37 PlacementFaults:[]}]}
    client_test.go:565: LinkedClone created from (volume b15e6dfe-77e8-4244-af93-491f34f95856 snapshot a1864630-8641-4b05-84ed-783f8b5d0c72) sucessfully. volumeId: 679a0762-203f-48f0-b0de-09eb04876d32
    client_test.go:571: Deleting volume: [{DynamicData:{} Id:679a0762-203f-48f0-b0de-09eb04876d32}]
    client_test.go:595: LinkedClone: "679a0762-203f-48f0-b0de-09eb04876d32" deleted sucessfully
```

Please describe any manual tests done to verify your changes.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
