### PR TITLE
Add API for CNS Volume Flags Control

### DIFF
--- a/cns/client.go
+++ b/cns/client.go
@@ -334,3 +334,23 @@ func (c *Client) UnregisterVolume(ctx context.Context, spec []cnstypes.CnsUnregi
 	}
 	return object.NewTask(c.vim25Client, res.Returnval), nil
 }
+
+// SetVolumeControlFlags calls the CNS CnsSetVolumeControlFlags API (synchronous).
+func (c *Client) SetVolumeControlFlags(ctx context.Context, controlFlagsSpecs []cnstypes.CnsVolumeControlFlagsSpec) error {
+	req := cnstypes.CnsSetVolumeControlFlags{
+		This:              CnsVolumeManagerInstance,
+		ControlFlagsSpecs: controlFlagsSpecs,
+	}
+	_, err := methods.CnsSetVolumeControlFlags(ctx, c, &req)
+	return err
+}
+
+// ClearVolumeControlFlags calls the CNS CnsClearVolumeControlFlags API (synchronous).
+func (c *Client) ClearVolumeControlFlags(ctx context.Context, controlFlagsSpecs []cnstypes.CnsVolumeControlFlagsSpec) error {
+	req := cnstypes.CnsClearVolumeControlFlags{
+		This:              CnsVolumeManagerInstance,
+		ControlFlagsSpecs: controlFlagsSpecs,
+	}
+	_, err := methods.CnsClearVolumeControlFlags(ctx, c, &req)
+	return err
+}

