### PR TITLE
api: BaseClusterClusterInitialPlacementAction interface

### DIFF
--- a/cli/folder/place.go
+++ b/cli/folder/place.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"reflect"
 	"strings"
 	"text/tabwriter"
 
@@ -145,10 +144,6 @@ func (cmd *place) Process(ctx context.Context) error {
 }
 
 func (cmd *place) Run(ctx context.Context, f *flag.FlagSet) error {
-
-	// Register runtime override before any unmarshalling/type casting.
-	types.Add("ClusterClusterInitialPlacementAction", reflect.TypeOf((*types.ClusterClusterInitialPlacementActionEx)(nil)).Elem())
-
 	client, err := cmd.Client()
 	if err != nil {
 		return err

--- a/object/folder.go
+++ b/object/folder.go
@@ -6,7 +6,6 @@ package object
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -216,7 +215,6 @@ func (f Folder) MoveInto(ctx context.Context, list []types.ManagedObjectReferenc
 }
 
 func (f Folder) PlaceVmsXCluster(ctx context.Context, spec types.PlaceVmsXClusterSpec) (*types.PlaceVmsXClusterResult, error) {
-	types.Add("ClusterClusterInitialPlacementAction", reflect.TypeOf((*types.ClusterClusterInitialPlacementActionEx)(nil)).Elem())
 	req := types.PlaceVmsXCluster{
 		This:          f.Reference(),
 		PlacementSpec: spec,

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -1027,7 +1027,9 @@ func generateInitialPlacementAction(ctx *Context, vmSpec *types.PlaceVmsXCluster
 	cluster *ClusterComputeResource, hostRequired, datastoreRequired bool) types.BaseClusterAction {
 
 	placementAction := &types.ClusterClusterInitialPlacementActionEx{
-		Pool: pool.Self,
+		ClusterClusterInitialPlacementAction: types.ClusterClusterInitialPlacementAction{
+			Pool: pool.Self,
+		},
 	}
 
 	if hostRequired {

--- a/vim25/types/unreleased.go
+++ b/vim25/types/unreleased.go
@@ -173,59 +173,26 @@ type PodVMOverheadInfo struct {
 // inside that cluster), the chosen host and the chosen datastores for the disks of
 // the virtual machine.
 type ClusterClusterInitialPlacementActionEx struct {
-	ClusterAction
-
-	// The host where the virtual machine should be initially placed.
-	//
-	// This field is optional because the primary use case of
-	// `Folder.PlaceVmsXCluster` is to select the best cluster for placing VMs. This
-	// `ClusterClusterInitialPlacementAction.targetHost` denotes the best host
-	// within the best cluster and it is only returned if the client asks for it,
-	// which is determined by `PlaceVmsXClusterSpec.hostRecommRequired`.
-	// If `PlaceVmsXClusterSpec.hostRecommRequired` is set to true, then the
-	// targetHost is returned with a valid value and if it is either set to false
-	// or left unset, then targetHost is also left unset. When this field is unset,
-	// then it means that the client did not ask for the target host within the
-	// recommended cluster. It does not mean that there is no recommended host
-	// for placing this VM in the recommended cluster.
-	//
-	// Refers instance of `HostSystem`.
-	TargetHost *ManagedObjectReference `xml:"targetHost,omitempty" json:"targetHost,omitempty"`
-
-	// The chosen resource pool for placing the virtual machine.
-	//
-	// This is non-optional because recommending the best cluster (by recommending the
-	// resource pool in the best cluster) is the primary use case for the
-	// `ClusterClusterInitialPlacementAction`.
-	//
-	// Refers instance of `ResourcePool`.
-	Pool ManagedObjectReference `xml:"pool" json:"pool"`
-
-	// The config spec of the virtual machine to be placed.
-	//
-	// The `Folder.PlaceVmsXCluster` method takes input of `VirtualMachineConfigSpec`
-	// from client and populates the backing for each virtual disk and the VM home
-	// path in it unless the input ConfigSpec already provides them. The existing
-	// settings in the input ConfigSpec are preserved and not overridden in the
-	// returned ConfigSpec in this action as well as the resulting
-	// `ClusterRecommendation`. This field is set based on whether the client needs
-	// `Folder.PlaceVmsXCluster` to recommend a backing datastore for the disks of
-	// the candidate VMs or not, which is specified via
-	// `PlaceVmsXClusterSpec.datastoreRecommRequired`. If
-	// `PlaceVmsXClusterSpec.datastoreRecommRequired` is set to true, then this
-	// `ClusterClusterInitialPlacementAction.configSpec` is also set with the
-	// backing of each disk populated. If
-	// `PlaceVmsXClusterSpec.datastoreRecommRequired` is either set to false or left
-	// unset, then this field is also left unset. When this field is left unset,
-	// then it means that the client did not ask to populate the backing datastore
-	// for the disks of the candidate VMs.
-	ConfigSpec *VirtualMachineConfigSpec `xml:"configSpec,omitempty" json:"configSpec,omitempty"`
+	ClusterClusterInitialPlacementAction
 
 	AvailableNetworks []ManagedObjectReference `xml:"availableNetworks,omitempty" json:"availableNetworks,omitempty"`
 }
 
+type BaseClusterClusterInitialPlacementAction interface {
+	GetClusterClusterInitialPlacementAction() *ClusterClusterInitialPlacementAction
+}
+
+func (a ClusterClusterInitialPlacementAction) GetClusterClusterInitialPlacementAction() *ClusterClusterInitialPlacementAction {
+	return &a
+}
+
+func (a ClusterClusterInitialPlacementActionEx) GetClusterClusterInitialPlacementAction() *ClusterClusterInitialPlacementAction {
+	return &a.ClusterClusterInitialPlacementAction
+}
+
 func init() {
 	minAPIVersionForType["ClusterClusterInitialPlacementActionEx"] = "9.1.0.0"
+	t["ClusterClusterInitialPlacementAction"] = reflect.TypeOf((*ClusterClusterInitialPlacementActionEx)(nil)).Elem()
 	t["ClusterClusterInitialPlacementActionEx"] = reflect.TypeOf((*ClusterClusterInitialPlacementActionEx)(nil)).Elem()
-	Add("ClusterClusterInitialPlacementAction", reflect.TypeOf((*ClusterClusterInitialPlacementActionEx)(nil)).Elem())
+	t["BaseClusterClusterInitialPlacementAction"] = reflect.TypeOf((*ClusterClusterInitialPlacementActionEx)(nil)).Elem()
 }


### PR DESCRIPTION


## Description

This patch introduces a base interfaces for the types `ClusterClusterInitialPlacementAction` and `ClusterClusterInitialPlacementActionEx`, named `BaseClusterClusterInitialPlacementAction`. Now clients can rely on the interface and get the base type when the new fields are not required.

Closes: #(issue-number)

## How Has This Been Tested?

With the following command:

```shell
go test -v -run TestPlaceVmsXClusterCreateAndPowerOnWithCandidateNetworks ./simulator
```

The output will resemble the following:

```shell
=== RUN   TestPlaceVmsXClusterCreateAndPowerOnWithCandidateNetworks
    folder_test.go:737: AvailableNetworks for VM <nil>:
    folder_test.go:739: - network-6
    folder_test.go:739: - dvportgroup-12
--- PASS: TestPlaceVmsXClusterCreateAndPowerOnWithCandidateNetworks (0.90s)
PASS
ok  	github.com/vmware/govmomi/simulator	0.937s
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
