### PR TITLE
add go binding for CnsNotRegisteredFault

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -640,6 +640,16 @@ func init() {
 	types.Add("CnsVolumeNotFoundFault", reflect.TypeOf((*CnsVolumeNotFoundFault)(nil)).Elem())
 }
 
+type CnsNotRegisteredFault struct {
+	CnsFault
+
+	VolumeId CnsVolumeId `xml:"volumeId" json:"volumeId"`
+}
+
+func init() {
+	types.Add("CnsNotRegisteredFault", reflect.TypeOf((*CnsNotRegisteredFault)(nil)).Elem())
+}
+
 type CnsVolumeAlreadyExistsFault struct {
 	CnsFault
 


### PR DESCRIPTION
## Description

This PR is adding go binding for CnsNotRegisteredFault


## How Has This Been Tested?

Executed test

```
divyenp@C02Z5410LVDQ cns % go test -run ^TestHandleCnsNotRegisteredFault$ -v
=== RUN   TestHandleCnsNotRegisteredFault
    client_test.go:2070: volumeCreateResult &{CnsVolumeOperationResult:{DynamicData:{} VolumeId:{DynamicData:{} Id:57308b70-5aa3-4048-a2c9-7e10a1c3c3f6} Fault:<nil>} Name:pvc-c6bf682a-57f5-4a0f-8001-425a2738da3d PlacementResults:[{Datastore:Datastore:datastore-40 PlacementFaults:[] Clusters:[]}]}
    client_test.go:2071: Volume created successfully. volumeId: 57308b70-5aa3-4048-a2c9-7e10a1c3c3f6
    client_test.go:2098: Volume unregistered successfully: 57308b70-5aa3-4048-a2c9-7e10a1c3c3f6
    client_test.go:2110: Extending volume using the spec: []types.CnsVolumeExtendSpec{
            {
                DynamicData: types.DynamicData{},
                VolumeId:    types.CnsVolumeId{
                    DynamicData: types.DynamicData{},
                    Id:          "57308b70-5aa3-4048-a2c9-7e10a1c3c3f6",
                },
                CapacityInMb: 10240,
            },
        }
    client_test.go:2124: extendVolumeOperationRes.: &types.CnsVolumeOperationResult{
            DynamicData: types.DynamicData{},
            VolumeId:    types.CnsVolumeId{},
            Fault:       &types.LocalizedMethodFault{
                DynamicData: types.DynamicData{},
                Fault:       &types.CnsNotRegisteredFault{
                    CnsFault: types.CnsFault{
                        MethodFault: types.MethodFault{},
                        Reason:      "The input volume 57308b70-5aa3-4048-a2c9-7e10a1c3c3f6 is not registered as a CNS volume.",
                    },
                    VolumeId: types.CnsVolumeId{
                        DynamicData: types.DynamicData{},
                        Id:          "57308b70-5aa3-4048-a2c9-7e10a1c3c3f6",
                    },
                },
                LocalizedMessage: "Volume with ID 57308b70-5aa3-4048-a2c9-7e10a1c3c3f6 is not registered as CNS Volume. Error message: The input volume 57308b70-5aa3-4048-a2c9-7e10a1c3c3f6 is not registered as a CNS volume.",
            },
        }
    client_test.go:2126: Failed to extend volume: fault=&{DynamicData:{} Fault:0xc000211980 LocalizedMessage:Volume with ID 57308b70-5aa3-4048-a2c9-7e10a1c3c3f6 is not registered as CNS Volume. Error message: The input volume 57308b70-5aa3-4048-a2c9-7e10a1c3c3f6 is not registered as a CNS volume.}
    client_test.go:2131: Fault is CnsNotRegisteredFault
    client_test.go:2149: Creating volume using the spec: types.CnsVolumeCreateSpec{
            DynamicData: types.DynamicData{},
            Name:        "pvc-c6bf682a-57f5-4a0f-8001-425a2738da3d",
            VolumeType:  "BLOCK",
            VolumeId:    (*types.CnsVolumeId)(nil),
            Datastores:  nil,
            Metadata:    types.CnsVolumeMetadata{
                DynamicData:      types.DynamicData{},
                ContainerCluster: types.CnsContainerCluster{
                    DynamicData:         types.DynamicData{},
                    ClusterType:         "KUBERNETES",
                    ClusterId:           "demo-cluster-id",
                    VSphereUser:         "Administrator@vsphere.local",
                    ClusterFlavor:       "VANILLA",
                    ClusterDistribution: "OpenShift",
                    Delete:              false,
                },
                EntityMetadata:        nil,
                ContainerClusterArray: nil,
            },
            BackingObjectDetails: &types.CnsBlockBackingDetails{
                CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                    DynamicData:  types.DynamicData{},
                    CapacityInMb: 5120,
                },
                BackingDiskId:                  "57308b70-5aa3-4048-a2c9-7e10a1c3c3f6",
                BackingDiskUrlPath:             "",
                BackingDiskObjectId:            "",
                AggregatedSnapshotCapacityInMb: 0,
                BackingDiskPath:                "",
            },
            Profile:        nil,
            ActiveClusters: nil,
            CreateSpec:     nil,
            VolumeSource:   nil,
        }
    client_test.go:2170: reCreateVolumeOperationRes.: &types.CnsVolumeOperationResult{
            DynamicData: types.DynamicData{},
            VolumeId:    types.CnsVolumeId{
                DynamicData: types.DynamicData{},
                Id:          "57308b70-5aa3-4048-a2c9-7e10a1c3c3f6",
            },
            Fault: (*types.LocalizedMethodFault)(nil),
        }
    client_test.go:2172: re-create same volume did not fail as expected
    client_test.go:2179: Deleting volume: [{DynamicData:{} Id:57308b70-5aa3-4048-a2c9-7e10a1c3c3f6}]
    client_test.go:2203: Volume: "57308b70-5aa3-4048-a2c9-7e10a1c3c3f6" deleted successfully
--- PASS: TestHandleCnsNotRegisteredFault (5.65s)
PASS
ok      github.com/vmware/govmomi/cns   6.020s
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
