### PR TITLE
Refactor simulated tag support

### DIFF
--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -77,10 +77,12 @@ type Registry struct {
 
 // tagManager is an interface to simplify internal interaction with the vapi tag manager simulator.
 type tagManager interface {
-	AttachedObjects(types.VslmTagEntry) ([]types.ManagedObjectReference, types.BaseMethodFault)
-	AttachedTags(id types.ManagedObjectReference) ([]types.VslmTagEntry, types.BaseMethodFault)
-	AttachTag(types.ManagedObjectReference, types.VslmTagEntry) types.BaseMethodFault
-	DetachTag(types.ManagedObjectReference, types.VslmTagEntry) types.BaseMethodFault
+	AttachedObjects(string) ([]types.ManagedObjectReference, types.BaseMethodFault)
+	AttachedTags(id types.ManagedObjectReference) ([]string, types.BaseMethodFault)
+	AttachTag(types.ManagedObjectReference, string) types.BaseMethodFault
+	DetachTag(types.ManagedObjectReference, string) types.BaseMethodFault
+	GetTagByCategoryAndName(string, string) (string, types.BaseMethodFault)
+	GetTagCategoryAndName(string) (string, string, types.BaseMethodFault)
 }
 
 // NewRegistry creates a new instances of Registry


### PR DESCRIPTION


## Description

This patch refactors how simulated tag support works. Now it is much closer to the actual behavior, with the internal helpers focused on tag IDs instead of VlsmTagEntry objects.

Additionally, the VM Reconfigure method now supports both tag ID and tag category and name.

Closes: `NA`

## How Has This Been Tested?

Run the existing packages that depend on simulated tag support:

```shell
go test -v -count=1 ./vapi/tags
```

```shell
go test -v -count=1 ./simulator
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
