### PR TITLE
feat(NamespaceNetwork): add implementation of NamespaceNetwork

### DIFF
--- a/vapi/namespace/namespace_v2.go
+++ b/vapi/namespace/namespace_v2.go
@@ -42,14 +42,15 @@ type NamespaceInstanceInfoV2 struct {
 // https://developer.broadcom.com/xapis/vsphere-automation-api/9.0/data-structures/Vcenter%20Namespaces%20Instances%20CreateSpecV2
 // Since 8.0.0.1
 type NamespaceInstanceCreateSpecV2 struct {
-	Namespace            string                   `json:"namespace"`
-	Supervisor           string                   `json:"supervisor"`
-	Description          *string                  `json:"description,omitempty"`
-	StorageSpecs         *[]StorageSpec           `json:"storage_specs,omitempty"`
-	VmServiceSpec        *VmServiceSpec           `json:"vm_service_spec,omitempty"`
-	ContentLibraries     *[]ContentLibraryV2      `json:"content_libraries,omitempty"`
-	SelfServiceNamespace *bool                    `json:"self_service_namespace,omitempty"`
-	NetworkSpec          *NetworkConfigCreateSpec `json:"network_spec,omitempty"`
+	Namespace            string                      `json:"namespace"`
+	Supervisor           string                      `json:"supervisor"`
+	Description          *string                     `json:"description,omitempty"`
+	StorageSpecs         *[]StorageSpec              `json:"storage_specs,omitempty"`
+	VmServiceSpec        *VmServiceSpec              `json:"vm_service_spec,omitempty"`
+	ContentLibraries     *[]ContentLibraryV2         `json:"content_libraries,omitempty"`
+	SelfServiceNamespace *bool                       `json:"self_service_namespace,omitempty"`
+	NetworkSpec          *NetworkConfigCreateSpec    `json:"network_spec,omitempty"`
+	NamespaceNetwork     *NamespaceNetworkCreateSpec `json:"namespace_network,omitempty"`
 }
 
 type Stats struct {
@@ -63,6 +64,29 @@ type ContentLibraryV2 struct {
 	Writable               bool   `json:"writable"`
 	AllowImport            bool   `json:"allow_import"`
 	ResourceNamingStrategy string `json:"resource_naming_strategy"`
+}
+
+// NamespaceNetworkCreateSpec represents the complete namespace_network field for creation
+type NamespaceNetworkCreateSpec struct {
+	NetworkProvider string                  `json:"network_provider"`
+	Network         *NamespaceNetworkConfig `json:"network,omitempty"`
+}
+
+// NamespaceNetworkConfig represents the network configuration within namespace_network
+type NamespaceNetworkConfig struct {
+	NamespaceNetworkCidrs []CidrBlock `json:"namespace_network_cidrs"`
+	IngressCidrs          []CidrBlock `json:"ingress_cidrs"`
+	EgressCidrs           []CidrBlock `json:"egress_cidrs"`
+	NsxTier0Gateway       string      `json:"nsx_tier0_gateway"`
+	SubnetPrefixLength    int         `json:"subnet_prefix_length"`
+	RoutedMode            bool        `json:"routed_mode"`
+	LoadBalancerSize      string      `json:"load_balancer_size"`
+}
+
+// CidrBlock represents a CIDR block with address and prefix
+type CidrBlock struct {
+	Address string `json:"address"`
+	Prefix  int    `json:"prefix"`
 }
 
 // NetworkConfigInfo


### PR DESCRIPTION
## Description

add implementation of NamespaceNetwork to support Network override in CreateNamespace

Closes: #4002

## How Has This Been Tested?

I wrote some code to test the call against the LAB instance.

```golang
package main

import (
	"context"
	"fmt"
	"log"
	"net/url"

	"github.com/vmware/govmomi"
	"github.com/vmware/govmomi/vapi/namespace"

	"github.com/vmware/govmomi/vapi/rest"
)

func main() {
	ctx := context.Background()

	// vCenter connection details (update these with your actual credentials)
	vcenterURL := "vcenter.my-lab.com"
	username := "user"
	password := "password"


	log.Println("=== Creating vSphere Client ===")
	client, err := NewVSphereClient(ctx, vcenterURL, username, password)
	if err != nil {
		log.Fatalf("Failed to create vSphere client: %v", err)
	}

	log.Println("=== Finding Supervisors ===")
	// Find supervisors using the namespace manager
	supervisors, err := client.NamespaceManager.GetSupervisorSummaries(ctx)
	if err != nil {
		log.Fatalf("Failed to list supervisors: %v", err)
	}

	if len(supervisors.Items) == 0 {
		log.Fatalf("No supervisors found")
	}

	if len(supervisors.Items) != 1 {
		log.Fatalf("Expected exactly one supervisor, found %d supervisors:", len(supervisors.Items))
	}

	supervisor := supervisors.Items[0]
	log.Printf("Found exactly one supervisor: %s (ID: %s)", supervisor.Supervisor, supervisor.Info.Name)

	log.Println("=== Creating Namespace Network Specification ===")
	// Define CIDR blocks
	namespaceCidrs := []namespace.CidrBlock{
		{Address: "192.168.101.0", Prefix: 24},
	}
	ingressCidrs := []namespace.CidrBlock{
		{Address: "10.11.1.0", Prefix: 24},
	}
	// Only on NAT Mode
	// egressCidrs := []namespace.CidrBlock{
	// 	{Address: "10.10.2.0", Prefix: 24},
	// }

	log.Println("=== Creating Namespace: test123 ===")
	description := "Test namespace with network override"

	namespaceSpec := namespace.NamespaceInstanceCreateSpecV2{
		// Standard govmomi fields
		Namespace:   "test321",
		Supervisor:  supervisor.Supervisor,
		Description: &description,
		NamespaceNetwork: &namespace.NamespaceNetworkCreateSpec{
			NetworkProvider: "NSXT_CONTAINER_PLUGIN", // or another valid network provider
			Network: &namespace.NamespaceNetworkConfig{
				NamespaceNetworkCidrs: namespaceCidrs,
				IngressCidrs:          ingressCidrs,
				// EgressCidrs:           egressCidrs,
				NsxTier0Gateway:    "labnsx01-t0-gw-01", // Update with your actual NSX-T Tier-0 Gateway name
				SubnetPrefixLength: 24,
				RoutedMode:         true,
				LoadBalancerSize:   "SMALL",
			},
		},
	}

	// Test the extended struct with vSphere API
	err = client.NamespaceManager.CreateNamespaceV2(ctx, namespaceSpec)
	if err != nil {
		log.Fatalf("Failed to create namespace: %v", err)
	}

	// log.Printf("Namespace '%s' created successfully with network override!", namespaceSpec.Namespace)

	// Verify the namespace was created
	log.Println("=== Verifying Namespace Creation ===")
	nsInfo, err := client.NamespaceManager.GetNamespaceV2(ctx, namespaceSpec.Namespace)
	if err != nil {
		log.Printf("Warning: Could not verify namespace creation: %v", err)
	} else {
		log.Printf("Namespace verified: %s on supervisor: %s", namespaceSpec.Namespace, nsInfo.Supervisor)
		log.Printf("   Status: %s", nsInfo.ConfigStatus)
		if nsInfo.NetworkSpec != nil {
			log.Printf("   Network Provider: %s", nsInfo.NetworkSpec.NetworkProvider)
		}
		if nsInfo.Networks != nil {
			log.Printf("   Networks: %v", nsInfo.Networks)
		}
	}
}

func NewVSphereClient(ctx context.Context, vcenterURL, username, password string) (*VSphereClient, error) {

	client, err := newGovmomiClient(ctx, vcenterURL, username, password)
	if err != nil {
		return nil, fmt.Errorf("failed to create vSphere client: %w", err)
	}

	// Create REST client for namespace management
	restClient := rest.NewClient(client.Client)

	// Login to REST API with the same credentials
	err = restClient.Login(ctx, url.UserPassword(username, password))
	if err != nil {
		return nil, fmt.Errorf("error logging into REST API: %w", err)
	}

	// Get namespace manager
	namespaceManager := namespace.NewManager(restClient)

	return &VSphereClient{
		Client:           client,
		NamespaceManager: namespaceManager,
	}, nil
}

type VSphereClient struct {
	Client           *govmomi.Client
	NamespaceManager *namespace.Manager
}

func newGovmomiClient(ctx context.Context, vcenterURL, username, password string) (*govmomi.Client, error) {
	vCenterURL := fmt.Sprintf("https://%s:%s@%s/sdk", username, password, vcenterURL)

	// Parse the vCenter URL
	u, err := url.Parse(vCenterURL)
	if err != nil {
		return nil, fmt.Errorf("error parsing URL: %w", err)
	}

	u.User = url.UserPassword(username, password)

	// Create the client
	client, err := govmomi.NewClient(ctx, u, true)
	if err != nil {
		return nil, fmt.Errorf("error creating client: %w", err)
	}
	if !client.IsVC() {
		return nil, fmt.Errorf("not connected to vCenter Server")
	}
	if !client.Client.IsVC() {
		return nil, fmt.Errorf("not connected to vCenter Server")
	}

	return client, nil

}

func listVirtualMachineClasses(ctx context.Context, mgr *namespace.Manager) ([]string, error) {
	// List all virtual machine classes
	vmClasses, err := mgr.ListVmClasses(ctx)
	if err != nil {
		return nil, fmt.Errorf("failed to list virtual machine classes: %w", err)
	}

	var classNames []string
	for _, class := range vmClasses {
		classNames = append(classNames, class.Id)
	}

	return classNames, nil
}

func (v *VSphereClient) ListNamespaces(ctx context.Context) ([]string, error) {
	// List all supervisor namespaces
	nsList, err := v.NamespaceManager.ListNamespaces(ctx)
	if err != nil {
		return nil, fmt.Errorf("failed to list namespaces: %w", err)
	}

	var namespaceNames []string
	for _, ns := range nsList {
		namespaceNames = append(namespaceNames, ns.Namespace)
	}

	return namespaceNames, nil
}
```
## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
