### PR TITLE
fix: change `controllerKey` and `unitNumber` to `*int32`

### DIFF
--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -1223,6 +1223,8 @@ func TestClient(t *testing.T) {
 	t.Logf("Volume detached successfully")
 
 	if run_shared_disk_tests_tests == "true" && isvSphereVersion91orAbove {
+		t.Logf("Running shared disk tests")
+
 		// Test AttachVolume API with multiwriter parameters
 		var cnsVolumeAttachSpecList []cnstypes.CnsVolumeAttachDetachSpec
 		cnsVolumeAttachSpec := cnstypes.CnsVolumeAttachDetachSpec{
@@ -1232,8 +1234,8 @@ func TestClient(t *testing.T) {
 			Vm:            nodeVM.Reference(),
 			DiskMode:      "independent_persistent",
 			Sharing:       "sharingMultiWriter",
-			UnitNumber:    23,
-			ControllerKey: 1000,
+			UnitNumber:    vim25types.NewInt32(23),
+			ControllerKey: vim25types.NewInt32(1002),
 		}
 
 		cnsVolumeAttachSpecList = append(cnsVolumeAttachSpecList, cnsVolumeAttachSpec)

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -218,8 +218,8 @@ type CnsVolumeAttachDetachSpec struct {
 	Vm            types.ManagedObjectReference `xml:"vm" json:"vm"`
 	DiskMode      string                       `xml:"diskMode,omitempty" json:"diskMode"`
 	Sharing       string                       `xml:"sharing,omitempty" json:"sharing"`
-	ControllerKey int64                        `xml:"controllerKey,omitempty" json:"controllerKey"`
-	UnitNumber    int64                        `xml:"unitNumber,omitempty" json:"unitNumber"`
+	ControllerKey *int32                       `xml:"controllerKey,omitempty" json:"controllerKey"`
+	UnitNumber    *int32                       `xml:"unitNumber,omitempty" json:"unitNumber"`
 }
 
 func init() {
@@ -480,12 +480,12 @@ func init() {
 // CnsKubernetesQueryFilter enables querying CNS volumes using Kubernetes metadata such as
 // namespaces, pod names, PVC names, and PV names.
 //
-// - Values in the PodNames, PvcNames, and PvNames lists are treated as OR conditions.
-// - Values in the Namespaces list are also treated as OR conditions.
-// - When PodNames, PvcNames, or PvNames are specified along with Namespaces,
-//   the filter applies an AND condition — i.e., the pod, PVC must belong to the specified namespace.
-// - When only Namespaces are provided (without any pod, PVC names),
-//   all volumes associated with those namespaces will be returned.
+//   - Values in the PodNames, PvcNames, and PvNames lists are treated as OR conditions.
+//   - Values in the Namespaces list are also treated as OR conditions.
+//   - When PodNames, PvcNames, or PvNames are specified along with Namespaces,
+//     the filter applies an AND condition — i.e., the pod, PVC must belong to the specified namespace.
+//   - When only Namespaces are provided (without any pod, PVC names),
+//     all volumes associated with those namespaces will be returned.
 //
 // This allows flexible volume queries such as:
 // - Listing all volumes in one or more namespaces.


### PR DESCRIPTION
## Description

Change the type if controllerKey and unitNumber to *int32 in CnsVolumeAttachDetachSpec.

Closes: https://github.com/vmware/govmomi/issues/3883

## How Has This Been Tested?

Complete govmomi testing logs: 
[Testing.rtf](https://github.com/user-attachments/files/22716462/Testing.rtf)

```
    client_test.go:1226: Running shared disk tests
    client_test.go:1243: Attaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:3d993b1a-32ea-4dae-80d8-91b1b693b5f0} Vm:VirtualMachine:vm-1022 DiskMode:independent_persistent Sharing:sharingMultiWriter ControllerKey:0xc00031c1dc UnitNumber:0xc00031c1d8}
    client_test.go:1268: Volume attached sucessfully with shared disk params. Disk UUID: 6000C299-269c-70ea-7ea7-87dbac4d3045
    client_test.go:1279: Detaching volume using the spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:3d993b1a-32ea-4dae-80d8-91b1b693b5f0} Vm:VirtualMachine:vm-1022 DiskMode: Sharing: ControllerKey:<nil> UnitNumber:<nil>}
    client_test.go:1303: Volume detached sucessfully

```

CNS logs for attaching disk with controllerKey and UnitNumber:

```
2025-10-06T06:58:06.193Z INFO vsanvcmgmtd 114601 [vc@4413 sub="CnsVolMgr" opId="457b15ed"] Attaching volume with spec: (vim.cns.VolumeAttachDetachSpec) [
-->    (vim.cns.VolumeAttachDetachSpec) {
-->       volumeId = (vim.cns.VolumeId) {
-->          id = "3d993b1a-32ea-4dae-80d8-91b1b693b5f0"
-->       }, 
-->       vm = 'vim.VirtualMachine:vm-1022',
-->       diskMode = "independent_persistent",
-->       sharing = "sharingMultiWriter",  
-->       controllerKey = 1002, 
-->       unitNumber = 23
-->    }
--> ]
```

CNS logs for attaching disk without shared disk params:

```
2025-10-06T06:58:04.590Z INFO vsanvcmgmtd 114892 [vc@4413 sub="CnsVolMgr" opId="457b15e8"] DetachVolume with spec: (vim.cns.VolumeAttachDetachSpec) [
-->    (vim.cns.VolumeAttachDetachSpec) { 
-->       volumeId = (vim.cns.VolumeId) {
-->          id = "3d993b1a-32ea-4dae-80d8-91b1b693b5f0"
-->       }, 
-->       vm = 'vim.VirtualMachine:vm-1022',
-->    }
--> ]
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
