### PR TITLE
chore(deps): bump go to 1.24.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/govmomi
 
-go 1.24.0 // required for slices/maps package and built-in clear function
+go 1.24.13 // required for slices/maps package and built-in clear function
 
 require (
 	github.com/a8m/tree v0.0.0-20240104212747-2c8764a5f17e

--- a/govc/go.mod
+++ b/govc/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/govmomi/govc
 
-go 1.24.0
+go 1.24.13
 
 replace github.com/vmware/govmomi => ../
 

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -301,7 +301,7 @@ EOF
   assert_success
   hostname="$output"
 
-  run docker inspect -f '{{.NetworkSettings.Gateway}}' "$name"
+  run docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' "$name"
   assert_success
   gateway="$output"
 

--- a/vcsim/go.mod
+++ b/vcsim/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/govmomi/vcsim
 
-go 1.24.0
+go 1.24.13
 
 replace github.com/vmware/govmomi => ../
 


### PR DESCRIPTION
## Description

Updates the Go version requirement from `1.24.0` to `1.24.13` across modules to ensure consistency and compatibility with latest patch release. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3) [[2]](diffhunk://#diff-66098ace550fb84a20b3b9e78d4301f9e7db20d7698a147e4ddc934d9045f117L3-R3) [[3]](diffhunk://#diff-2871072a5409239d3843b4b566c98b1baff5187085e062b9e8df4dace83b0cd3L3-R3)
