### PR TITLE
api: Fix OVF defVal & ConfigSpec vAppConfig

### DIFF
--- a/ovf/configspec.go
+++ b/ovf/configspec.go
@@ -1057,7 +1057,21 @@ func (e Envelope) toVAppConfig(
 				// configuration.
 				continue
 			}
-			vapp.Property = append(vapp.Property, types.VAppPropertySpec{
+
+			// Get the value for the current configuration from the list of
+			// values that are per-config.
+			var value string
+			if p.Value != nil {
+				value = *p.Value
+			}
+			for _, v := range p.Values {
+				if v.Configuration == nil || *v.Configuration == configName {
+					value = v.Value
+					break
+				}
+			}
+
+			np := types.VAppPropertySpec{
 				ArrayUpdateSpec: types.ArrayUpdateSpec{
 					Operation: types.ArrayUpdateOperationAdd,
 				},
@@ -1071,10 +1085,13 @@ func (e Envelope) toVAppConfig(
 					Type:             p.Type,
 					UserConfigurable: p.UserConfigurable,
 					DefaultValue:     deref(p.Default),
-					Value:            "",
+					Value:            value,
 					Description:      deref(p.Description),
 				},
-			})
+			}
+
+			vapp.Property = append(vapp.Property, np)
+
 			index++
 		}
 	}

--- a/ovf/configspec_test.go
+++ b/ovf/configspec_test.go
@@ -46,6 +46,28 @@ func TestEnvelopeToConfigSpec(t *testing.T) {
 		})
 	})
 
+	t.Run("Properties", func(t *testing.T) {
+		e := testEnvelope(t, "fixtures/properties.ovf")
+		configSpec, err := e.ToConfigSpec()
+		if assert.NoError(t, err) {
+			va := configSpec.VAppConfig.GetVmConfigSpec()
+			props := va.Property
+			if assert.Len(t, props, 4) {
+				assert.Equal(t, "ttylinux", props[0].Info.ClassId)
+				assert.Equal(t, "ntp-server", props[0].Info.Id)
+				assert.Equal(t, "string", props[0].Info.Type)
+				assert.Equal(t, "NTP Server(s)", props[0].Info.Label)
+				assert.Equal(t, "NTP Server(s) to use. Please specify space delimited list.", props[0].Info.Description)
+				assert.Equal(t, "", props[0].Info.DefaultValue)
+				assert.Equal(t, "", props[0].Info.Value)
+				assert.Equal(t, true, *props[0].Info.UserConfigurable)
+
+				assert.Equal(t, "vmname", props[3].Info.Id)
+				assert.Equal(t, "vm", props[3].Info.ClassId)
+			}
+		}
+	})
+
 	t.Run("VirtualSystemCollection", func(t *testing.T) {
 		t.Run("No index", func(t *testing.T) {
 			e := testEnvelope(t, "fixtures/virtualsystemcollection.ovf")
@@ -90,7 +112,10 @@ func TestEnvelopeToConfigSpec(t *testing.T) {
 					assert.Equal(t, "app_ip", va.Property[1].Info.Id)
 					assert.Equal(t, "string", va.Property[1].Info.Type)
 					assert.Equal(t, "The IP address of this appliance", va.Property[1].Info.Description)
-					assert.Equal(t, "", va.Property[1].Info.DefaultValue) // DefaultValue not being parsed correctly
+					assert.Equal(t, "192.168.0.10", va.Property[1].Info.DefaultValue)
+					if assert.NotNil(t, va.Property[1].Info.UserConfigurable) {
+						assert.Equal(t, false, *va.Property[1].Info.UserConfigurable)
+					}
 				}
 			}
 		})
@@ -132,7 +157,11 @@ func TestEnvelopeToConfigSpec(t *testing.T) {
 					assert.Equal(t, "app_ip", va.Property[1].Info.Id)
 					assert.Equal(t, "string", va.Property[1].Info.Type)
 					assert.Equal(t, "The IP address of this appliance", va.Property[1].Info.Description)
-					assert.Equal(t, "", va.Property[1].Info.DefaultValue) // DefaultValue not being parsed correctly
+					assert.Equal(t, "192.168.0.10", va.Property[1].Info.DefaultValue)
+					assert.Equal(t, "192.168.0.10", va.Property[1].Info.DefaultValue)
+					if assert.NotNil(t, va.Property[1].Info.UserConfigurable) {
+						assert.Equal(t, false, *va.Property[1].Info.UserConfigurable)
+					}
 				}
 			}
 		})
@@ -528,6 +557,7 @@ func TestEnvelopeToConfigSpec(t *testing.T) {
 					va.Product,
 				)
 			}
