### PR TITLE
refactor: update `NumCoresPerSocket` to `*int32`

### DIFF
--- a/ovf/configspec_test.go
+++ b/ovf/configspec_test.go
@@ -213,7 +213,7 @@ func TestEnvelopeToConfigSpec(t *testing.T) {
 
 		assert.Equal(t, "haproxy", cs.Name)
 		assert.Equal(t, int32(2), cs.NumCPUs)
-		assert.Equal(t, int32(2), cs.NumCoresPerSocket)
+		assert.Equal(t, int32(2), *cs.NumCoresPerSocket)
 		assert.Equal(t, int64(4096), cs.MemoryMB)
 		assert.Equal(t, "vmx-13", cs.Version)
 

--- a/simulator/ovf_manager.go
+++ b/simulator/ovf_manager.go
@@ -104,7 +104,6 @@ func (m *OvfManager) CreateImportSpec(ctx *Context, req *types.CreateImportSpec)
 	ds := ctx.Map.Get(req.Datastore).(*Datastore)
 	path := object.DatastorePath{Datastore: ds.Name}
 	vapp := &types.VAppConfigSpec{}
-	var coresPerSocket int32 = 1
 	spec := &types.VirtualMachineImportSpec{
 		ConfigSpec: types.VirtualMachineConfigSpec{
 			Name:    cisp.EntityName,
@@ -114,7 +113,7 @@ func (m *OvfManager) CreateImportSpec(ctx *Context, req *types.CreateImportSpec)
 				VmPathName: path.String(),
 			},
 			NumCPUs:           1,
-			NumCoresPerSocket: &coresPerSocket,
+			NumCoresPerSocket: types.NewInt32(1),
 			MemoryMB:          32,
 			VAppConfig:        vapp,
 		},

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -126,10 +126,9 @@ func NewVirtualMachine(ctx *Context, parent types.ManagedObjectReference, spec *
 	dsPath := path.Dir(spec.Files.VmPathName)
 	vm.uid = internal.OID(spec.Files.VmPathName)
 
-	var coresPerSocket int32 = 1
 	defaults := types.VirtualMachineConfigSpec{
 		NumCPUs:           1,
-		NumCoresPerSocket: &coresPerSocket,
+		NumCoresPerSocket: types.NewInt32(1),
 		MemoryMB:          32,
 		Uuid:              vm.uid.String(),
 		InstanceUuid:      newUUID(strings.ToUpper(spec.Files.VmPathName)),
@@ -326,8 +325,8 @@ func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 		vm.Summary.Config.NumCpu = vm.Config.Hardware.NumCPU
 	}
 
-	if spec.NumCoresPerSocket != nil && *spec.NumCoresPerSocket != 0 {
-		vm.Config.Hardware.NumCoresPerSocket = *spec.NumCoresPerSocket
+	if spec.NumCoresPerSocket != nil {
+		vm.Config.Hardware.NumCoresPerSocket = spec.NumCoresPerSocket
 	}
 
 	if spec.GuestId != "" {
@@ -2599,7 +2598,7 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 		// Copying hardware properties
 		config.NumCPUs = vm.Config.Hardware.NumCPU
 		config.MemoryMB = int64(vm.Config.Hardware.MemoryMB)
-		config.NumCoresPerSocket = &vm.Config.Hardware.NumCoresPerSocket
+		config.NumCoresPerSocket = vm.Config.Hardware.NumCoresPerSocket
 		config.VirtualICH7MPresent = vm.Config.Hardware.VirtualICH7MPresent
 		config.VirtualSMCPresent = vm.Config.Hardware.VirtualSMCPresent
 

--- a/vim25/types/helpers.go
+++ b/vim25/types/helpers.go
@@ -126,7 +126,7 @@ func (ci VirtualMachineConfigInfo) ToConfigSpec() VirtualMachineConfigSpec {
 		RebootPowerOff:               ci.RebootPowerOff,
 		NumCPUs:                      ci.Hardware.NumCPU,
 		VcpuConfig:                   ci.VcpuConfig,
-		NumCoresPerSocket:            &ci.Hardware.NumCoresPerSocket,
+		NumCoresPerSocket:            ci.Hardware.NumCoresPerSocket,
 		MemoryMB:                     int64(ci.Hardware.MemoryMB),
 		MemoryHotAddEnabled:          ci.MemoryHotAddEnabled,
 		CpuHotAddEnabled:             ci.CpuHotAddEnabled,

--- a/vim25/types/json_test.go
+++ b/vim25/types/json_test.go
@@ -427,7 +427,7 @@ var vmInfoObjForTests = VirtualMachineConfigInfo{
 	RebootPowerOff: NewBool(false),
 	Hardware: VirtualHardware{
 		NumCPU:              1,
-		NumCoresPerSocket:   1,
+		NumCoresPerSocket:   NewInt32(1),
 		AutoCoresPerSocket:  NewBool(true),
 		MemoryMB:            2048,
 		VirtualICH7MPresent: NewBool(false),

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -88398,7 +88398,7 @@ type VirtualHardware struct {
 	// implies numCoresPerSocket is 1.
 	// In other cases, this field represents the actual virtual socket
 	// size seen by the virtual machine.
-	NumCoresPerSocket int32 `xml:"numCoresPerSocket,omitempty" json:"numCoresPerSocket,omitempty"`
+	NumCoresPerSocket *int32 `xml:"numCoresPerSocket,omitempty" json:"numCoresPerSocket,omitempty"`
 	// Cores per socket is automatically determined.
 	AutoCoresPerSocket *bool `xml:"autoCoresPerSocket" json:"autoCoresPerSocket,omitempty" vim:"8.0.0.1"`
 	// Memory size, in MB.


### PR DESCRIPTION
## Description

`NumCoresPerSocket` on `types.VirtualMachineConfigSpec` is an `int32` and annotated with "omitempty"
This makes it impossible to pass 0 when calling `ReconfigVM` and `CreateVM`.

To remediate this I am changing the field to an `*int32`. Now its zero value will be nil and 0 will be serialized along with the rest of the structure.

Closes: N/A

## How Has This Been Tested?

Configured a local override for `vmware/govmomi` in `vmware/terraform-provider-vsphere` and ran tests which create and reconfigure virtual machines.
I verified that nil, 0 and any positive integer (if valid for that VM) is accepted by vCenter

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
