### PR TITLE
fix: guard against nil role in permissions.ls

### DIFF
--- a/cli/permissions/permissions.go
+++ b/cli/permissions/permissions.go
@@ -123,7 +123,10 @@ func (l *List) Write(w io.Writer) error {
 			propagate = "Yes"
 		}
 
-		name := l.Roles.ById(perm.RoleId).Name
+		name := fmt.Sprintf("%d", perm.RoleId)
+		if r := l.Roles.ById(perm.RoleId); r != nil {
+			name = r.Name
+		}
 
 		p := "-"
 		if perm.Entity != nil {


### PR DESCRIPTION
### Description

Safely handle cases where the role may not exist by defaulting to the role ID as a string, and only using the role name if it is present.

Updates the role name display in `func (l *List) Write(w io.Writer) error` in `cli/permissions/permissions.go`, preventing potential nil pointer errors by falling back to the role ID when the role is not found.

Closes #3833