### PR TITLE
Add bindings for cis Task API

### DIFF
--- a/vapi/cis/tasks/tasks.go
+++ b/vapi/cis/tasks/tasks.go
@@ -6,6 +6,9 @@ package tasks
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -18,6 +21,152 @@ const (
 	// The default interval in seconds for polling for task results
 	defaultPollingInterval = 10
 )
+
+// The {@name Status} {@term enumerated type} defines the status values that can be reported for an operation.
+type Status string
+
+const (
+
+	// The operation is in pending state.
+	Pending Status = "PENDING"
+
+	// The operation is in progress.
+	Running Status = "RUNNING"
+
+	// The operation is blocked.
+	Blocked Status = "BLOCKED"
+
+	// The operation completed successfully.
+	Succeeded Status = "SUCCEEDED"
+
+	// The operation failed.
+	Failed Status = "FAILED"
+)
+
+// The {@name Progress} {@term structure} contains information describe the progress of an operation.
+type Progress struct {
+	/**
+	 * Total amount of the work for the operation.
+	 */
+	Total uint64 `json:"total"`
+
+	/**
+	 * The amount of work completed for the operation. The value can only be
+	 * incremented.
+	 */
+	Completed uint64 `json:"completed"`
+
+	/**
+	 * Message about the work progress.
+	 */
+	Message rest.LocalizableMessage `json:"message"`
+}
+
+type Info struct {
+	/**
+	 * Description of the operation associated with the task.
+	 */
+	Description rest.LocalizableMessage `json:"description"`
+
+	/**
+	 * Identifier of the service containing the operation.
+	 */
+	Service string `json:"service"`
+
+	/**
+	 * Identifier of the operation associated with the task.
+	 */
+	Operation string `json:"operation"`
+
+	/**
+	 * Parent of the current task.
+	 *
+	 * @field.optional This {@term field} will be {@term unset} if the
+	 * task has no parent.
+	 */
+	Parent string `json:"parent"`
+
+	/**
+	 * Identifier of the target created by the operation or an existing one
+	 * the operation performed on.
+	 *
+	 * @field.optional This {@term field} will be {@term unset} if the
+	 * operation has no target or multiple targets.
+	 */
+	Target map[string]string `json:"target"`
+
+	/**
+	 * Status of the operation associated with the task.
+	 */
+	Status Status `json:"status"`
+
+	/**
+	 * Flag to indicate whether or not the operation can be cancelled.
+	 * The value may change as the operation progresses.
+	 */
+	Cancelable bool `json:"cancelable"`
+
+	/**
+	 * Description of the error if the operation status is "FAILED".
+	 *
+	 * @field.optional If {@term unset} the description of why the operation
+	 * failed will be included in the result of the operation
+	 * (see {@link Info#result}).
+	 */
+	Error rest.Error `json:"error"`
+
+	/**
+	 * Time when the operation is started.
+	 */
+	Start time.Time `json:"start_time"`
+
+	/**
+	 * Time when the operation is completed.
+	 */
+	End time.Time `json:"end_time"`
+
+	/**
+	 * Name of the user who performed the operation.
+	 *
+	 * @field.optional This {@term field} will be {@term unset} if the
+	 * operation is performed by the system.
+	 */
+	User string `json:"user"`
+
+	/**
+	 * Progress of the operation.
+	 */
+	Progress Progress `json:"progress"`
+
+	/**
+	 * Result of the operation.
+	 * <p>
+	 * If an operation reports partial results before it completes, this
+	 * {@term field} could be {@term set} before the {@link CommonInfo#status}
+	 * has the value {@link Status#SUCCEEDED}. The value could change as the
+	 * operation progresses.
+	 *
+	 * @field.optional This {@term field} will be {@term unset} if the
+	 * operation does not return a result or if the result is not available
+	 * at the current step of the operation.
+	 */
+	Result json.RawMessage `json:"result"`
+}
+
+func (t *Info) IsDone() bool {
+	return t.Status != Pending && t.Status != Running
+}
+
+// Err returns an error if the task state is Failed.
+func (t *Info) Err() error {
+	if t.Status != Failed {
+		return nil
+	}
+	if len(t.Error.Messages) > 0 {
+		return &t.Error.Messages[0]
+	}
+	return errors.New(string(t.Error.ErrorType))
+}
 
 // Manager extends rest.Client, adding task related methods.
 type Manager struct {
@@ -41,29 +190,53 @@ func NewManagerWithCustomInterval(client *rest.Client, pollingInterval int) *Man
 	}
 }
 
