### PR TITLE
Add omitempty to optional certificate field to EAM bindings

### DIFF
--- a/vapi/esx/settings/clusters/vms/ovf_resource.go
+++ b/vapi/esx/settings/clusters/vms/ovf_resource.go
@@ -43,7 +43,7 @@ type OvfResource struct {
 
 	// Certificate that is to be trusted by vLCM when downloading the OVF
 	// package from a file server.
-	Certificate string `json:"certificate"`
+	Certificate string `json:"certificate,omitempty"`
 
 	// AuthenticationScheme is the authentication scheme needed to access the OVF URL.
 	AuthenticationScheme AuthenticationScheme `json:"authentication_scheme"`


### PR DESCRIPTION
## Description

Add omitempty to optional certificate field to EAM bindings. 

## How Has This Been Tested?
➜  vms git:(fix-omitempty-eam) ✗ go build ./...
➜  vms git:(fix-omitempty-eam) ✗ go test ./... 
ok  	github.com/vmware/govmomi/vapi/esx/settings/clusters/vms	0.550s

Manually tested against a real VC and verified the API calls work as expected.
