### PR TITLE
Adds support for the vmRp (VM resource profile usage) field under ResourcePoolRuntimeInfo

### DIFF
--- a/vim25/types/unreleased.go
+++ b/vim25/types/unreleased.go
@@ -196,3 +196,45 @@ func init() {
 	t["ClusterClusterInitialPlacementActionEx"] = reflect.TypeOf((*ClusterClusterInitialPlacementActionEx)(nil)).Elem()
 	t["BaseClusterClusterInitialPlacementAction"] = reflect.TypeOf((*ClusterClusterInitialPlacementActionEx)(nil)).Elem()
 }
+
+type ResourcePoolVmResourceProfileUsage struct {
+	Id                           string `xml:"id"                            json:"id"`
+	ReservedForPool              int64  `xml:"reservedForPool"               json:"reservedForPool"`
+	ReservationUsedForVms        int64  `xml:"reservationUsedForVms"         json:"reservationUsedForVms"`
+	ReservationUsedForChildPools int64  `xml:"reservationUsedForChildPools"  json:"reservationUsedForChildPools"`
+}
+
+func init() {
+	t["ResourcePoolVmResourceProfileUsage"] = reflect.TypeOf((*ResourcePoolVmResourceProfileUsage)(nil)).Elem()
+}
+
+type ArrayOfResourcePoolVmResourceProfileUsage struct {
+	ResourcePoolVmResourceProfileUsage []ResourcePoolVmResourceProfileUsage `xml:"ResourcePoolVmResourceProfileUsage,omitempty"`
+}
+
+func init() {
+	t["ArrayOfResourcePoolVmResourceProfileUsage"] = reflect.TypeOf((*ArrayOfResourcePoolVmResourceProfileUsage)(nil)).Elem()
+}
+
+type ResourcePoolRuntimeInfoEx struct {
+	// Embed the released base type to inherit all fields.
+	ResourcePoolRuntimeInfo
+
+	VmRp []ResourcePoolVmResourceProfileUsage `xml:"vmRp>ResourcePoolVmResourceProfileUsage,omitempty" json:"vmRp,omitempty"`
+}
+
+type BaseResourcePoolRuntimeInfo interface {
+	GetResourcePoolRuntimeInfo() *ResourcePoolRuntimeInfo
+}
+
+func (r ResourcePoolRuntimeInfo) GetResourcePoolRuntimeInfo() *ResourcePoolRuntimeInfo { return &r }
+
+func (r ResourcePoolRuntimeInfoEx) GetResourcePoolRuntimeInfo() *ResourcePoolRuntimeInfo {
+	return &r.ResourcePoolRuntimeInfo
+}
+
+func init() {
+	minAPIVersionForType["ResourcePoolRuntimeInfoEx"] = "9.1.0.0"
+	t["ResourcePoolRuntimeInfoEx"] = reflect.TypeOf((*ResourcePoolRuntimeInfoEx)(nil)).Elem()
+	t["BaseResourcePoolRuntimeInfo"] = reflect.TypeOf((*ResourcePoolRuntimeInfoEx)(nil)).Elem()
+}

--- a/vim25/types/unreleased_test.go
+++ b/vim25/types/unreleased_test.go
@@ -5,7 +5,9 @@
 package types_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/xml"
 	"reflect"
 	"testing"
 
@@ -59,6 +61,7 @@ func TestTypeClusterClusterInitialPlacementActionEx(t *testing.T) {
 		t.Errorf("Expected ok==true")
 	}
 
+	// Expected type is the base struct (before override).
 	expected := reflect.TypeOf(types.ClusterClusterInitialPlacementAction{})
 
 	// Validate that the type lookup matches the base type.
