### PR TITLE
Fix AddLibraryUsage to return expected output format.

### DIFF
--- a/vapi/library/library_usage.go
+++ b/vapi/library/library_usage.go
@@ -68,8 +68,6 @@ func (c *Manager) AddLibraryUsage(ctx context.Context, libraryID string, addUsag
 		WithSubpath(libraryID).
 		WithSubpath(internal.LibraryUsages)
 
-	var res struct {
-		Value string `json:"value,omitempty"`
-	}
-	return res.Value, c.Do(ctx, url.Request(http.MethodPost, addUsage), &res)
+	var res string
+	return res, c.Do(ctx, url.Request(http.MethodPost, addUsage), &res)
 }


### PR DESCRIPTION
## Description

This change will fix the The [AddLibraryUsage](https://github.com/vmware/govmomi/blob/main/vapi/library/library_usage.go#L66) API to return "string" instead of a struct object, which is expected in the internal API.

The [AddLibraryUsage](https://github.com/vmware/govmomi/blob/main/vapi/library/library_usage.go#L66) API has response set to the below struct

var res struct {
		Value string `json:"value,omitempty"`
	} 

while the internal Content Library Usage API returns a string.
Hence, the Add Library Usage fails with the below error

```
err: json: cannot unmarshal string into Go value of type struct { Value string "json:\"value,omitempty\"" }
```

Closes: #3952 

## How Has This Been Tested?

The unit tests are utilising the simulated code.
Tested manually on a testbed by 
- Create a new Content Library and attach it to the supervisor.
- Content Library usage is set successfully.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
