### PR TITLE
govc: Fix vm.clone full path example root from ClusterName to DatacenterName

### DIFF
--- a/cli/vm/clone.go
+++ b/cli/vm/clone.go
@@ -116,7 +116,7 @@ Examples:
   govc vm.clone -vm template-vm -datastore-cluster dscluster new-vm # use datastore cluster placement
   govc vm.clone -vm template-vm -snapshot $(govc snapshot.tree -vm template-vm -C) new-vm
   govc vm.clone -vm template-vm -template new-template # clone a VM template
-  govc vm.clone -vm=/ClusterName/vm/FolderName/VM_templateName -on=true -host=myesxi01 -ds=datastore01 myVM_name`
+  govc vm.clone -vm=/DatacenterName/vm/FolderName/VM_templateName -on=true -host=myesxi01 -ds=datastore01 myVM_name`
 }
 
 func (cmd *clone) Process(ctx context.Context) error {

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -6869,7 +6869,7 @@ Examples:
   govc vm.clone -vm template-vm -datastore-cluster dscluster new-vm # use datastore cluster placement
   govc vm.clone -vm template-vm -snapshot $(govc snapshot.tree -vm template-vm -C) new-vm
   govc vm.clone -vm template-vm -template new-template # clone a VM template
-  govc vm.clone -vm=/ClusterName/vm/FolderName/VM_templateName -on=true -host=myesxi01 -ds=datastore01 myVM_name
+  govc vm.clone -vm=/DatacenterName/vm/FolderName/VM_templateName -on=true -host=myesxi01 -ds=datastore01 myVM_name
 
 Options:
   -annotation=           VM description


### PR DESCRIPTION
## Description

I found an incorrect example in the vm.clone help and fixed it.

## How Has This Been Tested?

This is only a documentation fix.