### PR TITLE
govc: add `device.sata.add`

### DIFF
--- a/cli/device/sata/add.go
+++ b/cli/device/sata/add.go
@@ -1,0 +1,78 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package sata
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/cli"
+	"github.com/vmware/govmomi/cli/flags"
+)
+
+type add struct {
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("device.sata.add", &add{})
+}
+
+func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *add) Description() string {
+	return `Add SATA controller to VM.
+
+Examples:
+  govc device.sata.add -vm $vm
+  govc device.info -vm $vm sata-*`
+}
+
+func (cmd *add) Process(ctx context.Context) error {
+	return cmd.VirtualMachineFlag.Process(ctx)
+}
+
+func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	d, err := devices.CreateSATAController()
+	if err != nil {
+		return err
+	}
+
+	err = vm.AddDevice(ctx, d)
+	if err != nil {
+		return err
+	}
+
+	devices, err = vm.Device(ctx)
+	if err != nil {
+		return err
+	}
+
+	devices = devices.SelectByType(d)
+
+	name := devices.Name(devices[len(devices)-1])
+
+	fmt.Println(name)
+
+	return nil
+}

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -118,6 +118,7 @@ but appear via `govc $cmd -h`:
  - [device.pci.ls](#devicepcils)
  - [device.pci.remove](#devicepciremove)
  - [device.remove](#deviceremove)
+ - [device.sata.add](#devicesataadd)
  - [device.scsi.add](#devicescsiadd)
  - [device.serial.add](#deviceserialadd)
  - [device.serial.connect](#deviceserialconnect)
@@ -2001,6 +2002,21 @@ Examples:
 
 Options:
   -keep=false            Keep files in datastore
+  -vm=                   Virtual machine [GOVC_VM]
+```
+
+## device.sata.add
+
+```
+Usage: govc device.sata.add [OPTIONS]
+
+Add SATA controller to VM.
+
+Examples:
+  govc device.sata.add -vm $vm
+  govc device.info -vm $vm sata-*
+
+Options:
   -vm=                   Virtual machine [GOVC_VM]
 ```
 

--- a/govc/main.go
+++ b/govc/main.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/vmware/govmomi/cli/device/floppy"
 	_ "github.com/vmware/govmomi/cli/device/model"
 	_ "github.com/vmware/govmomi/cli/device/pci"
+	_ "github.com/vmware/govmomi/cli/device/sata"
 	_ "github.com/vmware/govmomi/cli/device/scsi"
 	_ "github.com/vmware/govmomi/cli/device/serial"
 	_ "github.com/vmware/govmomi/cli/device/usb"

--- a/govc/test/device.bats
+++ b/govc/test/device.bats
@@ -227,6 +227,19 @@ load test_helper
   assert_failure "govc: device '$id' not found"
 }
 
+@test "device.sata" {
+  vcsim_env
+
+  vm=$(new_empty_vm)
+
+  run govc device.sata.add -vm $vm
+  assert_success
+  id=$output
+
+  result=$(govc device.ls -vm $vm | grep $id | wc -l)
+  [ $result -eq 1 ]
+}
+
 @test "device.scsi" {
   vcsim_env
 


### PR DESCRIPTION
### Description

- Added 'device.sata.add' command to add SATA controllers to virtual machines.
- Registered 'device.sata.add' in the 'govc' CLI entry point.
- Updated documentation and test suite to cover the new command.

Closes: #3780

### How Has This Been Tested?

`make govc-test` and manually.

```shell
govmomi on  govc/add-device-sata-add [!?] via 🐹 v1.25.5 
➜ vm="test-sata-$(date +%s)"
govc vm.create -on=false \
  -pool '/DC0/host/DC0_H0/Resources' \
  -net 'VM Network' \
  "$vm"

govmomi on  govc/add-device-sata-add [!?] via 🐹 v1.25.5 
➜ echo "== before =="
govc device.ls -vm "$vm" | egrep -i -- 'ahci|sata' || true

== before ==

govmomi on  govc/add-device-sata-add [!?] via 🐹 v1.25.5 
➜ id=$(govc device.sata.add -vm "$vm")
echo "added: $id"
govc device.info -vm "$vm" "$id"
added: ahci-204
Name:       ahci-204
  Type:     VirtualAHCIController
  Label:    ahci-204
  Summary:  ahci-204
  Key:      204
  Devices:  

govmomi on  govc/add-device-sata-add [!?] via 🐹 v1.25.5 
➜ echo "== after =="
govc device.ls -vm "$vm" | egrep -i -- 'ahci|sata' || true
== after ==
ahci-204      VirtualAHCIController      ahci-204
```