### PR TITLE
update CnsVolumeCreateSpec and CnsVolumeOperationResult

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -84,6 +84,7 @@ type CnsVolumeCreateSpec struct {
 	Metadata             CnsVolumeMetadata                     `xml:"metadata,omitempty" json:"metadata"`
 	BackingObjectDetails BaseCnsBackingObjectDetails           `xml:"backingObjectDetails,typeattr" json:"backingObjectDetails"`
 	Profile              []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr" json:"profile"`
+	ActiveClusters       []types.ManagedObjectReference        `xml:"activeClusters,omitempty,typeattr" json:"activeClusters"`
 	CreateSpec           BaseCnsBaseCreateSpec                 `xml:"createSpec,omitempty,typeattr" json:"createSpec"`
 	VolumeSource         BaseCnsVolumeSource                   `xml:"volumeSource,omitempty,typeattr" json:"volumeSource"`
 }
@@ -331,8 +332,9 @@ func init() {
 }
 
 type CnsPlacementResult struct {
-	Datastore       types.ManagedObjectReference  `xml:"datastore,omitempty" json:"datastore"`
-	PlacementFaults []*types.LocalizedMethodFault `xml:"placementFaults,omitempty" json:"placementFaults"`
+	Datastore       types.ManagedObjectReference   `xml:"datastore,omitempty" json:"datastore"`
+	PlacementFaults []*types.LocalizedMethodFault  `xml:"placementFaults,omitempty" json:"placementFaults"`
+	Clusters        []types.ManagedObjectReference `xml:"clusters,omitempty" json:"clusters"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

This PR introduces Go binding changes to support specifying Cluster MoRefs in CnsVolumeCreateSpec.

With this change in the API, the backend can determine the set of datastores applicable for volume provisioning that are accessible to the provided clusters and comply with the specified storage policy in CnsVolumeCreateSpec. 
Callers of the API no longer need to explicitly provide datastores when clusters and policy are specified.

CnsPlacementResult now includes a new Clusters field, indicating the list of clusters where the provisioned volume is accessible. This allows clients like CSI to compute node affinity rules directly from the response, eliminating the need for extra vCenter queries to determine where volume is accessible to.

## How Has This Been Tested?
Executed test on the environment with this FSS enabled.

Test logs

```
=== RUN   TestClient
    client_test.go:175: set cnsVolumeCreateSpec.ActiveClusters=[ClusterComputeResource:domain-c10]
    client_test.go:186: set cnsVolumeCreateSpec.Profile=0f26c5c0-95b0-4697-b6ac-d8ef873b89e6
    client_test.go:196: Creating volume using the spec: types.CnsVolumeCreateSpec{
            DynamicData: types.DynamicData{},
            Name:        "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
            VolumeType:  "BLOCK",
            VolumeId:    (*types.CnsVolumeId)(nil),
            Datastores:  nil,
            Metadata:    types.CnsVolumeMetadata{
                DynamicData:      types.DynamicData{},
                ContainerCluster: types.CnsContainerCluster{
                    DynamicData:         types.DynamicData{},
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "OpenShift",
                    Delete:              false,
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    DynamicData:  types.DynamicData{},
                    CapacityInMb: 5120,
                },
                BackingDiskId:                  "",
                BackingDiskUrlPath:             "",
                BackingDiskObjectId:            "",
                AggregatedSnapshotCapacityInMb: 0,
                BackingDiskPath:                "",
            },
            Profile: {
                &types.VirtualMachineDefinedProfileSpec{
                    VirtualMachineProfileSpec: types.VirtualMachineProfileSpec{},
                    ProfileId:                 "0f26c5c0-95b0-4697-b6ac-d8ef873b89e6",
                    ReplicationSpec:           (*types.ReplicationSpec)(nil),
                    ProfileData:               (*types.VirtualMachineProfileRawData)(nil),
                    ProfileParams:             nil,
                },
            },
            ActiveClusters: {
                {Type:"ClusterComputeResource", Value:"domain-c10", ServerGUID:""},
            },
            CreateSpec:   nil,
            VolumeSource: nil,
        }
    client_test.go:231: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:2100036d-f860-4273-9fac-72fb922ca1e7} Fault:<nil>} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0 PlacementResults:[{Datastore:Datastore:datastore-64 PlacementFaults:[] Clusters:[ClusterComputeResource:domain-c10]}]}
    client_test.go:238: Volume created successfully. volumeId: 2100036d-f860-4273-9fac-72fb922ca1e7
```
