### PR TITLE
vcsim: add SearchIndex.FindAllByUuid() support

### DIFF
--- a/object/search_index_test.go
+++ b/object/search_index_test.go
@@ -92,6 +92,17 @@ func TestSearch(t *testing.T) {
 		if !reflect.DeepEqual(ref, shost) {
 			t.Errorf("%#v != %#v\n", ref, shost)
 		}
+
+		shosts, err := s.FindAllByUuid(context.Background(), dc, host.Hardware.SystemInfo.Uuid, false, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(shosts) != 1 {
+			t.Errorf("len(shosts) != 1: %d\n", len(shosts))
+		}
+		if !reflect.DeepEqual(ref, shosts[0]) {
+			t.Errorf("%#v != %#v\n", ref, shosts[0])
+		}
 	}
 
 	vms, err := folders.VmFolder.Children(context.Background())
@@ -119,6 +130,17 @@ func TestSearch(t *testing.T) {
 		}
 		if !reflect.DeepEqual(ref, svm) {
 			t.Errorf("%#v != %#v\n", ref, svm)
+		}
+
+		svms, err := s.FindAllByUuid(context.Background(), dc, vm.Config.Uuid, true, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(svms) != 1 {
+			t.Errorf("len(svms) != 1: %d\n", len(svms))
+		}
+		if !reflect.DeepEqual(ref, svms[0]) {
+			t.Errorf("%#v != %#v\n", ref, svms[0])
 		}
 
 		if vm.Guest.HostName != "" {

--- a/simulator/search_index.go
+++ b/simulator/search_index.go
@@ -156,6 +156,45 @@ func (s *SearchIndex) FindByUuid(ctx *Context, req *types.FindByUuid) soap.HasFa
 	return body
 }
 
+func (s *SearchIndex) FindAllByUuid(ctx *Context, req *types.FindAllByUuid) soap.HasFault {
+	body := &methods.FindAllByUuidBody{Res: new(types.FindAllByUuidResponse)}
+
+	ctx.Map.m.Lock()
+	defer ctx.Map.m.Unlock()
+
+	if req.VmSearch {
+		// Find Virtual Machines using UUID
+		for ref, obj := range ctx.Map.objects {
+			vm, ok := asVirtualMachineMO(obj)
+			if !ok {
+				continue
+			}
+			if req.InstanceUuid != nil && *req.InstanceUuid {
+				if vm.Config.InstanceUuid == req.Uuid {
+					body.Res.Returnval = append(body.Res.Returnval, ref)
+				}
+			} else {
+				if vm.Config.Uuid == req.Uuid {
+					body.Res.Returnval = append(body.Res.Returnval, ref)
+				}
+			}
+		}
+	} else {
+		// Find Host System using UUID
+		for ref, obj := range ctx.Map.objects {
+			host, ok := asHostSystemMO(obj)
+			if !ok {
+				continue
+			}
+			if host.Summary.Hardware.Uuid == req.Uuid {
+				body.Res.Returnval = append(body.Res.Returnval, ref)
+			}
+		}
+	}
+
+	return body
+}
+
 func (s *SearchIndex) FindByDnsName(ctx *Context, req *types.FindByDnsName) soap.HasFault {
 	body := &methods.FindByDnsNameBody{Res: new(types.FindByDnsNameResponse)}
 


### PR DESCRIPTION
## Description

Add FindAllByUuid() implementation to vcsim for vm-operator use

Closes: #(issue-number)

## How Has This Been Tested?

Added tests. Works with WIP vm-operator branch

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
