### PR TITLE
vcsim: Fault injection

### DIFF
--- a/hack/header/config.json
+++ b/hack/header/config.json
@@ -19,7 +19,9 @@
     "scripts/**",
     "vim25/json/**",
     "vim25/xml/**",
-    "govc/**/*.sh"
+    "govc/**/*.sh",
+    "gen/**/*.yaml",
+    "dist/**/*"
   ],
   "maxScanLines": 10
 }

--- a/simulator/doc.go
+++ b/simulator/doc.go
@@ -3,7 +3,217 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
-Package simulator is a mock framework for the vSphere API.
+Package simulator provides fault injection capabilities to simulate various
+error conditions in vSphere operations for testing and development purposes.
+
+# Fault Injection Overview
+
+The fault injection system allows you to inject various types of faults into
+SOAP method calls made to the simulator. This is useful for:
+
+- Testing error handling in client applications
+- Simulating network and resource failures
+- Validating retry and recovery logic
+- Chaos engineering and resilience testing
+
+# Basic Usage
+
+To use fault injection, access the Service from the simulator context and add
+fault rules:
+
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		service := simulator.ServiceFromContext(ctx)
+
+		// Add a rule to inject authentication errors
+		rule := &simulator.FaultInjectionRule{
+			MethodName:  "PowerOnVM_Task",
+			ObjectType:  "VirtualMachine",
+			ObjectName:  "*",
+			Probability: 0.1, // 10% of calls will fail
+			FaultType:   simulator.FaultTypeNotAuthenticated,
+			Message:     "Authentication failed",
+			Enabled:     true,
+		}
+		service.AddFaultRule(rule)
+
+		// Now VM power on operations will randomly fail
+		finder := find.NewFinder(c)
+		vm, _ := finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
+		_, err := vm.PowerOn(ctx) // May fail with NotAuthenticated
+	})
+
+# Fault Types
+
+The following built-in fault types are available:
+
+- FaultTypeGeneric: Generic system errors
+- FaultTypeNotAuthenticated: Authentication failures
+- FaultTypeNoPermission: Permission denied errors
+- FaultTypeInvalidArgument: Invalid parameter errors
+- FaultTypeMethodNotFound: Method not found errors
+- FaultTypeManagedObjectNotFound: Object not found errors
+- FaultTypeInvalidState: Invalid object state errors
+- FaultTypeResourceInUse: Resource busy/in use errors
+- FaultTypeInsufficientResourcesFault: Resource exhaustion errors
+- FaultTypeNetworkFailure: Network connectivity issues
+- FaultTypeTimeout: Operation timeout errors
+- FaultTypeCustom: Custom VMware fault (specify in Fault field)
+
+# Rule Matching
+
+Fault injection rules are matched based on:
+
+1. Method name (e.g., "PowerOnVM_Task") - use "*" for all methods
+2. Object type (e.g., "VirtualMachine") - use "*" for all types
+3. Object name (e.g., "DC0_C0_RP0_VM0") - use "*" for all objects
+4. Probability (0.0 to 1.0) - percentage chance the fault will be injected
+
+Rules are evaluated in the order they were added. The first matching rule is
+used.
+
+# Advanced Features
+
+## Probabilistic Injection
+
+Control how often faults are injected:
+
+	rule := &simulator.FaultInjectionRule{
+		MethodName:  "*",
+		ObjectType:  "*",
+		ObjectName:  "*",
+		Probability: 0.05, // 5% of all operations fail
+		FaultType:   simulator.FaultTypeNetworkFailure,
+		Enabled:     true,
+	}
+
+## Limited Injection Count
+
+Limit how many times a rule triggers:
+
+	rule := &simulator.FaultInjectionRule{
+		MethodName:  "PowerOnVM_Task",
+		ObjectType:  "*",
+		ObjectName:  "*",
+		Probability: 1.0,
+		FaultType:   simulator.FaultTypeResourceInUse,
+		MaxCount:    3, // Only fail first 3 attempts
+		Enabled:     true,
+	}
+
+## Delays
+
+Add delays before returning faults to simulate slow responses:
+
+	rule := &simulator.FaultInjectionRule{
+		MethodName:  "*",
+		ObjectType:  "*",
+		ObjectName:  "*",
+		Probability: 0.02,
+		FaultType:   simulator.FaultTypeTimeout,
+		Delay:       5000, // 5 second delay
+		Enabled:     true,
+	}
+
+## Custom Faults
+
+Inject specific VMware fault types:
+
+	customFault := &types.ResourceInUse{
+		VimFault: types.VimFault{
+			MethodFault: types.MethodFault{
+				FaultCause: &types.LocalizedMethodFault{
+					LocalizedMessage: "CPU resource pool exhausted",
+				},
+			},
+		},
+		Type: "ResourcePool",
+		Name: "Production-RP",
+	}
+
+	rule := &simulator.FaultInjectionRule{
+		MethodName:  "PowerOnVM_Task",
+		ObjectType:  "VirtualMachine",
+		ObjectName:  "*",
+		Probability: 1.0,
+		FaultType:   simulator.FaultTypeCustom,
+		Fault:       customFault,
+		Enabled:     true,
+	}
+
+# Management Methods
+
+The Service provides several methods for managing fault injection:
+
+	service := simulator.ServiceFromContext(ctx)
+
+	// Add rules
+	service.AddFaultRule(rule)
+
+	// Remove specific rule by index
+	service.RemoveFaultRule(0)
+
+	// Get all rules
+	rules := service.GetFaultRules()
+
+	// Clear all rules
+	service.ClearFaultRules()
+
+	// Get statistics
+	stats := service.GetFaultStats()
+
+	// Reset counters
+	service.ResetFaultStats()
+
+# Example Scenarios
+
+## Simulating Authentication Service Outage
+
+	authOutageRule := &simulator.FaultInjectionRule{
+		MethodName:  "Login",
+		ObjectType:  "*",
+		ObjectName:  "*",
+		Probability: 1.0,
+		FaultType:   simulator.FaultTypeNotAuthenticated,
+		Message:     "Authentication service unavailable",
+		MaxCount:    10, // Outage affects first 10 login attempts
+		Enabled:     true,
+	}
+
+## Simulating Intermittent Network Issues
+
+	networkRule := &simulator.FaultInjectionRule{
+		MethodName:  "*",
+		ObjectType:  "*",
+		ObjectName:  "*",
+		Probability: 0.02, // 2% of operations affected
+		FaultType:   simulator.FaultTypeNetworkFailure,
+		Delay:       3000, // 3 second timeout
+		Enabled:     true,
+	}
+
+## Simulating Resource Exhaustion
+
+	resourceRule := &simulator.FaultInjectionRule{
+		MethodName:  "PowerOnVM_Task",
+		ObjectType:  "VirtualMachine",
+		ObjectName:  "*",
+		Probability: 0.8, // 80% of power-ons fail
+		FaultType:   simulator.FaultTypeInsufficientResourcesFault,
+		Message:     "Insufficient memory resources",
+		Enabled:     true,
+	}
+
+# Thread Safety
+
+The fault injection system is thread-safe and can be used from multiple
+goroutines simultaneously. All operations on fault rules are protected by
+internal mutexes.
+
+# Performance Impact
+
+Fault injection adds minimal overhead to normal operations. Rules are evaluated
+efficiently, and random number generation is optimized for concurrent access.
+When no rules are enabled, the performance impact is negligible.
 
 See also: https://github.com/vmware/govmomi/blob/main/vcsim/README.md
 */

