### PR TITLE
vcsim: fix snapshot state handling

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -2797,6 +2797,11 @@ func (vm *VirtualMachine) CreateSnapshotExTask(ctx *Context, req *types.CreateSn
 			quiesced = true
 		}
 
+		snapPowerState := vm.Runtime.PowerState
+		if !req.Memory {
+			snapPowerState = types.VirtualMachinePowerStatePoweredOff
+		}
+
 		treeItem := types.VirtualMachineSnapshotTree{
 			Snapshot:        snapshot.Self,
 			Vm:              snapshot.Vm,
@@ -2804,7 +2809,7 @@ func (vm *VirtualMachine) CreateSnapshotExTask(ctx *Context, req *types.CreateSn
 			Description:     req.Description,
 			Id:              atomic.AddInt32(&vm.sid, 1),
 			CreateTime:      time.Now(),
-			State:           vm.Runtime.PowerState,
+			State:           snapPowerState,
 			Quiesced:        quiesced,
 			BackupManifest:  "",
 			ReplaySupported: types.NewBool(false),


### PR DESCRIPTION
## Description

When a snapshot is created with memory, the snapshot's state should reflect
the VM's power state at the time of snapshot creation, and when snapshot
is create without memory, the state should be powered off. The simulator
was not setting this state correctly, leading to inconsistencies.

Closes: #(issue-number)

## How Has This Been Tested?

Unit tests are added in `simulator/virtual_machine_test.go`

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
