### PR TITLE
api: Add SetRootCAsFromPEM method

### DIFF
--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -306,6 +306,20 @@ func (c *Client) SetRootCAs(pemPaths string) error {
 	return nil
 }
 
+func (c *Client) SetRootCAsFromPEM(pems [][]byte) error {
+	pool := x509.NewCertPool()
+
+	for _, pem := range pems {
+		if ok := pool.AppendCertsFromPEM(pem); !ok {
+			return errInvalidCACertificate{}
+		}
+	}
+
+	c.t.TLSClientConfig.RootCAs = pool
+
+	return nil
+}
+
 // Add default https port if missing
 func hostAddr(addr string) string {
 	_, port := splitHostPort(addr)

--- a/vim25/soap/client_test.go
+++ b/vim25/soap/client_test.go
@@ -146,6 +146,74 @@ func setCAsOnClient(cas string) error {
 	return client.SetRootCAs(cas)
 }
 
+func TestValidRootCAsFromPEM(t *testing.T) {
+	pem, err := os.ReadFile("fixtures/valid-cert.pem")
+	if err != nil {
+		t.Fatalf("Failed to read valid cert: %v", err)
+	}
+
+	err = setCAsFromPEMOnClient([][]byte{pem})
+	if err != nil {
+		t.Fatalf("Err should not have occurred: %#v", err)
+	}
+}
+
+func TestInvalidRootCAsFromPEM(t *testing.T) {
+	cert := []byte(`-----BEGIN CERTIFICATE-----\n`)
+	err := setCAsFromPEMOnClient([][]byte{cert})
+
+	_, ok := err.(errInvalidCACertificate)
+	if !ok {
+		t.Fatalf("Expected errInvalidCACertificate to occur")
+	}
+}
+
+func TestMultipleRootCAsFromPEM(t *testing.T) {
+	pem, err := os.ReadFile("fixtures/valid-cert.pem")
+	if err != nil {
+		t.Fatalf("Failed to read valid cert: %v", err)
+	}
+
+	err = setCAsFromPEMOnClient([][]byte{pem, pem})
+	if err != nil {
+		t.Fatalf("Err should not have occurred with multiple valid certs: %#v", err)
+	}
+}
+
+func TestMixedValidInvalidRootCAsFromPEM(t *testing.T) {
+	validPem, err := os.ReadFile("fixtures/valid-cert.pem")
+	if err != nil {
+		t.Fatalf("Failed to read valid cert: %v", err)
+	}
+
+	invalidPem := []byte(`-----BEGIN CERTIFICATE-----\n`)
+
+	err = setCAsFromPEMOnClient([][]byte{validPem, invalidPem})
+	_, ok := err.(errInvalidCACertificate)
+	if !ok {
+		t.Fatalf("Expected errInvalidCACertificate to occur with mixed certs")
+	}
+}
+
+func TestEmptyRootCAsFromPEM(t *testing.T) {
+	err := setCAsFromPEMOnClient([][]byte{})
+	if err != nil {
+		t.Fatalf("Empty slice should not cause error: %#v", err)
+	}
+}
+
+func setCAsFromPEMOnClient(cas [][]byte) error {
+	url := &url.URL{
+		Scheme: "https",
+		Host:   "some.host.tld:8080",
+	}
+	insecure := false
+
+	client := NewClient(url, insecure)
+
+	return client.SetRootCAsFromPEM(cas)
+}
+
 func TestParseURL(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Add SetRootCAsFromPEM to allow passing in-memory PEM-encoded certificates instead of requiring them to be on disk. This is useful for read-only filesystems where CA contents are already available in memory.

## Description

Add SetRootCAsFromPEM to allow passing in-memory PEM-encoded
certificates instead of requiring them to be on disk. This is
useful for read-only filesystems where CA contents are already
available in memory.

## How Has This Been Tested?

Tested with a container doing:
```
	if len(config.CAContents) != 0 {
		if err = soapClient.SetRootCAsFromPEM([][]byte{config.CAContents}); err != nil {
			return fmt.Errorf("failed to set root CA %s: %w", config.CAFilePath, err)
		}
	}
```
and was able to connect to vCenter properly.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