--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -32,6 +32,7 @@ import (
 const VSphere70u3VersionInt = 703
 const VSphere80u3VersionInt = 803
 const VSphere91VersionInt = 910
+const VSphere92VersionInt = 920
 
 func TestClient(t *testing.T) {
 	// set CNS_DEBUG to true if you need to emit soap traces from these tests
@@ -1957,6 +1958,248 @@ func TestUnregisterVolume(t *testing.T) {
 	t.Logf("Volume unregistered successfully: %s", volumeId)
 }
 
+// TestBlockVolumeCBT exercises CnsSetVolumeControlFlags, CnsClearVolumeControlFlags,
+// QueryVolume changedBlockTracking (CnsVolumeCBTStatus), and snapshot changedBlockTrackingId.
+// Requires vSphere 9.2.0 or later.
+func TestBlockVolumeCBT(t *testing.T) {
+	ctx := context.Background()
+	url := os.Getenv("CNS_VC_URL")
+	datacenter := os.Getenv("CNS_DATACENTER")
+	datastore := os.Getenv("CNS_DATASTORE")
+	if url == "" || datacenter == "" || datastore == "" {
+		t.Skip("CNS_VC_URL, CNS_DATACENTER, and CNS_DATASTORE must be set")
+	}
+	u, err := soap.ParseURL(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := govmomi.NewClient(ctx, u, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isvSphereVersion92orAbove(ctx, c.ServiceContent.About) {
+		t.Skip("This test requires vSphere 9.2.0 or above")
+	}
+
+	cnsClient, err := NewClient(ctx, c.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finder := find.NewFinder(cnsClient.vim25Client, false)
+	dc, err := finder.Datacenter(ctx, datacenter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finder.SetDatacenter(dc)
+	ds, err := finder.Datastore(ctx, datastore)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var dsList []vim25types.ManagedObjectReference
+	dsList = append(dsList, ds.Reference())
+
+	containerCluster := cnstypes.CnsContainerCluster{
+		ClusterType:         string(cnstypes.CnsClusterTypeKubernetes),
+		ClusterId:           "demo-cluster-id",
+		VSphereUser:         "Administrator@vsphere.local",
+		ClusterFlavor:       string(cnstypes.CnsClusterFlavorVanilla),
+		ClusterDistribution: "OpenShift",
+	}
+
+	volumeName := "pvc-cbt-" + uuid.New().String()
+	cnsVolumeCreateSpec := cnstypes.CnsVolumeCreateSpec{
+		Name:       volumeName,
+		VolumeType: string(cnstypes.CnsVolumeTypeBlock),
+		Metadata: cnstypes.CnsVolumeMetadata{
+			ContainerCluster: containerCluster,
+		},
+		BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+			CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{
+				CapacityInMb: 5120,
+			},
+		},
+		Datastores: dsList,
+	}
+	var volumeID, snapshotID string
+	t.Cleanup(func() {
+		cctx := context.Background()
+		if snapshotID != "" && volumeID != "" {
+			delSnap := []cnstypes.CnsSnapshotDeleteSpec{{
+				VolumeId:   cnstypes.CnsVolumeId{Id: volumeID},
+				SnapshotId: cnstypes.CnsSnapshotId{Id: snapshotID},
+			}}
+			task, err := cnsClient.DeleteSnapshots(cctx, delSnap)
+			if err != nil {
+				t.Logf("cleanup DeleteSnapshots: %v", err)
+			} else if taskInfo, err := GetTaskInfo(cctx, task); err != nil {
+				t.Logf("cleanup GetTaskInfo DeleteSnapshots: %v", err)
+			} else if taskResult, err := GetTaskResult(cctx, taskInfo); err != nil {
+				t.Logf("cleanup GetTaskResult DeleteSnapshots: %v", err)
+			} else if taskResult != nil {
+				if op := taskResult.GetCnsVolumeOperationResult(); op != nil && op.Fault != nil {
+					t.Logf("cleanup DeleteSnapshots fault: %+v", op.Fault)
+				}
+			}
+		}
+		if volumeID != "" {
+			delVol := []cnstypes.CnsVolumeId{{Id: volumeID}}
+			task, err := cnsClient.DeleteVolume(cctx, delVol, true)
+			if err != nil {
+				t.Logf("cleanup DeleteVolume: %v", err)
+			} else if taskInfo, err := GetTaskInfo(cctx, task); err != nil {
+				t.Logf("cleanup GetTaskInfo DeleteVolume: %v", err)
+			} else if taskResult, err := GetTaskResult(cctx, taskInfo); err != nil {
+				t.Logf("cleanup GetTaskResult DeleteVolume: %v", err)
+			} else if taskResult != nil {
+				if op := taskResult.GetCnsVolumeOperationResult(); op != nil && op.Fault != nil {
+					t.Logf("cleanup DeleteVolume fault: %+v", op.Fault)
+				}
+			}
+		}
+	})
+
+	createTask, err := cnsClient.CreateVolume(ctx, []cnstypes.CnsVolumeCreateSpec{cnsVolumeCreateSpec})
+	if err != nil {
+		t.Fatal(err)
+	}
+	createTaskInfo, err := GetTaskInfo(ctx, createTask)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createTaskResult, err := GetTaskResult(ctx, createTaskInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if createTaskResult == nil {
+		t.Fatal("empty create volume task result")
+	}
+	createVolumeOperationRes := createTaskResult.GetCnsVolumeOperationResult()
+	if createVolumeOperationRes.Fault != nil {
+		t.Fatalf("create volume fault: %+v", createVolumeOperationRes.Fault)
+	}
+	volumeID = createVolumeOperationRes.VolumeId.Id
+	t.Logf("CBT test: created block volume %q", volumeID)
+
+	cbtFlag := string(cnstypes.CnsVolumeControlFlagsEnableChangedBlockTracking)
+	err = cnsClient.SetVolumeControlFlags(ctx, []cnstypes.CnsVolumeControlFlagsSpec{{
+		VolumeId:     cnstypes.CnsVolumeId{Id: volumeID},
+		ControlFlags: []string{cbtFlag},
+	}})
+	if err != nil {
+		t.Fatalf("SetVolumeControlFlags(enable CBT): %v", err)
+	}
+
+	queryFilter := cnstypes.CnsQueryFilter{
+		VolumeIds: []cnstypes.CnsVolumeId{{Id: volumeID}},
+	}
+	queryResult, err := cnsClient.QueryVolume(ctx, &queryFilter)
+	if err != nil {
+		t.Fatalf("QueryVolume after enabling CBT: %v", err)
+	}
+	if len(queryResult.Volumes) != 1 {
+		t.Fatalf("QueryVolume: want 1 volume, got %d", len(queryResult.Volumes))
+	}
+	queryByCBT := cnstypes.CnsQueryFilter{
+		VolumeIds:            []cnstypes.CnsVolumeId{{Id: volumeID}},
+		ChangedBlockTracking: cnstypes.CnsVolumeCBTStatusEnabled,
+	}
+	queryByCBTResult, err := cnsClient.QueryVolume(ctx, &queryByCBT)
+	if err != nil {
+		t.Fatalf("QueryVolume with ChangedBlockTracking=%s: %v", cnstypes.CnsVolumeCBTStatusEnabled, err)
+	}
+	if len(queryByCBTResult.Volumes) != 1 {
+		t.Fatalf("QueryVolume with CBT filter: want 1 volume, got %d", len(queryByCBTResult.Volumes))
+	}
+	if queryResult.Volumes[0].ChangedBlockTracking != cnstypes.CnsVolumeCBTStatusEnabled {
+		t.Fatalf("expected CBT enabled on volume, changedBlockTracking=%q (want %q)",
+			queryResult.Volumes[0].ChangedBlockTracking, cnstypes.CnsVolumeCBTStatusEnabled)
+	}
+	cnsSnapshotCreateSpec := cnstypes.CnsSnapshotCreateSpec{
+		VolumeId:    cnstypes.CnsVolumeId{Id: volumeID},
+		Description: "cbt-test-snapshot",
+	}
+	createSnapshotsTask, err := cnsClient.CreateSnapshots(ctx, []cnstypes.CnsSnapshotCreateSpec{cnsSnapshotCreateSpec})
+	if err != nil {
+		t.Fatal(err)
+	}
+	createSnapshotsTaskInfo, err := GetTaskInfo(ctx, createSnapshotsTask)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createSnapshotsTaskResult, err := GetTaskResult(ctx, createSnapshotsTaskInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if createSnapshotsTaskResult == nil {
+		t.Fatal("empty create snapshot task result")
+	}
+	if createSnapshotsOperationRes := createSnapshotsTaskResult.GetCnsVolumeOperationResult(); createSnapshotsOperationRes.Fault != nil {
+		t.Fatalf("CreateSnapshots fault: %+v", createSnapshotsOperationRes.Fault)
+	}
+	snapshotCreateResult, ok := createSnapshotsTaskResult.(*cnstypes.CnsSnapshotCreateResult)
+	if !ok {
+		t.Fatalf("unexpected create snapshot result type %T", createSnapshotsTaskResult)
+	}
+	snapshotID = snapshotCreateResult.Snapshot.SnapshotId.Id
+	if snapshotCreateResult.Snapshot.ChangedBlockTrackingId == "" {
+		t.Fatalf("expected non-empty changedBlockTrackingId (CBT change id) on snapshot, got %q",
+			snapshotCreateResult.Snapshot.ChangedBlockTrackingId)
+	}
+	t.Logf("snapshot %q changedBlockTrackingId=%q", snapshotID, snapshotCreateResult.Snapshot.ChangedBlockTrackingId)
+
+	snapshotQueryFilter := cnstypes.CnsSnapshotQueryFilter{
+		SnapshotQuerySpecs: []cnstypes.CnsSnapshotQuerySpec{{
+			VolumeId:   cnstypes.CnsVolumeId{Id: volumeID},
+			SnapshotId: &cnstypes.CnsSnapshotId{Id: snapshotID},
+		}},
+	}
+	querySnapshotsTask, err := cnsClient.QuerySnapshots(ctx, snapshotQueryFilter)
+	if err != nil {
+		t.Fatalf("QuerySnapshots: %v", err)
+	}
+	querySnapshotsTaskInfo, err := GetTaskInfo(ctx, querySnapshotsTask)
+	if err != nil {
+		t.Fatalf("QuerySnapshots GetTaskInfo: %v", err)
+	}
+	snapQueryResult, err := GetQuerySnapshotsTaskResult(ctx, querySnapshotsTaskInfo)
+	if err != nil {
+		t.Fatalf("QuerySnapshots GetQuerySnapshotsTaskResult: %v", err)
+	}
+	if len(snapQueryResult.Entries) != 1 {
+		t.Fatalf("QuerySnapshots: want 1 entry, got %d", len(snapQueryResult.Entries))
+	}
+	if snapQueryResult.Entries[0].Error != nil {
+		t.Fatalf("QuerySnapshots entry error: %+v", snapQueryResult.Entries[0].Error)
+	}
+	queriedSnap := snapQueryResult.Entries[0].Snapshot
+	if queriedSnap.ChangedBlockTrackingId == "" {
+		t.Fatalf("expected non-empty changedBlockTrackingId from QuerySnapshots, got %q",
+			queriedSnap.ChangedBlockTrackingId)
+	}
+	t.Logf("snapshot %q changedBlockTrackingId=%q (from QuerySnapshots)", snapshotID, queriedSnap.ChangedBlockTrackingId)
+
+	err = cnsClient.ClearVolumeControlFlags(ctx, []cnstypes.CnsVolumeControlFlagsSpec{{
+		VolumeId:     cnstypes.CnsVolumeId{Id: volumeID},
+		ControlFlags: []string{cbtFlag},
+	}})
+	if err != nil {
+		t.Fatalf("ClearVolumeControlFlags(disable CBT): %v", err)
+	}
+
+	queryResult, err = cnsClient.QueryVolume(ctx, &queryFilter)
+	if err != nil {
+		t.Fatalf("QueryVolume after disabling CBT: %v", err)
+	}
+	if len(queryResult.Volumes) != 1 {
+		t.Fatalf("QueryVolume: want 1 volume, got %d", len(queryResult.Volumes))
+	}
+	if queryResult.Volumes[0].ChangedBlockTracking == cnstypes.CnsVolumeCBTStatusEnabled {
+		t.Fatalf("expected CBT disabled on volume, changedBlockTracking=%q (want not %q)",
+			queryResult.Volumes[0].ChangedBlockTracking, cnstypes.CnsVolumeCBTStatusEnabled)
+	}
+}
+
 func TestHandleCnsNotRegisteredFault(t *testing.T) {
 	ctx := context.Background()
 	// Setup: create a CNS client and a volume to unregister
@@ -2268,5 +2511,22 @@ func isvSphereVersion91orAbove(ctx context.Context, aboutInfo vim25types.AboutIn
 		}
 	}
 	// For all other versions
+	return false
+}
+
+// isvSphereVersion92orAbove checks if specified version is 9.2.0 or higher
+// using the same compact version encoding as isvSphereVersion91orAbove (e.g. "9.2.0" → 920).
+func isvSphereVersion92orAbove(ctx context.Context, aboutInfo vim25types.AboutInfo) bool {
+	items := strings.Split(aboutInfo.Version, ".")
+	version := strings.Join(items[:], "")
+	if len(version) >= 3 {
+		vSphereVersionInt, err := strconv.Atoi(version[0:3])
+		if err != nil {
+			return false
+		}
+		if vSphereVersionInt >= VSphere92VersionInt {
+			return true
+		}
+	}
 	return false
 }

--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -2100,6 +2100,11 @@ func TestBlockVolumeCBT(t *testing.T) {
 	if len(queryResult.Volumes) != 1 {
 		t.Fatalf("QueryVolume: want 1 volume, got %d", len(queryResult.Volumes))
 	}
+	if queryResult.Volumes[0].ChangedBlockTracking != cnstypes.CnsVolumeCBTStatusEnabled {
+		t.Fatalf("expected CBT enabled on volume, changedBlockTracking=%q (want %q)",
+			queryResult.Volumes[0].ChangedBlockTracking, cnstypes.CnsVolumeCBTStatusEnabled)
+	}
+
 	queryByCBT := cnstypes.CnsQueryFilter{
 		VolumeIds:            []cnstypes.CnsVolumeId{{Id: volumeID}},
 		ChangedBlockTracking: cnstypes.CnsVolumeCBTStatusEnabled,
@@ -2111,10 +2116,7 @@ func TestBlockVolumeCBT(t *testing.T) {
 	if len(queryByCBTResult.Volumes) != 1 {
 		t.Fatalf("QueryVolume with CBT filter: want 1 volume, got %d", len(queryByCBTResult.Volumes))
 	}
-	if queryResult.Volumes[0].ChangedBlockTracking != cnstypes.CnsVolumeCBTStatusEnabled {
-		t.Fatalf("expected CBT enabled on volume, changedBlockTracking=%q (want %q)",
-			queryResult.Volumes[0].ChangedBlockTracking, cnstypes.CnsVolumeCBTStatusEnabled)
-	}
+
 	cnsSnapshotCreateSpec := cnstypes.CnsSnapshotCreateSpec{
 		VolumeId:    cnstypes.CnsVolumeId{Id: volumeID},
 		Description: "cbt-test-snapshot",

--- a/cns/methods/methods.go
+++ b/cns/methods/methods.go
@@ -395,3 +395,43 @@ func CnsUnregisterVolume(ctx context.Context, r soap.RoundTripper, req *types.Cn
 
 	return resBody.Res, nil
 }
+
+type CnsSetVolumeControlFlagsBody struct {
+	Req    *types.CnsSetVolumeControlFlags         `xml:"urn:vsan CnsSetVolumeControlFlags,omitempty"`
+	Res    *types.CnsSetVolumeControlFlagsResponse `xml:"urn:vsan CnsSetVolumeControlFlagsResponse,omitempty"`
+	Fault_ *soap.Fault                             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsSetVolumeControlFlagsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsSetVolumeControlFlags(ctx context.Context, r soap.RoundTripper, req *types.CnsSetVolumeControlFlags) (*types.CnsSetVolumeControlFlagsResponse, error) {
+	var reqBody, resBody CnsSetVolumeControlFlagsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CnsClearVolumeControlFlagsBody struct {
+	Req    *types.CnsClearVolumeControlFlags         `xml:"urn:vsan CnsClearVolumeControlFlags,omitempty"`
+	Res    *types.CnsClearVolumeControlFlagsResponse `xml:"urn:vsan CnsClearVolumeControlFlagsResponse,omitempty"`
+	Fault_ *soap.Fault                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CnsClearVolumeControlFlagsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CnsClearVolumeControlFlags(ctx context.Context, r soap.RoundTripper, req *types.CnsClearVolumeControlFlags) (*types.CnsClearVolumeControlFlagsResponse, error) {
+	var reqBody, resBody CnsClearVolumeControlFlagsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/cns/types/enum.go
+++ b/cns/types/enum.go
@@ -124,3 +124,32 @@ const (
 func init() {
 	types.Add("vsan:CnsVolumeBackingType", reflect.TypeOf((*CnsVolumeBackingType)(nil)).Elem())
 }
+
+// CnsVolumeControlFlags enumerates volume control flags for CnsSetVolumeControlFlags /
+// CnsClearVolumeControlFlags (aligned with vim.vslm.VStorageObjectControlFlag).
+type CnsVolumeControlFlags string
+
+const (
+	CnsVolumeControlFlagsKeepAfterDeleteVm          = CnsVolumeControlFlags("keepAfterDeleteVm")
+	CnsVolumeControlFlagsDisableRelocation          = CnsVolumeControlFlags("disableRelocation")
+	CnsVolumeControlFlagsEnableChangedBlockTracking = CnsVolumeControlFlags("enableChangedBlockTracking")
+)
+
+func init() {
+	types.Add("CnsVolumeControlFlags", reflect.TypeOf((*CnsVolumeControlFlags)(nil)).Elem())
+}
+
+// CnsVolumeCBTStatus enumerates changed block tracking (CBT) status for a CNS volume
+// (QueryVolume / CnsVolume and QueryFilter.changedBlockTracking).
+type CnsVolumeCBTStatus string
+
+const (
+	CnsVolumeCBTStatusEnabled  = CnsVolumeCBTStatus("ENABLED")
+	CnsVolumeCBTStatusDisabled = CnsVolumeCBTStatus("DISABLED")
+	// CnsVolumeCBTStatusUnknown is returned when an older client cannot interpret the value.
+	CnsVolumeCBTStatusUnknown = CnsVolumeCBTStatus("VolumeCBTStatus_Unknown")
+)
+
+func init() {
+	types.Add("CnsVolumeCBTStatus", reflect.TypeOf((*CnsVolumeCBTStatus)(nil)).Elem())
+}

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -310,6 +310,7 @@ type CnsVolume struct {
 	ComplianceStatus             string                      `xml:"complianceStatus,omitempty" json:"complianceStatus"`
 	DatastoreAccessibilityStatus string                      `xml:"datastoreAccessibilityStatus,omitempty" json:"datastoreAccessibilityStatus"`
 	HealthStatus                 string                      `xml:"healthStatus,omitempty" json:"healthStatus"`
+	ChangedBlockTracking         CnsVolumeCBTStatus          `xml:"changedBlockTracking,omitempty" json:"changedBlockTracking,omitempty"`
 }
 
 func init() {
@@ -465,6 +466,7 @@ type CnsQueryFilter struct {
 	DatastoreAccessibilityStatus string                         `xml:"datastoreAccessibilityStatus,omitempty" json:"datastoreAccessibilityStatus"`
 	Cursor                       *CnsCursor                     `xml:"cursor,omitempty" json:"cursor"`
 	HealthStatus                 string                         `xml:"healthStatus,omitempty" json:"healthStatus"`
+	ChangedBlockTracking         CnsVolumeCBTStatus             `xml:"changedBlockTracking,omitempty" json:"changedBlockTracking,omitempty"`
 }
 
 func (f *CnsQueryFilter) GetCnsQueryFilter() *CnsQueryFilter {
@@ -836,10 +838,11 @@ func init() {
 type CnsSnapshot struct {
 	types.DynamicData
 
-	SnapshotId  CnsSnapshotId `xml:"snapshotId" json:"snapshotId"`
-	VolumeId    CnsVolumeId   `xml:"volumeId" json:"volumeId"`
-	Description string        `xml:"description,omitempty" json:"description"`
-	CreateTime  time.Time     `xml:"createTime" json:"createTime"`
+	SnapshotId             CnsSnapshotId `xml:"snapshotId" json:"snapshotId"`
+	VolumeId               CnsVolumeId   `xml:"volumeId" json:"volumeId"`
+	Description            string        `xml:"description,omitempty" json:"description"`
+	CreateTime             time.Time     `xml:"createTime" json:"createTime"`
+	ChangedBlockTrackingId string        `xml:"changedBlockTrackingId,omitempty" json:"changedBlockTrackingId,omitempty"`
 }
 
 func init() {
@@ -1068,4 +1071,51 @@ type CnsUnregisterVolumeSpec struct {
 
 func init() {
 	types.Add("vsan:CnsUnregisterVolumeSpec", reflect.TypeOf((*CnsUnregisterVolumeSpec)(nil)).Elem())
+}
+
+type CnsVolumeControlFlagsSpec struct {
+	types.DynamicData
+
+	VolumeId     CnsVolumeId `xml:"volumeId" json:"volumeId"`
+	ControlFlags []string    `xml:"controlFlags,omitempty" json:"controlFlags,omitempty"`
+}
+
+func init() {
+	types.Add("CnsVolumeControlFlagsSpec", reflect.TypeOf((*CnsVolumeControlFlagsSpec)(nil)).Elem())
+}
+
+type CnsSetVolumeControlFlags CnsSetVolumeControlFlagsRequestType
+
+func init() {
+	types.Add("CnsSetVolumeControlFlags", reflect.TypeOf((*CnsSetVolumeControlFlags)(nil)).Elem())
+}
+
+type CnsSetVolumeControlFlagsRequestType struct {
+	This              types.ManagedObjectReference `xml:"_this" json:"-"`
+	ControlFlagsSpecs []CnsVolumeControlFlagsSpec  `xml:"controlFlagsSpecs,omitempty" json:"controlFlagsSpecs,omitempty"`
+}
+
+func init() {
+	types.Add("CnsSetVolumeControlFlagsRequestType", reflect.TypeOf((*CnsSetVolumeControlFlagsRequestType)(nil)).Elem())
+}
+
+type CnsSetVolumeControlFlagsResponse struct {
+}
+
+type CnsClearVolumeControlFlags CnsClearVolumeControlFlagsRequestType
+
+func init() {
+	types.Add("CnsClearVolumeControlFlags", reflect.TypeOf((*CnsClearVolumeControlFlags)(nil)).Elem())
+}
+
+type CnsClearVolumeControlFlagsRequestType struct {
+	This              types.ManagedObjectReference `xml:"_this" json:"-"`
+	ControlFlagsSpecs []CnsVolumeControlFlagsSpec  `xml:"controlFlagsSpecs,omitempty" json:"controlFlagsSpecs,omitempty"`
+}
+
+func init() {
+	types.Add("CnsClearVolumeControlFlagsRequestType", reflect.TypeOf((*CnsClearVolumeControlFlagsRequestType)(nil)).Elem())
+}
+
+type CnsClearVolumeControlFlagsResponse struct {
 }


### PR DESCRIPTION
## Description

This PR is adding go binding for Cns Volume Control Flags (mainly for changed block tracking) APIs
1,   add VolumeCBTStatus in Volume
2,  add APIs SetVolumeControlFlags and ClearVolumeControlFlags
3,  allow QueryVolume with CBT status

Note: will add support for simulator in following changes.

Closes: #(issue-number)

## How Has This Been Tested?

bash-4.4$ go test -v -count=1 ./cns -run TestBlockVolumeCBT
=== RUN   TestBlockVolumeCBT
    client_test.go:2082: CBT test: created block volume "b6d0bc60-094d-46c9-b7f4-8a5e3a6d974d"
    client_test.go:2149: snapshot "e9c6b988-b6aa-4822-a6fa-265fe0fd9218" changedBlockTrackingId="52 a8 9e 8f 17 3c 86 f0-08 52 f5 6e 9f bf 54 3b/1"
    client_test.go:2180: snapshot "e9c6b988-b6aa-4822-a6fa-265fe0fd9218" changedBlockTrackingId="52 a8 9e 8f 17 3c 86 f0-08 52 f5 6e 9f bf 54 3b/1" (from QuerySnapshots)
--- PASS: TestBlockVolumeCBT (9.83s)
PASS
ok      github.com/vmware/govmomi/cns   9.846s

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
