### PR TITLE
Update folder.PlaceVMsXCluster to return available candidate networks

### DIFF
--- a/cli/folder/place.go
+++ b/cli/folder/place.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"text/tabwriter"
 
@@ -144,6 +145,10 @@ func (cmd *place) Process(ctx context.Context) error {
 }
 
 func (cmd *place) Run(ctx context.Context, f *flag.FlagSet) error {
+
+	// Register runtime override before any unmarshalling/type casting.
+	types.Add("ClusterClusterInitialPlacementAction", reflect.TypeOf((*types.ClusterClusterInitialPlacementActionEx)(nil)).Elem())
+
 	client, err := cmd.Client()
 	if err != nil {
 		return err
@@ -296,6 +301,20 @@ func (res *placementResult) initialPlacementAction(w io.Writer, pinfo types.Plac
 		fmt.Fprintf(w, "%s:\t%s\n", f.name, path)
 	}
 
+	// Display the available network references from the placement recommendation.
+	if act, ok := any(action).(*types.ClusterClusterInitialPlacementActionEx); ok {
+		if len(act.AvailableNetworks) > 0 {
+			fmt.Fprintf(w, "  AvailableNetworks:\n")
+			for _, net := range act.AvailableNetworks {
+				path, err := find.InventoryPath(res.ctx, res.vimClient, net)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(w, "\t- %s\n", path)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -329,6 +348,17 @@ func (res *placementResult) relocatePlacementAction(w io.Writer, pinfo types.Pla
 		fmt.Fprintf(w, "%s:\t%s\n", f.name, path)
 	}
 
+	// Display the available network references from the placement recommendation.
+	if len(action.AvailableNetworks) > 0 {
+		fmt.Fprintf(w, "  AvailableNetworks:\n")
+		for _, net := range action.AvailableNetworks {
+			path, err := find.InventoryPath(res.ctx, res.vimClient, net)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "\t- %s\n", path)
+		}
+	}
 	return nil
 }
 

--- a/object/folder.go
+++ b/object/folder.go
@@ -6,6 +6,7 @@ package object
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -215,6 +216,7 @@ func (f Folder) MoveInto(ctx context.Context, list []types.ManagedObjectReferenc
 }
 
 func (f Folder) PlaceVmsXCluster(ctx context.Context, spec types.PlaceVmsXClusterSpec) (*types.PlaceVmsXClusterResult, error) {
+	types.Add("ClusterClusterInitialPlacementAction", reflect.TypeOf((*types.ClusterClusterInitialPlacementActionEx)(nil)).Elem())
 	req := types.PlaceVmsXCluster{
 		This:          f.Reference(),
 		PlacementSpec: spec,

--- a/simulator/folder_test.go
+++ b/simulator/folder_test.go
@@ -721,6 +721,38 @@ func TestPlaceVmsXClusterCreateAndPowerOnWithCandidateNetworks(t *testing.T) {
 		if len(res.PlacementInfos) != len(spec.VmPlacementSpecs) {
 			t.Errorf("%d PlacementInfos vs %d VmPlacementSpecs", len(res.PlacementInfos), len(spec.VmPlacementSpecs))
 		}
+
+		// Validate AvailableNetworks returned in placement recommendations.
+		for _, pinfo := range res.PlacementInfos {
+			for i, action := range pinfo.Recommendation.Action {
+				// Ensure the action is of expected extended type.
+				initPlaceAction, ok := action.(*types.ClusterClusterInitialPlacementActionEx)
+				if !ok {
+					t.Errorf("Action[%d] is not ClusterClusterInitialPlacementActionEx, got %T", i, action)
+					continue
+				}
+				if len(initPlaceAction.AvailableNetworks) == 0 {
+					t.Errorf("AvailableNetworks is empty for VM %v", pinfo.Vm)
+				} else {
+					t.Logf("AvailableNetworks for VM %v:", pinfo.Vm)
+					for _, net := range initPlaceAction.AvailableNetworks {
+						t.Logf("- %s", net.Value)
+					}
+				}
+				// Define the expected networks that should be present in AvailableNetworks.
+				expected := map[string]bool{
+					netA.Reference().Value: true,
+					netB.Reference().Value: true,
+				}
+
+				// Verify that all returned networks are part of the expected set.
+				for _, actual := range initPlaceAction.AvailableNetworks {
+					if !expected[actual.Value] {
+						t.Errorf("unexpected network in availableNetworks: %s", actual.Value)
+					}
+				}
+			}
+		}
 	}, vpx)
 }
 
@@ -850,14 +882,36 @@ func TestPlaceVmsXClusterRelocate(t *testing.T) {
 					t.Errorf("Test %v: %d PlacementInfos vs %d VmPlacementSpecs", testNo, len(res.PlacementInfos), len(placeVmsXClusterSpec.VmPlacementSpecs))
 				}
 
+				// Validate AvailableNetworks returned in placement recommendations.
 				for _, pinfo := range res.PlacementInfos {
 					for _, action := range pinfo.Recommendation.Action {
-						if relocateAction, ok := action.(*types.ClusterClusterRelocatePlacementAction); ok {
-							if relocateAction.TargetHost == nil {
-								t.Errorf("Test %v: received nil host recommendation", testNo)
-							}
-						} else {
+						relocateAction, ok := action.(*types.ClusterClusterRelocatePlacementAction)
+						if !ok {
 							t.Errorf("Test %v: received wrong action type in recommendation", testNo)
+							continue
+						}
+						if relocateAction.TargetHost == nil {
+							t.Errorf("Test %v: received nil host recommendation", testNo)
+						}
+						// Check if AvailableNetworks field is populated.
+						if len(relocateAction.AvailableNetworks) == 0 {
+							t.Errorf("AvailableNetworks is empty for VM %v", pinfo.Vm)
+						} else {
+							t.Logf("AvailableNetworks for VM %v:", pinfo.Vm)
+							for _, net := range relocateAction.AvailableNetworks {
+								t.Logf("- %s", net.Value)
+							}
+						}
+						// Define the expected networks that should be present in AvailableNetworks.
+						expected := map[string]bool{
+							netA.Reference().Value: true,
+							netB.Reference().Value: true,
+						}
+						// Verify that all returned networks are part of the expected set.
+						for _, actual := range relocateAction.AvailableNetworks {
+							if !expected[actual.Value] {
+								t.Errorf("unexpected network in availableNetworks: %s", actual.Value)
+							}
 						}
 					}
 				}

--- a/vim25/types/unreleased.go
+++ b/vim25/types/unreleased.go
@@ -145,9 +145,10 @@ func init() {
 
 type ClusterClusterRelocatePlacementAction struct {
 	ClusterAction
-	TargetHost   *ManagedObjectReference     `xml:"targetHost,omitempty"`
-	Pool         ManagedObjectReference      `xml:"pool"`
-	RelocateSpec *VirtualMachineRelocateSpec `xml:"relocateSpec,omitempty"`
+	TargetHost        *ManagedObjectReference     `xml:"targetHost,omitempty"`
+	Pool              ManagedObjectReference      `xml:"pool"`
+	RelocateSpec      *VirtualMachineRelocateSpec `xml:"relocateSpec,omitempty"`
+	AvailableNetworks []ManagedObjectReference    `xml:"availableNetworks,omitempty"`
 }
 
 func init() {
@@ -162,4 +163,69 @@ type PodVMOverheadInfo struct {
 	CrxPageSharingSupported         bool  `xml:"crxPageSharingSupported"`
 	PodVMOverheadWithoutPageSharing int32 `xml:"podVMOverheadWithoutPageSharing"`
 	PodVMOverheadWithPageSharing    int32 `xml:"podVMOverheadWithPageSharing"`
+}
+
+// Describes an action for the initial placement of a virtual machine in a cluster.
+//
+// This action is used by the cross cluster placement API when a virtual machine
+// needs to be placed across a set of given clusters. See `Folder.PlaceVmsXCluster`.
+// This action encapsulates details about the chosen cluster (via the resource pool
+// inside that cluster), the chosen host and the chosen datastores for the disks of
+// the virtual machine.
+type ClusterClusterInitialPlacementActionEx struct {
+	ClusterAction
+
+	// The host where the virtual machine should be initially placed.
+	//
+	// This field is optional because the primary use case of
+	// `Folder.PlaceVmsXCluster` is to select the best cluster for placing VMs. This
+	// `ClusterClusterInitialPlacementAction.targetHost` denotes the best host
+	// within the best cluster and it is only returned if the client asks for it,
+	// which is determined by `PlaceVmsXClusterSpec.hostRecommRequired`.
+	// If `PlaceVmsXClusterSpec.hostRecommRequired` is set to true, then the
+	// targetHost is returned with a valid value and if it is either set to false
+	// or left unset, then targetHost is also left unset. When this field is unset,
+	// then it means that the client did not ask for the target host within the
+	// recommended cluster. It does not mean that there is no recommended host
+	// for placing this VM in the recommended cluster.
+	//
+	// Refers instance of `HostSystem`.
+	TargetHost *ManagedObjectReference `xml:"targetHost,omitempty" json:"targetHost,omitempty"`
+
+	// The chosen resource pool for placing the virtual machine.
+	//
+	// This is non-optional because recommending the best cluster (by recommending the
+	// resource pool in the best cluster) is the primary use case for the
+	// `ClusterClusterInitialPlacementAction`.
+	//
+	// Refers instance of `ResourcePool`.
+	Pool ManagedObjectReference `xml:"pool" json:"pool"`
+
+	// The config spec of the virtual machine to be placed.
+	//
+	// The `Folder.PlaceVmsXCluster` method takes input of `VirtualMachineConfigSpec`
+	// from client and populates the backing for each virtual disk and the VM home
+	// path in it unless the input ConfigSpec already provides them. The existing
+	// settings in the input ConfigSpec are preserved and not overridden in the
+	// returned ConfigSpec in this action as well as the resulting
+	// `ClusterRecommendation`. This field is set based on whether the client needs
+	// `Folder.PlaceVmsXCluster` to recommend a backing datastore for the disks of
+	// the candidate VMs or not, which is specified via
+	// `PlaceVmsXClusterSpec.datastoreRecommRequired`. If
+	// `PlaceVmsXClusterSpec.datastoreRecommRequired` is set to true, then this
+	// `ClusterClusterInitialPlacementAction.configSpec` is also set with the
+	// backing of each disk populated. If
+	// `PlaceVmsXClusterSpec.datastoreRecommRequired` is either set to false or left
+	// unset, then this field is also left unset. When this field is left unset,
+	// then it means that the client did not ask to populate the backing datastore
+	// for the disks of the candidate VMs.
+	ConfigSpec *VirtualMachineConfigSpec `xml:"configSpec,omitempty" json:"configSpec,omitempty"`
+
+	AvailableNetworks []ManagedObjectReference `xml:"availableNetworks,omitempty" json:"availableNetworks,omitempty"`
+}
+
+func init() {
+	minAPIVersionForType["ClusterClusterInitialPlacementActionEx"] = "9.1.0.0"
+	t["ClusterClusterInitialPlacementActionEx"] = reflect.TypeOf((*ClusterClusterInitialPlacementActionEx)(nil)).Elem()
+	Add("ClusterClusterInitialPlacementAction", reflect.TypeOf((*ClusterClusterInitialPlacementActionEx)(nil)).Elem())
 }

--- a/vim25/types/unreleased_test.go
+++ b/vim25/types/unreleased_test.go
@@ -6,6 +6,7 @@ package types_test
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/vmware/govmomi/property"
@@ -36,4 +37,47 @@ func TestPodVMOverheadInfo(t *testing.T) {
 			t.Errorf("%#v", props.Capability.PodVMOverheadInfo)
 		}
 	})
+}
+
+func TestTypeClusterClusterInitialPlacementActionEx(t *testing.T) {
+	var ok bool
+
+	// Register the original base type for "ClusterClusterInitialPlacementAction".
+	// It simulates the default SDK behavior before override.
+	types.Add("ClusterClusterInitialPlacementAction", reflect.TypeOf((*types.ClusterClusterInitialPlacementAction)(nil)).Elem())
+	fn := types.TypeFunc()
+
+	// Lookup an unknown type - should return ok==false.
+	_, ok = fn("unknown")
+	if ok {
+		t.Errorf("Expected ok==false")
+	}
+
+	// Lookup the registered base type ClusterClusterInitialPlacementAction - should return ok==true.
+	actual, ok := fn("ClusterClusterInitialPlacementAction")
+	if !ok {
+		t.Errorf("Expected ok==true")
+	}
+
+	expected := reflect.TypeOf(types.ClusterClusterInitialPlacementAction{})
+
+	// Validate that the type lookup matches the base type.
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected: %#v, actual: %#v", expected, actual)
+	}
+
+	// Override the registered type with our extended struct ClusterClusterInitialPlacementActionEx.
+	types.Add("ClusterClusterInitialPlacementAction", reflect.TypeOf((*types.ClusterClusterInitialPlacementActionEx)(nil)).Elem())
+
+	// Lookup the same name again - should now return the extended type.
+	actual, ok = fn("ClusterClusterInitialPlacementAction")
+	if !ok {
+		t.Errorf("Expected ok==true")
+	}
+
+	// Expected type is now the extended struct.
+	expected = reflect.TypeOf(types.ClusterClusterInitialPlacementActionEx{})
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected: %#v, actual: %#v", expected, actual)
+	}
 }


### PR DESCRIPTION
## Description
The PlaceVmsXCluster API is being updated to return the list of available candidate networks in the recommendation.

This change does the following.

1. Extend the Initial Placement Action Struct

A new type ClusterClusterInitialPlacementActionEx is defined in types/unreleased.go to extend the existing ClusterClusterInitialPlacementAction. This struct adds the new field AvailableNetworks to ClusterClusterInitialPlacementActionEx.

2. Register the Extended Type Override
Registered the extended struct as the override for ClusterClusterInitialPlacementAction using:
types.Add("ClusterClusterInitialPlacementAction", reflect.TypeOf((*types.ClusterClusterInitialPlacementActionEx)(nil)).Elem())

This registration is needed in:

    types/unreleased.go (global override for simulator use)
    simulator/folder.go (for correct placement generation)
    simulator/folder_test.go (so test assertions succeed)
    gocli/place.go (so CLI unmarshalling + type assertion works at runtime)

3. Extend the RelocatePlacementAction to include the list of AvailableNetworks.

4.  Extends the simulator to return  and validate the available candidate networks in the recommendation of placeVmXCluster invocation.
Note : In the previous change - https://github.com/vmware/govmomi/pull/3815, PlaceVmsXCluster API is being updated to filter eligible clusters based on the availability of candidate networks.

5. Updated simulator tests
Updated test TestPlaceVmsXClusterCreateAndPowerOnWithCandidateNetworks  to validate that AvailableNetworks are populated and match expected networks.
The test asserts the returned action is of type ClusterClusterInitialPlacementActionEx and inspects the new field.
Updated test TestPlaceVmsXClusterRelocate  to validate that AvailableNetworks are populated and match expected networks.The test asserts the returned action is of type ClusterClusterRelocatePlacementAction and inspects the new field.

Closes: # CRM-3320

## How Has This Been Tested?

go test ./simulator
go test -v ./simulator -run ^TestPlaceVmsXCluster <-- test all placeVmsXCluster tests.

Ran below gocli commands on VC.

case1. Basic case where a network is available in only one cluster. DVPG2 is only in cluster2.
./govc-bin folder.place -vm standalone-82aeab91a-esx.0-vm.0 -pool /vcqaDC/host/cluster1/Resources/RP1 -pool /vcqaDC/host/cluster2/Resources/RP2 -pool /vcqaDC/host/cluster3/Resources/RP3 -type relocate -candidate-networks "DVPG2" /vcqaDC/vm/Production

Vm:	/vcqaDC/vm/standalone-82aeab91a-esx.0-vm.0
  Target:	/vcqaDC/host/cluster2
  Datastore:	/vcqaDC/datastore/vsanDatastore (1)
  AvailableNetworks:
    - /vcqaDC/network/DVPG2


case 2. Tested VM with multiple nics. cluster2 was the only cluster which had both DVPG2 and VM Network.
./govc-bin folder.place -vm standalone-82aeab91a-esx.0-vm.0 -pool /vcqaDC/host/cluster1/Resources/RP1 -pool /vcqaDC/host/cluster2/Resources/RP2 -pool /vcqaDC/host/cluster3/Resources/RP3 -type relocate -candidate-networks "DVPG2" -candidate-networks "VM Network" /vcqaDC/vm/Production

Vm:	/vcqaDC/vm/standalone-82aeab91a-esx.0-vm.0
  Target:	/vcqaDC/host/cluster2
  Datastore:	/vcqaDC/datastore/vsanDatastore (1)
  AvailableNetworks:
    - /vcqaDC/network/DVPG2
    - /vcqaDC/network/VM Network


case3. Tested VM with multiple network options. DVPG2 is only in cluster2. DVPG3 is in cluster3.
./govc-bin folder.place -vm standalone-82aeab91a-esx.0-vm.0 -pool /vcqaDC/host/cluster1/Resources/RP1 -pool /vcqaDC/host/cluster2/Resources/RP2 -pool /vcqaDC/host/cluster3/Resources/RP3 -type relocate -candidate-networks "DVPG2|DVPG3" /vcqaDC/vm/Production

Vm:	/vcqaDC/vm/standalone-82aeab91a-esx.0-vm.0
  Target:	/vcqaDC/host/cluster2
  Datastore:	/vcqaDC/datastore/vsanDatastore (1)
  AvailableNetworks:
    - /vcqaDC/network/DVPG2

 Similarly Tested gocli commands on simulator.

 ./govc-bin folder.place -vm DC0_C0_RP0_VM0 -pool /DC0/host/DC0_C0/Resources -type relocate -candidate-networks "VM Network|DC0_DVPG0" /DC0/vm/Production

Vm:	/DC0/vm/DC0_C0_RP0_VM0
  Target:	/DC0/host/DC0_C0
  Datastore:	/DC0/datastore/LocalDS_0
  AvailableNetworks:
    - /DC0/network/VM Network
    - /DC0/network/DC0_DVPG0

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
