### PR TITLE
Add SPBM types and methods related to K8s compliant names changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/vmware/govmomi
 go 1.23.0 // required for slices/maps package and built-in clear function
 
 require (
-	github.com/a8m/tree v0.0.0-20230208161321-36ae24ddad15
+	github.com/a8m/tree v0.0.0-20240104212747-2c8764a5f17e
 	github.com/dougm/pretty v0.0.0-20160325215624-add1dbc86daf
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
@@ -11,7 +11,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/vmware/vmw-guestinfo v0.0.0-20220317130741-510905f0efa3
 	github.com/xlab/treeprint v1.2.0
-	golang.org/x/text v0.25.0
+	golang.org/x/text v0.26.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/a8m/tree v0.0.0-20230208161321-36ae24ddad15 h1:t3qDzTv8T15tVVhJHHgY7hX5jiIz67xE2SxWQ2ehjH4=
-github.com/a8m/tree v0.0.0-20230208161321-36ae24ddad15/go.mod h1:j5astEcUkZQX8lK+KKlQ3NRQ50f4EE8ZjyZpCz3mrH4=
+github.com/a8m/tree v0.0.0-20240104212747-2c8764a5f17e h1:KMVieI1/Ub++GYfnhyFPoGE3g5TUiG4srE3TMGr5nM4=
+github.com/a8m/tree v0.0.0-20240104212747-2c8764a5f17e/go.mod h1:j5astEcUkZQX8lK+KKlQ3NRQ50f4EE8ZjyZpCz3mrH4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -29,8 +29,8 @@ github.com/vmware/vmw-guestinfo v0.0.0-20220317130741-510905f0efa3 h1:v6jG/tdl4O
 github.com/vmware/vmw-guestinfo v0.0.0-20220317130741-510905f0efa3/go.mod h1:CSBTxrhePCm0cmXNKDGeu+6bOQzpaEklfCqEpn89JWk=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
-golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
-golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
+golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
+golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/govc/go.mod
+++ b/govc/go.mod
@@ -7,11 +7,11 @@ replace github.com/vmware/govmomi => ../
 require github.com/vmware/govmomi v0.0.0-00010101000000-000000000000
 
 require (
-	github.com/a8m/tree v0.0.0-20230208161321-36ae24ddad15 // indirect
+	github.com/a8m/tree v0.0.0-20240104212747-2c8764a5f17e // indirect
 	github.com/dougm/pretty v0.0.0-20171025230240-2ee9d7453c02 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
-	golang.org/x/text v0.25.0 // indirect
+	golang.org/x/text v0.26.0 // indirect
 )

--- a/govc/go.sum
+++ b/govc/go.sum
@@ -1,5 +1,5 @@
-github.com/a8m/tree v0.0.0-20230208161321-36ae24ddad15 h1:t3qDzTv8T15tVVhJHHgY7hX5jiIz67xE2SxWQ2ehjH4=
-github.com/a8m/tree v0.0.0-20230208161321-36ae24ddad15/go.mod h1:j5astEcUkZQX8lK+KKlQ3NRQ50f4EE8ZjyZpCz3mrH4=
+github.com/a8m/tree v0.0.0-20240104212747-2c8764a5f17e h1:KMVieI1/Ub++GYfnhyFPoGE3g5TUiG4srE3TMGr5nM4=
+github.com/a8m/tree v0.0.0-20240104212747-2c8764a5f17e/go.mod h1:j5astEcUkZQX8lK+KKlQ3NRQ50f4EE8ZjyZpCz3mrH4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -24,8 +24,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
-golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
-golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
+golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
+golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pbm/client.go
+++ b/pbm/client.go
@@ -71,6 +71,20 @@ func (c *Client) QueryProfile(ctx context.Context, rtype types.PbmProfileResourc
 	return res.Returnval, nil
 }
 
+func (c *Client) QueryProfileDetails(ctx context.Context, category string, fetchAllFields bool) (*types.PbmQueryProfileDetailsResponse, error) {
+	req := types.PbmQueryProfileDetails{
+		This:            c.ServiceContent.ProfileManager,
+		ProfileCategory: category,
+		FetchAllFields:  fetchAllFields,
+	}
+
+	res, err := methods.PbmQueryProfileDetails(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
 func (c *Client) RetrieveContent(ctx context.Context, ids []types.PbmProfileId) ([]types.BasePbmProfile, error) {
 	req := types.PbmRetrieveContent{
 		This:       c.ServiceContent.ProfileManager,
@@ -333,4 +347,35 @@ func (c *Client) SupportsEncryption(
 		}
 	}
 	return false, nil
+}
+func (c *Client) ResolveK8sCompliantNames(ctx context.Context) error {
+	req := types.PbmResolveK8sCompliantNames{
+		This: c.ServiceContent.ProfileManager,
+	}
+
+	_, err := methods.PbmResolveK8sCompliantNames(ctx, c, &req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) UpdateK8sCompliantNames(ctx context.Context, profileID string,
+	k8sCompliantName string, otherK8sCompliantNames []string) error {
+	req := types.PbmUpdateK8sCompliantNames{
+		This: c.ServiceContent.ProfileManager,
+		K8sCompliantNameSpec: types.PbmProfileK8sCompliantNameSpec{
+			ProfileId:              profileID,
+			K8sCompliantName:       k8sCompliantName,
+			OtherK8sCompliantNames: otherK8sCompliantNames,
+		},
+	}
+
+	_, err := methods.PbmUpdateK8sCompliantNames(ctx, c, &req)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pbm/methods/internal_methods.go
+++ b/pbm/methods/internal_methods.go
@@ -30,3 +30,83 @@ func PbmQueryIOFiltersFromProfileId(ctx context.Context, r soap.RoundTripper, re
 
 	return resBody.Res, nil
 }
+
+type PbmQueryProfileDetailsBody struct {
+	Req    *types.PbmQueryProfileDetails         `xml:"urn:internalpbm PbmQueryProfileDetails,omitempty"`
+	Res    *types.PbmQueryProfileDetailsResponse `xml:"urn:internalpbm PbmQueryProfileDetailsResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *PbmQueryProfileDetailsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func PbmQueryProfileDetails(ctx context.Context, r soap.RoundTripper, req *types.PbmQueryProfileDetails) (*types.PbmQueryProfileDetailsResponse, error) {
+	var reqBody, resBody PbmQueryProfileDetailsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type PbmResolveK8sCompliantNamesBody struct {
+	Req    *types.PbmResolveK8sCompliantNames         `xml:"urn:internalpbm PbmResolveK8sCompliantNames,omitempty"`
+	Res    *types.PbmResolveK8sCompliantNamesResponse `xml:"urn:internalpbm PbmResolveK8sCompliantNamesResponse,omitempty"`
+	Fault_ *soap.Fault                                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *PbmResolveK8sCompliantNamesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func PbmResolveK8sCompliantNames(ctx context.Context, r soap.RoundTripper, req *types.PbmResolveK8sCompliantNames) (*types.PbmResolveK8sCompliantNamesResponse, error) {
+	var reqBody, resBody PbmResolveK8sCompliantNamesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type PbmUpdateK8sCompliantNamesBody struct {
+	Req    *types.PbmUpdateK8sCompliantNames         `xml:"urn:internalpbm PbmUpdateK8sCompliantNames,omitempty"`
+	Res    *types.PbmUpdateK8sCompliantNamesResponse `xml:"urn:internalpbm PbmUpdateK8sCompliantNamesResponse,omitempty"`
+	Fault_ *soap.Fault                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *PbmUpdateK8sCompliantNamesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func PbmUpdateK8sCompliantNames(ctx context.Context, r soap.RoundTripper, req *types.PbmUpdateK8sCompliantNames) (*types.PbmUpdateK8sCompliantNamesResponse, error) {
+	var reqBody, resBody PbmUpdateK8sCompliantNamesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type PbmValidateProfileK8sCompliantNameBody struct {
+	Req    *types.PbmValidateProfileK8sCompliantName         `xml:"urn:internalpbm PbmValidateProfileK8sCompliantName,omitempty"`
+	Res    *types.PbmValidateProfileK8sCompliantNameResponse `xml:"urn:internalpbm PbmValidateProfileK8sCompliantNameResponse,omitempty"`
+	Fault_ *soap.Fault                                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *PbmValidateProfileK8sCompliantNameBody) Fault() *soap.Fault { return b.Fault_ }
+
+func PbmValidateProfileK8sCompliantName(ctx context.Context, r soap.RoundTripper, req *types.PbmValidateProfileK8sCompliantName) (*types.PbmValidateProfileK8sCompliantNameResponse, error) {
+	var reqBody, resBody PbmValidateProfileK8sCompliantNameBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/pbm/pbm_util.go
+++ b/pbm/pbm_util.go
@@ -20,11 +20,12 @@ import (
 
 // A struct to capture pbm create spec details.
 type CapabilityProfileCreateSpec struct {
-	Name           string
-	SubProfileName string
-	Description    string
-	Category       string
-	CapabilityList []Capability
+	Name             string
+	SubProfileName   string
+	Description      string
+	Category         string
+	CapabilityList   []Capability
+	K8sCompliantName string
 }
 
 // A struct to capture pbm capability instance details.
@@ -63,6 +64,7 @@ func CreateCapabilityProfileSpec(pbmCreateSpec CapabilityProfileCreateSpec) (*ty
 				},
 			},
 		},
+		K8sCompliantName: pbmCreateSpec.K8sCompliantName,
 	}
 	return &pbmCapabilityProfileSpec, nil
 }

--- a/pbm/types/internal_types.go
+++ b/pbm/types/internal_types.go
@@ -81,3 +81,97 @@ type PbmProfileDetails struct {
 func init() {
 	types.Add("pbm:PbmProfileDetails", reflect.TypeOf((*PbmProfileDetails)(nil)).Elem())
 }
+
+type ArrayOfPbmProfileDetails struct {
+	PbmProfileDetails []PbmProfileDetails `xml:"PbmProfileDetails,omitempty" json:"_value"`
+}
+
+func init() {
+	types.Add("pbm:ArrayOfPbmProfileDetails", reflect.TypeOf((*ArrayOfPbmProfileDetails)(nil)).Elem())
+}
+
+type PbmQueryProfileDetails PbmQueryProfileDetailsRequestType
+
+func init() {
+	types.Add("pbm:PbmQueryProfileDetails", reflect.TypeOf((*PbmQueryProfileDetails)(nil)).Elem())
+}
+
+type PbmQueryProfileDetailsRequestType struct {
+	This            types.ManagedObjectReference `xml:"_this" json:"_this"`
+	ProfileCategory string                       `xml:"profileCategory" json:"profileCategory"`
+	FetchAllFields  bool                         `xml:"fetchAllFields" json:"fetchAllFields"`
+}
+
+func init() {
+	types.Add("pbm:PbmQueryProfileDetailsRequestType", reflect.TypeOf((*PbmQueryProfileDetailsRequestType)(nil)).Elem())
+}
+
+type PbmQueryProfileDetailsResponse struct {
+	Returnval []PbmProfileDetails `xml:"returnval,omitempty" json:"returnval,omitempty"`
+}
+
+type PbmResolveK8sCompliantNames PbmResolveK8sCompliantNamesRequestType
+
+func init() {
+	types.Add("pbm:PbmResolveK8sCompliantNames", reflect.TypeOf((*PbmResolveK8sCompliantNames)(nil)).Elem())
+}
+
+type PbmResolveK8sCompliantNamesRequestType struct {
+	This types.ManagedObjectReference `xml:"_this" json:"_this"`
+}
+
+func init() {
+	types.Add("pbm:PbmResolveK8sCompliantNamesRequestType", reflect.TypeOf((*PbmResolveK8sCompliantNamesRequestType)(nil)).Elem())
+}
+
+type PbmResolveK8sCompliantNamesResponse struct {
+}
+
+type PbmUpdateK8sCompliantNames PbmUpdateK8sCompliantNamesRequestType
+
+func init() {
+	types.Add("pbm:PbmUpdateK8sCompliantNames", reflect.TypeOf((*PbmUpdateK8sCompliantNames)(nil)).Elem())
+}
+
+type PbmUpdateK8sCompliantNamesRequestType struct {
+	This                 types.ManagedObjectReference   `xml:"_this" json:"_this"`
+	K8sCompliantNameSpec PbmProfileK8sCompliantNameSpec `xml:"k8sCompliantNameSpec" json:"k8sCompliantNameSpec"`
+}
+
+func init() {
+	types.Add("pbm:PbmUpdateK8sCompliantNamesRequestType", reflect.TypeOf((*PbmUpdateK8sCompliantNamesRequestType)(nil)).Elem())
+}
+
+type PbmUpdateK8sCompliantNamesResponse struct {
+}
+
+type PbmValidateProfileK8sCompliantName PbmValidateProfileK8sCompliantNameRequestType
+
+func init() {
+	types.Add("pbm:PbmValidateProfileK8sCompliantName", reflect.TypeOf((*PbmValidateProfileK8sCompliantName)(nil)).Elem())
+}
+
+type PbmValidateProfileK8sCompliantNameRequestType struct {
+	This             types.ManagedObjectReference `xml:"_this" json:"_this"`
+	K8sCompliantName string                       `xml:"k8sCompliantName" json:"k8sCompliantName"`
+}
+
+func init() {
+	types.Add("pbm:PbmValidateProfileK8sCompliantNameRequestType", reflect.TypeOf((*PbmValidateProfileK8sCompliantNameRequestType)(nil)).Elem())
+}
+
+type PbmK8sCompliantNameValidationResult struct {
+	types.DynamicData
+
+	K8sCompliantName string                      `xml:"k8sCompliantName" json:"k8sCompliantName"`
+	Valid            bool                        `xml:"valid" json:"valid"`
+	Fault            *types.LocalizedMethodFault `xml:"fault,omitempty" json:"fault,omitempty"`
+}
+
+func init() {
+	types.Add("pbm:PbmK8sCompliantNameValidationResult", reflect.TypeOf((*PbmK8sCompliantNameValidationResult)(nil)).Elem())
+}
+
+type PbmValidateProfileK8sCompliantNameResponse struct {
+	Returnval PbmK8sCompliantNameValidationResult `xml:"returnval" json:"returnval"`
+}

--- a/vcsim/go.mod
+++ b/vcsim/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/vmware/govmomi v0.0.0-00010101000000-000000000000
 )
+
+require golang.org/x/text v0.26.0 // indirect

--- a/vcsim/go.sum
+++ b/vcsim/go.sum
@@ -12,5 +12,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
+golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Description
This PR adds PBM internal types and methods that are required to set/fetch/update K8s compliant names for storage policies.

Closes: #(issue-number)

## How Has This Been Tested?
Added unittest to test the required methods and types

```
 go test -v -count 1 -run TestStoragePolicyK8sCompliantNames ./pbm
=== RUN   TestStoragePolicyK8sCompliantNames
=== RUN   TestStoragePolicyK8sCompliantNames/Validate_K8sCompliantName_set_for_existing_storage_profiles
    client_test.go:370: PBM version=2.0
=== RUN   TestStoragePolicyK8sCompliantNames/Validate_K8sCompliantName_set_after_new_policy_creation
    client_test.go:389: PBM version=2.0
    client_test.go:435: VSAN Profile: "c621a600-8840-4861-b3e1-f57e6c1f2ebb" with Name "Kubernetes-VSAN-TestPolicy" successfully created
    client_test.go:445: Profile "Kubernetes-VSAN-TestPolicy":"c621a600-8840-4861-b3e1-f57e6c1f2ebb" has K8sCompliant Name "kubernetes-vsan-testpolicy" set now on VCDB
=== RUN   TestStoragePolicyK8sCompliantNames/Validate_K8sCompliantName_and_OtherK8sCompliantNames_set_correctly_after_update
    client_test.go:458: PBM version=2.0
    client_test.go:507: VSAN Profile: "0f411ff5-e1c1-4366-b1ad-35fbe416406b" with Name "Kubernetes-VSAN-TestPolicy" successfully created
    client_test.go:525: Profile "Kubernetes-VSAN-TestPolicy":"0f411ff5-e1c1-4366-b1ad-35fbe416406b" has updated otherK8sCompliant Names on VCDB
    client_test.go:562: Profile "Kubernetes-VSAN-TestPolicy":"0f411ff5-e1c1-4366-b1ad-35fbe416406b" has resolved and updated otherK8sCompliant Names on VCDB
--- PASS: TestStoragePolicyK8sCompliantNames (1.33s)
    --- PASS: TestStoragePolicyK8sCompliantNames/Validate_K8sCompliantName_set_for_existing_storage_profiles (0.44s)
    --- PASS: TestStoragePolicyK8sCompliantNames/Validate_K8sCompliantName_set_after_new_policy_creation (0.45s)
    --- PASS: TestStoragePolicyK8sCompliantNames/Validate_K8sCompliantName_and_OtherK8sCompliantNames_set_correctly_after_update (0.45s)
PASS
ok      github.com/vmware/govmomi/pbm   1.341s
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
