### PR TITLE
govc: type alias support for ls -t

### DIFF
--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -4585,6 +4585,21 @@ Usage: govc ls [OPTIONS] [PATH]...
 
 List inventory items.
 
+The '-t' flag value can be a managed entity type or one of the following aliases:
+  a    VirtualApp
+  c    ClusterComputeResource
+  d    Datacenter
+  f    Folder
+  g    DistributedVirtualPortgroup
+  h    HostSystem
+  m    VirtualMachine
+  n    Network
+  o    OpaqueNetwork
+  p    ResourcePool
+  r    ComputeResource
+  s    Datastore
+  w    DistributedVirtualSwitch
+
 Examples:
   govc ls -l '*'
   govc ls -t ClusterComputeResource host
@@ -4595,7 +4610,7 @@ Options:
   -L=false               Follow managed object references
   -i=false               Print the managed object reference
   -l=false               Long listing format
-  -t=                    Object type
+  -t=[]                  Object type
 ```
 
 ## metric.change

--- a/govc/main.go
+++ b/govc/main.go
@@ -71,7 +71,6 @@ import (
 	_ "github.com/vmware/govmomi/cli/library/trust"
 	_ "github.com/vmware/govmomi/cli/license"
 	_ "github.com/vmware/govmomi/cli/logs"
-	_ "github.com/vmware/govmomi/cli/ls"
 	_ "github.com/vmware/govmomi/cli/metric"
 	_ "github.com/vmware/govmomi/cli/metric/interval"
 	_ "github.com/vmware/govmomi/cli/namespace"

--- a/govc/test/ls.bats
+++ b/govc/test/ls.bats
@@ -52,6 +52,14 @@ load test_helper
   assert_success
   [ ${#lines[@]} -eq 1 ]
 
+  run govc ls -t h ./...
+  assert_success
+  [ ${#lines[@]} -eq 1 ]
+
+  run govc ls -t h -t p ./...
+  assert_success
+  [ ${#lines[@]} -eq 2 ]
+
   run govc ls -t Datacenter /...
   assert_success
   [ ${#lines[@]} -eq 1 ]
@@ -132,6 +140,10 @@ load test_helper
   run govc ls
   assert_success
   # /DC[0,1]
+  [ ${#lines[@]} -eq 2 ]
+
+  run govc ls -t d
+  assert_success
   [ ${#lines[@]} -eq 2 ]
 
   run govc ls -dc enoent


### PR DESCRIPTION
Using the same type aliases as the find/collect/save commands.
