### PR TITLE
EAM 2.0 Transition API needs more fields in bindings

### DIFF
--- a/vapi/esx/settings/clusters/vms/solutions.go
+++ b/vapi/esx/settings/clusters/vms/solutions.go
@@ -46,6 +46,39 @@ const (
 	Sequential RemediationPolicy = "SEQUENTIAL"
 )
 
+// AlternativeVmSpec contains to describe alternative VM configuration to be applied on
+// VMs that matches a given selection criteria defined as VmSelectionSpec.
+type AlternativeVmSpec struct {
+	// SelectionCriteria is the criteria to match System VMs for which to apply this alternative VM spec.
+	SelectionCriteria VmSelectionSpec `json:"selection_criteria"`
+
+	// Devices of the VMs not defined in the OVF descriptor. This
+	// takes precedence over ClusterSolutionSpec#Devices.
+	//
+	// If ClusterSolutionSpec#VmDatastores is not set, the devices of
+	// the VMs not defined in the OVF descriptor should be provided to
+	// Devices and not as part of a VM lifecycle hook
+	// (VM reconfiguration). Otherwise, the compatibility of the devices with the
+	// selected host and datastore where the VM is deployed needs to be ensured
+	// by the client.
+	//
+	// 1. For VM initial placement the devices are added to the VM configuration.
+	// 2. For the reconfiguration it is checked what devices need to be added,
+	// removed, and edited on the existing VMs. NOTE: No VM relocation is
+	// executed before the VM reconfiguration.
+	//
+	// The supported property of vim.vm.ConfigSpec is
+	// vim.vm.ConfigSpec.deviceChange. The supported
+	// vim.vm.device.VirtualDeviceSpec.operation is Operation#add. For
+	// vim.vm.device.VirtualEthernetCard the unique identifier is
+	// vim.vm.device.VirtualDevice#unitNumber.
+	// ClusterSolutionSpec#vmNetworks and devices are mutually
+	// exclusive.
+	//
+	// If unset, ClusterSolutionSpec#Devices is used.
+	Devices json.RawMessage `json:"devices,omitempty"`
+}
+
 // ClusterSolutionSpec contains fields that describe solution configuration
 // only applicable for solutions with deployment type DeploymentType#CLUSTER_VM_SET}.
 type ClusterSolutionSpec struct {
@@ -100,9 +133,8 @@ type ClusterSolutionSpec struct {
 	RemediationPolicy RemediationPolicy `json:"remediation_policy"`
 
 	// AlternativeVmSpecs to be applied on the System VMs.
-	//
 	// If unset no AlternativeVmSpecs applied to the System VMs.
-	//Optional<List<AlternativeVmSpec>> alternativeVmSpecs;
+	AlternativeVmSpecs []AlternativeVmSpec `json:"alternative_vm_specs,omitempty"`
 }
 
 type DeploymentType string


### PR DESCRIPTION
## Description

The `ClusterSolutionSpec` needs to have the field `AlternativeVmSpecs`

## How Has This Been Tested?

Tested the new spec using govc with real VC

```
func TestMigrationWithGovc(t *testing.T) {
	ctx := context.Background()
	l := os.Getenv("GOVC_URL")
	if l == "" {
		t.Skip("GOVC_URL is not set")
	}

	u, err := soap.ParseURL(l)
	if err != nil {
		t.Fatal(err)
	}

	c, err := govmomi.NewClient(ctx, u, true)
	if err != nil {
		t.Fatal(err)
	}

	restClient := rest.NewClient(c.Client)
	err = restClient.Login(ctx, u.User)
	if err != nil {
		t.Fatal(err)
	}

	solutionManager := &Manager{
		Client: restClient,
	}
	taskManager := tasks.NewManager(restClient)

	targetCluster := types.ManagedObjectReference{
		Type:  "ClusterComputeResource",
		Value: "",
	}
	supervisorID := ""
	transitionSpec := &MultiSourceEnableSpec{
		EamAgencyIDs: []string{
			"17cc7cac",
			"8c4c84f1",
			"8ef44bb7",
		},
		SourceVmSelectionSpecs: map[string]VmSelectionSpec{
			"vm-77": {
				SelectionType:    VmSelectionTypeVmExtraConfig,
				ExtraConfigValue: "1",
			},
			"vm-78": {
				SelectionType:    VmSelectionTypeVmExtraConfig,
				ExtraConfigValue: "1",
			},
			"vm-79": {
				SelectionType:    VmSelectionTypeVmExtraConfig,
				ExtraConfigValue: "1",
			},
		},
		Solution: &SolutionSpec{
			DeploymentType: ClusterVmSet,
			DisplayName:    supervisorID,
			DisplayVersion: "1.23",
			VmNameTemplate: VmNameTemplate{
				Prefix: "VM",
				Suffix: Counter,
			},
			ClusterSolutionSpec: ClusterSolutionSpec{
				VmCount: 3,
				VmPlacementPolicies: []VmPlacementPolicy{
					VmVmAntiAffinity,
				},
				Devices:           json.RawMessage(""),
				RemediationPolicy: Parallel,
				AlternativeVmSpecs: &[]AlternativeVmSpec{
					{
						SelectionCriteria: VmSelectionSpec{
							SelectionType:    VmSelectionTypeVmExtraConfig,
							ExtraConfigValue: "1",
						},
						Devices: json.RawMessage(""),
					},
				},
			},
			HookConfigurations: map[LifecycleState]LifecycleHookConfig{},
			OvfResource: OvfResource{
				LocationType:             RemoteFile,
				Url:                      "photon-ova.ovf",
				SslCertificateValidation: SslCertificateValidationEnabled,
				AuthenticationScheme:     VmwareSessionId,
			},
			OvfDescriptorProperties: map[string]string{},
			VmCloneConfig:           NoClones,
			VmStoragePolicy:         Profile,
			VmStorageProfiles:       []string{"c6224269"},
			VmDiskType:              DiskTypeThick,
			VmResourcePool:          "resgroup-76",
			VmFolder:                "group-v75",
			VmResourceSpec: &VmResourceSpec{
				OvfDeploymentOption: stringPtr("small"),
			},
			RedeploymentPolicy: BlueGreen,
		},
	}

	taskID, err := solutionManager.MultiSourceEnableAsync(ctx, targetCluster, supervisorID, transitionSpec)
	if err != nil {
		t.Fatal(err)
	}
	info, err := taskManager.WaitForCompletion(ctx, taskID)
	if err != nil {
		t.Fatal(err)
	}
	t.Logf("info: %+v", info)

}
```