-func (c *Manager) WaitForCompletion(ctx context.Context, taskId string) (string, error) {
+// WaitForCompletion will wait for the task status to be in anything but the
+// Pending or Running state.
+func (c *Manager) WaitForCompletion(ctx context.Context, taskId string) (*Info, error) {
+	return c.waitForState(ctx, taskId, func(i *Info) bool { return i.IsDone() })
+}
+
+// WaitForRunningOrError will wait for the task status to be Running or Failed.
+// If the task has failed, it will return the TaskInfo Error field as an error.
+func (c *Manager) WaitForRunningOrError(ctx context.Context, taskId string) (*Info, error) {
+	check := func(i *Info) bool {
+		return i.Status == Running || i.Status == Failed
+	}
+	return c.waitForState(ctx, taskId, check)
+}
+
+func (c *Manager) waitForState(ctx context.Context, taskId string, check func(i *Info) bool) (*Info, error) {
 	ticker := time.NewTicker(time.Second * time.Duration(c.pollingInterval))
+	defer ticker.Stop()
 
 	for {
-		select {
-		case <-ctx.Done():
-		case <-ticker.C:
-			taskInfo, err := c.getTaskInfo(taskId)
-			status := taskInfo["status"].(string)
-			if err != nil {
-				return status, err
+		taskInfo, err := c.Get(ctx, taskId)
+		if err != nil {
+			return taskInfo, err
+		}
+
+		// Check for the state we care about.
+		if check(taskInfo) {
+			var err error
+			if taskInfo.Err() != nil {
+				err = fmt.Errorf("%s: %w", taskId, taskInfo.Err())
 			}
 
-			if status != "RUNNING" {
-				return status, nil
-			}
+			return taskInfo, err
+		}
+
+		// Try again.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
 		}
 	}
 }
 
-func (c *Manager) getTaskInfo(taskId string) (map[string]any, error) {
+func (c *Manager) Get(ctx context.Context, taskId string) (*Info, error) {
 	path := c.Resource(TasksPath).WithSubpath(taskId)
 	req := path.Request(http.MethodGet)
-	var res map[string]any
-	return res, c.Do(context.Background(), req, &res)
+	var res Info
+	return &res, c.Do(ctx, req, &res)
 }

--- a/vapi/rest/errors.go
+++ b/vapi/rest/errors.go
@@ -1,0 +1,69 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package rest
+
+import "encoding/json"
+
+type Type string
+
+const (
+	ErrError Type = "ERROR"
+
+	ErrorAlreadyExists Type = "ALREADY_EXISTS"
+
+	ErrAlreadyInDesiredState Type = "ALREADY_IN_DESIRED_STATE"
+
+	ErrCanceled Type = "CANCELED"
+
+	ErrConcurrentChange Type = "CONCURRENT_CHANGE"
+
+	ErrFeatureInUse Type = "FEATURE_IN_USE"
+
+	ErrInternalServer Type = "INTERNAL_SERVER_ERROR"
+
+	ErrInvalidArgument Type = "INVALID_ARGUMENT"
+
+	ErrInvalidElementConfiguration Type = "INVALID_ELEMENT_CONFIGURATION"
+
+	ErrInvalidElementType Type = "INVALID_ELEMENT_TYPE"
+
+	ErrInvalidRequest Type = "INVALID_REQUEST"
+
+	ErrNotAllowedInCurrentState Type = "NOT_ALLOWED_IN_CURRENT_STATE"
+
+	ErrNotFound Type = "NOT_FOUND"
+
+	ErrOperationNotFound Type = "OPERATION_NOT_FOUND"
+
+	ErrResourceBusy Type = "RESOURCE_BUSY"
+
+	ErrResourceInUse Type = "RESOURCE_IN_USE"
+
+	ErrResourceInaccessible Type = "RESOURCE_INACCESSIBLE"
+
+	ErrServiceUnavailable Type = "SERVICE_UNAVAILABLE"
+
+	ErrTimedOut Type = "TIMED_OUT"
+
+	ErrUnableToAllocateResource Type = "UNABLE_TO_ALLOCATE_RESOURCE"
+
+	ErrUnauthenticated Type = "UNAUTHENTICATED"
+
+	ErrUnauthorized Type = "UNAUTHORIZED"
+
+	ErrUnexpectedInput Type = "UNEXPECTED_INPUT"
+
+	ErrUnsupported Type = "UNSUPPORTED"
+
+	ErrUnverifiedPeer Type = "UNVERIFIED_PEER"
+)
+
+type Error struct {
+	Messages []LocalizableMessage `json:"messages"`
+
+	Data json.RawMessage `json:"data"`
+
+	ErrorType Type `json:"error_type"`
+}

--- a/vapi/rest/notifications.go
+++ b/vapi/rest/notifications.go
@@ -1,0 +1,33 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package rest
+
+import "time"
+
+// Notification contains fields to describe any info/warning/error messages
+// that Tasks can raise.
+type Notification struct {
+	// Id is the notification id.
+	Id string `json:"id"`
+
+	// Time the notification was raised/found.
+	Time time.Time `json:"time"`
+
+	Message LocalizableMessage `json:"message"`
+
+	Resolution LocalizableMessage `json:"resolution"`
+}
+
+// Notifications contains info/warning/error messages that can be reported.
+type Notifications struct {
+	// Info notification messages reported.
+	Info []Notification `json:"info"`
+
+	// Warning notification messages reported.
+	Warnings []Notification `json:"warnings"`
+
+	// Errors notification messages reported.
+	Errors []Notification `json:"errors"`
+}


### PR DESCRIPTION
## Description

Previously, tasks were being unmarshalled into a map and checked for completion using a const.

This change implements
* all of the status enums,
* the full Info and Progress structs,
* adds utility methods to wait for completion OR wait for RUNNING or ERORR

Also fixed a bug where waiting on a task would incur waiting for the poll interval even if the task was done.

## How Has This Been Tested?

Tested using a simple test file which created a task and waited for completion or error.

