### PR TITLE
Preventing Accidental Deletion of Library Items through Usage Config

### DIFF
--- a/vapi/library/library.go
+++ b/vapi/library/library.go
@@ -123,6 +123,9 @@ func (l *Library) Patch(src *Library) {
 	if src.Version != "" {
 		l.Version = src.Version
 	}
+	if src.Configuration != nil {
+		l.Configuration = src.Configuration
+	}
 }
 
 // Manager extends rest.Client, adding content library related methods.
@@ -217,8 +220,9 @@ func (c *Manager) UpdateLibrary(ctx context.Context, l *Library) error {
 		Library `json:"update_spec"`
 	}{
 		Library{
-			Name:        l.Name,
-			Description: l.Description,
+			Name:          l.Name,
+			Description:   l.Description,
+			Configuration: l.Configuration,
 		},
 	}
 	url := c.Resource(internal.LibraryPath).WithID(l.ID)

--- a/vapi/library/library_configuration.go
+++ b/vapi/library/library_configuration.go
@@ -6,5 +6,5 @@ package library
 
 // Configuration represents the configuration at individual Content Library level and applies to all types of libraries.
 type Configuration struct {
-	ApplyLibraryUsageToItems bool `json:"apply_library_uage_to_items,omitempty"`
+	ApplyLibraryUsageToItems *bool `json:"apply_library_usage_to_items,omitempty"`
 }

--- a/vapi/library/library_test.go
+++ b/vapi/library/library_test.go
@@ -155,6 +155,40 @@ func TestManagerLibraryUsage(t *testing.T) {
 			t.Fatalf("Library %s in use should not allowed for delete", id)
 		}
 
+		// Apply library usage to items.
+		trueValue := true
+		updateSpec := library.Library{ID: id, Name: libName, Configuration: &library.Configuration{ApplyLibraryUsageToItems: &trueValue}}
+		err = m.UpdateLibrary(ctx, &updateSpec)
+		if err != nil {
+			t.Fatalf("updating library %s with new configuration should not fail. err: %v", id, err)
+		}
+		// Add library item and deletion of the item should not be allowed.
+		itemDesc := "test item description"
+		itemID, err := m.CreateLibraryItem(ctx, library.Item{Name: "test-item", Description: &itemDesc, LibraryID: id})
+		if err != nil {
+			t.Fatalf("library item creation should not fail. err: %v", err)
+		}
+		err = m.DeleteLibraryItem(ctx, &library.Item{ID: itemID})
+		if err == nil {
+			t.Fatalf("library item %s deletion should fail. err: %v", itemID, err)
+
+		}
+
+		// Relax library usage to items.
+		falseValue := false
+		updateSpec = library.Library{ID: id, Name: libName, Configuration: &library.Configuration{ApplyLibraryUsageToItems: &falseValue}}
+		err = m.UpdateLibrary(ctx, &updateSpec)
+		if err != nil {
+			t.Fatalf("updating library %s with new configuration should not fail. err: %v", id, err)
+		}
+
+		// Remove library item should be allowed.
+		err = m.DeleteLibraryItem(ctx, &library.Item{ID: itemID})
+		if err != nil {
+			t.Fatalf("library item %s deletion should not fail. err: %v", itemID, err)
+
+		}
+
 		// Remove library usage
 		err = m.RemoveLibraryUsage(ctx, id, usageID)
 		if err != nil {


### PR DESCRIPTION
## Description
This change allows clients to update library configuration to apply library usage to items, protecting them from accidental deletion.

Closes: NA

## How Has This Been Tested?

Added unit tests that utilize the updated simulator code included in this change. Also ran the real testing in lab environment.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
