### PR TITLE
api: Helpers for GuestID->Family/CIMOSType

### DIFF
--- a/ovf/cim.go
+++ b/ovf/cim.go
@@ -159,3 +159,564 @@ type CIMStorageAllocationSettingData struct {
 	VirtualResourceBlockSize     *uint64         `xml:"VirtualResourceBlockSize" json:"virtualResourceBlockSize,omitempty"`
 	Weight                       *uint           `xml:"Weight" json:"weight,omitempty"`
 }
+
+// CIMOSType represents the CIM (Common Information Model) OSType enumeration
+// values. These values are defined by the DMTF CIM schema and used in various
+// management standards. Please refer to the following URL for more information:
+// https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/cim-operatingsystem
+type CIMOSType int
+
+const (
+	CIMOSTypeUnknown                          CIMOSType = 0
+	CIMOSTypeOther                            CIMOSType = 1
+	CIMOSTypeMACOS                            CIMOSType = 2
+	CIMOSTypeATTUNIX                          CIMOSType = 3
+	CIMOSTypeDGUX                             CIMOSType = 4
+	CIMOSTypeDECNT                            CIMOSType = 5
+	CIMOSTypeTru64UNIX                        CIMOSType = 6
+	CIMOSTypeOpenVMS                          CIMOSType = 7
+	CIMOSTypeHPUX                             CIMOSType = 8
+	CIMOSTypeAIX                              CIMOSType = 9
+	CIMOSTypeMVS                              CIMOSType = 10
+	CIMOSTypeOS400                            CIMOSType = 11
+	CIMOSTypeOS2                              CIMOSType = 12
+	CIMOSTypeJavaMachine                      CIMOSType = 13
+	CIMOSTypeMSDOS                            CIMOSType = 14
+	CIMOSTypeWIN3x                            CIMOSType = 15
+	CIMOSTypeWIN95                            CIMOSType = 16
+	CIMOSTypeWIN98                            CIMOSType = 17
+	CIMOSTypeWINNT                            CIMOSType = 18
+	CIMOSTypeWINCE                            CIMOSType = 19
+	CIMOSTypeNCR3000                          CIMOSType = 20
+	CIMOSTypeNetWare                          CIMOSType = 21
+	CIMOSTypeOSF                              CIMOSType = 22
+	CIMOSTypeDCOS                             CIMOSType = 23
+	CIMOSTypeReliantUNIX                      CIMOSType = 24
+	CIMOSTypeSCOUnixWare                      CIMOSType = 25
+	CIMOSTypeSCOOpenServer                    CIMOSType = 26
+	CIMOSTypeSequent                          CIMOSType = 27
+	CIMOSTypeIRIX                             CIMOSType = 28
+	CIMOSTypeSolaris                          CIMOSType = 29
+	CIMOSTypeSunOS                            CIMOSType = 30
+	CIMOSTypeU6000                            CIMOSType = 31
+	CIMOSTypeASERIES                          CIMOSType = 32
+	CIMOSTypeTandemNSK                        CIMOSType = 33
+	CIMOSTypeTandemNT                         CIMOSType = 34
+	CIMOSTypeBS2000                           CIMOSType = 35
+	CIMOSTypeLINUX                            CIMOSType = 36
+	CIMOSTypeLynx                             CIMOSType = 37
+	CIMOSTypeXENIX                            CIMOSType = 38
+	CIMOSTypeVMESA                            CIMOSType = 39
+	CIMOSTypeInteractive                      CIMOSType = 40
+	CIMOSTypeBSDUNIX                          CIMOSType = 41
+	CIMOSTypeFreeBSD                          CIMOSType = 42
+	CIMOSTypeNetBSD                           CIMOSType = 43
+	CIMOSTypeGNUHurd                          CIMOSType = 44
+	CIMOSTypeOS9                              CIMOSType = 45
+	CIMOSTypeMACHKernel                       CIMOSType = 46
+	CIMOSTypeInferno                          CIMOSType = 47
+	CIMOSTypeQNX                              CIMOSType = 48
+	CIMOSTypeEPOC                             CIMOSType = 49
+	CIMOSTypeIXWorks                          CIMOSType = 50
+	CIMOSTypeVxWorks                          CIMOSType = 51
+	CIMOSTypeMiNT                             CIMOSType = 52
+	CIMOSTypeBeOS                             CIMOSType = 53
+	CIMOSTypeHPMPE                            CIMOSType = 54
+	CIMOSTypeNextStep                         CIMOSType = 55
+	CIMOSTypePalmPilot                        CIMOSType = 56
+	CIMOSTypeRhapsody                         CIMOSType = 57
+	CIMOSTypeWindows2000                      CIMOSType = 58
+	CIMOSTypeDedicated                        CIMOSType = 59
+	CIMOSTypeOS390                            CIMOSType = 60
+	CIMOSTypeVSE                              CIMOSType = 61
+	CIMOSTypeTPF                              CIMOSType = 62
+	CIMOSTypeWindowsMe                        CIMOSType = 63
+	CIMOSTypeCalderaOpenUNIX                  CIMOSType = 64
+	CIMOSTypeOpenBSD                          CIMOSType = 65
+	CIMOSTypeNotApplicable                    CIMOSType = 66
+	CIMOSTypeWindowsXP                        CIMOSType = 67
+	CIMOSTypezOS                              CIMOSType = 68
+	CIMOSTypeMicrosoftWindowsServer2003       CIMOSType = 69
+	CIMOSTypeMicrosoftWindowsServer2003_64Bit CIMOSType = 70
+	CIMOSTypeWindowsXP64Bit                   CIMOSType = 71
+	CIMOSTypeWindowsXPEmbedded                CIMOSType = 72
+	CIMOSTypeWindowsVista                     CIMOSType = 73
+	CIMOSTypeWindowsVista64Bit                CIMOSType = 74
+	CIMOSTypeWindowsEmbeddedforPointofService CIMOSType = 75
+	CIMOSTypeMicrosoftWindowsServer2008       CIMOSType = 76
+	CIMOSTypeMicrosoftWindowsServer2008_64Bit CIMOSType = 77
+	CIMOSTypeFreeBSD64Bit                     CIMOSType = 78
+	CIMOSTypeRedHatEnterpriseLinux            CIMOSType = 79
+	CIMOSTypeRedHatEnterpriseLinux64Bit       CIMOSType = 80
+	CIMOSTypeSolaris64Bit                     CIMOSType = 81
+	CIMOSTypeSUSE                             CIMOSType = 82
+	CIMOSTypeSUSE64Bit                        CIMOSType = 83
+	CIMOSTypeSLES                             CIMOSType = 84
+	CIMOSTypeSLES64Bit                        CIMOSType = 85
+	CIMOSTypeNovellOES                        CIMOSType = 86
+	CIMOSTypeNovellLinuxDesktop               CIMOSType = 87
+	CIMOSTypeSunJavaDesktopSystem             CIMOSType = 88
+	CIMOSTypeMandriva                         CIMOSType = 89
+	CIMOSTypeMandriva64Bit                    CIMOSType = 90
+	CIMOSTypeTurboLinux                       CIMOSType = 91
+	CIMOSTypeTurboLinux64Bit                  CIMOSType = 92
+	CIMOSTypeUbuntu                           CIMOSType = 93
+	CIMOSTypeUbuntu64Bit                      CIMOSType = 94
+	CIMOSTypeDebian                           CIMOSType = 95
+	CIMOSTypeDebian64Bit                      CIMOSType = 96
+	CIMOSTypeLinux24x                         CIMOSType = 97
+	CIMOSTypeLinux24x64Bit                    CIMOSType = 98
+	CIMOSTypeLinux26x                         CIMOSType = 99
+	CIMOSTypeLinux26x64Bit                    CIMOSType = 100
+	CIMOSTypeLinux64Bit                       CIMOSType = 101
+	CIMOSTypeOther64Bit                       CIMOSType = 102
+	CIMOSTypeMicrosoftWindowsServer2008R2     CIMOSType = 103
+	CIMOSTypeVMwareESXi                       CIMOSType = 104
+	CIMOSTypeMicrosoftWindows7                CIMOSType = 105
+	CIMOSTypeCentOS32bit                      CIMOSType = 106
+	CIMOSTypeCentOS64bit                      CIMOSType = 107
+	CIMOSTypeOracle32bit                      CIMOSType = 108
+	CIMOSTypeOracle64bit                      CIMOSType = 109
+	CIMOSTypeeComStation32bitx                CIMOSType = 110
+	CIMOSTypeMicrosoftWindowsServer2011       CIMOSType = 111
+	CIMOSTypeMicrosoftWindowsServer2012       CIMOSType = 112
+	CIMOSTypeMicrosoftWindows8                CIMOSType = 113
+	CIMOSTypeMicrosoftWindows81               CIMOSType = 114
+	CIMOSTypeMicrosoftWindowsServer2012R2     CIMOSType = 115
+)
+
+// GuestIDToCIMOSType translates a vSphere Guest OS identifier to a CIM
+// OSType value.
+func GuestIDToCIMOSType[T ~string](guestID T) CIMOSType {
+	switch types.VirtualMachineGuestOsIdentifier(guestID) {
+	// Windows Desktop
+	case types.VirtualMachineGuestOsIdentifierDosGuest:
+		return CIMOSTypeMSDOS
+	case types.VirtualMachineGuestOsIdentifierWin31Guest:
+		return CIMOSTypeWIN3x
+	case types.VirtualMachineGuestOsIdentifierWin95Guest:
+		return CIMOSTypeWIN95
+	case types.VirtualMachineGuestOsIdentifierWin98Guest:
+		return CIMOSTypeWIN98
+	case types.VirtualMachineGuestOsIdentifierWinMeGuest:
+		return CIMOSTypeWindowsMe
+	case types.VirtualMachineGuestOsIdentifierWinNTGuest:
+		return CIMOSTypeWINNT
+	case types.VirtualMachineGuestOsIdentifierWin2000ProGuest:
+		return CIMOSTypeWindows2000
+	case types.VirtualMachineGuestOsIdentifierWin2000ServGuest:
+		return CIMOSTypeWindows2000
+	case types.VirtualMachineGuestOsIdentifierWin2000AdvServGuest:
+		return CIMOSTypeWindows2000
+	case types.VirtualMachineGuestOsIdentifierWinXPHomeGuest:
+		return CIMOSTypeWindowsXP
+	case types.VirtualMachineGuestOsIdentifierWinXPProGuest:
+		return CIMOSTypeWindowsXP
+	case types.VirtualMachineGuestOsIdentifierWinXPPro64Guest:
+		return CIMOSTypeWindowsXP64Bit
+	case types.VirtualMachineGuestOsIdentifierWinVistaGuest:
+		return CIMOSTypeWindowsVista
+	case types.VirtualMachineGuestOsIdentifierWinVista64Guest:
+		return CIMOSTypeWindowsVista64Bit
+	case types.VirtualMachineGuestOsIdentifierWindows7Guest:
+		return CIMOSTypeMicrosoftWindows7
+	case types.VirtualMachineGuestOsIdentifierWindows7_64Guest:
+		return CIMOSTypeMicrosoftWindows7
+	case types.VirtualMachineGuestOsIdentifierWindows8Guest:
+		return CIMOSTypeMicrosoftWindows8
+	case types.VirtualMachineGuestOsIdentifierWindows8_64Guest:
+		return CIMOSTypeMicrosoftWindows8
+	// TODO(akutz) The following guest IDs do not exist.
+	/*
+		case types.VirtualMachineGuestOsIdentifierWindows81Guest:
+			return CIMOSTypeMicrosoftWindows81
+		case types.VirtualMachineGuestOsIdentifierWindows81_64Guest:
+			return CIMOSTypeMicrosoftWindows81
+	*/
+	case types.VirtualMachineGuestOsIdentifierWindows9Guest:
+		return CIMOSTypeOther // Windows 10/11 - no specific CIM type
+	case types.VirtualMachineGuestOsIdentifierWindows9_64Guest:
+		return CIMOSTypeOther64Bit
+	case types.VirtualMachineGuestOsIdentifierWindows11_64Guest:
+		return CIMOSTypeOther64Bit
+	case types.VirtualMachineGuestOsIdentifierWindows12_64Guest:
+		return CIMOSTypeOther64Bit
+	case types.VirtualMachineGuestOsIdentifierWindowsHyperVGuest:
+		return CIMOSTypeOther64Bit
+
+	// Windows Server
+	case types.VirtualMachineGuestOsIdentifierWinNetEnterpriseGuest:
+		return CIMOSTypeMicrosoftWindowsServer2003
+	case types.VirtualMachineGuestOsIdentifierWinNetDatacenterGuest:
+		return CIMOSTypeMicrosoftWindowsServer2003
+	case types.VirtualMachineGuestOsIdentifierWinNetBusinessGuest:
+		return CIMOSTypeMicrosoftWindowsServer2003
+	case types.VirtualMachineGuestOsIdentifierWinNetStandardGuest:
+		return CIMOSTypeMicrosoftWindowsServer2003
+	case types.VirtualMachineGuestOsIdentifierWinNetWebGuest:
+		return CIMOSTypeMicrosoftWindowsServer2003
+	case types.VirtualMachineGuestOsIdentifierWinNetEnterprise64Guest:
+		return CIMOSTypeMicrosoftWindowsServer2003_64Bit
+	case types.VirtualMachineGuestOsIdentifierWinNetDatacenter64Guest:
+		return CIMOSTypeMicrosoftWindowsServer2003_64Bit
+	case types.VirtualMachineGuestOsIdentifierWinNetStandard64Guest:
+		return CIMOSTypeMicrosoftWindowsServer2003_64Bit
+	case types.VirtualMachineGuestOsIdentifierWinLonghornGuest:
+		return CIMOSTypeMicrosoftWindowsServer2008
+	case types.VirtualMachineGuestOsIdentifierWinLonghorn64Guest:
+		return CIMOSTypeMicrosoftWindowsServer2008_64Bit
+	case types.VirtualMachineGuestOsIdentifierWindows7Server64Guest:
+		return CIMOSTypeMicrosoftWindowsServer2008R2
+	case types.VirtualMachineGuestOsIdentifierWindows8Server64Guest:
+		return CIMOSTypeMicrosoftWindowsServer2012
+	case types.VirtualMachineGuestOsIdentifierWindows9Server64Guest:
+		return CIMOSTypeMicrosoftWindowsServer2012R2
+	case types.VirtualMachineGuestOsIdentifierWindows2019srv_64Guest:
+		return CIMOSTypeOther64Bit // No specific CIM type for 2019+
+	case types.VirtualMachineGuestOsIdentifierWindows2019srvNext_64Guest:
+		return CIMOSTypeOther64Bit
+	case types.VirtualMachineGuestOsIdentifierWindows2022srvNext_64Guest:
+		return CIMOSTypeOther64Bit
+
+	// Linux
+	case types.VirtualMachineGuestOsIdentifierAsianux3Guest:
+		return CIMOSTypeLINUX
+	case types.VirtualMachineGuestOsIdentifierAsianux3_64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierAsianux4Guest:
+		return CIMOSTypeLINUX
+	case types.VirtualMachineGuestOsIdentifierAsianux4_64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierAsianux5_64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierAsianux7_64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierAsianux8_64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierAsianux9_64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierCentos6Guest:
+		return CIMOSTypeCentOS32bit
+	case types.VirtualMachineGuestOsIdentifierCentos6_64Guest:
+		return CIMOSTypeCentOS64bit
+	case types.VirtualMachineGuestOsIdentifierCentos7Guest:
+		return CIMOSTypeCentOS32bit
+	case types.VirtualMachineGuestOsIdentifierCentos7_64Guest:
+		return CIMOSTypeCentOS64bit
+	case types.VirtualMachineGuestOsIdentifierCentos8_64Guest:
+		return CIMOSTypeCentOS64bit
+	case types.VirtualMachineGuestOsIdentifierCentos9_64Guest:
+		return CIMOSTypeCentOS64bit
+	case types.VirtualMachineGuestOsIdentifierCoreos64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierDebian4Guest:
+		return CIMOSTypeDebian
+	case types.VirtualMachineGuestOsIdentifierDebian4_64Guest:
+		return CIMOSTypeDebian64Bit
+	case types.VirtualMachineGuestOsIdentifierDebian5Guest:
+		return CIMOSTypeDebian
+	case types.VirtualMachineGuestOsIdentifierDebian5_64Guest:
+		return CIMOSTypeDebian64Bit
+	case types.VirtualMachineGuestOsIdentifierDebian6Guest:
+		return CIMOSTypeDebian
+	case types.VirtualMachineGuestOsIdentifierDebian6_64Guest:
+		return CIMOSTypeDebian64Bit
+	case types.VirtualMachineGuestOsIdentifierDebian7Guest:
+		return CIMOSTypeDebian
+	case types.VirtualMachineGuestOsIdentifierDebian7_64Guest:
+		return CIMOSTypeDebian64Bit
+	case types.VirtualMachineGuestOsIdentifierDebian8Guest:
+		return CIMOSTypeDebian
+	case types.VirtualMachineGuestOsIdentifierDebian8_64Guest:
+		return CIMOSTypeDebian64Bit
+	case types.VirtualMachineGuestOsIdentifierDebian9Guest:
+		return CIMOSTypeDebian
+	case types.VirtualMachineGuestOsIdentifierDebian9_64Guest:
+		return CIMOSTypeDebian64Bit
+	case types.VirtualMachineGuestOsIdentifierDebian10Guest:
+		return CIMOSTypeDebian
+	case types.VirtualMachineGuestOsIdentifierDebian10_64Guest:
+		return CIMOSTypeDebian64Bit
+	case types.VirtualMachineGuestOsIdentifierDebian11Guest:
+		return CIMOSTypeDebian
+	case types.VirtualMachineGuestOsIdentifierDebian11_64Guest:
+		return CIMOSTypeDebian64Bit
+	case types.VirtualMachineGuestOsIdentifierDebian12Guest:
+		return CIMOSTypeDebian
+	case types.VirtualMachineGuestOsIdentifierDebian12_64Guest:
+		return CIMOSTypeDebian64Bit
+	case types.VirtualMachineGuestOsIdentifierFedoraGuest:
+		return CIMOSTypeLINUX
+	case types.VirtualMachineGuestOsIdentifierFedora64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierFreebsd11Guest:
+		return CIMOSTypeFreeBSD
+	case types.VirtualMachineGuestOsIdentifierFreebsd11_64Guest:
+		return CIMOSTypeFreeBSD64Bit
+	case types.VirtualMachineGuestOsIdentifierFreebsd12Guest:
+		return CIMOSTypeFreeBSD
+	case types.VirtualMachineGuestOsIdentifierFreebsd12_64Guest:
+		return CIMOSTypeFreeBSD64Bit
+	case types.VirtualMachineGuestOsIdentifierFreebsd13Guest:
+		return CIMOSTypeFreeBSD
+	case types.VirtualMachineGuestOsIdentifierFreebsd13_64Guest:
+		return CIMOSTypeFreeBSD64Bit
+	case types.VirtualMachineGuestOsIdentifierFreebsd14Guest:
+		return CIMOSTypeFreeBSD
+	case types.VirtualMachineGuestOsIdentifierFreebsd14_64Guest:
+		return CIMOSTypeFreeBSD64Bit
+	case types.VirtualMachineGuestOsIdentifierFreebsdGuest:
+		return CIMOSTypeFreeBSD
+	case types.VirtualMachineGuestOsIdentifierFreebsd64Guest:
+		return CIMOSTypeFreeBSD64Bit
+	case types.VirtualMachineGuestOsIdentifierGenericLinuxGuest:
+		return CIMOSTypeLINUX
+	case types.VirtualMachineGuestOsIdentifierMandrakeGuest:
+		return CIMOSTypeMandriva
+	case types.VirtualMachineGuestOsIdentifierMandriva64Guest:
+		return CIMOSTypeMandriva64Bit
+	case types.VirtualMachineGuestOsIdentifierMandrivaGuest:
+		return CIMOSTypeMandriva
+	// TODO(akutz) The following guest IDs do not exist.
+	/*
+		case types.VirtualMachineGuestOsIdentifierNetbsd7Guest:
+			return CIMOSTypeNetBSD
+		case types.VirtualMachineGuestOsIdentifierNetbsd7_64Guest:
+			return CIMOSTypeNetBSD
+		case types.VirtualMachineGuestOsIdentifierNetbsd8Guest:
+			return CIMOSTypeNetBSD
+		case types.VirtualMachineGuestOsIdentifierNetbsd8_64Guest:
+			return CIMOSTypeNetBSD
+		case types.VirtualMachineGuestOsIdentifierNetbsd9Guest:
+			return CIMOSTypeNetBSD
+		case types.VirtualMachineGuestOsIdentifierNetbsd9_64Guest:
+			return CIMOSTypeNetBSD
+		case types.VirtualMachineGuestOsIdentifierOpenbsd7Guest:
+			return CIMOSTypeOpenBSD
+		case types.VirtualMachineGuestOsIdentifierOpenbsd7_64Guest:
+			return CIMOSTypeOpenBSD
+		case types.VirtualMachineGuestOsIdentifierOpenbsd8Guest:
+			return CIMOSTypeOpenBSD
+		case types.VirtualMachineGuestOsIdentifierOpenbsd8_64Guest:
+			return CIMOSTypeOpenBSD
+	*/
+	case types.VirtualMachineGuestOsIdentifierOpensuse64Guest:
+		return CIMOSTypeSUSE64Bit
+	case types.VirtualMachineGuestOsIdentifierOpensuseGuest:
+		return CIMOSTypeSUSE
+	case types.VirtualMachineGuestOsIdentifierOracleLinux6Guest:
+		return CIMOSTypeOracle32bit
+	case types.VirtualMachineGuestOsIdentifierOracleLinux6_64Guest:
+		return CIMOSTypeOracle64bit
+	case types.VirtualMachineGuestOsIdentifierOracleLinux7Guest:
+		return CIMOSTypeOracle32bit
+	case types.VirtualMachineGuestOsIdentifierOracleLinux7_64Guest:
+		return CIMOSTypeOracle64bit
+	case types.VirtualMachineGuestOsIdentifierOracleLinux8_64Guest:
+		return CIMOSTypeOracle64bit
+	case types.VirtualMachineGuestOsIdentifierOracleLinux9_64Guest:
+		return CIMOSTypeOracle64bit
+	case types.VirtualMachineGuestOsIdentifierOracleLinuxGuest:
+		return CIMOSTypeOracle32bit
+	case types.VirtualMachineGuestOsIdentifierOracleLinux64Guest:
+		return CIMOSTypeOracle64bit
+	case types.VirtualMachineGuestOsIdentifierOther24xLinux64Guest:
+		return CIMOSTypeLinux24x64Bit
+	case types.VirtualMachineGuestOsIdentifierOther24xLinuxGuest:
+		return CIMOSTypeLinux24x
+	case types.VirtualMachineGuestOsIdentifierOther26xLinux64Guest:
+		return CIMOSTypeLinux26x64Bit
+	case types.VirtualMachineGuestOsIdentifierOther26xLinuxGuest:
+		return CIMOSTypeLinux26x
+	case types.VirtualMachineGuestOsIdentifierOther3xLinux64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierOther3xLinuxGuest:
+		return CIMOSTypeLINUX
+	case types.VirtualMachineGuestOsIdentifierOther4xLinux64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierOther4xLinuxGuest:
+		return CIMOSTypeLINUX
+	case types.VirtualMachineGuestOsIdentifierOther5xLinux64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierOther5xLinuxGuest:
+		return CIMOSTypeLINUX
+	case types.VirtualMachineGuestOsIdentifierOther6xLinux64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierOther6xLinuxGuest:
+		return CIMOSTypeLINUX
+	case types.VirtualMachineGuestOsIdentifierOtherLinux64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierOtherLinuxGuest:
+		return CIMOSTypeLINUX
+	case types.VirtualMachineGuestOsIdentifierRedhatGuest:
+		return CIMOSTypeRedHatEnterpriseLinux
+	case types.VirtualMachineGuestOsIdentifierRhel2Guest:
+		return CIMOSTypeRedHatEnterpriseLinux
+	case types.VirtualMachineGuestOsIdentifierRhel3Guest:
+		return CIMOSTypeRedHatEnterpriseLinux
+	case types.VirtualMachineGuestOsIdentifierRhel3_64Guest:
+		return CIMOSTypeRedHatEnterpriseLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierRhel4Guest:
+		return CIMOSTypeRedHatEnterpriseLinux
+	case types.VirtualMachineGuestOsIdentifierRhel4_64Guest:
+		return CIMOSTypeRedHatEnterpriseLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierRhel5Guest:
+		return CIMOSTypeRedHatEnterpriseLinux
+	case types.VirtualMachineGuestOsIdentifierRhel5_64Guest:
+		return CIMOSTypeRedHatEnterpriseLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierRhel6Guest:
+		return CIMOSTypeRedHatEnterpriseLinux
+	case types.VirtualMachineGuestOsIdentifierRhel6_64Guest:
+		return CIMOSTypeRedHatEnterpriseLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierRhel7Guest:
+		return CIMOSTypeRedHatEnterpriseLinux
+	case types.VirtualMachineGuestOsIdentifierRhel7_64Guest:
+		return CIMOSTypeRedHatEnterpriseLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierRhel8_64Guest:
+		return CIMOSTypeRedHatEnterpriseLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierRhel9_64Guest:
+		return CIMOSTypeRedHatEnterpriseLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierRockylinux_64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierSles10Guest:
+		return CIMOSTypeSLES
+	case types.VirtualMachineGuestOsIdentifierSles10_64Guest:
+		return CIMOSTypeSLES64Bit
+	case types.VirtualMachineGuestOsIdentifierSles11Guest:
+		return CIMOSTypeSLES
+	case types.VirtualMachineGuestOsIdentifierSles11_64Guest:
+		return CIMOSTypeSLES64Bit
+	case types.VirtualMachineGuestOsIdentifierSles12Guest:
+		return CIMOSTypeSLES
+	case types.VirtualMachineGuestOsIdentifierSles12_64Guest:
+		return CIMOSTypeSLES64Bit
+	case types.VirtualMachineGuestOsIdentifierSles15_64Guest:
+		return CIMOSTypeSLES64Bit
+	case types.VirtualMachineGuestOsIdentifierSles16_64Guest:
+		return CIMOSTypeSLES64Bit
+	case types.VirtualMachineGuestOsIdentifierSlesGuest:
+		return CIMOSTypeSLES
+	case types.VirtualMachineGuestOsIdentifierSles64Guest:
+		return CIMOSTypeSLES64Bit
+	case types.VirtualMachineGuestOsIdentifierSuse64Guest:
+		return CIMOSTypeSUSE64Bit
+	case types.VirtualMachineGuestOsIdentifierSuseGuest:
+		return CIMOSTypeSUSE
+	case types.VirtualMachineGuestOsIdentifierTurboLinux64Guest:
+		return CIMOSTypeTurboLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierTurboLinuxGuest:
+		return CIMOSTypeTurboLinux
+	case types.VirtualMachineGuestOsIdentifierUbuntu64Guest:
+		return CIMOSTypeUbuntu64Bit
+	case types.VirtualMachineGuestOsIdentifierUbuntuGuest:
+		return CIMOSTypeUbuntu
+	case types.VirtualMachineGuestOsIdentifierUnixWare7Guest:
+		return CIMOSTypeSCOUnixWare
+
+	// macOS
+	case types.VirtualMachineGuestOsIdentifierDarwin10Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin10_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin11Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin11_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin12_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin13_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin14_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin15_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin16_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin17_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin18_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin19_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin20_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin21_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin22_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin23_64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwin64Guest:
+		return CIMOSTypeMACOS
+	case types.VirtualMachineGuestOsIdentifierDarwinGuest:
+		return CIMOSTypeMACOS
+
+	// Solaris
+	case types.VirtualMachineGuestOsIdentifierSolaris10Guest:
+		return CIMOSTypeSolaris
+	case types.VirtualMachineGuestOsIdentifierSolaris10_64Guest:
+		return CIMOSTypeSolaris64Bit
+	case types.VirtualMachineGuestOsIdentifierSolaris11_64Guest:
+		return CIMOSTypeSolaris64Bit
+	case types.VirtualMachineGuestOsIdentifierSolaris6Guest:
+		return CIMOSTypeSolaris
+	case types.VirtualMachineGuestOsIdentifierSolaris7Guest:
+		return CIMOSTypeSolaris
+	case types.VirtualMachineGuestOsIdentifierSolaris8Guest:
+		return CIMOSTypeSolaris
+	case types.VirtualMachineGuestOsIdentifierSolaris9Guest:
+		return CIMOSTypeSolaris
+
+	// Netware
+	case types.VirtualMachineGuestOsIdentifierNetware4Guest:
+		return CIMOSTypeNetWare
+	case types.VirtualMachineGuestOsIdentifierNetware5Guest:
+		return CIMOSTypeNetWare
+	case types.VirtualMachineGuestOsIdentifierNetware6Guest:
+		return CIMOSTypeNetWare
+	case types.VirtualMachineGuestOsIdentifierNld9Guest:
+		return CIMOSTypeNovellLinuxDesktop
+	case types.VirtualMachineGuestOsIdentifierOesGuest:
+		return CIMOSTypeNovellOES
+
+	// VMware
+	case types.VirtualMachineGuestOsIdentifierVmkernelGuest:
+		return CIMOSTypeVMwareESXi
+	case types.VirtualMachineGuestOsIdentifierVmkernel5Guest:
+		return CIMOSTypeVMwareESXi
+	case types.VirtualMachineGuestOsIdentifierVmkernel6Guest:
+		return CIMOSTypeVMwareESXi
+	case types.VirtualMachineGuestOsIdentifierVmkernel65Guest:
+		return CIMOSTypeVMwareESXi
+	case types.VirtualMachineGuestOsIdentifierVmkernel7Guest:
+		return CIMOSTypeVMwareESXi
+	case types.VirtualMachineGuestOsIdentifierVmkernel8Guest:
+		return CIMOSTypeVMwareESXi
+	case types.VirtualMachineGuestOsIdentifierVmwarePhoton64Guest:
+		return CIMOSTypeLinux64Bit
+
+	// OS/2
+	case types.VirtualMachineGuestOsIdentifierEComStationGuest:
+		return CIMOSTypeeComStation32bitx
+	case types.VirtualMachineGuestOsIdentifierEComStation2Guest:
+		return CIMOSTypeeComStation32bitx
+	case types.VirtualMachineGuestOsIdentifierOs2Guest:
+		return CIMOSTypeOS2
+
+	// Other
+	case types.VirtualMachineGuestOsIdentifierOtherGuest:
+		return CIMOSTypeOther
+	case types.VirtualMachineGuestOsIdentifierOtherGuest64:
+		return CIMOSTypeOther64Bit
+	case types.VirtualMachineGuestOsIdentifierAmazonlinux2_64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierAmazonlinux3_64Guest:
+		return CIMOSTypeLinux64Bit
+	case types.VirtualMachineGuestOsIdentifierCrxPod1Guest:
+		return CIMOSTypeOther
+
+	// Default to Unknown if not found
+	default:
+		return CIMOSTypeUnknown
+	}
+}