--- a/simulator/example_fault_injection_test.go
+++ b/simulator/example_fault_injection_test.go
@@ -1,0 +1,128 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// ExampleFaultInjector demonstrates how to use the fault injection system.
+func ExampleFaultInjector() {
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		// Get the simulator service to configure fault injection
+		service := simulator.ServiceFromContext(ctx)
+
+		// Example 1: Always fail PowerOn operations with authentication error
+		authRule := &simulator.FaultInjectionRule{
+			MethodName:  "PowerOnVM_Task",
+			ObjectType:  "*", // Match any object type
+			ObjectName:  "*", // Match any object name
+			Probability: 1.0, // Always inject (100% probability)
+			FaultType:   simulator.FaultTypeNotAuthenticated,
+			Message:     "Simulated authentication failure",
+			Enabled:     true,
+		}
+		service.AddFaultRule(authRule)
+
+		finder := find.NewFinder(c)
+		vm, _ := finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
+
+		// This will fail with NotAuthenticated
+		_, err := vm.PowerOn(ctx)
+		if err != nil {
+			fmt.Printf("PowerOn failed as expected: %v\n", err)
+		}
+
+		// Example 2: Probabilistic failures for specific VM
+		service.ClearFaultRules()
+
+		probabilisticRule := &simulator.FaultInjectionRule{
+			MethodName:  "*",              // Match any method
+			ObjectType:  "VirtualMachine", // Only VMs
+			ObjectName:  "DC0_C0_RP0_VM0", // Specific VM
+			Probability: 0.3,              // 30% chance of failure
+			FaultType:   simulator.FaultTypeInvalidState,
+			Message:     "VM is in an invalid state",
+			Enabled:     true,
+		}
+		service.AddFaultRule(probabilisticRule)
+
+		// Example 3: Custom fault with specific VMware error
+		customFault := &types.ResourceInUse{
+			VimFault: types.VimFault{
+				MethodFault: types.MethodFault{
+					FaultCause: &types.LocalizedMethodFault{
+						LocalizedMessage: "CPU resource is currently allocated to another VM",
+					},
+				},
+			},
+			Type: "VirtualMachine",
+			Name: "DC0_C0_RP0_VM0",
+		}
+
+		customRule := &simulator.FaultInjectionRule{
+			MethodName:  "PowerOnVM_Task",
+			ObjectType:  "VirtualMachine",
+			ObjectName:  "DC0_C0_RP0_VM0",
+			Probability: 1.0,
+			FaultType:   simulator.FaultTypeCustom,
+			Fault:       customFault, // Use custom VMware fault
+			Delay:       500,         // Add 500ms delay before fault
+			MaxCount:    3,           // Only inject 3 times
+			Enabled:     true,
+		}
+		service.AddFaultRule(customRule)
+
+		// Example 4: Multiple rules for different scenarios
+		service.ClearFaultRules()
+
+		// Rule for all VM power operations
+		powerRule := &simulator.FaultInjectionRule{
+			MethodName:  "Power*", // Wildcard matching would need to be implemented
+			ObjectType:  "VirtualMachine",
+			ObjectName:  "*",
+			Probability: 0.1,
+			FaultType:   simulator.FaultTypeGeneric,
+			Message:     "Power operation failed randomly",
+			Enabled:     true,
+		}
+
+		// Rule for network configuration
+		networkRule := &simulator.FaultInjectionRule{
+			MethodName:  "*",
+			ObjectType:  "Network",
+			ObjectName:  "*",
+			Probability: 0.05,
+			FaultType:   simulator.FaultTypeNoPermission,
+			Message:     "Insufficient permissions for network operation",
+			Enabled:     true,
+		}
+
+		service.AddFaultRule(powerRule)
+		service.AddFaultRule(networkRule)
+
+		// Get and display statistics
+		stats := service.GetFaultStats()
+		fmt.Printf("Total rules: %d\n", stats["total_rules"])
+		fmt.Printf("Enabled rules: %d\n", stats["enabled_rules"])
+
+		// Clean up
+		service.ClearFaultRules()
+
+		fmt.Println("Fault injection example completed")
+	})
+
+	// Output:
+	// PowerOn failed as expected: ServerFaultCode: Simulated authentication failure
+	// Total rules: 2
+	// Enabled rules: 2
+	// Fault injection example completed
+}

