### PR TITLE
api: add TransitGateway mo type

### DIFF
--- a/vim25/mo/extra.go
+++ b/vim25/mo/extra.go
@@ -44,6 +44,10 @@ func (m ResourcePool) GetManagedEntity() ManagedEntity {
 	return m.ManagedEntity
 }
 
+func (m TransitGateway) GetManagedEntity() ManagedEntity {
+	return m.ManagedEntity
+}
+
 func (m VirtualMachine) GetManagedEntity() ManagedEntity {
 	return m.ManagedEntity
 }

--- a/vim25/mo/registry.go
+++ b/vim25/mo/registry.go
@@ -12,7 +12,7 @@ import (
 
 var t = map[string]reflect.Type{}
 
-// TODO: 9.0 mo below, not included in the generate mo/mo.go, since the generator still uses older rbvmomi vmodl.db
+// TODO: 9.0+ MOs below, not included in the generated mo/mo.go, since the generator still uses older rbvmomi vmodl.db
 
 type DirectPathProfileManager struct {
 	Self types.ManagedObjectReference `json:"self"`
@@ -24,4 +24,18 @@ func (m DirectPathProfileManager) Reference() types.ManagedObjectReference {
 
 func init() {
 	t["DirectPathProfileManager"] = reflect.TypeOf((*DirectPathProfileManager)(nil)).Elem()
+}
+
+type TransitGateway struct {
+	ManagedEntity
+
+	Config types.TransitGatewayConfigInfo `json:"config"`
+}
+
+func (m TransitGateway) Reference() types.ManagedObjectReference {
+	return m.Self
+}
+
+func init() {
+	t["TransitGateway"] = reflect.TypeOf((*TransitGateway)(nil)).Elem()
 }


### PR DESCRIPTION
We updated vim25.Version and types recently, but the generator still does not update mo types. Bandaid for now to prevent the possible panic below.

```console
% govc find 
panic: unknown type: TransitGateway

goroutine 1 [running]:
github.com/vmware/govmomi/vim25/mo.typeInfoForType({0x1400059d840, 0xe})
	/.../govmomi/vim25/mo/type_info.go:42 +0x284
github.com/vmware/govmomi/vim25/mo.ObjectContentToType({{}, {{0x1400059d840, 0xe}, {0x1400059d858, 0x8}, {0x0, 0x0}}, {0x140003a8bc0, 0x2, 0x2}, ...}, ...)
	/.../govmomi/vim25/mo/retrieve.go:52 +0x24c
github.com/vmware/govmomi/vim25/mo.LoadObjectContent({0x14000376708, 0x5, 0x101af0178?}, {0x1016a0600, 0x1400001ef18})
	/.../govmomi/vim25/mo/retrieve.go:111 +0x480
github.com/vmware/govmomi/vim25/mo.RetrievePropertiesForRequest({0x101affd58?, 0x1027e83a0?}, {0x101af0178?, 0x14000336008?}, {{{0x14000130c90, 0x11}, {0x14000130ca8, 0x11}, {0x0, 0x0}}, ...}, ...)
	/.../govmomi/vim25/mo/retrieve.go:199 +0xc0
github.com/vmware/govmomi/vim25/mo.Ancestors({0x101affd58, 0x1027e83a0}, {0x101af0178, 0x14000336008}, {{0x14000130c90, 0x11}, {0x14000130ca8, 0x11}, {0x0, 0x0}}, ...)
	/.../govmomi/vim25/mo/ancestors.go:65 +0x4fc
github.com/vmware/govmomi/find.InventoryPath({0x101affd58?, 0x1027e83a0?}, 0x101565b78?, {{0x14000349a40, 0xe}, {0x14000349a60, 0x8}, {0x0, 0x0}})
	/.../govmomi/find/finder.go:66 +0x74
github.com/vmware/govmomi/find.(*Finder).find(0x140003a0510, {0x101affd58, 0x1027e83a0}, {0x1013d2370, 0x2}, 0x14000357920)
	/.../govmomi/find/finder.go:138 +0x2e4
github.com/vmware/govmomi/find.(*Finder).Element(0x140003a0510, {0x101affd58, 0x1027e83a0}, {{0x14000349a40, 0xe}, {0x14000349a60, 0x8}, {0x0, 0x0}})
	/.../govmomi/find/finder.go:301 +0xcc
github.com/vmware/govmomi/cli/object.(*find).Run(0x14000134bc0, {0x101affd58, 0x1027e83a0}, 0x140001ffb20)
	/.../govmomi/cli/object/find.go:391 +0xb60
github.com/vmware/govmomi/cli.Run({0x14000112070, 0x1, 0x1})
	/.../govmomi/cli/command.go:203 +0x220
main.main()
	/.../govmomi/govc/main.go:127 +0x50
```