### PR TITLE
Update simulator to return StatusOK for libraryUsages as it is /api endpoint.

### DIFF
--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -1739,7 +1739,7 @@ func (s *handler) libraryUsages(w http.ResponseWriter, r *http.Request) {
 		}
 		usageID := uuid.New().String()
 		s.addUsage(pathSegs.LibraryID, usageID, spec)
-		OK(w, usageID)
+		StatusOK(w, usageID)
 	case http.MethodGet:
 		// List usages on a library requested through
 		// - /api/content/library/{librryID}/usages


### PR DESCRIPTION
## Description

With [#3953 ](https://github.com/vmware/govmomi/pull/3953), the `AddLibraryUsage` API is updated to have the response object as string. To incorporate this, the simulator needs to be updated as it is /api.

Closes: #3952 

## How Has This Been Tested?

Ran `make go-test` locally on my machine to ensure the tests are successful.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
