### PR TITLE
fix: cluster configuration enablement and draft APIs

### DIFF
--- a/vapi/esx/settings/clusters/configuration/drafts/drafts.go
+++ b/vapi/esx/settings/clusters/configuration/drafts/drafts.go
@@ -42,8 +42,8 @@ type Draft struct {
 // CreateSpec a specification for creating configuration drafts
 // https://developer.broadcom.com/xapis/vsphere-automation-api/latest/data-structures/Esx%20Settings%20Clusters%20Configuration%20Drafts%20CreateSpec/
 type CreateSpec struct {
-	Config        string `json:"config"`
-	ReferenceHost string `json:"reference_host"`
+	Config        string `json:"config,omitempty"`
+	ReferenceHost string `json:"image_reference_host,omitempty"`
 }
 
 // ApplySpec a specification for committing a pending configuration draft

--- a/vapi/esx/settings/clusters/enablement/enablement.go
+++ b/vapi/esx/settings/clusters/enablement/enablement.go
@@ -34,6 +34,12 @@ type DraftImportResult struct {
 	Draft  string `json:"draft"`
 }
 
+// ConfigurationInfo contains details about the current configuration status of a cluster
+// https://developer.broadcom.com/xapis/vsphere-automation-api/latest/data-structures/Esx%20Settings%20Clusters%20Enablement%20Configuration%20Transition%20Info/
+type ConfigurationInfo struct {
+	Status string `json:"status"`
+}
+
 // Manager extends rest.Client, adding cluster configuration enablement related methods.
 type Manager struct {
 	*rest.Client
@@ -119,10 +125,10 @@ func (c *Manager) Cancel(clusterId string) (string, error) {
 // GetClusterConfigurationStatus returns the status of the current pending cluster configuration
 // Returns the config status and an error
 // https://developer.broadcom.com/xapis/vsphere-automation-api/latest/api/esx/settings/clusters/cluster/enablement/configuration/transition/get/
-func (c *Manager) GetClusterConfigurationStatus(clusterId string) (string, error) {
+func (c *Manager) GetClusterConfigurationStatus(clusterId string) (ConfigurationInfo, error) {
 	path := c.Resource(fmt.Sprintf(TransitionPath, clusterId))
 	req := path.Request(http.MethodGet)
-	var res string
+	var res ConfigurationInfo
 	return res, c.Do(context.Background(), req, &res)
 }
 


### PR DESCRIPTION
## Description

A couple of fixes to the bindings for cluster configuration profiles.

1. `GetClusterConfigurationStatus` - return a wrapper structure instead of a plain string
2. Draft `CreateSpec` - fix JSON mappings

## How Has This Been Tested?

Verified manually on vCenter 9

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
