### PR TITLE
Implement bindings for CNS Unregister Volume

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -320,3 +320,17 @@ func (c *Client) SyncVolume(ctx context.Context, syncSpecs []cnstypes.CnsSyncVol
 	}
 	return object.NewTask(c.vim25Client, res.Returnval), nil
 }
+
+// UnregisterVolume calls the CNS UnregisterVolume API
+func (c *Client) UnregisterVolume(ctx context.Context, spec []cnstypes.CnsUnregisterVolumeSpec) (*object.Task, error) {
+	req := cnstypes.CnsUnregisterVolume{
+		This:           CnsVolumeManagerInstance,
+		UnregisterSpec: spec,
+	}
+
+	res, err := methods.CnsUnregisterVolume(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(c.vim25Client, res.Returnval), nil
+}

--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -1794,6 +1794,148 @@ func TestClient(t *testing.T) {
 
 }
 
+func TestUnregisterVolume(t *testing.T) {
+	ctx := context.Background()
+	// Setup: create a CNS client and a volume to unregister
+	url := os.Getenv("CNS_VC_URL")
+	if url == "" {
+		t.Skip("CNS_VC_URL is not set")
+	}
+	datacenter := os.Getenv("CNS_DATACENTER")
+	datastore := os.Getenv("CNS_DATASTORE")
+	u, err := soap.ParseURL(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := govmomi.NewClient(ctx, u, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !isvSphereVersion91orAbove(context.Background(), c.ServiceContent.About) {
+		t.Skip("This test requires vSphere 9.1 or above")
+	}
+
+	cnsClient, err := NewClient(ctx, c.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finder := find.NewFinder(cnsClient.vim25Client, false)
+	dc, err := finder.Datacenter(ctx, datacenter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finder.SetDatacenter(dc)
+	ds, err := finder.Datastore(ctx, datastore)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	props := []string{"info", "summary"}
+	pc := property.DefaultCollector(c.Client)
+	var dsSummaries []mo.Datastore
+	err = pc.Retrieve(ctx, []vim25types.ManagedObjectReference{ds.Reference()}, props, &dsSummaries)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var dsList []vim25types.ManagedObjectReference
+	dsList = append(dsList, ds.Reference())
+
+	var containerClusterArray []cnstypes.CnsContainerCluster
+	containerCluster := cnstypes.CnsContainerCluster{
+		ClusterType:         string(cnstypes.CnsClusterTypeKubernetes),
+		ClusterId:           "demo-cluster-id",
+		VSphereUser:         "Administrator@vsphere.local",
+		ClusterFlavor:       string(cnstypes.CnsClusterFlavorVanilla),
+		ClusterDistribution: "OpenShift",
+	}
+	containerClusterArray = append(containerClusterArray, containerCluster)
+
+	// Test CreateVolume API
+	volumeName := "pvc-" + uuid.New().String()
+	var cnsVolumeCreateSpecList []cnstypes.CnsVolumeCreateSpec
+	cnsVolumeCreateSpec := cnstypes.CnsVolumeCreateSpec{
+		Name:       volumeName,
+		VolumeType: string(cnstypes.CnsVolumeTypeBlock),
+		Metadata: cnstypes.CnsVolumeMetadata{
+			ContainerCluster: containerCluster,
+		},
+		BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+			CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{
+				CapacityInMb: 5120,
+			},
+		},
+		Datastores: dsList,
+	}
+
+	cnsVolumeCreateSpecList = append(cnsVolumeCreateSpecList, cnsVolumeCreateSpec)
+
+	createTask, err := cnsClient.CreateVolume(ctx, cnsVolumeCreateSpecList)
+	if err != nil {
+		t.Errorf("Failed to create volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	createTaskInfo, err := GetTaskInfo(ctx, createTask)
+	if err != nil {
+		t.Errorf("Failed to create volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	createTaskResult, err := GetTaskResult(ctx, createTaskInfo)
+	if err != nil {
+		t.Errorf("Failed to create volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	if createTaskResult == nil {
+		t.Fatalf("Empty create task results")
+		t.FailNow()
+	}
+	createVolumeOperationRes := createTaskResult.GetCnsVolumeOperationResult()
+	if createVolumeOperationRes.Fault != nil {
+		if cnsFault, ok := createVolumeOperationRes.Fault.Fault.(*cnstypes.CnsFault); ok {
+			if cause := cnsFault.FaultCause; cause != nil {
+				if inner, ok := cause.Fault.(*vim25types.NotSupported); ok {
+					t.Logf("Caught NotSupported fault: %q", cause.LocalizedMessage)
+				} else {
+					t.Logf("Inner fault type: %T", inner)
+				}
+			}
+		}
+		t.Fatalf("Failed to create volume: fault=%+v", createVolumeOperationRes.Fault)
+	}
+	volumeId := createVolumeOperationRes.VolumeId.Id
+	volumeCreateResult := (createTaskResult).(*cnstypes.CnsVolumeCreateResult)
+	t.Logf("volumeCreateResult %+v", volumeCreateResult)
+	t.Logf("Volume created successfully. volumeId: %s", volumeId)
+
+	spec := []cnstypes.CnsUnregisterVolumeSpec{
+		{
+			VolumeId:         cnstypes.CnsVolumeId{Id: volumeId},
+			TargetVolumeType: string(cnstypes.CnsUnregisterTargetVolumeTypeFCD),
+		},
+	}
+	task, err := cnsClient.UnregisterVolume(ctx, spec)
+	if err != nil {
+		t.Fatalf("UnregisterVolume failed: %+v", err)
+	}
+	taskInfo, err := GetTaskInfo(ctx, task)
+	if err != nil {
+		t.Fatalf("GetTaskInfo failed: %+v", err)
+	}
+	taskResult, err := GetTaskResult(ctx, taskInfo)
+	if err != nil {
+		t.Fatalf("GetTaskResult failed: %+v", err)
+	}
+	if taskResult == nil {
+		t.Fatalf("Empty unregister task results")
+	}
+	operationRes := taskResult.GetCnsVolumeOperationResult()
+	if operationRes.Fault != nil {
+		t.Fatalf("Failed to unregister volume: fault=%+v", operationRes.Fault)
+	}
+	t.Logf("Volume unregistered successfully: %s", volumeId)
+}
+
 // isvSphereVersion70U3orAbove checks if specified version is 7.0 Update 3 or higher
 // The method takes aboutInfo{} as input which contains details about
 // VC version, build number and so on.

--- a/cns/methods/methods.go
+++ b/cns/methods/methods.go
@@ -375,3 +375,23 @@ func CnsSyncVolume(ctx context.Context, r soap.RoundTripper, req *types.CnsSyncV
 
 	return resBody.Res, nil
 }
+
+type CnsUnregisterVolumeBody struct {
+	Req    *types.CnsUnregisterVolume         `xml:"urn:vsan CnsUnregisterVolume,omitempty"`
+	Res    *types.CnsUnregisterVolumeResponse `xml:"urn:vsan CnsUnregisterVolumeResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsUnregisterVolumeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsUnregisterVolume(ctx context.Context, r soap.RoundTripper, req *types.CnsUnregisterVolume) (*types.CnsUnregisterVolumeResponse, error) {
+	var reqBody, resBody CnsUnregisterVolumeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/cns/types/enum.go
+++ b/cns/types/enum.go
@@ -95,3 +95,14 @@ const (
 func init() {
 	types.Add("vsan:CnsSyncVolumeMode", reflect.TypeOf((*CnsSyncVolumeMode)(nil)).Elem())
 }
+
+type CnsUnregisterTargetVolumeType string
+
+const (
+	CnsUnregisterTargetVolumeTypeFCD         = CnsUnregisterTargetVolumeType("FCD")
+	CnsUnregisterTargetVolumeTypeLEGACY_DISK = CnsUnregisterTargetVolumeType("LEGACY_DISK")
+)
+
+func init() {
+	types.Add("vsan:CnsUnregisterTargetVolumeType", reflect.TypeOf((*CnsUnregisterTargetVolumeType)(nil)).Elem())
+}

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -987,3 +987,33 @@ type CnsSyncVolumeSpec struct {
 func init() {
 	types.Add("vsan:CnsSyncVolumeSpec", reflect.TypeOf((*CnsSyncVolumeSpec)(nil)).Elem())
 }
+
+type CnsUnregisterVolume CnsUnregisterVolumeRequestType
+
+func init() {
+	types.Add("vsan:CnsUnregisterVolume", reflect.TypeOf((*CnsUnregisterVolume)(nil)).Elem())
+}
+
+type CnsUnregisterVolumeRequestType struct {
+	This           types.ManagedObjectReference `xml:"_this" json:"-"`
+	UnregisterSpec []CnsUnregisterVolumeSpec    `xml:"unregisterSpec,omitempty" json:"UnregisterSpec,omitempty"`
+}
+
+func init() {
+	types.Add("vsan:CnsUnregisterVolumeRequestType", reflect.TypeOf((*CnsUnregisterVolumeRequestType)(nil)).Elem())
+}
+
+type CnsUnregisterVolumeResponse struct {
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
+}
+
+type CnsUnregisterVolumeSpec struct {
+	types.DynamicData
+
+	VolumeId         CnsVolumeId `xml:"volumeId" json:"volumeId"`
+	TargetVolumeType string      `xml:"targetVolumeType" json:"targetVolumeType"`
+}
+
+func init() {
+	types.Add("vsan:CnsUnregisterVolumeSpec", reflect.TypeOf((*CnsUnregisterVolumeSpec)(nil)).Elem())
+}


### PR DESCRIPTION
## Description

Implements the bindings for CNSUnregisterVolume API

Closes: #(issue-number)

## How Has This Been Tested?

Tested the changes using `TestUnregisterVolume` function - 

1. Created a volume in the specified datastore
2. Unregistered the volume using CNSUnregisterVolume and convert it back to an FCD

**Test Logs:**

```
=== RUN   TestUnregisterVolume
    client_test.go:1908: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:eb9f416e-5d51-4aa4-86d2-21c5d311afc4} Fault:<nil>} Name:pvc-8708ec76-98e3-41e7-832a-cee1e5f47d23 PlacementResults:[{Datastore:Datastore:datastore-50 PlacementFaults:[] Clusters:[]}]}
    client_test.go:1909: Volume created successfully. volumeId: eb9f416e-5d51-4aa4-86d2-21c5d311afc4
    client_test.go:1936: Volume unregistered successfully: eb9f416e-5d51-4aa4-86d2-21c5d311afc4
```

3. Verified that the Volume is removed from CNS -
<img width="1253" height="519" alt="Screenshot 2025-08-04 at 1 10 11 PM" src="https://github.com/user-attachments/assets/beb78b78-e3b5-48cd-a791-bc13a8165bee" />

4. Verified that the volume still exists as an FCD
<img width="2534" height="664" alt="Screenshot 2025-08-04 at 1 23 52 PM" src="https://github.com/user-attachments/assets/39d6f582-8dc0-4fc1-87ac-aff914ca3bc2" />



## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
