### PR TITLE
Add PodVMInfo type and method

### DIFF
--- a/object/host_system.go
+++ b/object/host_system.go
@@ -148,20 +148,17 @@ func (h HostSystem) UpdatePodVMProperty(ctx context.Context, propertyPath string
 		PropertyPath: propertyPath,
 	}
 
-	if propertyPath == "podVMOverheadInfo" {
+	switch propertyPath {
+	case "podVMOverheadInfo":
 		req.Property = podVMInfo.PodVMOverheadInfo
-	} else if propertyPath == "hasPodVM" {
+	case "hasPodVM":
 		req.Property = podVMInfo.HasPodVM
-	} else if propertyPath == "podVMInfo" {
+	case "podVMInfo":
 		req.Property = podVMInfo
-	} else {
+	default:
 		return fmt.Errorf("unsupported propertyPath: %s", propertyPath)
 	}
 
 	_, err := methods.UpdatePodVMProperty(ctx, h.c, &req)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/object/host_system.go
+++ b/object/host_system.go
@@ -140,3 +140,28 @@ func (h HostSystem) ExitMaintenanceMode(ctx context.Context, timeout int32) (*Ta
 
 	return NewTask(h.c, res.Returnval), nil
 }
+
+func (h HostSystem) UpdatePodVMProperty(ctx context.Context, propertyPath string,
+	podVMInfo types.HostRuntimeInfoPodVMInfo) error {
+	req := types.UpdatePodVMProperty{
+		This:         h.Reference(),
+		PropertyPath: propertyPath,
+	}
+
+	if propertyPath == "podVMOverheadInfo" {
+		req.Property = podVMInfo.PodVMOverheadInfo
+	} else if propertyPath == "hasPodVM" {
+		req.Property = podVMInfo.HasPodVM
+	} else if propertyPath == "podVMInfo" {
+		req.Property = podVMInfo
+	} else {
+		return fmt.Errorf("unsupported propertyPath: %s", propertyPath)
+	}
+
+	_, err := methods.UpdatePodVMProperty(ctx, h.c, &req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vim25/methods/unreleased.go
+++ b/vim25/methods/unreleased.go
@@ -30,3 +30,23 @@ func PlaceVmsXCluster(ctx context.Context, r soap.RoundTripper, req *types.Place
 
 	return resBody.Res, nil
 }
+
+type UpdatePodVMPropertyBody struct {
+	Req    *types.UpdatePodVMProperty         `xml:"urn:vim25 UpdatePodVMProperty"`
+	Res    *types.UpdatePodVMPropertyResponse `xml:"UpdatePodVMPropertyResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdatePodVMPropertyBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdatePodVMProperty(ctx context.Context, r soap.RoundTripper, req *types.UpdatePodVMProperty) (*types.UpdatePodVMPropertyResponse, error) {
+	var reqBody, resBody UpdatePodVMPropertyBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return reqBody.Res, nil
+}

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -44786,6 +44786,8 @@ type HostRuntimeInfo struct {
 	PartialMaintenanceMode []HostPartialMaintenanceModeRuntimeInfo `xml:"partialMaintenanceMode,omitempty" json:"partialMaintenanceMode,omitempty" vim:"8.0.3.0"`
 	// Host persistent state encryption information.
 	StateEncryption *HostRuntimeInfoStateEncryptionInfo `xml:"stateEncryption,omitempty" json:"stateEncryption,omitempty" vim:"7.0.3.0"`
+	// PodVM related info for a host
+	PodVMInfo *HostRuntimeInfoPodVMInfo `xml:"podVMInfo,omitempty" json:"podVMInfo,omitempty" vim:"9.0.0.0"`
 }
 
 func init() {

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -44787,7 +44787,7 @@ type HostRuntimeInfo struct {
 	// Host persistent state encryption information.
 	StateEncryption *HostRuntimeInfoStateEncryptionInfo `xml:"stateEncryption,omitempty" json:"stateEncryption,omitempty" vim:"7.0.3.0"`
 	// PodVM related info for a host
-	PodVMInfo *HostRuntimeInfoPodVMInfo `xml:"podVMInfo,omitempty" json:"podVMInfo,omitempty" vim:"9.0.0.0"`
+	PodVMInfo *HostRuntimeInfoPodVMInfo `xml:"podVMInfo,omitempty" json:"podVMInfo,omitempty" vim:"9.1.0.0"`
 }
 
 func init() {

--- a/vim25/types/unreleased.go
+++ b/vim25/types/unreleased.go
@@ -165,6 +165,40 @@ type PodVMOverheadInfo struct {
 	PodVMOverheadWithPageSharing    int32 `xml:"podVMOverheadWithPageSharing"`
 }
 
+func init() {
+	minAPIVersionForType["HostRuntimeInfoPodVMInfo"] = "9.1.0.0"
+	Add("HostRuntimeInfoPodVMInfo", reflect.TypeOf((*HostRuntimeInfoPodVMInfo)(nil)).Elem())
+}
+
+type HostRuntimeInfoPodVMInfo struct {
+	DynamicData
+
+	HasPodVM          bool              `xml:"hasPodVM"`
+	PodVMOverheadInfo PodVMOverheadInfo `xml:"podVMOverheadInfo"`
+}
+
+type UpdatePodVMPropertyRequestType struct {
+	This ManagedObjectReference `xml:"_this" json:"-"`
+	// Indicates the property within PodVMInfo to update
+	PropertyPath string `xml:"propertyPath" json:"propertyPath"`
+	// Value of propertyPath requested to be updated
+	Property AnyType `xml:"property,omitempty,typeattr" json:"property,omitempty"`
+}
+
+func init() {
+	t["UpdatePodVMPropertyRequestType"] = reflect.TypeOf((*UpdatePodVMPropertyRequestType)(nil)).Elem()
+}
+
+type UpdatePodVMProperty UpdatePodVMPropertyRequestType
+
+func init() {
+	minAPIVersionForType["UpdatePodVMProperty"] = "9.1.0.0"
+	t["UpdatePodVMProperty"] = reflect.TypeOf((*UpdatePodVMProperty)(nil)).Elem()
+}
+
+type UpdatePodVMPropertyResponse struct {
+}
+
 // Describes an action for the initial placement of a virtual machine in a cluster.
 //
 // This action is used by the cross cluster placement API when a virtual machine

--- a/vim25/types/unreleased_test.go
+++ b/vim25/types/unreleased_test.go
@@ -81,3 +81,28 @@ func TestTypeClusterClusterInitialPlacementActionEx(t *testing.T) {
 		t.Errorf("Expected: %#v, actual: %#v", expected, actual)
 	}
 }
+
+func TestPodVMInfo(t *testing.T) {
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		host := simulator.Map(ctx).Any("HostSystem").(*simulator.HostSystem)
+
+		host.Runtime.PodVMInfo = &types.HostRuntimeInfoPodVMInfo{
+			HasPodVM: true,
+			PodVMOverheadInfo: types.PodVMOverheadInfo{
+				PodVMOverheadWithoutPageSharing: int32(50),
+				PodVMOverheadWithPageSharing:    int32(25),
+			},
+		}
+
+		var props mo.HostSystem
+		pc := property.DefaultCollector(c)
+		err := pc.RetrieveOne(ctx, host.Self, []string{"runtime"}, &props)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if *props.Runtime.PodVMInfo != *host.Runtime.PodVMInfo {
+			t.Errorf("%#v", props.Runtime.PodVMInfo)
+		}
+	})
+}


### PR DESCRIPTION
## Description

This patch adds support to PodVMInfo VMODL APIs under HostRuntimeInfo which includes hasPodVM and podVMOverheadInfo properties. In addition this patch also adds UpdatePodVMProperty method under HostSystem. The PodVMInfo property and method will be updated by ESXi host and will be consumed by DRS to determine PodVM placement. The change also includes a unit test that tests the setting of PodVMInfo property.

Note: PodVMOverheadInfo that is currently exposed as part of HostCapability will be removed
as a follow-up change, once existing consumers have moved away from it.

## How Has This Been Tested?
- make test:
  === RUN   TestPodVMInfo
  --- PASS: TestPodVMInfo (0.69s)
- Verified UpdatePodVMProperty() method from ESXi:
  --- PASS: TestSetOverheadVMODLProperty (0.20s)
  PASS