### PR TITLE
add volumeEncrypted flag to CnsVolumeAttachDetachSpec

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -221,6 +221,7 @@ type CnsVolumeAttachDetachSpec struct {
 	ControllerKey   *int32                       `xml:"controllerKey,omitempty" json:"controllerKey"`
 	UnitNumber      *int32                       `xml:"unitNumber,omitempty" json:"unitNumber"`
 	BackingTypeName CnsVolumeBackingType         `xml:"backingTypeName,omitempty" json:"backingTypeName"`
+	VolumeEncrypted bool                         `xml:"volumeEncrypted,omitempty" json:"volumeEncrypted"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

This PR is adding `volumeEncrypted` flag to `CnsVolumeAttachDetachSpec`
When set to false, the volume is not encrypted and vpxd API  call will be skipped.
This is added to improve performance of batch attach API to skip calling vpxd API when volume is not encrypted.


## How Has This Been Tested?

Not tested. Backend changes are not ready yet.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