--- a/simulator/fault_injection.go
+++ b/simulator/fault_injection.go
@@ -1,0 +1,324 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// FaultInjectionRule defines a rule for injecting faults into method responses.
+type FaultInjectionRule struct {
+	// MethodName is the SOAP method name to inject faults into
+	// (e.g., "PowerOnVM_Task").
+	// Use "*" to match all methods
+	MethodName string
+
+	// ObjectType is the managed object type to inject faults into
+	// (e.g., "VirtualMachine").
+	// Use "*" to match all object types
+	ObjectType string
+
+	// ObjectName is the name of the specific object to inject faults into
+	// Use "*" to match all object names
+	ObjectName string
+
+	// Probability is the probability (0.0 to 1.0) that a fault will be
+	// injected.
+	Probability float64
+
+	// FaultType is the type of fault to inject
+	FaultType FaultType
+
+	// Message is the error message for the fault
+	Message string
+
+	// Fault is the specific VMware fault to inject (optional, overrides
+	// FaultType).
+	Fault types.BaseMethodFault
+
+	// Delay introduces a delay before returning the fault (in milliseconds)
+	Delay int
+
+	// MaxCount limits the number of times this rule can be triggered
+	// (0 = unlimited)
+	MaxCount int
+
+	// Enabled controls whether this rule is active
+	Enabled bool
+
+	// Internal fields
+	count int64
+	rng   *rand.Rand
+}
+
+// FaultType represents the type of fault to inject
+type FaultType int
+
+const (
+	// FaultTypeGeneric injects a generic fault
+	FaultTypeGeneric FaultType = iota
+	// FaultTypeNotAuthenticated injects authentication errors
+	FaultTypeNotAuthenticated
+	// FaultTypeNoPermission injects permission errors
+	FaultTypeNoPermission
+	// FaultTypeInvalidArgument injects invalid argument errors
+	FaultTypeInvalidArgument
+	// FaultTypeMethodNotFound injects method not found errors
+	FaultTypeMethodNotFound
+	// FaultTypeManagedObjectNotFound injects object not found errors
+	FaultTypeManagedObjectNotFound
+	// FaultTypeInvalidState injects invalid state errors
+	FaultTypeInvalidState
+	// FaultTypeResourceInUse injects resource in use errors
+	FaultTypeResourceInUse
+	// FaultTypeInsufficientResourcesFault injects insufficient resources errors
+	FaultTypeInsufficientResourcesFault
+	// FaultTypeCustom allows injection of custom faults specified in the Fault
+	// field
+	FaultTypeCustom
+	// FaultTypeNetworkFailure simulates network-level failures
+	FaultTypeNetworkFailure
+	// FaultTypeTimeout simulates timeout errors
+	FaultTypeTimeout
+)
+
+// FaultInjector manages fault injection rules and applies them to method calls
+type FaultInjector struct {
+	mu    sync.RWMutex
+	rules []*FaultInjectionRule
+	rng   *rand.Rand
+}
+
+// NewFaultInjector creates a new fault injector
+func NewFaultInjector() *FaultInjector {
+	return &FaultInjector{
+		rng: rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// AddRule adds a fault injection rule
+func (f *FaultInjector) AddRule(rule *FaultInjectionRule) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Initialize rule's RNG if not set
+	if rule.rng == nil {
+		rule.rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+	}
+
+	f.rules = append(f.rules, rule)
+}
+
+// RemoveRule removes a fault injection rule by index
+func (f *FaultInjector) RemoveRule(index int) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if index < 0 || index >= len(f.rules) {
+		return false
+	}
+
+	f.rules = append(f.rules[:index], f.rules[index+1:]...)
+	return true
+}
+
+// ClearRules removes all fault injection rules
+func (f *FaultInjector) ClearRules() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rules = nil
+}
+
+// GetRules returns a copy of all fault injection rules
+func (f *FaultInjector) GetRules() []*FaultInjectionRule {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	rules := make([]*FaultInjectionRule, len(f.rules))
+	copy(rules, f.rules)
+	return rules
+}
+
+// ShouldInjectFault determines if a fault should be injected for the given method call
+func (f *FaultInjector) ShouldInjectFault(method *Method, objectName string) *FaultInjectionRule {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	for _, rule := range f.rules {
+		if !rule.Enabled {
+			continue
+		}
+
+		// Check if we've exceeded the max count
+		if rule.MaxCount > 0 && rule.count >= int64(rule.MaxCount) {
+			continue
+		}
+
+		// Check method name match
+		if rule.MethodName != "*" && rule.MethodName != method.Name {
+			continue
+		}
+
+		// Check object type match
+		if rule.ObjectType != "*" && rule.ObjectType != method.This.Type {
+			continue
+		}
+
+		// Check object name match
+		if rule.ObjectName != "*" && rule.ObjectName != objectName {
+			continue
+		}
+
+		// Check probability
+		if rule.rng.Float64() > rule.Probability {
+			continue
+		}
+
+		// This rule matches, increment count and return it
+		rule.count++
+		return rule
+	}
+
+	return nil
+}
+
+// CreateFault creates a SOAP fault based on the rule
+func (f *FaultInjector) CreateFault(rule *FaultInjectionRule, method *Method) soap.HasFault {
+	// Apply delay if specified
+	if rule.Delay > 0 {
+		time.Sleep(time.Duration(rule.Delay) * time.Millisecond)
+	}
+
+	var fault types.BaseMethodFault
+	message := rule.Message
+	if message == "" {
+		message = "Fault injected by simulator"
+	}
+
+	// Use custom fault if specified
+	if rule.FaultType == FaultTypeCustom && rule.Fault != nil {
+		fault = rule.Fault
+	} else {
+		// Create fault based on type
+		switch rule.FaultType {
+		case FaultTypeNotAuthenticated:
+			fault = &types.NotAuthenticated{
+				NoPermission: types.NoPermission{
+					Object:      &method.This,
+					PrivilegeId: "System.View",
+				},
+			}
+		case FaultTypeNoPermission:
+			fault = &types.NoPermission{
+				Object:      &method.This,
+				PrivilegeId: "System.Modify",
+			}
+		case FaultTypeInvalidArgument:
+			fault = &types.InvalidArgument{
+				InvalidProperty: "injected_fault_property",
+			}
+		case FaultTypeMethodNotFound:
+			fault = &types.MethodNotFound{
+				Receiver: method.This,
+				Method:   method.Name,
+			}
+		case FaultTypeManagedObjectNotFound:
+			fault = &types.ManagedObjectNotFound{
+				Obj: method.This,
+			}
+		case FaultTypeInvalidState:
+			fault = &types.InvalidState{
+				VimFault: types.VimFault{
+					MethodFault: types.MethodFault{
+						FaultCause: &types.LocalizedMethodFault{
+							Fault: &types.SystemErrorFault{
+								Reason: message,
+							},
+							LocalizedMessage: message,
+						},
+					},
+				},
+			}
+		case FaultTypeResourceInUse:
+			fault = &types.ResourceInUse{
+				VimFault: types.VimFault{
+					MethodFault: types.MethodFault{
+						FaultCause: &types.LocalizedMethodFault{
+							LocalizedMessage: message,
+						},
+					},
+				},
+				Type: method.This.Type,
+				Name: "injected_resource",
+			}
+		case FaultTypeInsufficientResourcesFault:
+			fault = &types.InsufficientResourcesFault{
+				VimFault: types.VimFault{
+					MethodFault: types.MethodFault{
+						FaultCause: &types.LocalizedMethodFault{
+							LocalizedMessage: message,
+						},
+					},
+				},
+			}
+		case FaultTypeNetworkFailure:
+			fault = &types.SystemErrorFault{
+				Reason: "Network connection failed: " + message,
+			}
+		case FaultTypeTimeout:
+			fault = &types.SystemErrorFault{
+				Reason: "Operation timed out: " + message,
+			}
+		default:
+			// FaultTypeGeneric
+			fault = &types.SystemErrorFault{
+				Reason: message,
+			}
+		}
+	}
+
+	return &serverFaultBody{Reason: Fault(message, fault)}
+}
+
+// GetStats returns statistics about fault injection
+func (f *FaultInjector) GetStats() map[string]interface{} {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	stats := make(map[string]interface{})
+	stats["total_rules"] = len(f.rules)
+
+	enabledRules := 0
+	totalInjections := int64(0)
+
+	for i, rule := range f.rules {
+		if rule.Enabled {
+			enabledRules++
+		}
+		totalInjections += rule.count
+		stats[fmt.Sprintf("rule_%d_count", i)] = rule.count
+	}
+
+	stats["enabled_rules"] = enabledRules
+	stats["total_injections"] = totalInjections
+
+	return stats
+}
+
+// ResetStats resets the injection counters for all rules
+func (f *FaultInjector) ResetStats() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for _, rule := range f.rules {
+		rule.count = 0
+	}
+}

