### PR TITLE
vcsim : Remove the single VM limitation for PlaceVmsXCluster API

### DIFF
--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -1138,7 +1138,6 @@ func (f *Folder) PlaceVmsXCluster(ctx *Context, req *types.PlaceVmsXCluster) soa
 	}
 
 	pools := req.PlacementSpec.ResourcePools
-	specs := req.PlacementSpec.VmPlacementSpecs
 
 	if len(pools) == 0 {
 		body.Fault_ = Fault("", &types.InvalidArgument{InvalidProperty: "resourcePools"})
@@ -1159,12 +1158,6 @@ func (f *Folder) PlaceVmsXCluster(ctx *Context, req *types.PlaceVmsXCluster) soa
 			return body
 		}
 		clusters[pool.Owner] = struct{}{}
-	}
-
-	// MVP: Only a single VM placement spec is supported.
-	if len(specs) != 1 {
-		body.Fault_ = Fault("", &types.InvalidArgument{InvalidProperty: "vmPlacementSpecs"})
-		return body
 	}
 
 	placementType := types.PlaceVmsXClusterSpecPlacementType(req.PlacementSpec.PlacementType)


### PR DESCRIPTION
## Description

Currently, PlaceVmsXCluster API supports placement of only one VM at a time. In VCF 9.1, the API will support placing multiple VMs in a single call.

In this PR, I am removing the check which validates if the length of VmPlacementSpecs is equal to 1.

Also, added a new test  to verify that the placement passes with multiple VMs in input spec.

Closes: #CRM-3431

## How Has This Been Tested?

[# govmomi]$ go test ./simulator
ok      github.com/vmware/govmomi/simulator     65.270s

[# govmomi]$ go test -v ./simulator -run ^TestPlaceVmsXCluster
=== RUN   TestPlaceVmsXClusterCreateAndPowerOn
--- PASS: TestPlaceVmsXClusterCreateAndPowerOn (0.81s)
=== RUN   TestPlaceVmsXClusterCreateAndPowerOnWithCandidateNetworks
--- PASS: TestPlaceVmsXClusterCreateAndPowerOnWithCandidateNetworks (0.81s)
=== RUN   TestPlaceVmsXClusterRelocate
--- PASS: TestPlaceVmsXClusterRelocate (1.00s)
=== RUN   TestPlaceVmsXClusterReconfigure
--- PASS: TestPlaceVmsXClusterReconfigure (0.26s)
=== RUN   TestPlaceVmsXClusterCreateAndPowerOnWithMultipleVms
--- PASS: TestPlaceVmsXClusterCreateAndPowerOnWithMultipleVms (0.81s)
PASS
ok      github.com/vmware/govmomi/simulator     3.703s

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
