### PR TITLE
Add shared disk parameters to Cns AttachDetach Spec

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -214,8 +214,12 @@ type CnsDetachVolumeResponse struct {
 type CnsVolumeAttachDetachSpec struct {
 	types.DynamicData
 
-	VolumeId CnsVolumeId                  `xml:"volumeId" json:"volumeId"`
-	Vm       types.ManagedObjectReference `xml:"vm" json:"vm"`
+	VolumeId      CnsVolumeId                  `xml:"volumeId" json:"volumeId"`
+	Vm            types.ManagedObjectReference `xml:"vm" json:"vm"`
+	DiskMode      string                       `xml:"diskMode,omitempty" json:"diskMode"`
+	Sharing       string                       `xml:"sharing,omitempty" json:"sharing"`
+	ControllerKey int64                        `xml:"controllerKey,omitempty" json:"controllerKey"`
+	UnitNumber    int64                        `xml:"unitNumber,omitempty" json:"unitNumber"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

Add new parameters to Cns AttachDetach Spec for supporting multiwriter.
Also fixed the test where CnsAlreadyRegisteredFault is expected when the same volume is re-created. This has changed and we should not be getting any error: https://bugzilla-vcf.lvn.broadcom.net/show_bug.cgi?id=3538552#c1

Closes: #(issue-number)

## How Has This Been Tested?

Verified that these changes work with CNS_RUN_SHARED_DISK_TESTS set to true as well false.

Completed Govmomi CNS  test output: https://docs.google.com/document/d/1qNhQm46moqRvZjPdHY76uJafQuPKVQeXP3klM-YxhWo/edit?usp=sharing

Re-creating same disk:

```
    client_test.go:337: reCreateVolumeOperationRes.: &types.CnsVolumeOperationResult{
            DynamicData: types.DynamicData{},
            VolumeId:    types.CnsVolumeId{
                DynamicData: types.DynamicData{},
                Id:          "40381bfe-a17b-465f-80bd-e154ea23f1af",
            },
            Fault: (*types.LocalizedMethodFault)(nil),
        }
    client_test.go:339: re-create same volume did not fail as expected

```

Attaching with multiwriter parameter:
```
    client_test.go:1219: Attaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:40381bfe-a17b-465f-80bd-e154ea23f1af} Vm:VirtualMachine:vm-96 DiskMode:independent_persistent Sharing:sharingMultiWriter ControllerKey:1000 UnitNumber:23}
    client_test.go:1244: Volume attached sucessfully with shared disk params. Disk UUID: 6000C29d-9d11-b478-fef0-c0e193cebebb
    client_test.go:1255: Detaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:40381bfe-a17b-465f-80bd-e154ea23f1af} Vm:VirtualMachine:vm-96 DiskMode: Sharing: ControllerKey:0 UnitNumber:0}
    client_test.go:1279: Volume detached sucessfully

```