### PR TITLE
feat: add `govc vm.customize` command to support password and custom script

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -6970,12 +6970,15 @@ Examples:
   govc vm.customize -vm VM -auto-login 3 NAME
   govc vm.customize -vm VM -prefix demo NAME
   govc vm.customize -vm VM -tz America/New_York NAME
+  # Change password, expire password, run customization script, and specify the VCF Automation signature
+  govc vm.customize -vm VM -name my-hostname -ip dhcp -pwd '<your password>' -expire-pwd -script-file './test.bat' -vcfa-sig '<your hash>'
 
 Options:
   -auto-login=0          Number of times the VM should automatically login as an administrator
   -dns-server=[]         DNS server list
   -dns-suffix=[]         DNS suffix list
   -domain=               Domain name
+  -expire-pwd=false      Expire administrator (for Windows) or root (for Linux) password after customization
   -gateway=[]            Gateway
   -ip=[]                 IPv4 address
   -ip6=[]                IPv6 addresses with optional netmask (defaults to /64), separated by comma
@@ -6984,9 +6987,12 @@ Options:
   -netmask=[]            Netmask
   -org=                  Windows only : name of the org that owns the VM
   -prefix=               Host name generator prefix
+  -pwd=                  The new administrator (for Windows) or root (for Linux) password
+  -script-file=          Path to a script to run before and after customization
   -type=Linux            Customization type if spec NAME is not specified (Linux|Windows)
   -tz=                   Time zone
   -username=             Windows only : full name of the end user in firstname lastname format
+  -vcfa-sig=             The VCF Automation signature to identify customization request source
   -vm=                   Virtual machine [GOVC_VM]
 ```
 


### PR DESCRIPTION
## Description
This change enhances the `govc vm.customize` command by adding support for:  

- **`-pwd`**: Change the password of the default administrator (`Administrator` for Windows, `root` for Linux).
- **`-expire-pwd`**: Expire the password of the default administrator, requiring users to set a new password at the next login.
- **`-script-file`**: Specify a script to be executed before and after the customization process.

---
## How Has This Been Tested?
Deployed a vCenter with both Windows and Linux VMs, then ran:

```shell
govc vm.customize -vm rhel -name rhel -ip dhcp \
          -pwd 'NewPwd@123' -expire-pwd -script-file './test.sh'
```

and

```shell
govc vm.customize -type Windows -vm win10 -name win10 -ip dhcp \
          -pwd 'NewPwd@123' -expire-pwd -script-file '~/test.bat' \
          -username fake -org dummy
```

Power on the VM and wait for customization complete, verify below:
- Customization completed successfully
- Administrator/root password was updated
- Password expiration enforced (required reset before login)
- Custom script executed successfully

## feat
https://github.com/vmware/govmomi/issues/3888