+
 			if assert.Len(t, va.Property, 6) {
 				assert.ElementsMatch(t,
 					[]types.VAppPropertySpec{
@@ -543,7 +573,7 @@ func TestEnvelopeToConfigSpec(t *testing.T) {
 								Id:               "BUILD_TIMESTAMP",
 								Type:             "string",
 								UserConfigurable: types.NewBool(false),
-								DefaultValue:     "1615488399",
+								Value:            "1615488399",
 							},
 						},
 						{
@@ -556,7 +586,7 @@ func TestEnvelopeToConfigSpec(t *testing.T) {
 								Id:               "BUILD_DATE",
 								Type:             "string",
 								UserConfigurable: types.NewBool(false),
-								DefaultValue:     "2021-03-11T18:46:39Z",
+								Value:            "2021-03-11T18:46:39Z",
 							},
 						},
 
@@ -590,7 +620,7 @@ func TestEnvelopeToConfigSpec(t *testing.T) {
 								Label:            "2.1. Host Name",
 								Type:             "string",
 								UserConfigurable: types.NewBool(true),
-								DefaultValue:     "haproxy.local",
+								Value:            "haproxy.local",
 								Description:      "The host name. A fully-qualified domain name is also supported.",
 							},
 						},

--- a/ovf/envelope.go
+++ b/ovf/envelope.go
@@ -111,14 +111,15 @@ type Property struct {
 	Type             string  `xml:"type,attr" json:"type,omitempty"`
 	Qualifiers       *string `xml:"qualifiers,attr" json:"qualifiers,omitempty"`
 	UserConfigurable *bool   `xml:"userConfigurable,attr" json:"userConfigurable,omitempty"`
-	Default          *string `xml:"value,attr" json:"default,omitempty"`
+	Default          *string `xml:"defaultValue,attr" json:"defaultValue,omitempty"`
 	Password         *bool   `xml:"password,attr" json:"password,omitempty"`
 	Configuration    *string `xml:"configuration,attr" json:"configuration,omitempty"`
+	Value            *string `xml:"value,attr" json:"value,omitempty"`
 
 	Label       *string `xml:"Label" json:"label,omitempty"`
 	Description *string `xml:"Description" json:"description,omitempty"`
 
-	Values []PropertyConfigurationValue `xml:"Value" json:"value,omitempty"`
+	Values []PropertyConfigurationValue `xml:"Value" json:"values,omitempty"`
 }
 
 type PropertyConfigurationValue struct {

--- a/ovf/fixtures/configspec.ovf
+++ b/ovf/fixtures/configspec.ovf
@@ -587,7 +587,7 @@ EVALUATION LICENSE.  If You are licensing the Software for evaluation purposes, 
         <Label>3.1. Load Balancer IP Ranges, comma-separated in CIDR format (Eg 1.2.3.4/28,5.6.7.8/28)</Label>
         <Description>The IP ranges the load balancer will use for Kubernetes Services and Control Planes. The Appliance will currently respond to ALL the IPs in these ranges whether they're assigned or not. As such, these ranges must not overlap with the IPs assigned for the appliance or any other VMs on the network.</Description>
       </Property>
-      <Property ovf:key="dataplane_port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="5556">
+      <Property ovf:key="dataplane_port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:defaultValue="5556">
         <Label>3.2. Dataplane API Management Port</Label>
         <Description>Specifies the port on which the Dataplane API will be advertized on the Management Network.</Description>
       </Property>

--- a/ovf/fixtures/properties.ovf
+++ b/ovf/fixtures/properties.ovf
@@ -146,7 +146,7 @@
         <Label>Enable SSH root login</Label>
         <Description>Check here to enable SSH login for root user.  SSH login for root is disabled by default.</Description>
       </Property>
-      <Property ovf:key="nfs_mount" ovf:type="string" ovf:userConfigurable="false" ovf:value="/transfer" ovf:qualifiers="MinLen(0),MaxLen(65535)">
+      <Property ovf:key="nfs_mount" ovf:type="string" ovf:userConfigurable="false" ovf:defaultValue="/transfer" ovf:qualifiers="MinLen(0),MaxLen(65535)">
         <Label>NFS mount for transfer file location</Label>
         <Description>Ex: 10.0.0.1:/transfer</Description>
       </Property>

--- a/ovf/fixtures/virtualsystemcollection.ovf
+++ b/ovf/fixtures/virtualsystemcollection.ovf
@@ -49,7 +49,7 @@ Example 3 from https://www.dmtf.org/sites/default/files/standards/documents/DSP0
                 <Property ovf:key="adminemail" ovf:type="string">
                     <Description>Email address of administrator</Description>
                 </Property>
-                <Property ovf:key="app_ip" ovf:type="string" ovf:defaultValue="192.168.0.10">
+                <Property ovf:key="app_ip" ovf:type="string" ovf:defaultValue="192.168.0.10" ovf:userConfigurable="false">
                     <Description>The IP address of this appliance</Description>
                 </Property>
             </ProductSection>
@@ -124,7 +124,7 @@ Example 3 from https://www.dmtf.org/sites/default/files/standards/documents/DSP0
                 <Property ovf:key="adminemail" ovf:type="string">
                     <Description>Email address of administrator</Description>
                 </Property>
-                <Property ovf:key="app_ip" ovf:type="string" ovf:defaultValue="192.168.0.10">
+                <Property ovf:key="app_ip" ovf:type="string" ovf:defaultValue="192.168.0.10" ovf:userConfigurable="false">
                     <Description>The IP address of this appliance</Description>
                 </Property>
             </ProductSection>


### PR DESCRIPTION


## Description

This patch addresses some bugs in the way OVFs are unmarshalled as well as transformed into ConfigSpec objects. For some reason the original OVF unmarshalling code ignored the fact that properties have a "value" attribute and not just sub-elements. In fact, the latter is not even in the DMTF OVF spec. There was also a bug in how the default value and value were treated as the same, when they are not.

Closes: `NA`

## How Has This Been Tested?

Added unit tests and enhanced existing ones. Just run `go test -v -count=1 ./ovf`

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
