### PR TITLE
API for Library Usage CRUD Operations using GoVMOMI Bindings

### DIFF
--- a/vapi/internal/internal.go
+++ b/vapi/internal/internal.go
@@ -24,6 +24,7 @@ const (
 	LibraryItemUpdateSessionFile   = "/com/vmware/content/library/item/updatesession/file"
 	LibraryItemDownloadSession     = "/com/vmware/content/library/item/download-session"
 	LibraryItemDownloadSessionFile = "/com/vmware/content/library/item/downloadsession/file"
+	LibraryUsages                  = "/com/vmware/content/library/usages"
 	LocalLibraryPath               = "/com/vmware/content/local-library"
 	SubscribedLibraryPath          = "/com/vmware/content/subscribed-library"
 	SecurityPoliciesPath           = "/api/content/security-policies"
@@ -35,6 +36,22 @@ const (
 	SessionCookieName              = "vmware-api-session-id"
 	UseHeaderAuthn                 = "vmware-use-header-authn"
 	DebugEcho                      = "/vc-sim/debug/echo"
+)
+
+// VAPI sub path
+const (
+	LibraryUsagesSubPath = "usages"
+)
+
+// VAPI URL params
+const (
+	LibraryParam      = "library"
+	LibraryUsageParam = "usage"
+)
+
+// VAPI actions
+const (
+	LibraryUsageAddAction = "add"
 )
 
 // AssociatedObject is the same structure as types.ManagedObjectReference,
@@ -79,4 +96,8 @@ type SubscriptionDestinationSpec struct {
 type SubscriptionItemDestinationSpec struct {
 	Force         bool                      `json:"force_sync_content"`
 	Subscriptions []SubscriptionDestination `json:"subscriptions,omitempty"`
+}
+
+type LibraryUsageDestination struct {
+	ID string `json:"usage"`
 }

--- a/vapi/library/library.go
+++ b/vapi/library/library.go
@@ -40,6 +40,7 @@ type Library struct {
 	UnsetSecurityPolicyID bool             `json:"unset_security_policy_id,omitempty"`
 	ServerGUID            string           `json:"server_guid,omitempty"`
 	StateInfo             *StateInfo       `json:"state_info,omitempty"`
+	Configuration         *Configuration   `json:"configuration_info,omitempty"`
 }
 
 // StateInfo provides the state info of a content library.
@@ -231,6 +232,16 @@ func (c *Manager) DeleteLibrary(ctx context.Context, library *Library) error {
 		path = internal.SubscribedLibraryPath
 	}
 	url := c.Resource(path).WithID(library.ID)
+	return c.Do(ctx, url.Request(http.MethodDelete), nil)
+}
+
+// ForceDeleteLibrary Force deletes the specified library by skipping the usage check.
+func (c *Manager) ForceDeleteLibrary(ctx context.Context, library *Library) error {
+	path := internal.LocalLibraryPath
+	if library.Type == "SUBSCRIBED" {
+		path = internal.SubscribedLibraryPath
+	}
+	url := c.Resource(path).WithID(library.ID).WithAction("force-delete")
 	return c.Do(ctx, url.Request(http.MethodDelete), nil)
 }
 

--- a/vapi/library/library_configuration.go
+++ b/vapi/library/library_configuration.go
@@ -1,0 +1,10 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package library
+
+// Configuration represents the configuration at individual Content Library level and applies to all types of libraries.
+type Configuration struct {
+	ApplyLibraryUsageToItems bool `json:"apply_library_uage_to_items,omitempty"`
+}

--- a/vapi/library/library_usage.go
+++ b/vapi/library/library_usage.go
@@ -1,0 +1,68 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package library
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/vmware/govmomi/vapi/internal"
+)
+
+// Usage provides methods to get usage information on content library.
+type Usage struct {
+	ID           string     `json:"usage,omitempty"`
+	ResourceUrn  string     `json:"resource_urn,omitempty"`
+	AdditionTime *time.Time `json:"addition_time,omitempty"`
+}
+
+// UsageSummary contains commonly used information about the usage of a content library.
+type UsageSummary struct {
+	ID          string `json:"usage,omitempty"`
+	ResourceUrn string `json:"resource_urn,omitempty"`
+}
+
+// UsageList lists the usage by resource(s) on a content library.
+type UsageList struct {
+	LibraryUsageList []UsageSummary `json:"library_usage_list,omitempty"`
+}
+
+// GetLibraryUsage retrieves the library usage information for a given usage identifier.
+func (c *Manager) GetLibraryUsage(ctx context.Context, libraryID, usageID string) (Usage, error) {
+	id := internal.LibraryUsageDestination{ID: usageID}
+	url := c.Resource(internal.LibraryUsages).WithID(libraryID).WithAction("get")
+	var res Usage
+	return res, c.Do(ctx, url.Request(http.MethodPost, &id), &res)
+}
+
+// ListLibraryUsage retrieves the list of resources currently using a content library.
+// A content library can be safely deleted if no usage is present for that library.
+func (c *Manager) ListLibraryUsage(ctx context.Context, libraryID string) (UsageList, error) {
+	url := c.Resource(internal.LibraryUsages).WithParam("library", libraryID)
+	var res UsageList
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// RemoveLibraryUsage removes a resource usage on a content library.
+func (c *Manager) RemoveLibraryUsage(ctx context.Context, libraryID string, usageID string) error {
+	id := internal.LibraryUsageDestination{ID: usageID}
+	url := c.Resource(internal.LibraryUsages).WithID(libraryID).WithAction("remove")
+	return c.Do(ctx, url.Request(http.MethodPost, &id), nil)
+}
+
+// AddUsage defines the information required to add a resource usage on a content library.
+type AddUsage struct {
+	ResourceUrn string `json:"resource_urn,omitempty"`
+}
+
+// AddLibraryUsage adds a resource usage on a content library.
+func (c *Manager) AddLibraryUsage(ctx context.Context, libraryID string, addUsage AddUsage) (string, error) {
+	url := c.Resource(internal.LibraryUsages).
+		WithID(libraryID).
+		WithAction(internal.LibraryUsageAddAction)
+	var res string
+	return res, c.Do(ctx, url.Request(http.MethodPost, addUsage), &res)
+}


### PR DESCRIPTION
## Description

This patch adds client bindings to perform library usage CRUD operations via govmomi.

Closes: NA

## How Has This Been Tested?
Added unit tests that utilize the updated simulator code included in this change.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
