### PR TITLE
Add VirtualVmxnet to EthernetCardTypes

### DIFF
--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -50,6 +50,7 @@ func EthernetCardTypes() VirtualDeviceList {
 	return VirtualDeviceList([]types.BaseVirtualDevice{
 		&types.VirtualE1000{},
 		&types.VirtualE1000e{},
+		&types.VirtualVmxnet{},
 		&types.VirtualVmxnet2{},
 		&types.VirtualVmxnet3{},
 		&types.VirtualVmxnet3Vrdma{},

--- a/object/virtual_device_list_test.go
+++ b/object/virtual_device_list_test.go
@@ -780,7 +780,7 @@ func TestCreateEthernetCard(t *testing.T) {
 		t.Error("should fail")
 	}
 
-	for _, name := range []string{"", "e1000", "e1000e", "vmxnet2", "vmxnet3", "pcnet32", "sriov"} {
+	for _, name := range []string{"", "e1000", "e1000e", "vmxnet", "vmxnet2", "vmxnet3", "pcnet32", "sriov"} {
 		c, err := EthernetCardTypes().CreateEthernetCard(name, nil)
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
## Description

Similar to commit 76b1ceafdb77cb1622a2532e5444e08b0bed300d which added VirtualVmxnet2, this adds support for VirtualVmxnet (the base vmxnet adapter type) to the list of available ethernet card types.

VC doesn't explicity block creating VirtualVmxnet network adapters for VM.
Which means it allows users to create VirtualVmxnet network adapters for specific type of VM. 

But Govmomi doesn't support and return empty for VirtualVmxnet adaptor. There is no depreciation story of this type of adaptor. So our workflow is still try not block this type of VM.

## How Has This Been Tested?
Before the fix, my workflow keeps panic because BaseVirtualEthernetCard return nil

59ef298972a4" panic="interface conversion: interface is nil, not types.BaseVirtualEthernetCard" panicGoValue="&runtime.TypeAssertionError{_interface:(*abi.Type)(nil), concrete:(*abi.Type)(nil), asserted:(*abi.Type)(0x21fdaa0),

After the fix, I tested on my testbed. The govmomi call doesn't return empty type for VirtualVmxnet adaptor which unblocked the test.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

Signed-off-by: Zexing Jiang <zexing.jiang@broadcom.com>
