### PR TITLE
update CNS CnsVolumeCreateSpec and CnsSnapshotCreateSpec for Transaction Support

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -79,6 +79,7 @@ type CnsVolumeCreateSpec struct {
 	types.DynamicData
 	Name                 string                                `xml:"name" json:"name"`
 	VolumeType           string                                `xml:"volumeType" json:"volumeType"`
+	VolumeId             CnsVolumeId                           `xml:"volumeId,omitempty" json:"volumeId"`
 	Datastores           []types.ManagedObjectReference        `xml:"datastores,omitempty" json:"datastores"`
 	Metadata             CnsVolumeMetadata                     `xml:"metadata,omitempty" json:"metadata"`
 	BackingObjectDetails BaseCnsBackingObjectDetails           `xml:"backingObjectDetails,typeattr" json:"backingObjectDetails"`
@@ -590,6 +591,17 @@ func init() {
 	types.Add("CnsVolumeNotFoundFault", reflect.TypeOf((*CnsVolumeNotFoundFault)(nil)).Elem())
 }
 
+type CnsVolumeAlreadyExistsFault struct {
+	CnsFault
+
+	VolumeId  CnsVolumeId                  `xml:"volumeId" json:"volumeId"`
+	Datastore types.ManagedObjectReference `xml:"datastore,omitempty" json:"datastore"`
+}
+
+func init() {
+	types.Add("CnsVolumeAlreadyExistsFault", reflect.TypeOf((*CnsVolumeAlreadyExistsFault)(nil)).Elem())
+}
+
 type CnsAlreadyRegisteredFault struct {
 	CnsFault `xml:"fault,typeattr"`
 
@@ -713,8 +725,9 @@ type CnsCreateSnapshotsResponse struct {
 type CnsSnapshotCreateSpec struct {
 	types.DynamicData
 
-	VolumeId    CnsVolumeId `xml:"volumeId" json:"volumeId"`
-	Description string      `xml:"description" json:"description"`
+	VolumeId    CnsVolumeId   `xml:"volumeId" json:"volumeId"`
+	Description string        `xml:"description" json:"description"`
+	SnapshotId  CnsSnapshotId `xml:"snapshotId,omitempty" json:"snapshotId"`
 }
 
 func init() {


### PR DESCRIPTION


## Description

This PR enhances the CNS API spec definitions to support transactional workflows during volume and snapshot creation.

**CnsVolumeCreateSpec**
- Added VolumeId field to enable volume creation using a generated FCD ID. 

**CnsSnapshotCreateSpec**
- Added SnapshotId field to support creating a snapshot using a pre-supplied ID.

**New Fault: CnsVolumeAlreadyExistsFault**
- Introduced to handle the scenario where a volume with the same ID already exists on a different datastore.

Closes: #(issue-number)

## How Has This Been Tested?

- Added test in the cns/client_test.go 

Testing Log

```
    client_test.go:150: setting volumeID: "300e3eb4-90b5-49fc-a902-e7c8f2c9efcc" in the cnsVolumeCreateSpec
    client_test.go:156: Creating volume using the spec: types.CnsVolumeCreateSpec{
            DynamicData: types.DynamicData{},
            Name:        "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
            VolumeType:  "BLOCK",
            VolumeId:    types.CnsVolumeId{
                DynamicData: types.DynamicData{},
                Id:          "300e3eb4-90b5-49fc-a902-e7c8f2c9efcc",
            },
            Datastores: {
                {Type:"Datastore", Value:"datastore-55", ServerGUID:""},
            },
            Metadata: types.CnsVolumeMetadata{
                DynamicData:      types.DynamicData{},
                ContainerCluster: types.CnsContainerCluster{
                    DynamicData:         types.DynamicData{},
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "OpenShift",
                    Delete:              false,
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    DynamicData:  types.DynamicData{},
                    CapacityInMb: 5120,
                },
                BackingDiskId:                  "",
                BackingDiskUrlPath:             "",
                BackingDiskObjectId:            "",
                AggregatedSnapshotCapacityInMb: 0,
                BackingDiskPath:                "",
            },
            Profile:      nil,
            CreateSpec:   nil,
            VolumeSource: nil,
        }
    client_test.go:182: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:300e3eb4-90b5-49fc-a902-e7c8f2c9efcc} Fault:<nil>} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0 PlacementResults:[{Datastore:Datastore:datastore-55 PlacementFaults:[]}]}
    client_test.go:189: Volume created sucessfully. volumeId: 300e3eb4-90b5-49fc-a902-e7c8f2c9efcc
    client_test.go:204: Creating Volume again on diffrent datastore using same generated Volume ID
    client_test.go:206: Creating volume using the spec: types.CnsVolumeCreateSpec{
            DynamicData: types.DynamicData{},
            Name:        "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
            VolumeType:  "BLOCK",
            VolumeId:    types.CnsVolumeId{
                DynamicData: types.DynamicData{},
                Id:          "300e3eb4-90b5-49fc-a902-e7c8f2c9efcc",
            },
            Datastores: {
                {Type:"Datastore", Value:"datastore-33", ServerGUID:""},
            },
            Metadata: types.CnsVolumeMetadata{
                DynamicData:      types.DynamicData{},
                ContainerCluster: types.CnsContainerCluster{
                    DynamicData:         types.DynamicData{},
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "OpenShift",
                    Delete:              false,
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    DynamicData:  types.DynamicData{},
                    CapacityInMb: 5120,
                },
                BackingDiskId:                  "",
                BackingDiskUrlPath:             "",
                BackingDiskObjectId:            "",
                AggregatedSnapshotCapacityInMb: 0,
                BackingDiskPath:                "",
            },
            Profile:      nil,
            CreateSpec:   nil,
            VolumeSource: nil,
        }
    client_test.go:228: createVolumeOperationRes.Fault: &types.CnsVolumeOperationResult{
            DynamicData: types.DynamicData{},
            VolumeId:    types.CnsVolumeId{},
            Fault:       &types.LocalizedMethodFault{
                DynamicData: types.DynamicData{},
                Fault:       types.CnsVolumeAlreadyExistsFault{
                    CnsFault: types.CnsFault{
                        BaseMethodFault: nil,
                        Reason:          "Volume already exists.",
                    },
                    VolumeId: types.CnsVolumeId{
                        DynamicData: types.DynamicData{},
                        Id:          "300e3eb4-90b5-49fc-a902-e7c8f2c9efcc",
                    },
                    Datastore: types.ManagedObjectReference{Type:"Datastore", Value:"datastore-55", ServerGUID:""},
                },
                LocalizedMessage: "** FIXME CnsVolumeAlreadyExistsFault.summary (fault.vmsg) - fault.CnsVolumeAlreadyExistsFault.summary",
            },
        }
```
