### PR TITLE
Add tests for syncvolume api and update json tags 

### DIFF
--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -1763,34 +1763,34 @@ func TestClient(t *testing.T) {
 	t.Logf("syncDatastore on %v with full sync successful\n", dsUrl)
 
 	// Test CnsSyncVolume API
-	/*
-		t.Logf("Calling syncVolume for volumeId: %v ...\n", volumeId)
-		var cnsSyncVolumeSpecs []cnstypes.CnsSyncVolumeSpec
-		dataStore := ds.Reference()
-		cnsSyncVolumeSpec := cnstypes.CnsSyncVolumeSpec{
-			VolumeId: cnstypes.CnsVolumeId{
-				Id: volumeId,
-			},
-			Datastore: &dataStore,
-			SyncMode:  []string{string(cnstypes.CnsSyncVolumeModeSPACE_USAGE)},
-		}
-		cnsSyncVolumeSpecs = append(cnsSyncVolumeSpecs, cnsSyncVolumeSpec)
-		syncVolumeTask, err := cnsClient.SyncVolume(ctx, cnsSyncVolumeSpecs)
-		if err != nil {
-			t.Errorf("Failed to sync volume %v. Error: %+v \n", volumeId, err)
-			t.Fatal(err)
-		}
-		syncVolumeTaskInfo, err := GetTaskInfo(ctx, syncVolumeTask)
-		if err != nil {
-			t.Errorf("Failed to get sync volume taskInfo. Error: %+v \n", err)
-			t.Fatal(err)
-		}
-		if syncVolumeTaskInfo.State != vim25types.TaskInfoStateSuccess {
-			t.Errorf("Failed to sync volume. Error: %+v \n", syncVolumeTaskInfo.Error)
-			t.Fatalf("%+v", syncVolumeTaskInfo.Error)
-		}
-		t.Logf("syncVolume for volumeId: %v successful...\n", volumeId)
-	*/
+
+	t.Logf("Calling syncVolume for volumeId: %v ...\n", volumeId)
+	var cnsSyncVolumeSpecs []cnstypes.CnsSyncVolumeSpec
+	dataStore := ds.Reference()
+	cnsSyncVolumeSpec := cnstypes.CnsSyncVolumeSpec{
+		VolumeId: cnstypes.CnsVolumeId{
+			Id: volumeId,
+		},
+		Datastore: &dataStore,
+		SyncMode:  []string{string(cnstypes.CnsSyncVolumeModeSPACE_USAGE)},
+	}
+
+	cnsSyncVolumeSpecs = append(cnsSyncVolumeSpecs, cnsSyncVolumeSpec)
+	syncVolumeTask, err := cnsClient.SyncVolume(ctx, cnsSyncVolumeSpecs)
+	if err != nil {
+		t.Errorf("Failed to sync volume %v. Error: %+v \n", volumeId, err)
+		t.Fatal(err)
+	}
+	syncVolumeTaskInfo, err := GetTaskInfo(ctx, syncVolumeTask)
+	if err != nil {
+		t.Errorf("Failed to get sync volume taskInfo. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	if syncVolumeTaskInfo.State != vim25types.TaskInfoStateSuccess {
+		t.Errorf("Failed to sync volume. Error: %+v \n", syncVolumeTaskInfo.Error)
+		t.Fatalf("%+v", syncVolumeTaskInfo.Error)
+	}
+	t.Logf("syncVolume for volumeId: %v successful...\n", volumeId)
 
 }
 

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -964,8 +964,8 @@ func init() {
 }
 
 type CnsSyncVolumeRequestType struct {
-	This      types.ManagedObjectReference `xml:"_this"`
-	SyncSpecs []CnsSyncVolumeSpec          `xml:"syncSpecs,omitempty"`
+	This      types.ManagedObjectReference `xml:"_this" json:"-"`
+	SyncSpecs []CnsSyncVolumeSpec          `xml:"syncSpecs,omitempty" json:"syncSpecs,omitempty"`
 }
 
 func init() {
@@ -973,15 +973,15 @@ func init() {
 }
 
 type CnsSyncVolumeResponse struct {
-	Returnval types.ManagedObjectReference `xml:"returnval"`
+	Returnval types.ManagedObjectReference `xml:"returnval" json:"returnval"`
 }
 
 type CnsSyncVolumeSpec struct {
 	types.DynamicData
 
-	VolumeId  CnsVolumeId                   `xml:"volumeId"`
-	Datastore *types.ManagedObjectReference `xml:"datastore,omitempty"`
-	SyncMode  []string                      `xml:"syncMode,omitempty"`
+	VolumeId  CnsVolumeId                   `xml:"volumeId" json:"volumeId"`
+	Datastore *types.ManagedObjectReference `xml:"datastore,omitempty" json:"datastore,omitempty"`
+	SyncMode  []string                      `xml:"syncMode,omitempty" json:"syncMode,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
## Description
Added json tags to cns syncvolume api types
Added unit test for sync volume api 
(tests were commented out earlier as SyncVolume Api was not ready ref PR [#3813](https://github.com/vmware/govmomi/pull/3813))

Closes: #(issue-number)

## How Has This Been Tested?
Ran unit tests.
1. Created a volume in the specified datastore
2. Synced Volume the volume using CNSSyncVolume.

**Test Logs:**
```
=== RUN   TestClient
    client_test.go:206: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:7bb81711-2884-425b-acb7-73a1cb76ae8d} Fault:<nil>} Name:pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0 PlacementResults:[{Datastore:Datastore:datastore-42 PlacementFaults:[] Clusters:[]}]}
    client_test.go:213: Volume created successfully. volumeId: 7bb81711-2884-425b-acb7-73a1cb76ae8d
    client_test.go:1738: Calling syncVolume for volumeId: 62c82cc9-a50b-43b0-ac71-da77760c80ae ...
    client_test.go:1764: syncVolume for volumeId: {{} 7bb81711-2884-425b-acb7-73a1cb76ae8d} successful...
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