--- a/simulator/fault_injection_test.go
+++ b/simulator/fault_injection_test.go
@@ -1,0 +1,272 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestFaultInjection(t *testing.T) {
+	Test(func(ctx context.Context, c *vim25.Client) {
+		// Get service to add fault injection rules
+		service := ServiceFromContext(ctx)
+
+		// Test 1: Inject NotAuthenticated fault for all PowerOnVM_Task calls
+		rule1 := &FaultInjectionRule{
+			MethodName:  "PowerOnVM_Task",
+			ObjectType:  "*",
+			ObjectName:  "*",
+			Probability: 1.0, // Always inject
+			FaultType:   FaultTypeNotAuthenticated,
+			Message:     "Authentication failed for power on operation",
+			Enabled:     true,
+		}
+		service.AddFaultRule(rule1)
+
+		finder := find.NewFinder(c)
+		vm, err := finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// This should fail with NotAuthenticated
+		_, err = vm.PowerOn(ctx)
+		if err == nil {
+			t.Fatal("expected authentication error")
+		}
+
+		// Check that we got an error (fault injection worked)
+		t.Logf("Fault injection worked, got error: %v", err)
+
+		// Clear rules and test again
+		service.ClearFaultRules()
+
+		// Test 2: Inject InvalidArgument fault for specific VM
+		rule2 := &FaultInjectionRule{
+			MethodName:  "PowerOnVM_Task",
+			ObjectType:  "VirtualMachine",
+			ObjectName:  "DC0_C0_RP0_VM0",
+			Probability: 1.0,
+			FaultType:   FaultTypeInvalidArgument,
+			Message:     "Invalid argument provided",
+			Enabled:     true,
+		}
+		service.AddFaultRule(rule2)
+
+		// This should fail with InvalidArgument
+		_, err = vm.PowerOn(ctx)
+		if err == nil {
+			t.Fatal("expected invalid argument error")
+		}
+
+		// Check that we got an error (fault injection worked)
+		t.Logf("InvalidArgument fault injection worked, got error: %v", err)
+
+		// Test 3: Probability-based fault injection
+		service.ClearFaultRules()
+
+		rule3 := &FaultInjectionRule{
+			MethodName:  "PowerOnVM_Task",
+			ObjectType:  "*",
+			ObjectName:  "*",
+			Probability: 0.5, // 50% chance
+			FaultType:   FaultTypeGeneric,
+			Message:     "Random failure",
+			Enabled:     true,
+		}
+		service.AddFaultRule(rule3)
+
+		// Run multiple times to test probability
+		failures := 0
+		attempts := 100
+		for i := 0; i < attempts; i++ {
+			vm.PowerOff(ctx) // Reset state
+			taskResult, err := vm.PowerOn(ctx)
+			if err != nil {
+				failures++
+			} else if taskResult != nil {
+				taskResult.Wait(ctx) // Wait for task completion
+			}
+		}
+
+		// Should have roughly 50% failures (allow for variance)
+		if failures < attempts/4 || failures > 3*attempts/4 {
+			t.Logf("Expected ~50%% failures, got %d/%d (%.1f%%)", failures, attempts, float64(failures)/float64(attempts)*100)
+		}
+
+		// Test 4: Custom fault injection
+		service.ClearFaultRules()
+
+		customFault := &types.ResourceInUse{
+			VimFault: types.VimFault{
+				MethodFault: types.MethodFault{
+					FaultCause: &types.LocalizedMethodFault{
+						LocalizedMessage: "Resource is currently in use",
+					},
+				},
+			},
+			Type: "VirtualMachine",
+			Name: "TestVM",
+		}
+
+		rule4 := &FaultInjectionRule{
+			MethodName:  "PowerOnVM_Task",
+			ObjectType:  "*",
+			ObjectName:  "*",
+			Probability: 1.0,
+			FaultType:   FaultTypeCustom,
+			Fault:       customFault,
+			Enabled:     true,
+		}
+		service.AddFaultRule(rule4)
+
+		_, err = vm.PowerOn(ctx)
+		if err == nil {
+			t.Fatal("expected resource in use error")
+		}
+
+		// Check that we got an error (fault injection worked)
+		t.Logf("Custom fault injection worked, got error: %v", err)
+
+		// Test 5: Test statistics
+		stats := service.GetFaultStats()
+		if stats["total_rules"].(int) != 1 {
+			t.Errorf("expected 1 rule, got %d", stats["total_rules"])
+		}
+
+		service.ClearFaultRules()
+	})
+}
+
+func TestFaultInjectionWithDelay(t *testing.T) {
+	Test(func(ctx context.Context, c *vim25.Client) {
+		service := ServiceFromContext(ctx)
+
+		// Test fault injection with delay
+		rule := &FaultInjectionRule{
+			MethodName:  "PowerOnVM_Task",
+			ObjectType:  "*",
+			ObjectName:  "*",
+			Probability: 1.0,
+			FaultType:   FaultTypeGeneric,
+			Message:     "Delayed failure",
+			Delay:       100, // 100ms delay
+			Enabled:     true,
+		}
+		service.AddFaultRule(rule)
+
+		finder := find.NewFinder(c)
+		vm, err := finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// This should fail after a delay
+		_, err = vm.PowerOn(ctx)
+		if err == nil {
+			t.Fatal("expected error with delay")
+		}
+
+		service.ClearFaultRules()
+	})
+}
+
+func TestFaultInjectionMaxCount(t *testing.T) {
+	Test(func(ctx context.Context, c *vim25.Client) {
+		service := ServiceFromContext(ctx)
+
+		// Test max count limiting
+		rule := &FaultInjectionRule{
+			MethodName:  "PowerOnVM_Task",
+			ObjectType:  "*",
+			ObjectName:  "*",
+			Probability: 1.0,
+			FaultType:   FaultTypeGeneric,
+			Message:     "Limited failure",
+			MaxCount:    2, // Only fail twice
+			Enabled:     true,
+		}
+		service.AddFaultRule(rule)
+
+		finder := find.NewFinder(c)
+		vm, err := finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// First two attempts should fail
+		for i := 0; i < 2; i++ {
+			vm.PowerOff(ctx)
+			_, err := vm.PowerOn(ctx)
+			if err == nil {
+				t.Fatalf("expected error on attempt %d", i+1)
+			}
+		}
+
+		// Third attempt should succeed (no more faults)
+		vm.PowerOff(ctx)
+		taskResult, err := vm.PowerOn(ctx)
+		if err != nil {
+			t.Fatalf("expected success on third attempt, got: %v", err)
+		}
+		if taskResult != nil {
+			taskResult.Wait(ctx)
+		}
+
+		service.ClearFaultRules()
+	})
+}
+
+func TestMultipleFaultRules(t *testing.T) {
+	Test(func(ctx context.Context, c *vim25.Client) {
+		service := ServiceFromContext(ctx)
+
+		// Add multiple rules with different priorities
+		rule1 := &FaultInjectionRule{
+			MethodName:  "PowerOnVM_Task",
+			ObjectType:  "VirtualMachine",
+			ObjectName:  "DC0_C0_RP0_VM0",
+			Probability: 1.0,
+			FaultType:   FaultTypeInvalidArgument,
+			Message:     "Specific VM rule",
+			Enabled:     true,
+		}
+
+		rule2 := &FaultInjectionRule{
+			MethodName:  "PowerOnVM_Task",
+			ObjectType:  "*",
+			ObjectName:  "*",
+			Probability: 1.0,
+			FaultType:   FaultTypeGeneric,
+			Message:     "General rule",
+			Enabled:     true,
+		}
+
+		service.AddFaultRule(rule1)
+		service.AddFaultRule(rule2)
+
+		finder := find.NewFinder(c)
+		vm, err := finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Should match the first rule (more specific)
+		_, err = vm.PowerOn(ctx)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+
+		// Check that we got an error (fault injection worked)
+		t.Logf("Multiple rules fault injection worked, got error: %v", err)
+
+		service.ClearFaultRules()
+	})
+}

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -46,6 +46,11 @@ func Map(ctx context.Context) *Registry {
 	return ctx.(*Context).Map
 }
 
