### PR TITLE
api: remove podVMOverheadInfo host capability

### DIFF
--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -35595,8 +35595,6 @@ type HostCapability struct {
 	NpivSupported *bool `xml:"npivSupported" json:"npivSupported,omitempty" vim:"9.0.0.0"`
 	// Indicates whether this host supports license entitlements
 	EntitlementSupported *bool `xml:"entitlementSupported" json:"entitlementSupported,omitempty" vim:"9.0.0.0"`
-	// Contains the memory overhead info for PodVMs for this host.
-	PodVMOverheadInfo *PodVMOverheadInfo `xml:"podVMOverheadInfo,omitempty" json:"podVMOverheadInfo,omitempty" vim:"9.1.0.0"`
 	// Indicates whether "FCD Linked Clone feature" supported on this host.
 	FcdLinkedCloneSupported *bool `xml:"fcdLinkedCloneSupported" json:"fcdLinkedCloneSupported,omitempty" vim:"9.1.0.0"`
 }

--- a/vim25/types/unreleased_test.go
+++ b/vim25/types/unreleased_test.go
@@ -15,29 +15,6 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-func TestPodVMOverheadInfo(t *testing.T) {
-	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		host := simulator.Map(ctx).Any("HostSystem").(*simulator.HostSystem)
-
-		host.Capability.PodVMOverheadInfo = &types.PodVMOverheadInfo{
-			CrxPageSharingSupported:         true,
-			PodVMOverheadWithoutPageSharing: int32(42),
-			PodVMOverheadWithPageSharing:    int32(53),
-		}
-
-		var props mo.HostSystem
-		pc := property.DefaultCollector(c)
-		err := pc.RetrieveOne(ctx, host.Self, []string{"capability"}, &props)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if *props.Capability.PodVMOverheadInfo != *host.Capability.PodVMOverheadInfo {
-			t.Errorf("%#v", props.Capability.PodVMOverheadInfo)
-		}
-	})
-}
-
 func TestPodVMInfo(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
 		host := simulator.Map(ctx).Any("HostSystem").(*simulator.HostSystem)


### PR DESCRIPTION
## Description

The podVMOverheadInfo property has moved to the host runtime info under the podVMInfo property. Hence this unused host capability can be removed along with its test.

Note: This is a follow up to https://github.com/vmware/govmomi/pull/3850 and reverts some unreleased changes from https://github.com/vmware/govmomi/pull/3747

## How Has This Been Tested?
Ran make test and ensured the TestPodVM test passed as it still verifies the host runtime info podVMOverheadInfo