### PR TITLE
handle vim25:NotSupported returned with CnsFault

### DIFF
--- a/cli/volume/ls.go
+++ b/cli/volume/ls.go
@@ -186,7 +186,7 @@ func (r *lsWriter) backing(id types.CnsVolumeId) string {
 		}
 
 		if fault := res.Fault; fault != nil {
-			if f, ok := fault.Fault.(types.CnsFault); ok {
+			if f, ok := fault.Fault.(*types.CnsFault); ok {
 				if strings.Contains(f.Reason, id.Id) {
 					return f.Reason
 				}

--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -179,6 +179,15 @@ func TestClient(t *testing.T) {
 	}
 	createVolumeOperationRes := createTaskResult.GetCnsVolumeOperationResult()
 	if createVolumeOperationRes.Fault != nil {
+		if cnsFault, ok := createVolumeOperationRes.Fault.Fault.(*cnstypes.CnsFault); ok {
+			if cause := cnsFault.FaultCause; cause != nil {
+				if inner, ok := cause.Fault.(*vim25types.NotSupported); ok {
+					t.Logf("Caught NotSupported fault: %q", cause.LocalizedMessage)
+				} else {
+					t.Logf("Inner fault type: %T", inner)
+				}
+			}
+		}
 		t.Fatalf("Failed to create volume: fault=%+v", createVolumeOperationRes.Fault)
 	}
 	volumeId := createVolumeOperationRes.VolumeId.Id
@@ -230,7 +239,7 @@ func TestClient(t *testing.T) {
 			createVolumeOperationRes := createTaskResult.GetCnsVolumeOperationResult()
 			if createVolumeOperationRes.Fault != nil {
 				t.Logf("createVolumeOperationRes.Fault: %+v", pretty.Sprint(createVolumeOperationRes))
-				_, ok := createVolumeOperationRes.Fault.Fault.(cnstypes.CnsVolumeAlreadyExistsFault)
+				_, ok := createVolumeOperationRes.Fault.Fault.(*cnstypes.CnsVolumeAlreadyExistsFault)
 				if !ok {
 					t.Fatalf("Fault is not CnsVolumeAlreadyExistsFault")
 				}
@@ -282,7 +291,7 @@ func TestClient(t *testing.T) {
 		t.Logf("reCreateVolumeOperationRes.: %+v", pretty.Sprint(reCreateVolumeOperationRes))
 		if reCreateVolumeOperationRes.Fault != nil {
 			t.Logf("reCreateVolumeOperationRes.Fault: %+v", pretty.Sprint(reCreateVolumeOperationRes.Fault))
-			_, ok := reCreateVolumeOperationRes.Fault.Fault.(cnstypes.CnsAlreadyRegisteredFault)
+			_, ok := reCreateVolumeOperationRes.Fault.Fault.(*cnstypes.CnsAlreadyRegisteredFault)
 			if !ok {
 				t.Fatalf("Fault is not a CnsAlreadyRegisteredFault")
 			}
@@ -1416,7 +1425,7 @@ func TestClient(t *testing.T) {
 		var volumeID string
 		if createVolumeOperationRes.Fault != nil {
 			t.Logf("Failed to create volume: fault=%+v", createVolumeOperationRes.Fault)
-			fault, ok := createVolumeOperationRes.Fault.Fault.(cnstypes.CnsAlreadyRegisteredFault)
+			fault, ok := createVolumeOperationRes.Fault.Fault.(*cnstypes.CnsAlreadyRegisteredFault)
 			if !ok {
 				t.Fatalf("Fault is not CnsAlreadyRegisteredFault")
 			} else {
@@ -1465,7 +1474,7 @@ func TestClient(t *testing.T) {
 			t.Logf("reCreateVolumeOperationRes.: %+v", pretty.Sprint(reCreateVolumeOperationRes))
 			if reCreateVolumeOperationRes.Fault != nil {
 				t.Logf("Failed to create volume: fault=%+v", reCreateVolumeOperationRes.Fault)
-				_, ok := reCreateVolumeOperationRes.Fault.Fault.(cnstypes.CnsAlreadyRegisteredFault)
+				_, ok := reCreateVolumeOperationRes.Fault.Fault.(*cnstypes.CnsAlreadyRegisteredFault)
 				if !ok {
 					t.Fatalf("Fault is not CnsAlreadyRegisteredFault")
 				} else {

--- a/cns/simulator/simulator.go
+++ b/cns/simulator/simulator.go
@@ -6,8 +6,9 @@ package simulator
 
 import (
 	"context"
-	"slices"
 	"time"
+
+	"slices"
 
 	"github.com/google/uuid"
 
@@ -724,7 +725,7 @@ func (m *CnsVolumeManager) CnsQuerySnapshots(ctx *simulator.Context, req *cnstyp
 				// volumeId in snapshotQuerySpecs does not exist
 				snapshotQueryResultEntries = append(snapshotQueryResultEntries, cnstypes.CnsSnapshotQueryResultEntry{
 					Error: &vim25types.LocalizedMethodFault{
-						Fault: cnstypes.CnsVolumeNotFoundFault{
+						Fault: &cnstypes.CnsVolumeNotFoundFault{
 							VolumeId: snapshotQuerySpec.VolumeId,
 						},
 					},
@@ -742,7 +743,7 @@ func (m *CnsVolumeManager) CnsQuerySnapshots(ctx *simulator.Context, req *cnstyp
 				if isSnapshotQueryFilter && len(snapshotQueryResultEntries) == 0 {
 					snapshotQueryResultEntries = append(snapshotQueryResultEntries, cnstypes.CnsSnapshotQueryResultEntry{
 						Error: &vim25types.LocalizedMethodFault{
-							Fault: cnstypes.CnsSnapshotNotFoundFault{
+							Fault: &cnstypes.CnsSnapshotNotFoundFault{
 								VolumeId:   snapshotQuerySpec.VolumeId,
 								SnapshotId: *snapshotQuerySpec.SnapshotId,
 							},

--- a/cns/simulator/simulator_test.go
+++ b/cns/simulator/simulator_test.go
@@ -477,7 +477,7 @@ func TestSimulator(t *testing.T) {
 	}
 	t.Logf("snapshotQueryFilter with unknown volumeId in SnapshotQuerySpecs: %+v", snapshotQueryFilter)
 	querySnapshotsTaskResult = QuerySnapshotsFunc(snapshotQueryFilter)
-	_, ok := querySnapshotsTaskResult.Entries[0].Error.Fault.(cnstypes.CnsVolumeNotFoundFault)
+	_, ok := querySnapshotsTaskResult.Entries[0].Error.Fault.(*cnstypes.CnsVolumeNotFoundFault)
 	if !ok {
 		t.Fatalf("Unexpected error returned while CnsVolumeNotFoundFault is expected. Error: %+v \n", querySnapshotsTaskResult.Entries[0].Error.Fault)
 	}
@@ -494,7 +494,7 @@ func TestSimulator(t *testing.T) {
 	}
 	t.Logf("snapshotQueryFilter with unknown snapshotId in SnapshotQuerySpecs: %+v", snapshotQueryFilter)
 	querySnapshotsTaskResult = QuerySnapshotsFunc(snapshotQueryFilter)
-	_, ok = querySnapshotsTaskResult.Entries[0].Error.Fault.(cnstypes.CnsSnapshotNotFoundFault)
+	_, ok = querySnapshotsTaskResult.Entries[0].Error.Fault.(*cnstypes.CnsSnapshotNotFoundFault)
 	if !ok {
 		t.Fatalf("Unexpected error returned while CnsSnapshotNotFoundFault is expected. Error: %+v \n", querySnapshotsTaskResult.Entries[0].Error.Fault)
 	}

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -572,13 +572,14 @@ func init() {
 }
 
 type CnsFault struct {
-	types.BaseMethodFault `xml:"fault,typeattr"`
+	types.MethodFault
 
 	Reason string `xml:"reason,omitempty" json:"reason"`
 }
 
 func init() {
 	types.Add("CnsFault", reflect.TypeOf((*CnsFault)(nil)).Elem())
+	types.Add("NotSupported", reflect.TypeOf((*types.NotSupported)(nil)).Elem())
 }
 
 type CnsVolumeNotFoundFault struct {


### PR DESCRIPTION
## Description

This PR is adding changes required to support handling of vim25:NotSupported returned with CnsFault.

We need to catch this fault in the vSphere CSI Driver for the case when VC is upgraded with certain capability but none of the hosts are upgraded to support that capability. Specifically with CNS Transaction support, if VC is upgraded but none of the hosts are upgraded, API returns CNSFault with Not Supported, and vSphere CSI drier need to fall back to use API without transaction support.


```xml
<vim25:result xsi:type="CnsVolumeOperationBatchResult">
	<volumeResults xsi:type="CnsVolumeCreateResult">
		<fault>
			<fault xsi:type="CnsFault">
				<faultCause>
					<fault xsi:type="vim25:NotSupported"
						xmlns:vim25="urn:vim25">
					</fault>
					<localizedMessage>The operation is not supported on the object.</localizedMessage>
				</faultCause>
				<reason>VSLM task failed</reason>
			</fault>
			<localizedMessage>CnsFault error: VSLM task failed</localizedMessage>
		</fault>
	</volumeResults>
</vim25:result>
```

## How Has This Been Tested?
Executed cns/client_test.go file on the environment with vCenter is upgraded but hosts are not and confirmed, NotSupported fault is handled properly.

Test log

```
divyenp@C02Z5410LVDQ cns % go test -v
=== RUN   TestClient
    client_test.go:154: setting volumeID: "901e87eb-c2bd-11e9-806f-005056a0c9a0" in the cnsVolumeCreateSpec
    client_test.go:160: Creating volume using the spec: types.CnsVolumeCreateSpec{
            DynamicData: types.DynamicData{},
            Name:        "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
            VolumeType:  "BLOCK",
            VolumeId:    &types.CnsVolumeId{
                DynamicData: types.DynamicData{},
                Id:          "901e87eb-c2bd-11e9-806f-005056a0c9a0",
            },
            Datastores: {
                {Type:"Datastore", Value:"datastore-49", ServerGUID:""},
            },
            Metadata: types.CnsVolumeMetadata{
                DynamicData:      types.DynamicData{},
                ContainerCluster: types.CnsContainerCluster{
                    DynamicData:         types.DynamicData{},
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "OpenShift",
                    Delete:              false,
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    DynamicData:  types.DynamicData{},
                    CapacityInMb: 5120,
                },
                BackingDiskId:                  "",
                BackingDiskUrlPath:             "",
                BackingDiskObjectId:            "",
                AggregatedSnapshotCapacityInMb: 0,
                BackingDiskPath:                "",
            },
            Profile:      nil,
            CreateSpec:   nil,
            VolumeSource: nil,
        }
    client_test.go:185: Caught NotSupported fault: "The operation is not supported on the object."
    client_test.go:191: Failed to create volume: fault=&{DynamicData:{} Fault:0xc0003bbbf0 LocalizedMessage:CnsFault error: VSLM task failed}
--- FAIL: TestClient (1.16s)
```
 

