### PR TITLE
vmdk: Add stream-optimised VMDK writer

### DIFF
--- a/vmdk/writer.go
+++ b/vmdk/writer.go
@@ -1,0 +1,367 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmdk
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	// SparseMagicNumber is copied from
+	// https://github.com/vmware/open-vmdk/blob/c977d2012d33cff8df3e809f20aa5df01e017f64/vmdk/vmware_vmdk.h#L48.
+	SparseMagicNumber = 0x564d444b // "VMDK"
+
+	// SparseVersionIncompatFlags is copied from
+	// https://github.com/vmware/open-vmdk/blob/c977d2012d33cff8df3e809f20aa5df01e017f64/vmdk/vmware_vmdk.h#L51.
+	SparseVersionIncompatFlags = 3
+
+	// SparseFlagCompressed is copied from
+	// https://github.com/vmware/open-vmdk/blob/c977d2012d33cff8df3e809f20aa5df01e017f64/vmdk/vmware_vmdk.h#L61.
+	SparseFlagCompressed = (1 << 16)
+
+	// SparseFlagEmbeddedLBA is copied from
+	// https://github.com/vmware/open-vmdk/blob/c977d2012d33cff8df3e809f20aa5df01e017f64/vmdk/vmware_vmdk.h#L62.
+	SparseFlagEmbeddedLBA = (1 << 17)
+
+	// SparseFlagValidNewlineDetector is copied from
+	// https://github.com/vmware/open-vmdk/blob/c977d2012d33cff8df3e809f20aa5df01e017f64/vmdk/vmware_vmdk.h#L57.
+	SparseFlagValidNewlineDetector = (1 << 0)
+
+	// GrainMarkerEndOfStream is copied from
+	// https://github.com/vmware/open-vmdk/blob/c977d2012d33cff8df3e809f20aa5df01e017f64/vmdk/vmware_vmdk.h#L93.
+	GrainMarkerEndOfStream = 0
+
+	// GrainSize represents the size of a grain in sectors (128 sectors = 64KB).
+	// This is the default grain size for VMDK sparse extents as specified in the VMDK specification.
+	// The grain size must be a power of 2 and greater than 8 (4KB).
+	GrainSize = 128
+
+	// GrainDirectoryOffset is the offset in sectors where the Grain Directory starts.
+	// This is calculated as 1 sector for the sparse extent header + 20 sectors for the embedded descriptor.
+	GrainDirectoryOffset = 1 + 20
+)
+
+// SparseExtentHeaderOnDisk represents the on-disk structure of a sparse VMDK extent header.
+// Corresponds to SparseExtentHeaderOnDisk in open-vmdk/vmdk/sparse.h
+type SparseExtentHeaderOnDisk struct {
+	MagicNumber        uint32
+	Version            uint32
+	Flags              uint32
+	Capacity           uint64
+	GrainSize          uint64
+	DescriptorOffset   uint64
+	DescriptorSize     uint64
+	NumGTEsPerGT       uint32
+	RGDOffset          uint64
+	GDOffset           uint64
+	Overhead           uint64
+	UncleanShutdown    byte
+	SingleEndLine      byte
+	NonEndLine         byte
+	DoubleEndLineChar1 byte
+	DoubleEndLineChar2 byte
+	CompressAlgorithm  uint16
+	Padding            [433]byte
+}
+
+// SparseGrainLBAHeaderOnDisk represents the on-disk structure of a sparse grain LBA header.
+// Corresponds to SparseGrainLBAHeaderOnDisk in open-vmdk/vmdk/sparse.h
+type SparseGrainLBAHeaderOnDisk struct {
+	Lba     uint64
+	CmpSize uint32
+}
+
+// SparseMetaDataMarkerOnDisk represents the on-disk structure of a sparse metadata marker.
+// Corresponds to SparseMetaDataMarkerOnDisk in open-vmdk/vmdk/sparse.h
+type SparseMetaDataMarkerOnDisk struct {
+	NumSectors uint64
+	Size       uint32
+	SectorType uint32
+	Padding    [496]byte
+}
+
+// StreamOptimizedWriter creates stream-optimised VMDK files.
+// It converts raw disk images into compressed VMDK format on-the-fly.
+type StreamOptimizedWriter struct {
+	file           *os.File
+	header         SparseExtentHeaderOnDisk
+	Capacity       int64
+	GrainTables    []uint64 // stores individual grain table locations
+	GrainDirectory []uint64 // stores grain table locations
+}
+
+// NewStreamOptimizedWriter creates a new StreamOptimizedWriter for writing VMDK files.
+// It takes the output filename and the total capacity of the virtual disk in bytes as inputs
+// It returns a pointer to the StreamOptimizedWriter and an error if any.
+//
+// Corresponds to StreamOptimized_Create() in open-vmdk/vmdk/sparse.c
+func NewStreamOptimizedWriter(filename string, capacity int64) (*StreamOptimizedWriter, error) {
+	outputFile, err := os.Create(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create output file: %v", err)
+	}
+
+	return &StreamOptimizedWriter{
+		file:     outputFile,
+		Capacity: capacity,
+		header: SparseExtentHeaderOnDisk{
+			MagicNumber:        SparseMagicNumber,
+			Version:            3,
+			Capacity:           uint64(capacity / SectorSize),
+			DescriptorOffset:   1,
+			GrainSize:          GrainSize,
+			CompressAlgorithm:  1, // zlib
+			SingleEndLine:      '\n',
+			NonEndLine:         ' ',
+			DoubleEndLineChar1: '\r',
+			DoubleEndLineChar2: '\n',
+			DescriptorSize:     20,
+			NumGTEsPerGT:       512,
+			Flags:              SparseFlagCompressed | SparseFlagEmbeddedLBA | SparseFlagValidNewlineDetector,
+			Overhead:           1 + 20 + getGrainDirectorySize(capacity) + (getGrainTables(capacity) * 4),
+			GDOffset:           GrainDirectoryOffset,
+		},
+		GrainDirectory: calculateGrainTableLocations(capacity),
+		GrainTables:    make([]uint64, getGrains(capacity)),
+	}, nil
+}
+
+// getGrains calculates the number of grains needed for the given capacity.
+func getGrains(capacity int64) uint64 {
+	return uint64(capacity) / (GrainSize * SectorSize)
+}
+
+// getGrainTables calculates the number of Grain Tables needed for the given capacity.
+func getGrainTables(capacity int64) uint64 {
+	grains := getGrains(capacity)
+	grainTables := grains / uint64(512)
+	if grains%uint64(512) != 0 {
+		grainTables++
+	}
+	return grainTables
+}
+
+// getGrainDirectorySize calculates the size of the Grain Directory in sectors.
+func getGrainDirectorySize(capacity int64) uint64 {
+	grainTables := getGrainTables(capacity)
+	grainDirectory := (grainTables * 4) / 512
+	if (grainTables*4)%512 != 0 {
+		grainDirectory++
+	}
+	return grainDirectory
+}
+
+// Write reads raw disk data from the provided io.Reader, compresses it, and writes it to the VMDK file.
+// It handles grain allocation, compression, and updates the Grain Tables and Grain Directory accordingly.
+// Corresponds to StreamOptimizedPwrite() in open-vmdk/vmdk/sparse.c
+func (w *StreamOptimizedWriter) Write(data io.Reader) error {
+	err := w.writeMetadata()
+	if err != nil {
+		return fmt.Errorf("failed to write metadata: %v", err)
+	}
+	var compressedBuf bytes.Buffer
+	zlibWriter := zlib.NewWriter(&compressedBuf)
+
+	grainIndex := 0
+	for {
+		// Read a grain of raw data
+		// Write the compressed data to the header
+		// Track locations in GrainTables and GrainDirectory
+		rawGrain := make([]byte, GrainSize*SectorSize)
+		n, err := io.ReadFull(data, rawGrain)
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read grain data: %v", err)
+		}
+		if n < len(rawGrain) {
+			rawGrain = rawGrain[:n]
+		}
+
+		// Check if the grain is all zeroes
+		if isZeroed(rawGrain) {
+			// Mark grain as unallocated in GrainTables
+			w.GrainTables[grainIndex] = 0
+			grainIndex++
+			if grainIndex >= len(w.GrainTables) {
+				break
+			}
+			continue
+		}
+
+		// Compress it using zlib
+		compressedBuf.Reset()
+		zlibWriter.Reset(&compressedBuf)
+		_, err = zlibWriter.Write(rawGrain)
+		if err != nil {
+			w.Abort()
+			return fmt.Errorf("failed to compress grain data: %v", err)
+		}
+		zlibWriter.Close()
+		compressedData := compressedBuf.Bytes()
+		// Update GrainTables and GrainDirectory
+		nextOffset, err := w.file.Seek(0, io.SeekCurrent)
+		if err != nil {
+			w.Abort()
+			return fmt.Errorf("failed to get current file offset: %v", err)
+		}
+
+		// Write SparseGrainLBAHeaderOnDisk
+		sparseGrainLBAHeaderOnDisk := SparseGrainLBAHeaderOnDisk{
+			Lba:     uint64(grainIndex) * uint64(GrainSize),
+			CmpSize: uint32(len(compressedBuf.Bytes())),
+		}
+		err = binary.Write(w.file, binary.LittleEndian, &sparseGrainLBAHeaderOnDisk)
+		if err != nil {
+			w.Abort()
+			return fmt.Errorf("failed to write SparseGrainLBAHeaderOnDisk: %v", err)
+		}
+
+		w.GrainTables[grainIndex] = uint64(nextOffset) / SectorSize
+
+		// Write compressed data to file
+		_, err = w.file.Write(compressedData)
+		if err != nil {
+			w.Abort()
+			return fmt.Errorf("failed to write compressed grain data: %v", err)
+		}
+
+		grainIndex++
+		if grainIndex >= len(w.GrainTables) {
+			break
+		}
+	}
+	return nil
+}
+
+// isZeroed checks if the given byte slice is entirely zeroes.
+// Corresponds to the zero-checking logic in StreamOptimizedPwrite() in open-vmdk/vmdk/sparse.c
+func isZeroed(data []byte) bool {
+	for _, b := range data {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// calculateGrainTableLocations calculates the locations of Grain Tables in the VMDK file.
+// Corresponds to the Grain Table location calculation in StreamOptimized_Create() in open-vmdk/vmdk/sparse.c
+func calculateGrainTableLocations(capacity int64) []uint64 {
+	// Calculate where the first grain table starts
+	grainDirectoryStart := uint64(GrainDirectoryOffset)
+	grainDirectorySize := getGrainDirectorySize(capacity)
+	grainDirectoryEnd := grainDirectoryStart + grainDirectorySize - 1
+	grainTableStart := grainDirectoryEnd + 1
+	// Loop through the number of grain tables
+	grainTableLocations := make([]uint64, getGrainTables(capacity))
+	for i := uint64(0); i < getGrainTables(capacity); i++ {
+		grainTableLocations[i] = grainTableStart + (i * 4)
+	}
+
+	// Add each grain table's location to the slice (each one is 4 sectors apart)
+	return grainTableLocations
+}
+
+// writeMetadata writes the SparseExtentHeaderOnDisk, Descriptor, and reserves space for Grain Directory and Grain Tables.
+func (w *StreamOptimizedWriter) writeMetadata() error {
+	// Write SparseExtentHeaderOnDisk
+	err := binary.Write(w.file, binary.LittleEndian, &w.header)
+	if err != nil {
+		return fmt.Errorf("failed to write SparseMetaDataMarkerOnDisk: %v", err)
+	}
+
+	// Write the descriptor
+	extent := Extent{
+		Size: w.Capacity / SectorSize,
+		Type: "SPARSE",
+	}
+	descriptor := NewDescriptor(extent)
+	buf := &bytes.Buffer{}
+	err = descriptor.Write(buf)
+	if err != nil {
+		return fmt.Errorf("failed to write descriptor: %v", err)
+	}
+	n, err := w.file.Write(buf.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to write descriptor to file: %v", err)
+	}
+	// Add padding to make descriptor size 20 sectors
+	paddingSize := (20 * SectorSize) - n
+	if paddingSize > 0 {
+		padding := make([]byte, paddingSize)
+		_, err = w.file.Write(padding)
+		if err != nil {
+			return fmt.Errorf("failed to write padding to file: %v", err)
+		}
+	}
+
+	// Reserve space for Grain Directory and Grain Tables
+	overhead := make([]byte, (w.header.Overhead-1-20)*SectorSize)
+	if _, err := w.file.Write(overhead); err != nil {
+		w.Abort()
+		return fmt.Errorf("failed to write overhead space: %v", err)
+	}
+
+	return nil
+}
+
+// Close finalizes the VMDK file by writing Grain Tables, Grain Directory, and Metadata Marker.
+// And marking the End of Stream.
+// Corresponds to StreamOptimizedClose() in open-vmdk/vmdk/sparse.c
+func (w *StreamOptimizedWriter) Close() error {
+	// Write Metadata Marker
+	metadataMarker := SparseMetaDataMarkerOnDisk{
+		NumSectors: 0,
+		Size:       0,
+		SectorType: GrainMarkerEndOfStream,
+	}
+	err := binary.Write(w.file, binary.LittleEndian, &metadataMarker)
+	if err != nil {
+		return fmt.Errorf("failed to write SparseMetaDataMarkerOnDisk: %v", err)
+	}
+
+	// Write Grain Tables to the reserved space we created in writeMetadata
+	// seek back to where the Grain Directory starts
+	_, err = w.file.Seek(int64(w.header.GDOffset*SectorSize), io.SeekStart)
+	if err != nil {
+		return fmt.Errorf("failed to seek to Grain Directory: %v", err)
+	}
+	// Write Grain Directory
+	for _, grainDirOffset := range w.GrainDirectory {
+		err := binary.Write(w.file, binary.LittleEndian, grainDirOffset)
+		if err != nil {
+			return fmt.Errorf("failed to write Grain Directory: %v", err)
+		}
+	}
+	// Write Grain Tables
+	for _, grainTableOffset := range w.GrainTables {
+		err := binary.Write(w.file, binary.LittleEndian, grainTableOffset)
+		if err != nil {
+			return fmt.Errorf("failed to write Grain Table: %v", err)
+		}
+	}
+
+	return w.file.Close()
+}
+
+// Abort cleans up the VMDK file in case of an error during writing.
+// It closes and removes the partially written file.
+// Corresponds to StreamOptimizedAbort() in open-vmdk/vmdk/sparse.c
+func (w *StreamOptimizedWriter) Abort() error {
+	if err := w.file.Close(); err != nil {
+		return fmt.Errorf("failed to close file during abort: %v", err)
+	}
+	if err := os.Remove(w.file.Name()); err != nil {
+		return fmt.Errorf("failed to remove file during abort: %v", err)
+	}
+	return nil
+}

--- a/vmdk/writer_test.go
+++ b/vmdk/writer_test.go
@@ -1,0 +1,299 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmdk
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	diskSize           = int64(10485760) // 10 MB in KB
+	numberOfGrains     = uint64(160)     // Each grain is 128 sectors × 512 bytes = 65536 bytes So 10485760 / 65536 = 160 grains
+	grainTables        = uint64(1)       // Each grain table holds 512 entries So 160 / 512 = 0.3125, which rounds up to 1 grain table
+	grainDirectorySize = uint64(1)       // 1 grain table × 4 bytes per entry = 4 bytes So 4 bytes / 512 bytes per sector = 0.0078, which rounds up to 1 sector
+)
+
+func TestGetGrains(t *testing.T) {
+	result := getGrains(diskSize)
+	assert.Equal(t, numberOfGrains, result)
+}
+
+func TestGetGrainTables(t *testing.T) {
+	result := getGrainTables(diskSize)
+	assert.Equal(t, grainTables, result)
+}
+
+func TestGetGrainDirectorySize(t *testing.T) {
+	result := getGrainDirectorySize(diskSize)
+	assert.Equal(t, grainDirectorySize, result)
+}
+
+func TestCalculateGrainTableLocations(t *testing.T) {
+	expected := []uint64{22} // Overhead is 22 sectors for 10MB disk
+	result := calculateGrainTableLocations(diskSize)
+
+	assert.Equal(t, expected, result)
+}
+
+type zeroReader struct{}
+
+func (z *zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func TestNewStreamOptimizedWriter(t *testing.T) {
+	// case 1: valid parameters
+	tmpDir := t.TempDir()
+	imgPath := filepath.Join(tmpDir, "test.img")
+	imgFile, err := os.Create(imgPath)
+	require.NoError(t, err, "Failed to create test img file")
+
+	_, err = io.CopyN(imgFile, rand.Reader, 1024*1024) // Create a 1MB random img file
+	require.NoError(t, err, "Failed to create test img file")
+	imgFile.Close()
+
+	writer, err := NewStreamOptimizedWriter(filepath.Join(tmpDir, "output.vmdk"), 1024*1024)
+	require.NoError(t, err, "Failed to create StreamOptimizedWriter")
+
+	file, err := os.Open(imgPath)
+	require.NoError(t, err, "Failed to open test img file")
+	defer file.Close()
+
+	err = writer.Write(file)
+	require.NoError(t, err, "Failed to write data to VMDK")
+
+	err = writer.Close()
+	require.NoError(t, err, "Failed to close VMDK writer")
+
+	outputInfo, err := os.Open(filepath.Join(tmpDir, "output.vmdk"))
+	require.NoError(t, err, "Failed to open output VMDK file")
+	defer outputInfo.Close()
+
+	magicBytes := make([]byte, 4)
+	_, err = io.ReadFull(outputInfo, magicBytes)
+	require.NoError(t, err, "Failed to read output VMDK file")
+	assert.Equal(t, uint32(SparseMagicNumber), binary.LittleEndian.Uint32(magicBytes), "Output VMDK magic number mismatch")
+
+	// Case 2: Create a 1MB img file with zeroes
+	imgPath2 := filepath.Join(tmpDir, "test2.img")
+	imgFile2, err := os.Create(imgPath2)
+	require.NoError(t, err, "Failed to create test img file")
+
+	zeros := io.LimitReader(&zeroReader{}, 1024*1024)
+	_, err = io.CopyN(imgFile2, zeros, 1024*1024) // Create a 1MB img file with zeroes
+	require.NoError(t, err, "Failed to create test2 img file")
+	imgFile2.Close()
+
+	writer2, err := NewStreamOptimizedWriter(filepath.Join(tmpDir, "output2.vmdk"), 1024*1024)
+	require.NoError(t, err, "Failed to create StreamOptimizedWriter")
+
+	file2, err := os.Open(imgPath2)
+	require.NoError(t, err, "Failed to open test img file")
+	defer file2.Close()
+
+	err = writer2.Write(file2)
+	require.NoError(t, err, "Failed to write data to VMDK")
+
+	err = writer2.Close()
+	require.NoError(t, err, "Failed to close VMDK writer")
+
+	outputInfo2, err := os.Open(filepath.Join(tmpDir, "output2.vmdk"))
+	require.NoError(t, err, "Failed to open output VMDK file")
+	defer outputInfo2.Close()
+
+	magicBytes2 := make([]byte, 4)
+	_, err = io.ReadFull(outputInfo2, magicBytes2)
+	require.NoError(t, err, "Failed to read output VMDK file")
+	assert.Equal(t, uint32(SparseMagicNumber), binary.LittleEndian.Uint32(magicBytes2), "Output VMDK magic number mismatch")
+
+	// Verify sizes
+	info, err := outputInfo.Stat()
+	require.NoError(t, err, "Failed to stat output VMDK file")
+
+	info2, err := outputInfo2.Stat()
+	require.NoError(t, err, "Failed to stat output2 VMDK file")
+
+	assert.Greater(t, info.Size(), info2.Size(), "Output VMDK size with random data should be greater than output2 VMDK size with zeros")
+
+	// Case 3: Disk size is not a multiple of sector size
+	imgPath3 := filepath.Join(tmpDir, "test3.img")
+	imgFile3, err := os.Create(imgPath3)
+	require.NoError(t, err, "Failed to create test img file")
+
+	_, err = io.CopyN(imgFile3, rand.Reader, 10000) // Create a 100KB img file with zeroes
+	require.NoError(t, err, "Failed to create test3 img file")
+	imgFile3.Close()
+
+	writer3, err := NewStreamOptimizedWriter(filepath.Join(tmpDir, "output3.vmdk"), 10000)
+	require.NoError(t, err, "Failed to create StreamOptimizedWriter")
+
+	file3, err := os.Open(imgPath3)
+	require.NoError(t, err, "Failed to open test img file")
+	defer file3.Close()
+
+	err = writer3.Write(file3)
+	require.NoError(t, err, "Failed to write data to VMDK")
+
+	err = writer3.Close()
+	require.NoError(t, err, "Failed to close VMDK writer")
+
+	outputInfo3, err := os.Open(filepath.Join(tmpDir, "output3.vmdk"))
+	require.NoError(t, err, "Failed to open output VMDK file")
+	defer outputInfo3.Close()
+
+	magicBytes3 := make([]byte, 4)
+	_, err = io.ReadFull(outputInfo3, magicBytes3)
+	require.NoError(t, err, "Failed to read output VMDK file")
+	assert.Equal(t, uint32(SparseMagicNumber), binary.LittleEndian.Uint32(magicBytes3), "Output VMDK magic number mismatch")
+}
+
+func TestGetGrains_TableDriven(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity int64
+		want     uint64
+	}{
+		{"10MB", 10485760, 160},
+		{"1MB", 1048576, 16},
+		{"1GB", 1073741824, 16384},
+		{"1 grain", 65536, 1},
+		{"0 bytes", 0, 0},
+		{"1TB", 1099511627776, 16777216},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getGrains(tt.capacity)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestGetGrainTables_TableDriven(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity int64
+		want     uint64
+	}{
+		{"10MB", 10485760, 1},
+		{"1MB", 1048576, 1},
+		{"1GB", 1073741824, 32},
+		{"1 grain", 65536, 1},
+		{"0 bytes", 0, 0},
+		{"1TB", 1099511627776, 32768},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getGrainTables(tt.capacity)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestGetGrainDirectorySize_TableDriven(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity int64
+		want     uint64
+	}{
+		{"10MB", 10485760, 1},
+		{"1MB", 1048576, 1},
+		{"1GB", 1073741824, 1},
+		{"1 grain", 65536, 1},
+		{"0 bytes", 0, 0},
+		{"1TB", 1099511627776, 256},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getGrainDirectorySize(tt.capacity)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestCalculateGrainTableLocations_TableDriven(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity int64
+		want     []uint64
+	}{
+		{"10MB", 10485760, []uint64{22}},
+		{"1MB", 1048576, []uint64{22}},
+		{"1GB", 1073741824, []uint64{22, 26, 30, 34, 38, 42, 46, 50, 54, 58, 62, 66, 70, 74, 78, 82, 86, 90, 94, 98, 102, 106, 110, 114, 118, 122, 126, 130, 134, 138, 142, 146}},
+		{"1 grain", 65536, []uint64{22}},
+		{"0 bytes", 0, []uint64{}},
+		{"1TB", 1099511627776, func() []uint64 {
+			locations := make([]uint64, 32768)
+			for i := uint64(0); i < 32768; i++ {
+				locations[i] = 277 + (i * 4)
+			}
+			return locations
+		}()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateGrainTableLocations(tt.capacity)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestNewStreamOptimizedWriter_TableDriven(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		capacity int64
+		wantErr  bool
+	}{
+		{"Valid case", "output1.vmdk", 1048576, false},
+		{"Zero capacity", "output2.vmdk", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			writer, err := NewStreamOptimizedWriter(filepath.Join(tmpDir, tt.filename), tt.capacity)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				writer.Close()
+			}
+		})
+	}
+}
+
+func TestIsZeroed(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{"All zeroes", []byte{0, 0, 0, 0}, true},
+		{"Some non-zeroes", []byte{0, 1, 0, 0}, false},
+		{"All non-zeroes", []byte{1, 1, 1, 1}, false},
+		{"Empty slice", []byte{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isZeroed(tt.data)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This adds functionality to create stream-optimized VMDK files from raw disk images, complementing the existing reader functionality in the vmdk package.

Key features:
- Creates stream-optimized VMDKs with zlib compression
- Optimizes zero-filled grains to save space
- Handles partial grains and edge cases
- Includes error recovery with Abort() method
- Comprehensive test coverage including 1TB disk calculations

Implementation based on C library [open-vmdk/sparse.c](https://github.com/vmware/open-vmdk/blob/master/vmdk/sparse.c)

Closes: `NA`

## How Has This Been Tested?

Manually.

New unit tests have been added to test coverage.

```
$ go test -v ./vmdk/
=== RUN   TestGetGrains
--- PASS: TestGetGrains (0.00s)
=== RUN   TestGetGrainTables
--- PASS: TestGetGrainTables (0.00s)
=== RUN   TestGetGrainDirectorySize
--- PASS: TestGetGrainDirectorySize (0.00s)
=== RUN   TestCalculateGrainTableLocations
--- PASS: TestCalculateGrainTableLocations (0.00s)
=== RUN   TestNewStreamOptimizedWriter
--- PASS: TestNewStreamOptimizedWriter (0.03s)
=== RUN   TestGetGrains_TableDriven
=== RUN   TestGetGrains_TableDriven/10MB
=== RUN   TestGetGrains_TableDriven/1MB
=== RUN   TestGetGrains_TableDriven/1GB
=== RUN   TestGetGrains_TableDriven/1_grain
=== RUN   TestGetGrains_TableDriven/0_bytes
=== RUN   TestGetGrains_TableDriven/1TB
--- PASS: TestGetGrains_TableDriven (0.00s)
    --- PASS: TestGetGrains_TableDriven/10MB (0.00s)
    --- PASS: TestGetGrains_TableDriven/1MB (0.00s)
    --- PASS: TestGetGrains_TableDriven/1GB (0.00s)
    --- PASS: TestGetGrains_TableDriven/1_grain (0.00s)
    --- PASS: TestGetGrains_TableDriven/0_bytes (0.00s)
    --- PASS: TestGetGrains_TableDriven/1TB (0.00s)
=== RUN   TestGetGrainTables_TableDriven
=== RUN   TestGetGrainTables_TableDriven/10MB
=== RUN   TestGetGrainTables_TableDriven/1MB
=== RUN   TestGetGrainTables_TableDriven/1GB
=== RUN   TestGetGrainTables_TableDriven/1_grain
=== RUN   TestGetGrainTables_TableDriven/0_bytes
=== RUN   TestGetGrainTables_TableDriven/1TB
--- PASS: TestGetGrainTables_TableDriven (0.00s)
    --- PASS: TestGetGrainTables_TableDriven/10MB (0.00s)
    --- PASS: TestGetGrainTables_TableDriven/1MB (0.00s)
    --- PASS: TestGetGrainTables_TableDriven/1GB (0.00s)
    --- PASS: TestGetGrainTables_TableDriven/1_grain (0.00s)
    --- PASS: TestGetGrainTables_TableDriven/0_bytes (0.00s)
    --- PASS: TestGetGrainTables_TableDriven/1TB (0.00s)
=== RUN   TestGetGrainDirectorySize_TableDriven
=== RUN   TestGetGrainDirectorySize_TableDriven/10MB
=== RUN   TestGetGrainDirectorySize_TableDriven/1MB
=== RUN   TestGetGrainDirectorySize_TableDriven/1GB
=== RUN   TestGetGrainDirectorySize_TableDriven/1_grain
=== RUN   TestGetGrainDirectorySize_TableDriven/0_bytes
=== RUN   TestGetGrainDirectorySize_TableDriven/1TB
--- PASS: TestGetGrainDirectorySize_TableDriven (0.00s)
    --- PASS: TestGetGrainDirectorySize_TableDriven/10MB (0.00s)
    --- PASS: TestGetGrainDirectorySize_TableDriven/1MB (0.00s)
    --- PASS: TestGetGrainDirectorySize_TableDriven/1GB (0.00s)
    --- PASS: TestGetGrainDirectorySize_TableDriven/1_grain (0.00s)
    --- PASS: TestGetGrainDirectorySize_TableDriven/0_bytes (0.00s)
    --- PASS: TestGetGrainDirectorySize_TableDriven/1TB (0.00s)
=== RUN   TestCalculateGrainTableLocations_TableDriven
=== RUN   TestCalculateGrainTableLocations_TableDriven/10MB
=== RUN   TestCalculateGrainTableLocations_TableDriven/1MB
=== RUN   TestCalculateGrainTableLocations_TableDriven/1GB
=== RUN   TestCalculateGrainTableLocations_TableDriven/1_grain
=== RUN   TestCalculateGrainTableLocations_TableDriven/0_bytes
=== RUN   TestCalculateGrainTableLocations_TableDriven/1TB
--- PASS: TestCalculateGrainTableLocations_TableDriven (0.00s)
    --- PASS: TestCalculateGrainTableLocations_TableDriven/10MB (0.00s)
    --- PASS: TestCalculateGrainTableLocations_TableDriven/1MB (0.00s)
    --- PASS: TestCalculateGrainTableLocations_TableDriven/1GB (0.00s)
    --- PASS: TestCalculateGrainTableLocations_TableDriven/1_grain (0.00s)
    --- PASS: TestCalculateGrainTableLocations_TableDriven/0_bytes (0.00s)
    --- PASS: TestCalculateGrainTableLocations_TableDriven/1TB (0.00s)
=== RUN   TestNewStreamOptimizedWriter_TableDriven
=== RUN   TestNewStreamOptimizedWriter_TableDriven/Valid_case
=== RUN   TestNewStreamOptimizedWriter_TableDriven/Zero_capacity
--- PASS: TestNewStreamOptimizedWriter_TableDriven (0.00s)
    --- PASS: TestNewStreamOptimizedWriter_TableDriven/Valid_case (0.00s)
    --- PASS: TestNewStreamOptimizedWriter_TableDriven/Zero_capacity (0.00s)
=== RUN   TestIsZeroed
=== RUN   TestIsZeroed/All_zeroes
=== RUN   TestIsZeroed/Some_non-zeroes
=== RUN   TestIsZeroed/All_non-zeroes
=== RUN   TestIsZeroed/Empty_slice
--- PASS: TestIsZeroed (0.00s)
    --- PASS: TestIsZeroed/All_zeroes (0.00s)
    --- PASS: TestIsZeroed/Some_non-zeroes (0.00s)
    --- PASS: TestIsZeroed/All_non-zeroes (0.00s)
    --- PASS: TestIsZeroed/Empty_slice (0.00s)
=== RUN   TestDescriptor
=== RUN   TestDescriptor/Write
=== RUN   TestDescriptor/Parse
--- PASS: TestDescriptor (0.00s)
    --- PASS: TestDescriptor/Write (0.00s)
    --- PASS: TestDescriptor/Parse (0.00s)
=== RUN   TestGetVirtualDiskInfoByUUID
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/diskUUID_is_empty
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/no_matching_disks
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_VirtualDiskFlatVer2BackingInfo
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/one_encrypted_disk_w_VirtualDiskFlatVer2BackingInfo
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_VirtualDiskSeSparseBackingInfo
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/one_encrypted_disk_w_VirtualDiskSeSparseBackingInfo
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_VirtualDiskRawDiskMappingVer1BackingInfo
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_VirtualDiskSparseVer2BackingInfo
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/one_encrypted_disk_w_VirtualDiskSparseVer2BackingInfo
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_VirtualDiskRawDiskVer2BackingInfo
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_multiple_chain_entries
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w/o_chain_entries,_it_should_return_0_for_size_and_unique_size
=== RUN   TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_multiple_chain_entries_and_includeSnapshots_is_false,_it_should_exclude_the_snapshot_delta_disks,_only_the_size_offile_keys_(8,_9)_should_be_included
=== RUN   TestGetVirtualDiskInfoByUUID/fetch_properties
=== RUN   TestGetVirtualDiskInfoByUUID/fetch_properties/ctx_is_nil
=== RUN   TestGetVirtualDiskInfoByUUID/fetch_properties/client_is_nil
=== RUN   TestGetVirtualDiskInfoByUUID/fetch_properties/failed_to_retrieve_properties
=== RUN   TestGetVirtualDiskInfoByUUID/fetch_properties/fetchProperties_is_false_but_cached_properties_are_missing
=== RUN   TestGetVirtualDiskInfoByUUID/fetch_properties/fetchProperties_is_true_and_cached_properties_are_stale
--- PASS: TestGetVirtualDiskInfoByUUID (0.42s)
    --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/diskUUID_is_empty (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/no_matching_disks (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_VirtualDiskFlatVer2BackingInfo (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/one_encrypted_disk_w_VirtualDiskFlatVer2BackingInfo (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_VirtualDiskSeSparseBackingInfo (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/one_encrypted_disk_w_VirtualDiskSeSparseBackingInfo (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_VirtualDiskRawDiskMappingVer1BackingInfo (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_VirtualDiskSparseVer2BackingInfo (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/one_encrypted_disk_w_VirtualDiskSparseVer2BackingInfo (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_VirtualDiskRawDiskVer2BackingInfo (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_multiple_chain_entries (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w/o_chain_entries,_it_should_return_0_for_size_and_unique_size (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/w_cached_properties/one_disk_w_multiple_chain_entries_and_includeSnapshots_is_false,_it_should_exclude_the_snapshot_delta_disks,_only_the_size_offile_keys_(8,_9)_should_be_included (0.00s)
    --- PASS: TestGetVirtualDiskInfoByUUID/fetch_properties (0.42s)
        --- PASS: TestGetVirtualDiskInfoByUUID/fetch_properties/ctx_is_nil (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/fetch_properties/client_is_nil (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/fetch_properties/failed_to_retrieve_properties (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/fetch_properties/fetchProperties_is_false_but_cached_properties_are_missing (0.00s)
        --- PASS: TestGetVirtualDiskInfoByUUID/fetch_properties/fetchProperties_is_true_and_cached_properties_are_stale (0.00s)
=== RUN   TestDiskInfo
--- SKIP: TestDiskInfo (0.00s)
=== RUN   TestDiskInvalid
--- PASS: TestDiskInvalid (0.00s)
PASS
ok      github.com/vmware/govmomi/vmdk  0.459s
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
