### PR TITLE
api: CnsVolumeBackingType

### DIFF
--- a/cns/types/enum.go
+++ b/cns/types/enum.go
@@ -106,3 +106,21 @@ const (
 func init() {
 	types.Add("vsan:CnsUnregisterTargetVolumeType", reflect.TypeOf((*CnsUnregisterTargetVolumeType)(nil)).Elem())
 }
+
+// CnsVolumeBackingType enumerates types of backing for batch attach operations.
+// These values correspond to VirtualDevice.FileBackingInfo subclasses.
+type CnsVolumeBackingType string
+
+const (
+	CnsVolumeBackingTypeFlatVer1BackingInfo           = CnsVolumeBackingType("FlatVer1BackingInfo")
+	CnsVolumeBackingTypeFlatVer2BackingInfo           = CnsVolumeBackingType("FlatVer2BackingInfo")
+	CnsVolumeBackingTypeSparseVer1BackingInfo         = CnsVolumeBackingType("SparseVer1BackingInfo")
+	CnsVolumeBackingTypeSparseVer2BackingInfo         = CnsVolumeBackingType("SparseVer2BackingInfo")
+	CnsVolumeBackingTypeRawDiskMappingVer1BackingInfo = CnsVolumeBackingType("RawDiskMappingVer1BackingInfo")
+	CnsVolumeBackingTypeSeSparseBackingInfo           = CnsVolumeBackingType("SeSparseBackingInfo")
+	CnsVolumeBackingTypeLocalPMemBackingInfo          = CnsVolumeBackingType("LocalPMemBackingInfo")
+)
+
+func init() {
+	types.Add("vsan:CnsVolumeBackingType", reflect.TypeOf((*CnsVolumeBackingType)(nil)).Elem())
+}

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -214,12 +214,13 @@ type CnsDetachVolumeResponse struct {
 type CnsVolumeAttachDetachSpec struct {
 	types.DynamicData
 
-	VolumeId      CnsVolumeId                  `xml:"volumeId" json:"volumeId"`
-	Vm            types.ManagedObjectReference `xml:"vm" json:"vm"`
-	DiskMode      string                       `xml:"diskMode,omitempty" json:"diskMode"`
-	Sharing       string                       `xml:"sharing,omitempty" json:"sharing"`
-	ControllerKey *int32                       `xml:"controllerKey,omitempty" json:"controllerKey"`
-	UnitNumber    *int32                       `xml:"unitNumber,omitempty" json:"unitNumber"`
+	VolumeId        CnsVolumeId                  `xml:"volumeId" json:"volumeId"`
+	Vm              types.ManagedObjectReference `xml:"vm" json:"vm"`
+	DiskMode        string                       `xml:"diskMode,omitempty" json:"diskMode"`
+	Sharing         string                       `xml:"sharing,omitempty" json:"sharing"`
+	ControllerKey   *int32                       `xml:"controllerKey,omitempty" json:"controllerKey"`
+	UnitNumber      *int32                       `xml:"unitNumber,omitempty" json:"unitNumber"`
+	BackingTypeName CnsVolumeBackingType         `xml:"backingTypeName,omitempty" json:"backingTypeName"`
 }
 
 func init() {


### PR DESCRIPTION

## Description

This patch updates the CNS API with the new CnsVolumeBackingType enum and its use in AttachDetachVolumeSpec.


Closes: `NA`

## How Has This Been Tested?

Other than the linters and GH tests, nothing, as this is just a type-def.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
