### PR TITLE
Remove IgnoredDuringExecution VM placement policy strictness

### DIFF
--- a/vim25/types/enum.go
+++ b/vim25/types/enum.go
@@ -16137,36 +16137,6 @@ type VmPlacementPolicyVmPlacementPolicyStrictness string
 
 const (
 	// A VmPlacementPolicy with this strictness is enforced on a best-effort
-	// basis and only once while placing the VM for the operation where this
-	// policy has been specified via `VirtualMachineConfigSpec.vmPlacementPolicies`
-	// or `VirtualMachineRelocateSpec.vmPlacementPolicies`.
-	//
-	// The same policy is not
-	// enforced after that operation.
-	//
-	// Below is a detailed explanation:
-	// If an operation requires specifying a VM's `VirtualMachineConfigSpec` or
-	// `VirtualMachineRelocateSpec` and there is a VmPlacementPolicy specified in
-	// that `VirtualMachineConfigSpec.vmPlacementPolicies` or
-	// `VirtualMachineRelocateSpec.vmPlacementPolicies` with this
-	// VmPlacementPolicyStrictness, then it means the following:
-	//
-	// (1) This VmPlacementPolicy will be considered as "preferred". This
-	// means that if a VM with this VmPlacementPolicy cannot be successfully
-	// placed on any host due to this policy, then the policy will be dropped
-	// and a placement recommendation can still be generated even if it
-	// results in violating that policy. This is denoted by the
-	// "PreferredDuringPlacement" part of this strictness value.
-	//
-	// (2) This VmPlacementPolicy will be enforced for that operation only.
-	// Once that operation is complete and the VM has been placed, the same
-	// policy will not be enforced for any subsequent operation. This
-	// essentially means that such a VmPlacementPolicy will not be converted
-	// into a vSphere compute-policy and hence it will be ignored thereafer
-	// during that VM's execution. This is denoted by the
-	// "IgnoredDuringExecution" part of this strictness value.
-	VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementIgnoredDuringExecution = VmPlacementPolicyVmPlacementPolicyStrictness("PreferredDuringPlacementIgnoredDuringExecution")
-	// A VmPlacementPolicy with this strictness is enforced on a best-effort
 	// basis whenever a VM linked with this policy (via that VM's
 	// `VirtualMachineConfigSpec.vmPlacementPolicies` or
 	// `VirtualMachineRelocateSpec.vmPlacementPolicies`) needs to be placed.
@@ -16193,37 +16163,6 @@ const (
 	// This is denoted by the "PreferredDuringExecution" part of this
 	// strictness value.
 	VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution = VmPlacementPolicyVmPlacementPolicyStrictness("PreferredDuringPlacementPreferredDuringExecution")
-	// A VmPlacementPolicy with this strictness is enforced on a strict
-	// basis and only once while placing the VM for the operation where this
-	// policy has been specified via `VirtualMachineConfigSpec.vmPlacementPolicies`
-	// or `VirtualMachineRelocateSpec.vmPlacementPolicies`.
-	//
-	// The same policy is not
-	// enforced after that operation.
-	//
-	// Below is a detailed explanation:
-	// If an operation requires specifying a VM's `VirtualMachineConfigSpec` or
-	// `VirtualMachineRelocateSpec` and there is a VmPlacementPolicy specified in
-	// that `VirtualMachineConfigSpec.vmPlacementPolicies` or
-	// `VirtualMachineRelocateSpec.vmPlacementPolicies` with this
-	// VmPlacementPolicyStrictness, then it means the following:
-	//
-	// (1) This VmPlacementPolicy will be considered as "required". This
-	// means that if a VM with this VmPlacementPolicy cannot be successfully
-	// placed on any host due to this policy, then the policy will still be
-	// honored and no placement recommendation will be generated. The policy
-	// must be satisfied to find a successful placement target for the VM.
-	// This is denoted by the "RequiredDuringPlacement" part of this
-	// strictness value.
-	//
-	// (2) This VmPlacementPolicy will be enforced for that operation only.
-	// Once that operation is complete and the VM has been placed, the same
-	// policy will not be enforced for any subsequent operation. This
-	// essentially means that such a VmPlacementPolicy will not be converted
-	// into a vSphere compute-policy and hence it will be ignored thereafer
-	// during that VM's execution. This is denoted by the
-	// "IgnoredDuringExecution" part of this strictness value.
-	VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementIgnoredDuringExecution = VmPlacementPolicyVmPlacementPolicyStrictness("RequiredDuringPlacementIgnoredDuringExecution")
 	// A VmPlacementPolicy with this strictness is enforced on a strict
 	// basis while placing the VM for the operation where this policy has
 	// been specified via `VirtualMachineConfigSpec.vmPlacementPolicies` or
@@ -16260,9 +16199,7 @@ const (
 
 func (e VmPlacementPolicyVmPlacementPolicyStrictness) Values() []VmPlacementPolicyVmPlacementPolicyStrictness {
 	return []VmPlacementPolicyVmPlacementPolicyStrictness{
-		VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementIgnoredDuringExecution,
 		VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution,
-		VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementIgnoredDuringExecution,
 		VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution,
 	}
 }

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -98436,7 +98436,7 @@ type VmToVmGroupsAntiAffinity struct {
 	// `VmPlacementPolicyVmPlacementPolicyStrictness_enum`
 	//
 	// If this field is left unset, then the default value of
-	// `PreferredDuringPlacementIgnoredDuringExecution`
+	// `PreferredDuringPlacementPreferredDuringExecution`
 	// will be assumed.
 	PolicyStrictness string `xml:"policyStrictness,omitempty" json:"policyStrictness,omitempty"`
 	// Specifies the topology for enforcing this `VmToVmGroupsAntiAffinity`
@@ -98618,7 +98618,7 @@ type VmVmAffinity struct {
 	// `VmPlacementPolicyVmPlacementPolicyStrictness_enum`
 	//
 	// If this field is left unset, then the default value of
-	// `PreferredDuringPlacementIgnoredDuringExecution`
+	// `PreferredDuringPlacementPreferredDuringExecution`
 	// will be assumed.
 	PolicyStrictness string `xml:"policyStrictness,omitempty" json:"policyStrictness,omitempty"`
 	// Specifies the topology for enforcing this VmVmAffinity placement
@@ -98678,7 +98678,7 @@ type VmVmAntiAffinity struct {
 	// `VmPlacementPolicyVmPlacementPolicyStrictness_enum`
 	//
 	// If this field is left unset, then the default value of
-	// `PreferredDuringPlacementIgnoredDuringExecution`
+	// `PreferredDuringPlacementPreferredDuringExecution`
 	// will be assumed.
 	PolicyStrictness string `xml:"policyStrictness,omitempty" json:"policyStrictness,omitempty"`
 	// Specifies the topology for enforcing this VmVmAntiAffinity placement


### PR DESCRIPTION
## Description

This patch removes the `IgnoredDuringExecution` VM placement policy strictness API bindings to reflect the VMODL. 

Closes: #(issue-number)

## How Has This Been Tested?

GitHub Actions. Also verify no IgnoredDuringExecution exists in the repo:

```
$ git grep -r 'IgnoredDuringExecution' .
$
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