@@ -69,15 +72,84 @@ func TestTypeClusterClusterInitialPlacementActionEx(t *testing.T) {
 	// Override the registered type with our extended struct ClusterClusterInitialPlacementActionEx.
 	types.Add("ClusterClusterInitialPlacementAction", reflect.TypeOf((*types.ClusterClusterInitialPlacementActionEx)(nil)).Elem())
 
+	var actual2 reflect.Type
 	// Lookup the same name again - should now return the extended type.
-	actual, ok = fn("ClusterClusterInitialPlacementAction")
+	// Now `actual` refers to the reflect.Type of the extended struct.
+	actual2, ok = fn("ClusterClusterInitialPlacementAction")
 	if !ok {
 		t.Errorf("Expected ok==true")
 	}
 
-	// Expected type is now the extended struct.
-	expected = reflect.TypeOf(types.ClusterClusterInitialPlacementActionEx{})
-	if !reflect.DeepEqual(expected, actual) {
-		t.Errorf("Expected: %#v, actual: %#v", expected, actual)
+	// Expected type is now the extended struct (after override).
+	expected2 := reflect.TypeOf(types.ClusterClusterInitialPlacementActionEx{})
+	if !reflect.DeepEqual(expected2, actual2) {
+		t.Errorf("Expected: %#v, actual: %#v", expected2, actual2)
+	}
+}
+
+func TestTypeResourcePoolRuntimeInfoEx(t *testing.T) {
+	fn := types.TypeFunc()
+
+	// By default, the registry should return the BASE type.
+	actual, ok := fn("ResourcePoolRuntimeInfo")
+	if !ok {
+		t.Fatalf("expected ok for ResourcePoolRuntimeInfo")
+	}
+	if want := reflect.TypeOf(types.ResourcePoolRuntimeInfo{}); !reflect.DeepEqual(want, actual) {
+		t.Fatalf("default mapping should be base; want=%#v got=%#v", want, actual)
+	}
+
+	// override: map the name to Ex and verify.
+	prev := actual
+	types.Add("ResourcePoolRuntimeInfo", reflect.TypeOf(types.ResourcePoolRuntimeInfoEx{}))
+	defer types.Add("ResourcePoolRuntimeInfo", prev)
+
+	actual2, ok := fn("ResourcePoolRuntimeInfo")
+	if !ok {
+		t.Fatalf("expected ok for ResourcePoolRuntimeInfo after override")
+	}
+	if want := reflect.TypeOf(types.ResourcePoolRuntimeInfoEx{}); !reflect.DeepEqual(want, actual2) {
+		t.Fatalf("override mapping failed; want=%#v got=%#v", want, actual2)
+	}
+}
+
+func TestResourcePoolRuntimeInfoEx_XML_vmRp(t *testing.T) {
+	// Case 1: VmRp is nil – do NOT assert absence of <vmRp>, just ensure no items.
+	exNil := &types.ResourcePoolRuntimeInfoEx{}
+	bNil, err := xml.Marshal(exNil)
+	if err != nil {
+		t.Fatalf("marshal (nil VmRp) failed: %v", err)
+	}
+	if bytes.Contains(bNil, []byte("<ResourcePoolVmResourceProfileUsage")) {
+		t.Fatalf("unexpected item when VmRp is nil: %s", string(bNil))
+	}
+
+	// Case 2: VmRp empty slice – same: allow <vmRp>, but no items.
+	exEmpty := &types.ResourcePoolRuntimeInfoEx{VmRp: []types.ResourcePoolVmResourceProfileUsage{}}
+	bEmpty, err := xml.Marshal(exEmpty)
+	if err != nil {
+		t.Fatalf("marshal (empty VmRp) failed: %v", err)
+	}
+	if bytes.Contains(bEmpty, []byte("<ResourcePoolVmResourceProfileUsage")) {
+		t.Fatalf("unexpected item when VmRp is empty: %s", string(bEmpty))
+	}
+
+	// Case 3: VmRp with one item – expect both <vmRp> and an item.
+	exOne := &types.ResourcePoolRuntimeInfoEx{
+		VmRp: []types.ResourcePoolVmResourceProfileUsage{
+			{Id: "small-vm", ReservedForPool: 2, ReservationUsedForVms: 0, ReservationUsedForChildPools: 0},
+		},
+	}
+	bOne, err := xml.Marshal(exOne)
+	if err != nil {
+		t.Fatalf("marshal (one VmRp) failed: %v", err)
+	}
+	// <vmRp> must be present in encoded xml.
+	if !bytes.Contains(bOne, []byte("<vmRp")) {
+		t.Fatalf("expected <vmRp> when VmRp has items, got: %s", string(bOne))
+	}
+	// <ResourcePoolVmResourceProfileUsage in encoded xml.
+	if !bytes.Contains(bOne, []byte("<ResourcePoolVmResourceProfileUsage")) {
+		t.Fatalf("expected ResourcePoolVmResourceProfileUsage item, got: %s", string(bOne))
 	}
 }

--- a/vim25/types/unreleased_vc_test.go
+++ b/vim25/types/unreleased_vc_test.go
@@ -1,0 +1,173 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func insecureFromEnv() bool {
+	v := os.Getenv("GOVC_INSECURE")
+	if v == "" {
+		// Verify TLS certs.
+		return false
+	}
+	// 1 - Skip TLS validation. 0 - Enforce TLS validation.
+	b, _ := strconv.ParseBool(v)
+	return b
+}
+
+func credsFromEnvOrURL(u *url.URL, t *testing.T) *url.Userinfo {
+	t.Helper()
+	if u.User != nil {
+		return u.User
+	}
+	user := os.Getenv("GOVC_USERNAME")
+	if user == "" {
+		t.Fatal("no credentials provided: set user:pass in GOVC_URL or GOVC_USERNAME/GOVC_PASSWORD")
+	}
+	return url.UserPassword(user, os.Getenv("GOVC_PASSWORD"))
+}
+
+// Scoped override for the *types* registry only.
+func withTypesOverride(name string, to reflect.Type, fn func() error) error {
+	// Lookup the current registered type for that VMODL name.
+	prev, _ := types.TypeFunc()(name)
+	// Temporarily override mapping (e.g. ResourcePoolRuntimeInfo → ResourcePoolRuntimeInfoEx)
+	types.Add(name, to)
+	// Restore original mapping at the end.
+	defer types.Add(name, prev)
+	// Run the block while override is in effect.
+	return fn()
+}
+
+func TestResourcePoolRuntimeWithVmRp(t *testing.T) {
+	rawURL := os.Getenv("GOVC_URL")
+	if rawURL == "" {
+		t.Skip("GOVC_URL not set")
+	}
+
+	ctx := context.Background()
+
+	u, err := soap.ParseURL(rawURL)
+	if err != nil {
+		t.Fatalf("parse GOVC_URL: %v", err)
+	}
+
+	// SOAP + vim25 client (honor GOVC_INSECURE)
+	sc := soap.NewClient(u, insecureFromEnv())
+	c, err := vim25.NewClient(ctx, sc)
+	if err != nil {
+		t.Fatalf("vim25.NewClient: %v", err)
+	}
+
+	err = c.UseServiceVersion()
+	if err != nil {
+		t.Fatalf("vim25.NewClient use service version: %v", err)
+	}
+
+	// Login
+	userinfo := credsFromEnvOrURL(u, t)
+	m := session.NewManager(c)
+	if err := m.Login(ctx, userinfo); err != nil {
+		t.Fatalf("login failed: %v", err)
+	}
+	defer m.Logout(ctx)
+
+	// Get Datacenter & Resource pool by env ----
+	dcName := os.Getenv("GOVC_DATACENTER")
+	if dcName == "" {
+		t.Fatal("set GOVC_DATACENTER")
+	}
+	rpPath := os.Getenv("GOVC_RESOURCE_POOL")
+	if rpPath == "" {
+		t.Fatal("set GOVC_RESOURCE_POOL (full inventory path)")
+	}
+
+	f := find.NewFinder(c, true)
+	dc, err := f.Datacenter(ctx, dcName)
+	if err != nil {
+		t.Fatalf("Datacenter(%q): %v", dcName, err)
+	}
+	f.SetDatacenter(dc)
+	t.Logf("using datacenter: %s", dc.InventoryPath)
+
+	rpObj, err := f.ResourcePool(ctx, rpPath)
+	if err != nil {
+		t.Fatalf("ResourcePool(%q): %v", rpPath, err)
+	}
+	rpRef := rpObj.Reference()
+	t.Logf("using resource pool: %s", rpObj.InventoryPath)
+
+	// ---- Retrieve "runtime.vmRp" as ObjectContent and decode via *types* override ----
+	props := []string{"runtime.vmRp"}
+	var oc []types.ObjectContent
+	pc := property.DefaultCollector(c)
+
+	err = withTypesOverride("ResourcePoolRuntimeInfo", reflect.TypeOf(types.ResourcePoolRuntimeInfoEx{}), func() error {
+		return pc.Retrieve(ctx, []types.ManagedObjectReference{rpRef}, props, &oc)
+	})
+	if err != nil {
+		t.Fatalf("Retrieve(runtime.vmRp): %v", err)
+	}
+	if len(oc) == 0 || len(oc[0].PropSet) == 0 {
+		t.Fatalf("no properties returned for %s", rpRef.String())
+	}
+
+	for _, p := range oc[0].PropSet {
+		t.Logf("Property: %s, Type: %T, Value: %#v", p.Name, p.Val, p.Val)
+	}
+	// Find "runtime" and assert it's the Ex type; then dump vmRp
+	var got any
+	for _, p := range oc[0].PropSet {
+		if p.Name == "runtime.vmRp" {
+			got = p.Val
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("runtime not in PropSet")
+	}
+
+	t.Logf("runtime dynamic type: %T", got)
+
+	var items []types.ResourcePoolVmResourceProfileUsage
+
+	switch v := got.(type) {
+	case types.ArrayOfResourcePoolVmResourceProfileUsage:
+		// Leaf property "runtime.vmRp" often decodes to the wrapper struct.
+		items = v.ResourcePoolVmResourceProfileUsage
+	case *types.ArrayOfResourcePoolVmResourceProfileUsage:
+		items = v.ResourcePoolVmResourceProfileUsage
+	case []types.ResourcePoolVmResourceProfileUsage:
+		// When decoding the whole "runtime" into ResourcePoolRuntimeInfoEx,
+		// the slice field (VmRp []...) is filled directly.
+		items = v
+	default:
+		t.Fatalf("unexpected type for runtime.vmRp: %T", got)
+	}
+
+	if len(items) == 0 {
+		t.Log("vmRp present but empty")
+	} else {
+		t.Logf("vmRp items: %d", len(items))
+		for i, u := range items {
+			t.Logf("vmRp[%d]: id=%q reservedForPool=%d usedForVms=%d usedForChildPools=%d",
+				i, u.Id, u.ReservedForPool, u.ReservationUsedForVms, u.ReservationUsedForChildPools)
+		}
+	}
+}


### PR DESCRIPTION
## Description
Adds support for the vmRp (VM resource profile usage) field under ResourcePoolRuntimeInfo

Please include a summary of the change.

This PR adds support for the vmRp (VM resource profile usage) field under ResourcePoolRuntimeInfo. This field is under FSS WCP_Zone_Resource_Utilization_Monitoring. Since vmRp is controlled by a feature state switch (FSS) and only available in newer API versions, the change introduces a new Ex type:

types.ResourcePoolRuntimeInfoEx — extends the base ResourcePoolRuntimeInfo with an optional VmRp []ResourcePoolVmResourceProfileUsage.

The new Ex type is registered in unreleased.go but does not override the base globally. Consumers can opt into Ex when they want to access vmRp.

Git hub Link to the vmodl change where VmResourceProfileUsage is included as part of resource pool run time - https://github-vcf.devops.broadcom.net/vcf/tera/pull/24307/files



Closes: #(issue-number)
CRM-3551

## How Has This Been Tested?

Added 3 unit tests in unreleased_test.go:

TestTypeResourcePoolRuntimeInfoEx - verifies the type registry maps "ResourcePoolRuntimeInfo" to ResourcePoolRuntimeInfoEx.

TestResourcePoolRuntimeWithVmRp – retrieves runtime.vmRp from a real vCenter and checks decoding into ResourcePoolRuntimeInfoEx.

TestResourcePoolRuntimeInfoEx_XML_vmRp – validates XML marshaling behavior of the VmRp field for nil, empty, and populated slices.

% go test -v ./vim25/types -run TestResourcePoolRuntimeWithVmRp
=== RUN   TestResourcePoolRuntimeWithVmRp
    unreleased_vc_test.go:103: using datacenter: /vcqaDC
    unreleased_vc_test.go:110: using resource pool: /vcqaDC/host/cls/Resources/Namespaces
    unreleased_vc_test.go:128: Property: runtime.vmRp, Type: types.ArrayOfResourcePoolVmResourceProfileUsage, Value: types.ArrayOfResourcePoolVmResourceProfileUsage{ResourcePoolVmResourceProfileUsage:[]types.ResourcePoolVmResourceProfileUsage{types.ResourcePoolVmResourceProfileUsage{Id:"small-vm", ReservedForPool:5, ReservationUsedForVms:0, ReservationUsedForChildPools:0}}}
    unreleased_vc_test.go:142: runtime dynamic type: types.ArrayOfResourcePoolVmResourceProfileUsage
    unreleased_vc_test.go:163: vmRp items: 1
    unreleased_vc_test.go:165: vmRp[0]: id="small-vm" reservedForPool=5 usedForVms=0 usedForChildPools=0
--- PASS: TestResourcePoolRuntimeWithVmRp (0.55s)
PASS
ok  	github.com/vmware/govmomi/vim25/types	0.590s


go test -v github.com/vmware/govmomi/vim25/types -run TTestResourcePoolRuntimeInfoEx_XML_vmRp
=== RUN   TestResourcePoolRuntimeInfoEx_XML_vmRp
--- PASS: TestResourcePoolRuntimeInfoEx_XML_vmRp (0.00s)
PASS
ok  	github.com/vmware/govmomi/vim25/types	0.022s

 go test -v github.com/vmware/govmomi/vim25/types -run TestTypeResourcePoolRuntimeInfoEx
=== RUN   TestTypeResourcePoolRuntimeInfoEx
--- PASS: TestTypeResourcePoolRuntimeInfoEx (0.00s)
PASS
ok  	github.com/vmware/govmomi/vim25/types	0.032s

Please describe any manual tests done to verify your changes.

Ran the testcase TestResourcePoolRuntimeWithVmRp on VC setup and checked for runtime.vmRp property of resourcePool.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
