### PR TITLE
Bump release go-version

### DIFF
--- a/.github/workflows/govmomi-release.yaml
+++ b/.github/workflows/govmomi-release.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: '1.23'
+          go-version: '1.25'
       - name: Update version.go
         run: |
           # strip semantic v


### PR DESCRIPTION
When running release action:
```failed to get module path: exit status 1: go: go.mod requires go >= 1.24.13 (running go 1.23.12; GOTOOLCHAIN=local)```
