### PR TITLE
api: Fix volumeEncrypted in CNS

### DIFF
--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -221,7 +221,7 @@ type CnsVolumeAttachDetachSpec struct {
 	ControllerKey   *int32                       `xml:"controllerKey,omitempty" json:"controllerKey"`
 	UnitNumber      *int32                       `xml:"unitNumber,omitempty" json:"unitNumber"`
 	BackingTypeName CnsVolumeBackingType         `xml:"backingTypeName,omitempty" json:"backingTypeName"`
-	VolumeEncrypted bool                         `xml:"volumeEncrypted,omitempty" json:"volumeEncrypted"`
+	VolumeEncrypted *bool                        `xml:"volumeEncrypted,omitempty" json:"volumeEncrypted"`
 }
 
 func init() {


### PR DESCRIPTION


## Description

This patch fixes volumeEncrypted to be optional.

Closes: `NA`

## How Has This Been Tested?

There are no tests associated with this. So does it build? If so, we good.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
