### PR TITLE
Update hasPodVM to hasPageSharingPodVM

### DIFF
--- a/object/host_system.go
+++ b/object/host_system.go
@@ -151,8 +151,8 @@ func (h HostSystem) UpdatePodVMProperty(ctx context.Context, propertyPath string
 	switch propertyPath {
 	case "podVMOverheadInfo":
 		req.Property = podVMInfo.PodVMOverheadInfo
-	case "hasPodVM":
-		req.Property = podVMInfo.HasPodVM
+	case "hasPageSharingPodVM":
+		req.Property = podVMInfo.HasPageSharingPodVM
 	case "podVMInfo":
 		req.Property = podVMInfo
 	default:

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -63377,8 +63377,8 @@ func init() {
 type PodVMInfo struct {
 	DynamicData
 
-	// Indicates if the host has a powered on PodVM.
-	HasPodVM bool `xml:"hasPodVM" json:"hasPodVM"`
+	// Indicates if the host has a powered on page sharing PodVM.
+	HasPageSharingPodVM bool `xml:"hasPageSharingPodVM" json:"hasPageSharingPodVM"`
 	// Contains the memory overhead info for PodVMs on the host.
 	PodVMOverheadInfo PodVMOverheadInfo `xml:"podVMOverheadInfo" json:"podVMOverheadInfo"`
 }

--- a/vim25/types/unreleased.go
+++ b/vim25/types/unreleased.go
@@ -163,8 +163,8 @@ func init() {
 type HostRuntimeInfoPodVMInfo struct {
 	DynamicData
 
-	HasPodVM          bool              `xml:"hasPodVM"`
-	PodVMOverheadInfo PodVMOverheadInfo `xml:"podVMOverheadInfo"`
+	HasPageSharingPodVM bool              `xml:"hasPageSharingPodVM"`
+	PodVMOverheadInfo   PodVMOverheadInfo `xml:"podVMOverheadInfo"`
 }
 
 type UpdatePodVMPropertyRequestType struct {

--- a/vim25/types/unreleased_test.go
+++ b/vim25/types/unreleased_test.go
@@ -20,7 +20,7 @@ func TestPodVMInfo(t *testing.T) {
 		host := simulator.Map(ctx).Any("HostSystem").(*simulator.HostSystem)
 
 		host.Runtime.PodVMInfo = &types.PodVMInfo{
-			HasPodVM: true,
+			HasPageSharingPodVM: true,
 			PodVMOverheadInfo: types.PodVMOverheadInfo{
 				PodVMOverheadWithoutPageSharing: int32(50),
 				PodVMOverheadWithPageSharing:    int32(25),


### PR DESCRIPTION
## Description

This change updates the name of the property hasPodVM to hasPageSharingPodVM as a part of the PodVMInfo host runtime property. This new name better reflects what this VMODL actually represents.

## How Has This Been Tested?
Ran make test and ensured the TestPodVM test passed.

