### PR TITLE
Conditionally set disk UUID if empty in backing info

### DIFF
--- a/simulator/virtual_disk_manager.go
+++ b/simulator/virtual_disk_manager.go
@@ -153,7 +153,7 @@ func vdmCreateVirtualDisk(
 	}
 	_ = b.Close()
 
-	return nil, nil
+	return desc, nil
 }
 
 func vdmExtendVirtualDisk(ctx *Context, req *types.ExtendVirtualDisk_Task) types.BaseMethodFault {

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1640,7 +1640,10 @@ func (vm *VirtualMachine) configureDevice(
 						*prop = types.NewBool(false)
 					}
 				}
-				disk.Uuid = virtualDiskUUID(&dc.Self, info.FileName)
+
+				if disk.Uuid == "" {
+					disk.Uuid = virtualDiskUUID(&dc.Self, info.FileName)
+				}
 			}
 		}
 	case *types.VirtualCdrom:
@@ -2618,6 +2621,8 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 				// Leave FileName empty so CreateVM will just create a new one under VmPathName
 				disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo).FileName = ""
 				disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo).Parent = nil
+				// Clear UUID so a new unique UUID is generated for the cloned disk
+				disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo).Uuid = ""
 			}
 
 			config.DeviceChange = append(config.DeviceChange, &types.VirtualDeviceConfigSpec{


### PR DESCRIPTION
## Description

Previously, the UUID was always set to a new value even if it was already present. This patch ensures that the disk UUID is now set only if it is
currently empty in the backing information.

## How Has This Been Tested?

Made changes to govmomi pulled by https://github.com/vmware-tanzu/vm-operator/pull/1258 and tested whether the UUID if set, remains same. With this patch, the expected behavior is validated.

Adds an unit test to validate the contract.

```
❯ go test -v -timeout 30s -run ^TestVirtualDiskUUIDAssignment$ github.com/vmware/govmomi/simulator
=== RUN   TestVirtualDiskUUIDAssignment
=== RUN   TestVirtualDiskUUIDAssignment/empty_UUID
=== RUN   TestVirtualDiskUUIDAssignment/generated_UUID
=== RUN   TestVirtualDiskUUIDAssignment/explicit_UUID
--- PASS: TestVirtualDiskUUIDAssignment (0.44s)
    --- PASS: TestVirtualDiskUUIDAssignment/empty_UUID (0.16s)
    --- PASS: TestVirtualDiskUUIDAssignment/generated_UUID (0.05s)
    --- PASS: TestVirtualDiskUUIDAssignment/explicit_UUID (0.05s)
PASS
ok      github.com/vmware/govmomi/simulator     1.304s
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
