### PR TITLE
vcsim: Consider default devs from VM spec

### DIFF
--- a/simulator/esx/virtual_device.go
+++ b/simulator/esx/virtual_device.go
@@ -6,193 +6,156 @@ package esx
 
 import "github.com/vmware/govmomi/vim25/types"
 
+const (
+	VirtualMachineDefaultDevicePCIControllerKey = int32(100)
+	VirtualMachineDefaultDevicePS2ControllerKey = int32(300)
+)
+
+var VirtualMachineDefaultDevicePCIController = &types.VirtualPCIController{
+	VirtualController: types.VirtualController{
+		VirtualDevice: types.VirtualDevice{
+			Key: VirtualMachineDefaultDevicePCIControllerKey,
+			DeviceInfo: &types.Description{
+				Label:   "PCI controller 0",
+				Summary: "PCI controller 0",
+			},
+		},
+		Device: []int32{
+			VirtualMachineDefaultDeviceVideoCard.Key,
+			VirtualMachineDefaultDeviceVMCIDevice.Key,
+		},
+	},
+}
+
+var VirtualMachineDefaultDeviceIDEControllerBus0 = &types.VirtualIDEController{
+	VirtualController: types.VirtualController{
+		VirtualDevice: types.VirtualDevice{
+			Key: 200,
+			DeviceInfo: &types.Description{
+				Label:   "IDE 0",
+				Summary: "IDE 0",
+			},
+		},
+		BusNumber: 0,
+	},
+}
+
+var VirtualMachineDefaultDeviceIDEControllerBus1 = &types.VirtualIDEController{
+	VirtualController: types.VirtualController{
+		VirtualDevice: types.VirtualDevice{
+			Key: 201,
+			DeviceInfo: &types.Description{
+				Label:   "IDE 1",
+				Summary: "IDE 1",
+			},
+		},
+		BusNumber: 1,
+	},
+}
+
+var VirtualMachineDefaultDevicePS2Controller = &types.VirtualPS2Controller{
+	VirtualController: types.VirtualController{
+		VirtualDevice: types.VirtualDevice{
+			Key: VirtualMachineDefaultDevicePS2ControllerKey,
+			DeviceInfo: &types.Description{
+				Label:   "PS2 controller 0",
+				Summary: "PS2 controller 0",
+			},
+		},
+		Device: []int32{
+			VirtualMachineDefaultDeviceVirtualKeyboard.Key,
+			VirtualMachineDefaultDeviceVirtualPointingDevice.Key,
+		},
+	},
+}
+
+var VirtualMachineDefaultDeviceSIOController = &types.VirtualSIOController{
+	VirtualController: types.VirtualController{
+		VirtualDevice: types.VirtualDevice{
+			Key: 400,
+			DeviceInfo: &types.Description{
+				Label:   "SIO controller 0",
+				Summary: "SIO controller 0",
+			},
+		},
+	},
+}
+var VirtualMachineDefaultDeviceVirtualKeyboard = &types.VirtualKeyboard{
+	VirtualDevice: types.VirtualDevice{
+		Key: 600,
+		DeviceInfo: &types.Description{
+			Label:   "Keyboard ",
+			Summary: "Keyboard",
+		},
+		ControllerKey: VirtualMachineDefaultDevicePS2ControllerKey,
+		UnitNumber:    types.NewInt32(0),
+	},
+}
+var VirtualMachineDefaultDeviceVirtualPointingDevice = &types.VirtualPointingDevice{
+	VirtualDevice: types.VirtualDevice{
+		Key: 700,
+		DeviceInfo: &types.Description{
+			Label:   "Pointing device",
+			Summary: "Pointing device; Device",
+		},
+		Backing: &types.VirtualPointingDeviceDeviceBackingInfo{
+			VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
+				UseAutoDetect: types.NewBool(false),
+			},
+			HostPointingDevice: "autodetect",
+		},
+		ControllerKey: VirtualMachineDefaultDevicePS2ControllerKey,
+		UnitNumber:    types.NewInt32(1),
+	},
+}
+var VirtualMachineDefaultDeviceVideoCard = &types.VirtualMachineVideoCard{
+	VirtualDevice: types.VirtualDevice{
+		Key: 500,
+		DeviceInfo: &types.Description{
+			Label:   "Video card ",
+			Summary: "Video card",
+		},
+		ControllerKey: VirtualMachineDefaultDevicePCIControllerKey,
+		UnitNumber:    types.NewInt32(0),
+	},
+	VideoRamSizeInKB:       4096,
+	NumDisplays:            1,
+	UseAutoDetect:          types.NewBool(false),
+	Enable3DSupport:        types.NewBool(false),
+	Use3dRenderer:          "automatic",
+	GraphicsMemorySizeInKB: 262144,
+}
+
+var VirtualMachineDefaultDeviceVMCIDevice = &types.VirtualMachineVMCIDevice{
+	VirtualDevice: types.VirtualDevice{
+		Key: 12000,
+		DeviceInfo: &types.Description{
+			Label:   "VMCI device",
+			Summary: "Device on the virtual machine PCI bus that provides support for the virtual machine communication interface",
+		},
+		ControllerKey: VirtualMachineDefaultDevicePCIControllerKey,
+		UnitNumber:    types.NewInt32(17),
+	},
+	Id:                             -1,
+	AllowUnrestrictedCommunication: types.NewBool(false),
+	FilterEnable:                   types.NewBool(true),
+}
+
 // VirtualDevice is the default set of VirtualDevice types created for a VirtualMachine
 // Capture method:
 //
 //	govc vm.create foo
 //	govc object.collect -s -dump vm/foo config.hardware.device
 var VirtualDevice = []types.BaseVirtualDevice{
-	&types.VirtualIDEController{
-		VirtualController: types.VirtualController{
-			VirtualDevice: types.VirtualDevice{
-				DynamicData: types.DynamicData{},
-				Key:         200,
-				DeviceInfo: &types.Description{
-					DynamicData: types.DynamicData{},
-					Label:       "IDE 0",
-					Summary:     "IDE 0",
-				},
-				Backing:       nil,
-				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
-				SlotInfo:      nil,
-				ControllerKey: 0,
-				UnitNumber:    (*int32)(nil),
-			},
-			BusNumber: 0,
-			Device:    nil,
-		},
-	},
-	&types.VirtualIDEController{
-		VirtualController: types.VirtualController{
-			VirtualDevice: types.VirtualDevice{
-				DynamicData: types.DynamicData{},
-				Key:         201,
-				DeviceInfo: &types.Description{
-					DynamicData: types.DynamicData{},
-					Label:       "IDE 1",
-					Summary:     "IDE 1",
-				},
-				Backing:       nil,
-				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
-				SlotInfo:      nil,
-				ControllerKey: 0,
-				UnitNumber:    (*int32)(nil),
-			},
-			BusNumber: 1,
-			Device:    nil,
-		},
-	},
-	&types.VirtualPS2Controller{
-		VirtualController: types.VirtualController{
-			VirtualDevice: types.VirtualDevice{
-				DynamicData: types.DynamicData{},
-				Key:         300,
-				DeviceInfo: &types.Description{
-					DynamicData: types.DynamicData{},
-					Label:       "PS2 controller 0",
-					Summary:     "PS2 controller 0",
-				},
-				Backing:       nil,
-				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
-				SlotInfo:      nil,
-				ControllerKey: 0,
-				UnitNumber:    (*int32)(nil),
-			},
-			BusNumber: 0,
-			Device:    []int32{600, 700},
-		},
-	},
-	&types.VirtualPCIController{
-		VirtualController: types.VirtualController{
-			VirtualDevice: types.VirtualDevice{
-				DynamicData: types.DynamicData{},
-				Key:         100,
-				DeviceInfo: &types.Description{
-					DynamicData: types.DynamicData{},
-					Label:       "PCI controller 0",
-					Summary:     "PCI controller 0",
-				},
-				Backing:       nil,
-				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
-				SlotInfo:      nil,
-				ControllerKey: 0,
-				UnitNumber:    (*int32)(nil),
-			},
-			BusNumber: 0,
-			Device:    []int32{500, 12000},
-		},
-	},
-	&types.VirtualSIOController{
-		VirtualController: types.VirtualController{
-			VirtualDevice: types.VirtualDevice{
-				DynamicData: types.DynamicData{},
-				Key:         400,
-				DeviceInfo: &types.Description{
-					DynamicData: types.DynamicData{},
-					Label:       "SIO controller 0",
-					Summary:     "SIO controller 0",
-				},
-				Backing:       nil,
-				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
-				SlotInfo:      nil,
-				ControllerKey: 0,
-				UnitNumber:    (*int32)(nil),
-			},
-			BusNumber: 0,
-			Device:    nil,
-		},
-	},
-	&types.VirtualKeyboard{
-		VirtualDevice: types.VirtualDevice{
-			DynamicData: types.DynamicData{},
-			Key:         600,
-			DeviceInfo: &types.Description{
-				DynamicData: types.DynamicData{},
-				Label:       "Keyboard ",
-				Summary:     "Keyboard",
-			},
-			Backing:       nil,
-			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
-			SlotInfo:      nil,
-			ControllerKey: 300,
-			UnitNumber:    types.NewInt32(0),
-		},
-	},
-	&types.VirtualPointingDevice{
-		VirtualDevice: types.VirtualDevice{
-			DynamicData: types.DynamicData{},
-			Key:         700,
-			DeviceInfo: &types.Description{
-				DynamicData: types.DynamicData{},
-				Label:       "Pointing device",
-				Summary:     "Pointing device; Device",
-			},
-			Backing: &types.VirtualPointingDeviceDeviceBackingInfo{
-				VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
-					VirtualDeviceBackingInfo: types.VirtualDeviceBackingInfo{},
-					DeviceName:               "",
-					UseAutoDetect:            types.NewBool(false),
-				},
-				HostPointingDevice: "autodetect",
-			},
-			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
-			SlotInfo:      nil,
-			ControllerKey: 300,
-			UnitNumber:    types.NewInt32(1),
-		},
-	},
-	&types.VirtualMachineVideoCard{
-		VirtualDevice: types.VirtualDevice{
-			DynamicData: types.DynamicData{},
-			Key:         500,
-			DeviceInfo: &types.Description{
-				DynamicData: types.DynamicData{},
-				Label:       "Video card ",
-				Summary:     "Video card",
-			},
-			Backing:       nil,
-			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
-			SlotInfo:      nil,
-			ControllerKey: 100,
-			UnitNumber:    types.NewInt32(0),
-		},
-		VideoRamSizeInKB:       4096,
-		NumDisplays:            1,
-		UseAutoDetect:          types.NewBool(false),
-		Enable3DSupport:        types.NewBool(false),
-		Use3dRenderer:          "automatic",
-		GraphicsMemorySizeInKB: 262144,
-	},
-	&types.VirtualMachineVMCIDevice{
-		VirtualDevice: types.VirtualDevice{
-			DynamicData: types.DynamicData{},
-			Key:         12000,
-			DeviceInfo: &types.Description{
-				DynamicData: types.DynamicData{},
-				Label:       "VMCI device",
-				Summary:     "Device on the virtual machine PCI bus that provides support for the virtual machine communication interface",
-			},
-			Backing:       nil,
-			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
-			SlotInfo:      nil,
-			ControllerKey: 100,
-			UnitNumber:    types.NewInt32(17),
-		},
-		Id:                             -1,
-		AllowUnrestrictedCommunication: types.NewBool(false),
-		FilterEnable:                   types.NewBool(true),
-		FilterInfo:                     (*types.VirtualMachineVMCIDeviceFilterInfo)(nil),
-	},
+	VirtualMachineDefaultDevicePCIController,
+	VirtualMachineDefaultDeviceIDEControllerBus0,
+	VirtualMachineDefaultDeviceIDEControllerBus1,
+	VirtualMachineDefaultDevicePS2Controller,
+	VirtualMachineDefaultDeviceSIOController,
+	VirtualMachineDefaultDeviceVirtualKeyboard,
+	VirtualMachineDefaultDeviceVirtualPointingDevice,
+	VirtualMachineDefaultDeviceVideoCard,
+	VirtualMachineDefaultDeviceVMCIDevice,
 }
 
 // EthernetCard template for types.VirtualEthernetCard

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -1331,6 +1331,9 @@ func TestCreateVmWithDevices(t *testing.T) {
 	vm := m.Map().Get(info.Result.(types.ManagedObjectReference)).(*VirtualMachine)
 
 	expect := len(esx.VirtualDevice) + len(devices)
+
+	expect-- // Do not double-count the IDE controller as it's a default device.
+
 	ndevice := len(vm.Config.Hardware.Device)
 
 	if expect != ndevice {


### PR DESCRIPTION

## Description

This patch updates the way vC Sim creates a new VM. Previously the VM's default devices were always added, regardless of whether or not the incoming ConfigSpec specified any of the default device info.

This patch instructs vC Sim to consider the incoming ConfigSpec and check if it contains one or more of the default devices, using them from the ConfigSpec if it does.


Closes: `NA`

## How Has This Been Tested?

The GitHub actions. Also, @fabriziopandini will test this with the Cluster API Provider for vSphere to see if it fixes his issue.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
