### PR TITLE
binding for CnsKubernetesQueryFilter

### DIFF
--- a/cli/volume/ls.go
+++ b/cli/volume/ls.go
@@ -224,7 +224,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 	var info []types.BaseCnsVolumeOperationResult
 
 	for {
-		res, err := c.QueryVolume(ctx, cmd.CnsQueryFilter)
+		res, err := c.QueryVolume(ctx, &cmd.CnsQueryFilter)
 		if err != nil {
 			return err
 		}

--- a/cns/client.go
+++ b/cns/client.go
@@ -157,7 +157,7 @@ func (c *Client) DetachVolume(ctx context.Context, detachSpecList []cnstypes.Cns
 }
 
 // QueryVolume calls the CNS QueryVolume API.
-func (c *Client) QueryVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
+func (c *Client) QueryVolume(ctx context.Context, queryFilter cnstypes.BaseCnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
 	req := cnstypes.CnsQueryVolume{
 		This:   CnsVolumeManagerInstance,
 		Filter: queryFilter,

--- a/cns/simulator/simulator.go
+++ b/cns/simulator/simulator.go
@@ -6,9 +6,8 @@ package simulator
 
 import (
 	"context"
-	"time"
-
 	"slices"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -285,15 +284,15 @@ func matchesFilter(filter cnstypes.CnsQueryFilter, volume *types.CnsVolume) bool
 	return true
 }
 
-func (m *CnsVolumeManager) queryVolume(filter cnstypes.CnsQueryFilter) []cnstypes.CnsVolume {
+func (m *CnsVolumeManager) queryVolume(filter cnstypes.BaseCnsQueryFilter) []cnstypes.CnsVolume {
 	var matches []cnstypes.CnsVolume
 
 	for ds, volumes := range m.volumes {
-		if !matchesDatastore(filter, ds) {
+		if !matchesDatastore(*filter.GetCnsQueryFilter(), ds) {
 			continue
 		}
 		for _, volume := range volumes {
-			if matchesFilter(filter, volume) {
+			if matchesFilter(*filter.GetCnsQueryFilter(), volume) {
 				matches = append(matches, *volume)
 			}
 		}
@@ -321,7 +320,7 @@ func (m *CnsVolumeManager) CnsQueryAllVolume(ctx context.Context, req *cnstypes.
 	return &methods.CnsQueryAllVolumeBody{
 		Res: &cnstypes.CnsQueryAllVolumeResponse{
 			Returnval: cnstypes.CnsQueryResult{
-				Volumes: m.queryVolume(req.Filter),
+				Volumes: m.queryVolume(req.Filter.GetCnsQueryFilter()),
 			},
 		},
 	}

--- a/cns/simulator/simulator_test.go
+++ b/cns/simulator/simulator_test.go
@@ -51,7 +51,7 @@ func TestSimulator(t *testing.T) {
 	}
 	// Query
 	queryFilter := cnstypes.CnsQueryFilter{}
-	queryResult, err := cnsClient.QueryVolume(ctx, queryFilter)
+	queryResult, err := cnsClient.QueryVolume(ctx, &queryFilter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,7 +287,7 @@ func TestSimulator(t *testing.T) {
 
 	// Query
 	queryFilter = cnstypes.CnsQueryFilter{}
-	queryResult, err = cnsClient.QueryVolume(ctx, queryFilter)
+	queryResult, err = cnsClient.QueryVolume(ctx, &queryFilter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +321,7 @@ func TestSimulator(t *testing.T) {
 
 	// QueryVolume
 	queryFilter = cnstypes.CnsQueryFilter{}
-	queryResult, err = cnsClient.QueryVolume(ctx, queryFilter)
+	queryResult, err = cnsClient.QueryVolume(ctx, &queryFilter)
 	if err != nil {
 		t.Fatalf("Failed to query volume with QueryFilter: err=%+v", err)
 	}
@@ -585,7 +585,7 @@ func TestSimulator(t *testing.T) {
 	}
 
 	queryFilter = cnstypes.CnsQueryFilter{}
-	queryResult, err = cnsClient.QueryVolume(ctx, queryFilter)
+	queryResult, err = cnsClient.QueryVolume(ctx, &queryFilter)
 	if err != nil {
 		t.Fatalf("Failed to query volume with QueryFilter: err=%+v", err)
 	}

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -234,7 +234,7 @@ func init() {
 
 type CnsQueryVolumeRequestType struct {
 	This   types.ManagedObjectReference `xml:"_this" json:"-"`
-	Filter CnsQueryFilter               `xml:"filter" json:"filter"`
+	Filter BaseCnsQueryFilter           `xml:"filter,typeattr" json:"filter"`
 }
 
 func init() {
@@ -446,6 +446,10 @@ func init() {
 	types.Add("CnsVSANFileCreateSpec", reflect.TypeOf((*CnsVSANFileCreateSpec)(nil)).Elem())
 }
 
+type BaseCnsQueryFilter interface {
+	GetCnsQueryFilter() *CnsQueryFilter
+}
+
 type CnsQueryFilter struct {
 	types.DynamicData
 
@@ -461,8 +465,44 @@ type CnsQueryFilter struct {
 	HealthStatus                 string                         `xml:"healthStatus,omitempty" json:"healthStatus"`
 }
 
+func (f *CnsQueryFilter) GetCnsQueryFilter() *CnsQueryFilter {
+	return f
+}
+
+func (f *CnsKubernetesQueryFilter) GetCnsQueryFilter() *CnsQueryFilter {
+	return &f.CnsQueryFilter
+}
+
 func init() {
 	types.Add("CnsQueryFilter", reflect.TypeOf((*CnsQueryFilter)(nil)).Elem())
+}
+
+// CnsKubernetesQueryFilter enables querying CNS volumes using Kubernetes metadata such as
+// namespaces, pod names, PVC names, and PV names.
+//
+// - Values in the PodNames, PvcNames, and PvNames lists are treated as OR conditions.
+// - Values in the Namespaces list are also treated as OR conditions.
+// - When PodNames, PvcNames, or PvNames are specified along with Namespaces,
+//   the filter applies an AND condition — i.e., the pod, PVC must belong to the specified namespace.
+// - When only Namespaces are provided (without any pod, PVC names),
+//   all volumes associated with those namespaces will be returned.
+//
+// This allows flexible volume queries such as:
+// - Listing all volumes in one or more namespaces.
+// - Querying volumes associated with specific PVCs or pods within a given namespace.
+// - Finding volumes by specific PV names within specified namespaces.
+type CnsKubernetesQueryFilter struct {
+	CnsQueryFilter
+
+	Namespaces []string `xml:"namespaces,omitempty" json:"namespaces,omitempty"`
+	PodNames   []string `xml:"podNames,omitempty" json:"podNames,omitempty"`
+	PvcNames   []string `xml:"pvcNames,omitempty" json:"pvcNames,omitempty"`
+	PvNames    []string `xml:"pvNames,omitempty" json:"pvNames,omitempty"`
+}
+
+func init() {
+	types.Add("CnsKubernetesQueryFilter", reflect.TypeOf((*CnsKubernetesQueryFilter)(nil)).Elem())
+
 }
 
 type CnsQuerySelection struct {


### PR DESCRIPTION
## Description

This PR is adding go binding for CnsKubernetesQueryFilter

## How Has This Been Tested?

Verified executing test against vCenter and confirmed QueryVolume API using CnsKubernetesQueryFilter as filter and CnsQueryFilter as filter working as expected.


Request with KubernetesQueryFilter

```
<Envelope
	xmlns="http://schemas.xmlsoap.org/soap/envelope/">
	<Body>
		<CnsQueryVolume
			xmlns="urn:vsan">
			<_this type="CnsVolumeManager">cns-volume-manager</_this>
			<filter
				xmlns:_XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" _XMLSchema-instance:type="CnsKubernetesQueryFilter">
				<containerClusterIds>demo-cluster-id</containerClusterIds>
				<namespaces>default</namespaces>
			</filter>
		</CnsQueryVolume>
	</Body>
```

Response of QueryVolume API using KubernetesQueryFilter

```
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope
	xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
	xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
	<soapenv:Body>
		<CnsQueryVolumeResponse
			xmlns="urn:vsan">
			<returnval>
				<volumes>
					<volumeId>
						<id>aecb70f2-344c-4f97-bba9-ebe568057ae5</id>
					</volumeId>
					<datastoreUrl>ds:///vmfs/volumes/6889247d-1c83cea6-a811-020078bf71bd/</datastoreUrl>
					<name>pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0</name>
					<volumeType>BLOCK</volumeType>
					<metadata>
						<containerCluster>
							<clusterType>KUBERNETES</clusterType>
							<clusterId>demo-cluster-id</clusterId>
							<vSphereUser>Administrator@vsphere.local</vSphereUser>
							<clusterFlavor>VANILLA</clusterFlavor>
							<clusterDistribution>OpenShift</clusterDistribution>
							<delete>false</delete>
						</containerCluster>
						<entityMetadata xsi:type="CnsKubernetesEntityMetadata">
							<entityName>example-pod</entityName>
							<delete>false</delete>
							<clusterId>demo-cluster-id</clusterId>
							<entityType>POD</entityType>
							<namespace>default</namespace>
							<referredEntity>
								<entityType>PERSISTENT_VOLUME_CLAIM</entityType>
								<entityName>example-vanilla-block-pvc</entityName>
								<namespace>default</namespace>
								<clusterId>demo-cluster-id</clusterId>
							</referredEntity>
						</entityMetadata>
						<entityMetadata xsi:type="CnsKubernetesEntityMetadata">
							<entityName>example-vanilla-block-pvc</entityName>
							<labels>
								<key
									xmlns="urn:vim25">testLabel
								</key>
								<value
									xmlns="urn:vim25">testValue
								</value>
							</labels>
							<delete>false</delete>
							<clusterId>demo-cluster-id</clusterId>
							<entityType>PERSISTENT_VOLUME_CLAIM</entityType>
							<namespace>default</namespace>
							<referredEntity>
								<entityType>PERSISTENT_VOLUME</entityType>
								<entityName>pvc-53465372-5c12-4818-96f8-0ace4f4fd116</entityName>
								<namespace></namespace>
								<clusterId>demo-cluster-id</clusterId>
							</referredEntity>
						</entityMetadata>
						<entityMetadata xsi:type="CnsKubernetesEntityMetadata">
							<entityName>pvc-53465372-5c12-4818-96f8-0ace4f4fd116</entityName>
							<labels>
								<key
									xmlns="urn:vim25">testLabel
								</key>
								<value
									xmlns="urn:vim25">testValue
								</value>
							</labels>
							<delete>false</delete>
							<clusterId>demo-cluster-id</clusterId>
							<entityType>PERSISTENT_VOLUME</entityType>
							<namespace></namespace>
						</entityMetadata>
						<containerClusterArray>
							<clusterType>KUBERNETES</clusterType>
							<clusterId>demo-cluster-id</clusterId>
							<vSphereUser>Administrator@vsphere.local</vSphereUser>
							<clusterFlavor>VANILLA</clusterFlavor>
							<clusterDistribution>OpenShift</clusterDistribution>
							<delete>false</delete>
						</containerClusterArray>
					</metadata>
					<backingObjectDetails xsi:type="CnsBlockBackingDetails">
						<capacityInMb>10240</capacityInMb>
						<backingDiskId>aecb70f2-344c-4f97-bba9-ebe568057ae5</backingDiskId>
						<backingDiskPath>[sharedVmfs-0] fcd/a6633619fa95426eb894bd41e7cf889d.vmdk</backingDiskPath>
						<backingDiskObjectId></backingDiskObjectId>
						<usedCapacityInMb>-1</usedCapacityInMb>
						<aggregatedSnapshotCapacityInMb>0</aggregatedSnapshotCapacityInMb>
					</backingObjectDetails>
					<datastoreAccessibilityStatus>accessible</datastoreAccessibilityStatus>
					<healthStatus>green</healthStatus>
				</volumes>
				<cursor>
					<offset>1</offset>
					<limit>1000</limit>
					<totalRecords>1</totalRecords>
				</cursor>
			</returnval>
		</CnsQueryVolumeResponse>
	</soapenv:Body>
</soapenv:Envelope>
```


Request with QueryFilter

```
<?xml version="1.0" encoding="UTF-8"?>
<Envelope
	xmlns="http://schemas.xmlsoap.org/soap/envelope/">
	<Body>
		<CnsQueryVolume
			xmlns="urn:vsan">
			<_this type="CnsVolumeManager">cns-volume-manager</_this>
			<filter
				xmlns:_XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" _XMLSchema-instance:type="CnsQueryFilter">
				<volumeIds>
					<id>aecb70f2-344c-4f97-bba9-ebe568057ae5</id>
				</volumeIds>
			</filter>
		</CnsQueryVolume>
	</Body>
</Envelope>`
```

Response for QueryVolume API with QueryFilter

```
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope
	xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
	xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
	<soapenv:Body>
		<CnsQueryVolumeResponse
			xmlns="urn:vsan">
			<returnval>
				<volumes>
					<volumeId>
						<id>aecb70f2-344c-4f97-bba9-ebe568057ae5</id>
					</volumeId>
					<datastoreUrl>ds:///vmfs/volumes/6889247d-1c83cea6-a811-020078bf71bd/</datastoreUrl>
					<name>pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0</name>
					<volumeType>BLOCK</volumeType>
					<metadata>
						<containerCluster>
							<clusterType>KUBERNETES</clusterType>
							<clusterId>demo-cluster-id</clusterId>
							<vSphereUser>Administrator@vsphere.local</vSphereUser>
							<clusterFlavor>VANILLA</clusterFlavor>
							<clusterDistribution>OpenShift</clusterDistribution>
							<delete>false</delete>
						</containerCluster>
						<containerClusterArray>
							<clusterType>KUBERNETES</clusterType>
							<clusterId>demo-cluster-id</clusterId>
							<vSphereUser>Administrator@vsphere.local</vSphereUser>
							<clusterFlavor>VANILLA</clusterFlavor>
							<clusterDistribution>OpenShift</clusterDistribution>
							<delete>false</delete>
						</containerClusterArray>
					</metadata>
					<backingObjectDetails xsi:type="CnsBlockBackingDetails">
						<capacityInMb>5120</capacityInMb>
						<backingDiskId>aecb70f2-344c-4f97-bba9-ebe568057ae5</backingDiskId>
						<backingDiskPath>[sharedVmfs-0] fcd/a6633619fa95426eb894bd41e7cf889d.vmdk</backingDiskPath>
						<backingDiskObjectId></backingDiskObjectId>
						<usedCapacityInMb>-1</usedCapacityInMb>
						<aggregatedSnapshotCapacityInMb>0</aggregatedSnapshotCapacityInMb>
					</backingObjectDetails>
					<datastoreAccessibilityStatus>accessible</datastoreAccessibilityStatus>
					<healthStatus>green</healthStatus>
				</volumes>
				<cursor>
					<offset>1</offset>
					<limit>1000</limit>
					<totalRecords>1</totalRecords>
				</cursor>
			</returnval>
		</CnsQueryVolumeResponse>
	</soapenv:Body>
</soapenv:Envelope>
```

Logs:
[test.log](https://github.com/user-attachments/files/21585866/test.log)






## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
