### PR TITLE
Fixes for EAM 2.0 Transition API Definitions

### DIFF
--- a/vapi/esx/settings/clusters/vms/list.go
+++ b/vapi/esx/settings/clusters/vms/list.go
@@ -6,6 +6,7 @@ package vms
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/vmware/govmomi/vim25/types"
@@ -67,6 +68,13 @@ type ClusterSolutionInfo struct {
 	//
 	// If unset no AlternativeVmSpecs applied to the System VMs.
 	//Optional<List<AlternativeVmSpec>> alternativeVmSpecs;
+
+	// Devices of the VMs not defined in the OVF descriptor. If VmDatastores is
+	// not set, the devices of the VMs not defined in the OVF descriptor should
+	// be provided and not as part of a VM lifecycle hook (VM reconfiguration).
+	// Otherwise, the compatibility of the devices with the selected host and
+	// datastore where the VM is deployed needs to be ensured by the client.
+	Devices json.RawMessage `json:"devices,omitempty"`
 }
 
 type SolutionInfo struct {

--- a/vapi/esx/settings/clusters/vms/transition.go
+++ b/vapi/esx/settings/clusters/vms/transition.go
@@ -60,7 +60,7 @@ type VmSelectionSpec struct {
 // TransitionSpec contains fields that describe the specification for transitioning a System VM Solution.
 type TransitionSpec struct {
 	// SourceCluster is the cluster to transition from.
-	SourceCluster types.ManagedObjectReference `json:"source_cluster"`
+	SourceCluster string `json:"source_cluster"`
 
 	// Solution is the target desired solution specification in vLCM.
 	Solution *SolutionSpec `json:"solution"`
@@ -125,8 +125,7 @@ func (m *Manager) EnableAsync(ctx context.Context, cluster types.ManagedObjectRe
 		return "", err
 	}
 
-	_, err := tasks.NewManager(m.Client).WaitForRunningOrError(ctx, taskId)
-	return taskId, err
+	return taskId, nil
 }
 
 // Enable enables an EAM managed solution in vLCM.
@@ -136,7 +135,7 @@ func (m *Manager) Enable(ctx context.Context, cluster types.ManagedObjectReferen
 		return err
 	}
 
-	_, err = tasks.NewManager(m.Client).WaitForRunningOrError(ctx, taskId)
+	_, err = tasks.NewManager(m.Client).WaitForCompletion(ctx, taskId)
 	return err
 }
 
@@ -164,8 +163,7 @@ func (m *Manager) MultiSourceEnableAsync(ctx context.Context, cluster types.Mana
 		return "", err
 	}
 
-	_, err := tasks.NewManager(m.Client).WaitForRunningOrError(ctx, taskId)
-	return taskId, err
+	return taskId, nil
 }
 
 // MultiSourceEnable enables multiple EAM managed solutions in vLCM as a single solution.
@@ -175,7 +173,7 @@ func (m *Manager) MultiSourceEnable(ctx context.Context, cluster types.ManagedOb
 		return err
 	}
 
-	_, err = tasks.NewManager(m.Client).WaitForRunningOrError(ctx, taskId)
+	_, err = tasks.NewManager(m.Client).WaitForCompletion(ctx, taskId)
 	return err
 }
 
@@ -198,8 +196,7 @@ func (m *Manager) TransitionAsync(ctx context.Context, cluster types.ManagedObje
 		return "", err
 	}
 
-	_, err := tasks.NewManager(m.Client).WaitForRunningOrError(ctx, taskId)
-	return taskId, err
+	return taskId, nil
 }
 
 // Transition transitions a System VM Solution desired state to a target cluster.
@@ -209,6 +206,6 @@ func (m *Manager) Transition(ctx context.Context, cluster types.ManagedObjectRef
 		return err
 	}
 
-	_, err = tasks.NewManager(m.Client).WaitForRunningOrError(ctx, taskId)
+	_, err = tasks.NewManager(m.Client).WaitForCompletion(ctx, taskId)
 	return err
 }


### PR DESCRIPTION
## Description

TransitionSpec's `SourceCluster` should be of type `string`. 
And those `Async` function should simply return taskID.

## How Has This Been Tested?

Tested this with local govc test against a real VC

Sample Code:

```
func TestTransitionGovc(t *testing.T) {

	ctx := context.Background()
	l := os.Getenv("GOVC_URL")
	if l == "" {
		t.Skip("GOVC_URL is not set")
	}

	u, err := soap.ParseURL(l)
	if err != nil {
		t.Fatal(err)
	}

	c, err := govmomi.NewClient(ctx, u, true)
	if err != nil {
		t.Fatal(err)
	}

	restClient := rest.NewClient(c.Client)
	err = restClient.Login(ctx, u.User)
	if err != nil {
		t.Fatal(err)
	}

	manager := &Manager{
		Client: restClient,
	}
	taskManager := tasks.NewManager(restClient)

	targetCluster := types.ManagedObjectReference{
		Type:  "ClusterComputeResource",
		Value: "",
	}
	sourceCluster := types.ManagedObjectReference{
		Type:  "ClusterComputeResource",
		Value: "",
	}
	supervisorID := ""

	// get source solution
	sourceSolution, err := manager.Get(ctx, sourceCluster, supervisorID)
	if err != nil {
		t.Fatal(err)
	}
	targetSpec := SpecFromInfo(sourceSolution)
	targetSpec.VmResourcePool = ""

	transitionSpec := &TransitionSpec{
		SourceCluster: sourceCluster.Value,
		Solution:      targetSpec,
	}
	// Print the transition spec in JSON format
	jsonData, err := json.MarshalIndent(transitionSpec, "", "  ")
	if err != nil {
		t.Fatal(err)
	}
	t.Logf("TransitionSpec JSON:\n%s", string(jsonData))

	taskID, err := manager.TransitionAsync(ctx, targetCluster, supervisorID, transitionSpec)
	require.NoError(t, err)
	t.Logf("taskID: %s", taskID)

	info, err := taskManager.WaitForCompletion(ctx, taskID)
	require.NoError(t, err)
	t.Logf("info: %+v", info)
}
```