+// ServiceFromContext returns the simulator Service from the given ctx
+func ServiceFromContext(ctx context.Context) *Service {
+	return ctx.(*Context).svc
+}
+
 // RegisterObject interface supports callbacks when objects are created, updated and deleted from the Registry
 type RegisterObject interface {
 	mo.Reference


### PR DESCRIPTION


## Description

This patch adds fault injection support to vC Sim.

Closes: `NA`

## How Has This Been Tested?

```shell
$ go -C simulator test -v -run '(Example)?.*FaultInject(or|ion).*'
=== RUN   TestFaultInjection
    fault_injection_test.go:46: Fault injection worked, got error: ServerFaultCode: Authentication failed for power on operation
    fault_injection_test.go:70: InvalidArgument fault injection worked, got error: ServerFaultCode: Invalid argument provided
    fault_injection_test.go:136: Custom fault injection worked, got error: ServerFaultCode: Fault injected by simulator
--- PASS: TestFaultInjection (0.73s)
=== RUN   TestFaultInjectionWithDelay
--- PASS: TestFaultInjectionWithDelay (0.50s)
=== RUN   TestFaultInjectionMaxCount
--- PASS: TestFaultInjectionMaxCount (0.43s)
=== RUN   ExampleFaultInjector
--- PASS: ExampleFaultInjector (0.40s)
PASS
ok  	github.com/vmware/govmomi/simulator	2.395s
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