--- a/ovf/cim_test.go
+++ b/ovf/cim_test.go
@@ -1,0 +1,1119 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package ovf
+
+import (
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestGuestIDToCIMOSType(t *testing.T) {
+	tests := []struct {
+		name     string
+		guestID  types.VirtualMachineGuestOsIdentifier
+		expected CIMOSType
+	}{
+		// Windows Desktop
+		{
+			name:     "DOS Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDosGuest,
+			expected: CIMOSTypeMSDOS,
+		},
+		{
+			name:     "Windows 3.1 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWin31Guest,
+			expected: CIMOSTypeWIN3x,
+		},
+		{
+			name:     "Windows 95 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWin95Guest,
+			expected: CIMOSTypeWIN95,
+		},
+		{
+			name:     "Windows 98 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWin98Guest,
+			expected: CIMOSTypeWIN98,
+		},
+		{
+			name:     "Windows ME Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinMeGuest,
+			expected: CIMOSTypeWindowsMe,
+		},
+		{
+			name:     "Windows NT Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinNTGuest,
+			expected: CIMOSTypeWINNT,
+		},
+		{
+			name:     "Windows 2000 Pro Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWin2000ProGuest,
+			expected: CIMOSTypeWindows2000,
+		},
+		{
+			name:     "Windows 2000 Server Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWin2000ServGuest,
+			expected: CIMOSTypeWindows2000,
+		},
+		{
+			name:     "Windows 2000 Advanced Server Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWin2000AdvServGuest,
+			expected: CIMOSTypeWindows2000,
+		},
+		{
+			name:     "Windows XP Home Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinXPHomeGuest,
+			expected: CIMOSTypeWindowsXP,
+		},
+		{
+			name:     "Windows XP Pro Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinXPProGuest,
+			expected: CIMOSTypeWindowsXP,
+		},
+		{
+			name:     "Windows XP Pro 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinXPPro64Guest,
+			expected: CIMOSTypeWindowsXP64Bit,
+		},
+		{
+			name:     "Windows Vista Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinVistaGuest,
+			expected: CIMOSTypeWindowsVista,
+		},
+		{
+			name:     "Windows Vista 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinVista64Guest,
+			expected: CIMOSTypeWindowsVista64Bit,
+		},
+		{
+			name:     "Windows 7 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows7Guest,
+			expected: CIMOSTypeMicrosoftWindows7,
+		},
+		{
+			name:     "Windows 7 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows7_64Guest,
+			expected: CIMOSTypeMicrosoftWindows7,
+		},
+		{
+			name:     "Windows 8 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows8Guest,
+			expected: CIMOSTypeMicrosoftWindows8,
+		},
+		{
+			name:     "Windows 8 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows8_64Guest,
+			expected: CIMOSTypeMicrosoftWindows8,
+		},
+		{
+			name:     "Windows 9 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows9Guest,
+			expected: CIMOSTypeOther,
+		},
+		{
+			name:     "Windows 9 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows9_64Guest,
+			expected: CIMOSTypeOther64Bit,
+		},
+		{
+			name:     "Windows 11 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows11_64Guest,
+			expected: CIMOSTypeOther64Bit,
+		},
+		{
+			name:     "Windows 12 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows12_64Guest,
+			expected: CIMOSTypeOther64Bit,
+		},
+		{
+			name:     "Windows Hyper-V Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindowsHyperVGuest,
+			expected: CIMOSTypeOther64Bit,
+		},
+
+		// Windows Server
+		{
+			name:     "Windows Server 2003 Enterprise Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinNetEnterpriseGuest,
+			expected: CIMOSTypeMicrosoftWindowsServer2003,
+		},
+		{
+			name:     "Windows Server 2003 Datacenter Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinNetDatacenterGuest,
+			expected: CIMOSTypeMicrosoftWindowsServer2003,
+		},
+		{
+			name:     "Windows Server 2003 Business Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinNetBusinessGuest,
+			expected: CIMOSTypeMicrosoftWindowsServer2003,
+		},
+		{
+			name:     "Windows Server 2003 Standard Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinNetStandardGuest,
+			expected: CIMOSTypeMicrosoftWindowsServer2003,
+		},
+		{
+			name:     "Windows Server 2003 Web Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinNetWebGuest,
+			expected: CIMOSTypeMicrosoftWindowsServer2003,
+		},
+		{
+			name:     "Windows Server 2003 Enterprise 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinNetEnterprise64Guest,
+			expected: CIMOSTypeMicrosoftWindowsServer2003_64Bit,
+		},
+		{
+			name:     "Windows Server 2003 Datacenter 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinNetDatacenter64Guest,
+			expected: CIMOSTypeMicrosoftWindowsServer2003_64Bit,
+		},
+		{
+			name:     "Windows Server 2003 Standard 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinNetStandard64Guest,
+			expected: CIMOSTypeMicrosoftWindowsServer2003_64Bit,
+		},
+		{
+			name:     "Windows Longhorn Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinLonghornGuest,
+			expected: CIMOSTypeMicrosoftWindowsServer2008,
+		},
+		{
+			name:     "Windows Longhorn 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWinLonghorn64Guest,
+			expected: CIMOSTypeMicrosoftWindowsServer2008_64Bit,
+		},
+		{
+			name:     "Windows 7 Server 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows7Server64Guest,
+			expected: CIMOSTypeMicrosoftWindowsServer2008R2,
+		},
+		{
+			name:     "Windows 8 Server 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows8Server64Guest,
+			expected: CIMOSTypeMicrosoftWindowsServer2012,
+		},
+		{
+			name:     "Windows 9 Server 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows9Server64Guest,
+			expected: CIMOSTypeMicrosoftWindowsServer2012R2,
+		},
+		{
+			name:     "Windows Server 2019 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows2019srv_64Guest,
+			expected: CIMOSTypeOther64Bit,
+		},
+		{
+			name:     "Windows Server 2019 Next 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows2019srvNext_64Guest,
+			expected: CIMOSTypeOther64Bit,
+		},
+		{
+			name:     "Windows Server 2022 Next 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierWindows2022srvNext_64Guest,
+			expected: CIMOSTypeOther64Bit,
+		},
+
+		// Linux - Red Hat
+		{
+			name:     "Red Hat Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRedhatGuest,
+			expected: CIMOSTypeRedHatEnterpriseLinux,
+		},
+		{
+			name:     "RHEL 2 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel2Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux,
+		},
+		{
+			name:     "RHEL 3 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel3Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux,
+		},
+		{
+			name:     "RHEL 3 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel3_64Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux64Bit,
+		},
+		{
+			name:     "RHEL 4 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel4Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux,
+		},
+		{
+			name:     "RHEL 4 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel4_64Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux64Bit,
+		},
+		{
+			name:     "RHEL 5 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel5Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux,
+		},
+		{
+			name:     "RHEL 5 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel5_64Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux64Bit,
+		},
+		{
+			name:     "RHEL 6 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel6Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux,
+		},
+		{
+			name:     "RHEL 6 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel6_64Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux64Bit,
+		},
+		{
+			name:     "RHEL 7 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel7Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux,
+		},
+		{
+			name:     "RHEL 7 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel7_64Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux64Bit,
+		},
+		{
+			name:     "RHEL 8 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel8_64Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux64Bit,
+		},
+		{
+			name:     "RHEL 9 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel9_64Guest,
+			expected: CIMOSTypeRedHatEnterpriseLinux64Bit,
+		},
+		{
+			name:     "RHEL 10 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRhel10_64Guest,
+			expected: CIMOSTypeUnknown,
+		},
+
+		// Linux - CentOS
+		{
+			name:     "CentOS Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierCentosGuest,
+			expected: CIMOSTypeUnknown,
+		},
+		{
+			name:     "CentOS 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierCentos64Guest,
+			expected: CIMOSTypeUnknown,
+		},
+		{
+			name:     "CentOS 6 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierCentos6Guest,
+			expected: CIMOSTypeCentOS32bit,
+		},
+		{
+			name:     "CentOS 6 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierCentos6_64Guest,
+			expected: CIMOSTypeCentOS64bit,
+		},
+		{
+			name:     "CentOS 7 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierCentos7Guest,
+			expected: CIMOSTypeCentOS32bit,
+		},
+		{
+			name:     "CentOS 7 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierCentos7_64Guest,
+			expected: CIMOSTypeCentOS64bit,
+		},
+		{
+			name:     "CentOS 8 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierCentos8_64Guest,
+			expected: CIMOSTypeCentOS64bit,
+		},
+		{
+			name:     "CentOS 9 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierCentos9_64Guest,
+			expected: CIMOSTypeCentOS64bit,
+		},
+
+		// Linux - Oracle
+		{
+			name:     "Oracle Linux Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOracleLinuxGuest,
+			expected: CIMOSTypeOracle32bit,
+		},
+		{
+			name:     "Oracle Linux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOracleLinux64Guest,
+			expected: CIMOSTypeOracle64bit,
+		},
+		{
+			name:     "Oracle Linux 6 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOracleLinux6Guest,
+			expected: CIMOSTypeOracle32bit,
+		},
+		{
+			name:     "Oracle Linux 6 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOracleLinux6_64Guest,
+			expected: CIMOSTypeOracle64bit,
+		},
+		{
+			name:     "Oracle Linux 7 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOracleLinux7Guest,
+			expected: CIMOSTypeOracle32bit,
+		},
+		{
+			name:     "Oracle Linux 7 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOracleLinux7_64Guest,
+			expected: CIMOSTypeOracle64bit,
+		},
+		{
+			name:     "Oracle Linux 8 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOracleLinux8_64Guest,
+			expected: CIMOSTypeOracle64bit,
+		},
+		{
+			name:     "Oracle Linux 9 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOracleLinux9_64Guest,
+			expected: CIMOSTypeOracle64bit,
+		},
+		{
+			name:     "Oracle Linux 10 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOracleLinux10_64Guest,
+			expected: CIMOSTypeUnknown,
+		},
+
+		// Linux - SUSE
+		{
+			name:     "SUSE Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSuseGuest,
+			expected: CIMOSTypeSUSE,
+		},
+		{
+			name:     "SUSE 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSuse64Guest,
+			expected: CIMOSTypeSUSE64Bit,
+		},
+		{
+			name:     "SLES Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSlesGuest,
+			expected: CIMOSTypeSLES,
+		},
+		{
+			name:     "SLES 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSles64Guest,
+			expected: CIMOSTypeSLES64Bit,
+		},
+		{
+			name:     "SLES 10 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSles10Guest,
+			expected: CIMOSTypeSLES,
+		},
+		{
+			name:     "SLES 10 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSles10_64Guest,
+			expected: CIMOSTypeSLES64Bit,
+		},
+		{
+			name:     "SLES 11 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSles11Guest,
+			expected: CIMOSTypeSLES,
+		},
+		{
+			name:     "SLES 11 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSles11_64Guest,
+			expected: CIMOSTypeSLES64Bit,
+		},
+		{
+			name:     "SLES 12 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSles12Guest,
+			expected: CIMOSTypeSLES,
+		},
+		{
+			name:     "SLES 12 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSles12_64Guest,
+			expected: CIMOSTypeSLES64Bit,
+		},
+		{
+			name:     "SLES 15 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSles15_64Guest,
+			expected: CIMOSTypeSLES64Bit,
+		},
+		{
+			name:     "SLES 16 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSles16_64Guest,
+			expected: CIMOSTypeSLES64Bit,
+		},
+		{
+			name:     "OpenSUSE Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOpensuseGuest,
+			expected: CIMOSTypeSUSE,
+		},
+		{
+			name:     "OpenSUSE 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOpensuse64Guest,
+			expected: CIMOSTypeSUSE64Bit,
+		},
+
+		// Linux - Ubuntu
+		{
+			name:     "Ubuntu Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierUbuntuGuest,
+			expected: CIMOSTypeUbuntu,
+		},
+		{
+			name:     "Ubuntu 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierUbuntu64Guest,
+			expected: CIMOSTypeUbuntu64Bit,
+		},
+
+		// Linux - Debian
+		{
+			name:     "Debian 4 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian4Guest,
+			expected: CIMOSTypeDebian,
+		},
+		{
+			name:     "Debian 4 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian4_64Guest,
+			expected: CIMOSTypeDebian64Bit,
+		},
+		{
+			name:     "Debian 5 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian5Guest,
+			expected: CIMOSTypeDebian,
+		},
+		{
+			name:     "Debian 5 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian5_64Guest,
+			expected: CIMOSTypeDebian64Bit,
+		},
+		{
+			name:     "Debian 6 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian6Guest,
+			expected: CIMOSTypeDebian,
+		},
+		{
+			name:     "Debian 6 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian6_64Guest,
+			expected: CIMOSTypeDebian64Bit,
+		},
+		{
+			name:     "Debian 7 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian7Guest,
+			expected: CIMOSTypeDebian,
+		},
+		{
+			name:     "Debian 7 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian7_64Guest,
+			expected: CIMOSTypeDebian64Bit,
+		},
+		{
+			name:     "Debian 8 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian8Guest,
+			expected: CIMOSTypeDebian,
+		},
+		{
+			name:     "Debian 8 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian8_64Guest,
+			expected: CIMOSTypeDebian64Bit,
+		},
+		{
+			name:     "Debian 9 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian9Guest,
+			expected: CIMOSTypeDebian,
+		},
+		{
+			name:     "Debian 9 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian9_64Guest,
+			expected: CIMOSTypeDebian64Bit,
+		},
+		{
+			name:     "Debian 10 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian10Guest,
+			expected: CIMOSTypeDebian,
+		},
+		{
+			name:     "Debian 10 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian10_64Guest,
+			expected: CIMOSTypeDebian64Bit,
+		},
+		{
+			name:     "Debian 11 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian11Guest,
+			expected: CIMOSTypeDebian,
+		},
+		{
+			name:     "Debian 11 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian11_64Guest,
+			expected: CIMOSTypeDebian64Bit,
+		},
+		{
+			name:     "Debian 12 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian12Guest,
+			expected: CIMOSTypeDebian,
+		},
+		{
+			name:     "Debian 12 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian12_64Guest,
+			expected: CIMOSTypeDebian64Bit,
+		},
+		{
+			name:     "Debian 13 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian13Guest,
+			expected: CIMOSTypeUnknown,
+		},
+		{
+			name:     "Debian 13 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDebian13_64Guest,
+			expected: CIMOSTypeUnknown,
+		},
+
+		// Linux - Fedora
+		{
+			name:     "Fedora Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFedoraGuest,
+			expected: CIMOSTypeLINUX,
+		},
+		{
+			name:     "Fedora 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFedora64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+
+		// Linux - Mandrake/Mandriva
+		{
+			name:     "Mandrake Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierMandrakeGuest,
+			expected: CIMOSTypeMandriva,
+		},
+		{
+			name:     "Mandriva Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierMandrivaGuest,
+			expected: CIMOSTypeMandriva,
+		},
+		{
+			name:     "Mandriva 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierMandriva64Guest,
+			expected: CIMOSTypeMandriva64Bit,
+		},
+
+		// Linux - TurboLinux
+		{
+			name:     "TurboLinux Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierTurboLinuxGuest,
+			expected: CIMOSTypeTurboLinux,
+		},
+		{
+			name:     "TurboLinux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierTurboLinux64Guest,
+			expected: CIMOSTypeTurboLinux64Bit,
+		},
+
+		// Linux - Asianux
+		{
+			name:     "Asianux 3 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierAsianux3Guest,
+			expected: CIMOSTypeLINUX,
+		},
+		{
+			name:     "Asianux 3 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierAsianux3_64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Asianux 4 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierAsianux4Guest,
+			expected: CIMOSTypeLINUX,
+		},
+		{
+			name:     "Asianux 4 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierAsianux4_64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Asianux 5 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierAsianux5_64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Asianux 7 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierAsianux7_64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Asianux 8 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierAsianux8_64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Asianux 9 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierAsianux9_64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+
+		// Linux - Other specific distributions
+		{
+			name:     "CoreOS 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierCoreos64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "VMware Photon 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierVmwarePhoton64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Amazon Linux 2 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierAmazonlinux2_64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Amazon Linux 3 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierAmazonlinux3_64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Rocky Linux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierRockylinux_64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Miracle Linux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierMiraclelinux_64Guest,
+			expected: CIMOSTypeUnknown,
+		},
+		{
+			name:     "Pardus 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierPardus_64Guest,
+			expected: CIMOSTypeUnknown,
+		},
+
+		// Linux - Generic
+		{
+			name:     "Generic Linux Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierGenericLinuxGuest,
+			expected: CIMOSTypeLINUX,
+		},
+		{
+			name:     "Other 24x Linux Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther24xLinuxGuest,
+			expected: CIMOSTypeLinux24x,
+		},
+		{
+			name:     "Other 24x Linux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther24xLinux64Guest,
+			expected: CIMOSTypeLinux24x64Bit,
+		},
+		{
+			name:     "Other 26x Linux Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther26xLinuxGuest,
+			expected: CIMOSTypeLinux26x,
+		},
+		{
+			name:     "Other 26x Linux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther26xLinux64Guest,
+			expected: CIMOSTypeLinux26x64Bit,
+		},
+		{
+			name:     "Other 3x Linux Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther3xLinuxGuest,
+			expected: CIMOSTypeLINUX,
+		},
+		{
+			name:     "Other 3x Linux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther3xLinux64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Other 4x Linux Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther4xLinuxGuest,
+			expected: CIMOSTypeLINUX,
+		},
+		{
+			name:     "Other 4x Linux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther4xLinux64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Other 5x Linux Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther5xLinuxGuest,
+			expected: CIMOSTypeLINUX,
+		},
+		{
+			name:     "Other 5x Linux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther5xLinux64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Other 6x Linux Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther6xLinuxGuest,
+			expected: CIMOSTypeLINUX,
+		},
+		{
+			name:     "Other 6x Linux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther6xLinux64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+		{
+			name:     "Other 7x Linux Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther7xLinuxGuest,
+			expected: CIMOSTypeUnknown,
+		},
+		{
+			name:     "Other 7x Linux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOther7xLinux64Guest,
+			expected: CIMOSTypeUnknown,
+		},
+		{
+			name:     "Other Linux Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOtherLinuxGuest,
+			expected: CIMOSTypeLINUX,
+		},
+		{
+			name:     "Other Linux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOtherLinux64Guest,
+			expected: CIMOSTypeLinux64Bit,
+		},
+
+		// FreeBSD
+		{
+			name:     "FreeBSD Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFreebsdGuest,
+			expected: CIMOSTypeFreeBSD,
+		},
+		{
+			name:     "FreeBSD 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFreebsd64Guest,
+			expected: CIMOSTypeFreeBSD64Bit,
+		},
+		{
+			name:     "FreeBSD 11 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFreebsd11Guest,
+			expected: CIMOSTypeFreeBSD,
+		},
+		{
+			name:     "FreeBSD 11 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFreebsd11_64Guest,
+			expected: CIMOSTypeFreeBSD64Bit,
+		},
+		{
+			name:     "FreeBSD 12 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFreebsd12Guest,
+			expected: CIMOSTypeFreeBSD,
+		},
+		{
+			name:     "FreeBSD 12 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFreebsd12_64Guest,
+			expected: CIMOSTypeFreeBSD64Bit,
+		},
+		{
+			name:     "FreeBSD 13 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFreebsd13Guest,
+			expected: CIMOSTypeFreeBSD,
+		},
+		{
+			name:     "FreeBSD 13 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFreebsd13_64Guest,
+			expected: CIMOSTypeFreeBSD64Bit,
+		},
+		{
+			name:     "FreeBSD 14 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFreebsd14Guest,
+			expected: CIMOSTypeFreeBSD,
+		},
+		{
+			name:     "FreeBSD 14 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFreebsd14_64Guest,
+			expected: CIMOSTypeFreeBSD64Bit,
+		},
+		{
+			name:     "FreeBSD 15 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFreebsd15Guest,
+			expected: CIMOSTypeUnknown,
+		},
+		{
+			name:     "FreeBSD 15 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFreebsd15_64Guest,
+			expected: CIMOSTypeUnknown,
+		},
+
+		// macOS / Darwin
+		{
+			name:     "Darwin Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwinGuest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 10 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin10Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 10 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin10_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 11 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin11Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 11 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin11_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 12 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin12_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 13 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin13_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 14 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin14_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 15 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin15_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 16 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin16_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 17 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin17_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 18 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin18_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 19 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin19_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 20 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin20_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 21 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin21_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 22 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin22_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+		{
+			name:     "Darwin 23 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierDarwin23_64Guest,
+			expected: CIMOSTypeMACOS,
+		},
+
+		// Solaris
+		{
+			name:     "Solaris 6 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSolaris6Guest,
+			expected: CIMOSTypeSolaris,
+		},
+		{
+			name:     "Solaris 7 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSolaris7Guest,
+			expected: CIMOSTypeSolaris,
+		},
+		{
+			name:     "Solaris 8 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSolaris8Guest,
+			expected: CIMOSTypeSolaris,
+		},
+		{
+			name:     "Solaris 9 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSolaris9Guest,
+			expected: CIMOSTypeSolaris,
+		},
+		{
+			name:     "Solaris 10 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSolaris10Guest,
+			expected: CIMOSTypeSolaris,
+		},
+		{
+			name:     "Solaris 10 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSolaris10_64Guest,
+			expected: CIMOSTypeSolaris64Bit,
+		},
+		{
+			name:     "Solaris 11 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSolaris11_64Guest,
+			expected: CIMOSTypeSolaris64Bit,
+		},
+
+		// Netware / Novell
+		{
+			name:     "Netware 4 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierNetware4Guest,
+			expected: CIMOSTypeNetWare,
+		},
+		{
+			name:     "Netware 5 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierNetware5Guest,
+			expected: CIMOSTypeNetWare,
+		},
+		{
+			name:     "Netware 6 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierNetware6Guest,
+			expected: CIMOSTypeNetWare,
+		},
+		{
+			name:     "NLD 9 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierNld9Guest,
+			expected: CIMOSTypeNovellLinuxDesktop,
+		},
+		{
+			name:     "OES Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOesGuest,
+			expected: CIMOSTypeNovellOES,
+		},
+		{
+			name:     "SJDS Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierSjdsGuest,
+			expected: CIMOSTypeUnknown,
+		},
+
+		// VMware
+		{
+			name:     "VMkernel Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierVmkernelGuest,
+			expected: CIMOSTypeVMwareESXi,
+		},
+		{
+			name:     "VMkernel 5 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierVmkernel5Guest,
+			expected: CIMOSTypeVMwareESXi,
+		},
+		{
+			name:     "VMkernel 6 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierVmkernel6Guest,
+			expected: CIMOSTypeVMwareESXi,
+		},
+		{
+			name:     "VMkernel 65 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierVmkernel65Guest,
+			expected: CIMOSTypeVMwareESXi,
+		},
+		{
+			name:     "VMkernel 7 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierVmkernel7Guest,
+			expected: CIMOSTypeVMwareESXi,
+		},
+		{
+			name:     "VMkernel 8 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierVmkernel8Guest,
+			expected: CIMOSTypeVMwareESXi,
+		},
+
+		// OS/2
+		{
+			name:     "OS/2 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOs2Guest,
+			expected: CIMOSTypeOS2,
+		},
+		{
+			name:     "eComStation Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierEComStationGuest,
+			expected: CIMOSTypeeComStation32bitx,
+		},
+		{
+			name:     "eComStation 2 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierEComStation2Guest,
+			expected: CIMOSTypeeComStation32bitx,
+		},
+
+		// Unix
+		{
+			name:     "UnixWare 7 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierUnixWare7Guest,
+			expected: CIMOSTypeSCOUnixWare,
+		},
+		{
+			name:     "OpenServer 5 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOpenServer5Guest,
+			expected: CIMOSTypeUnknown,
+		},
+		{
+			name:     "OpenServer 6 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOpenServer6Guest,
+			expected: CIMOSTypeUnknown,
+		},
+
+		// Other
+		{
+			name:     "Other Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierOtherGuest,
+			expected: CIMOSTypeOther,
+		},
+		{
+			name:     "Other Guest 64",
+			guestID:  types.VirtualMachineGuestOsIdentifierOtherGuest64,
+			expected: CIMOSTypeOther64Bit,
+		},
+		{
+			name:     "CRX Pod 1 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierCrxPod1Guest,
+			expected: CIMOSTypeOther,
+		},
+		{
+			name:     "Fusion OS 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierFusionos_64Guest,
+			expected: CIMOSTypeUnknown,
+		},
+		{
+			name:     "ProLinux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierProlinux_64Guest,
+			expected: CIMOSTypeUnknown,
+		},
+		{
+			name:     "KylinLinux 64 Guest",
+			guestID:  types.VirtualMachineGuestOsIdentifierKylinlinux_64Guest,
+			expected: CIMOSTypeUnknown,
+		},
+
+		// Custom string tests (not enum constants)
+		{
+			name:     "Unknown Guest ID",
+			guestID:  types.VirtualMachineGuestOsIdentifier("unknownGuestID"),
+			expected: CIMOSTypeUnknown,
+		},
+		{
+			name:     "Empty Guest ID",
+			guestID:  types.VirtualMachineGuestOsIdentifier(""),
+			expected: CIMOSTypeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GuestIDToCIMOSType(tt.guestID)
+			if result != tt.expected {
+				t.Errorf("GuestIDToCIMOSType(%q) = %v, want %v", tt.guestID, result, tt.expected)
+			}
+		})
+	}
+}

--- a/vim25/types/guest.go
+++ b/vim25/types/guest.go
@@ -1,0 +1,42 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"regexp"
+)
+
+var (
+	isGuestIDWindowsRx = regexp.MustCompile(`(?i)^win.+$`)
+	isGuestIDDarwinRx  = regexp.MustCompile(`(?i)^darwin.+$`)
+	isGuestIDLinuxRx   = regexp.MustCompile(`(?i)((^.*linux.*$)|(^(centos|coreos|debian|fedora|mandrake|mandriva|opensuse|redhat|rhel|suse|sles|ubuntu|vmwarephoton).+$))`)
+	isGuestIDNetwareRx = regexp.MustCompile(`(?i)^netware.+$`)
+	isGuestIDSolarisRx = regexp.MustCompile(`(?i)^solaris.+$`)
+)
+
+// ToFamily returns the family to which the provided guest identifier belongs.
+func (g VirtualMachineGuestOsIdentifier) ToFamily() VirtualMachineGuestOsFamily {
+	return GuestIDToFamily(g)
+}
+
+// GuestIDToFamily returns the family to which the provided guest identifier
+// belongs.
+func GuestIDToFamily[T ~string](guestID T) VirtualMachineGuestOsFamily {
+	szGuestID := string(guestID)
+	switch {
+	case isGuestIDDarwinRx.MatchString(szGuestID):
+		return VirtualMachineGuestOsFamilyDarwinGuestFamily
+	case isGuestIDLinuxRx.MatchString(szGuestID):
+		return VirtualMachineGuestOsFamilyLinuxGuest
+	case isGuestIDSolarisRx.MatchString(szGuestID):
+		return VirtualMachineGuestOsFamilySolarisGuest
+	case isGuestIDNetwareRx.MatchString(szGuestID):
+		return VirtualMachineGuestOsFamilyNetwareGuest
+	case isGuestIDWindowsRx.MatchString(szGuestID):
+		return VirtualMachineGuestOsFamilyWindowsGuest
+	default:
+		return VirtualMachineGuestOsFamilyOtherGuestFamily
+	}
+}

--- a/vim25/types/guest_test.go
+++ b/vim25/types/guest_test.go
@@ -1,0 +1,980 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import "testing"
+
+func TestGuestIDToFamily(t *testing.T) {
+	tests := []struct {
+		name     string
+		guestID  VirtualMachineGuestOsIdentifier
+		expected VirtualMachineGuestOsFamily
+	}{
+		// Windows family tests
+		{
+			name:     "DOS Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDosGuest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "Windows 31 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWin31Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 95 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWin95Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 98 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWin98Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows ME Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinMeGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows NT Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinNTGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 2000 Pro Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWin2000ProGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 2000 Server Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWin2000ServGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 2000 Advanced Server Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWin2000AdvServGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows XP Home Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinXPHomeGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows XP Pro Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinXPProGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows XP Pro 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinXPPro64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Server 2003 Web Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinNetWebGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Server 2003 Standard Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinNetStandardGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Server 2003 Enterprise Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinNetEnterpriseGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Server 2003 Datacenter Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinNetDatacenterGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Server 2003 Business Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinNetBusinessGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Server 2003 Standard 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinNetStandard64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Server 2003 Enterprise 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinNetEnterprise64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Longhorn Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinLonghornGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Longhorn 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinLonghorn64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Server 2003 Datacenter 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinNetDatacenter64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Vista Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinVistaGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Vista 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWinVista64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 7 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows7Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 7 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows7_64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Server 2008 R2 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows7Server64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 8 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows8Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 8 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows8_64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 8 Server 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows8Server64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 9 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows9Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 9 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows9_64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 9 Server 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows9Server64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 11 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows11_64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows 12 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows12_64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Hyper-V Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindowsHyperVGuest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Server 2019 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows2019srv_64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Server 2022 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows2019srvNext_64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Windows Server 2025 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierWindows2022srvNext_64Guest,
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+
+		// FreeBSD family tests (should be Other)
+		{
+			name:     "FreeBSD Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFreebsdGuest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "FreeBSD 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFreebsd64Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "FreeBSD 11 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFreebsd11Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "FreeBSD 11 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFreebsd11_64Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "FreeBSD 12 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFreebsd12Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "FreeBSD 12 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFreebsd12_64Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "FreeBSD 13 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFreebsd13Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "FreeBSD 13 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFreebsd13_64Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "FreeBSD 14 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFreebsd14Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "FreeBSD 14 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFreebsd14_64Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "FreeBSD 15 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFreebsd15Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "FreeBSD 15 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFreebsd15_64Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+
+		// Red Hat Linux family tests
+		{
+			name:     "Red Hat Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRedhatGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 2 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel2Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 3 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel3Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 3 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel3_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 4 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel4Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 4 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel4_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 5 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel5Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 5 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel5_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 6 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel6Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 6 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel6_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 7 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel7Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 7 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel7_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 8 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel8_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 9 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel9_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "RHEL 10 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierRhel10_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+
+		// CentOS Linux family tests
+		{
+			name:     "CentOS Guest",
+			guestID:  VirtualMachineGuestOsIdentifierCentosGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "CentOS 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierCentos64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "CentOS 6 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierCentos6Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "CentOS 6 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierCentos6_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "CentOS 7 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierCentos7Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "CentOS 7 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierCentos7_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "CentOS 8 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierCentos8_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "CentOS 9 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierCentos9_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+
+		// Oracle Linux family tests
+		{
+			name:     "Oracle Linux Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOracleLinuxGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Oracle Linux 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOracleLinux64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Oracle Linux 6 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOracleLinux6Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Oracle Linux 6 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOracleLinux6_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Oracle Linux 7 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOracleLinux7Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Oracle Linux 7 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOracleLinux7_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Oracle Linux 8 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOracleLinux8_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Oracle Linux 9 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOracleLinux9_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Oracle Linux 10 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOracleLinux10_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+
+		// SUSE Linux family tests
+		{
+			name:     "SUSE Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSuseGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "SUSE 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSuse64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "SLES Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSlesGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "SLES 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSles64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "SLES 10 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSles10Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "SLES 10 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSles10_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "SLES 11 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSles11Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "SLES 11 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSles11_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "SLES 12 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSles12Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "SLES 12 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSles12_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "SLES 15 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSles15_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "SLES 16 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSles16_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+
+		// OpenSUSE Linux family tests
+		{
+			name:     "OpenSUSE Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOpensuseGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "OpenSUSE 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOpensuse64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+
+		// Mandrake/Mandriva Linux family tests
+		{
+			name:     "Mandrake Guest",
+			guestID:  VirtualMachineGuestOsIdentifierMandrakeGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Mandriva Guest",
+			guestID:  VirtualMachineGuestOsIdentifierMandrivaGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Mandriva 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierMandriva64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+
+		// Ubuntu Linux family tests
+		{
+			name:     "Ubuntu Guest",
+			guestID:  VirtualMachineGuestOsIdentifierUbuntuGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Ubuntu 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierUbuntu64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+
+		// Debian Linux family tests
+		{
+			name:     "Debian 4 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian4Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 4 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian4_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 5 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian5Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 5 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian5_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 6 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian6Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 6 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian6_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 7 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian7Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 7 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian7_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 8 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian8Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 8 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian8_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 9 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian9Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 9 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian9_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 10 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian10Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 10 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian10_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 11 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian11Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 11 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian11_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 12 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian12Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 12 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian12_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 13 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian13Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Debian 13 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDebian13_64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+
+		// Fedora Linux family tests
+		{
+			name:     "Fedora Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFedoraGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Fedora 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierFedora64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+
+		// VMware Photon Linux family tests
+		{
+			name:     "VMware Photon 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierVmwarePhoton64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+
+		// Other Linux family tests
+		{
+			name:     "CoreOS 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierCoreos64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 24x Linux Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther24xLinuxGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 26x Linux Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther26xLinuxGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other Linux Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOtherLinuxGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 3x Linux Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther3xLinuxGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 4x Linux Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther4xLinuxGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 5x Linux Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther5xLinuxGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 6x Linux Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther6xLinuxGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 7x Linux Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther7xLinuxGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Generic Linux Guest",
+			guestID:  VirtualMachineGuestOsIdentifierGenericLinuxGuest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 24x Linux 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther24xLinux64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 26x Linux 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther26xLinux64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 3x Linux 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther3xLinux64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 4x Linux 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther4xLinux64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 5x Linux 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther5xLinux64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 6x Linux 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther6xLinux64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other 7x Linux 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOther7xLinux64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Other Linux 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOtherLinux64Guest,
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+
+		// Solaris family tests
+		{
+			name:     "Solaris 6 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSolaris6Guest,
+			expected: VirtualMachineGuestOsFamilySolarisGuest,
+		},
+		{
+			name:     "Solaris 7 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSolaris7Guest,
+			expected: VirtualMachineGuestOsFamilySolarisGuest,
+		},
+		{
+			name:     "Solaris 8 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSolaris8Guest,
+			expected: VirtualMachineGuestOsFamilySolarisGuest,
+		},
+		{
+			name:     "Solaris 9 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSolaris9Guest,
+			expected: VirtualMachineGuestOsFamilySolarisGuest,
+		},
+		{
+			name:     "Solaris 10 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSolaris10Guest,
+			expected: VirtualMachineGuestOsFamilySolarisGuest,
+		},
+		{
+			name:     "Solaris 10 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSolaris10_64Guest,
+			expected: VirtualMachineGuestOsFamilySolarisGuest,
+		},
+		{
+			name:     "Solaris 11 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierSolaris11_64Guest,
+			expected: VirtualMachineGuestOsFamilySolarisGuest,
+		},
+
+		// Netware family tests
+		{
+			name:     "Netware 4 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierNetware4Guest,
+			expected: VirtualMachineGuestOsFamilyNetwareGuest,
+		},
+		{
+			name:     "Netware 5 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierNetware5Guest,
+			expected: VirtualMachineGuestOsFamilyNetwareGuest,
+		},
+		{
+			name:     "Netware 6 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierNetware6Guest,
+			expected: VirtualMachineGuestOsFamilyNetwareGuest,
+		},
+
+		// Darwin/macOS family tests
+		{
+			name:     "Darwin Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwinGuest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 10 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin10Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 10 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin10_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 11 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin11Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 11 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin11_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 12 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin12_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 13 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin13_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 14 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin14_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 15 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin15_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 16 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin16_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 17 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin17_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 18 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin18_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 19 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin19_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 20 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin20_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 21 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin21_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 22 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin22_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Darwin 23 64 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierDarwin23_64Guest,
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+
+		// Other family tests (various non-matching OS types)
+		{
+			name:     "OS/2 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOs2Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "eComStation Guest",
+			guestID:  VirtualMachineGuestOsIdentifierEComStationGuest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "eComStation 2 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierEComStation2Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "OpenServer 5 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOpenServer5Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "OpenServer 6 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierOpenServer6Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "UnixWare 7 Guest",
+			guestID:  VirtualMachineGuestOsIdentifierUnixWare7Guest,
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+
+		// Custom string tests (not enum constants)
+		{
+			name:     "Custom Windows String",
+			guestID:  VirtualMachineGuestOsIdentifier("winCustom"),
+			expected: VirtualMachineGuestOsFamilyWindowsGuest,
+		},
+		{
+			name:     "Custom Linux String",
+			guestID:  VirtualMachineGuestOsIdentifier("customLinux"),
+			expected: VirtualMachineGuestOsFamilyLinuxGuest,
+		},
+		{
+			name:     "Custom Darwin String",
+			guestID:  VirtualMachineGuestOsIdentifier("darwinCustom"),
+			expected: VirtualMachineGuestOsFamilyDarwinGuestFamily,
+		},
+		{
+			name:     "Custom Solaris String",
+			guestID:  VirtualMachineGuestOsIdentifier("solarisCustom"),
+			expected: VirtualMachineGuestOsFamilySolarisGuest,
+		},
+		{
+			name:     "Custom Netware String",
+			guestID:  VirtualMachineGuestOsIdentifier("netwareCustom"),
+			expected: VirtualMachineGuestOsFamilyNetwareGuest,
+		},
+		{
+			name:     "Unknown OS String",
+			guestID:  VirtualMachineGuestOsIdentifier("unknownOS"),
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+		{
+			name:     "Empty String",
+			guestID:  VirtualMachineGuestOsIdentifier(""),
+			expected: VirtualMachineGuestOsFamilyOtherGuestFamily,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.guestID.ToFamily()
+			if result != tt.expected {
+				t.Errorf("GuestIDToFamily(%q) = %q, want %q", tt.guestID, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION


## Description

This patch adds support for the functions GuestIDToFamily and GuestIDToCIMOSType. Each function takes a VIM guest ID value and translates it to the function's eponymous analogue.

Closes: `NA`

## How Has This Been Tested?

The unit tests in this PR.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
