### PR TITLE
api: add FetchVmGroupForMultiwriterDisks vim25 bindings and vcsim support

### DIFF
--- a/simulator/multiwriter_disk.go
+++ b/simulator/multiwriter_disk.go
@@ -1,0 +1,93 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// AttachMultiWriterDisk adds a multi-writer VirtualDisk to vm backed by
+// sharedPath (VirtualDiskFlatVer2BackingInfo with Sharing set to
+// sharingMultiWriter). The disk is placed on vm's first ParaVirtualSCSI
+// controller.
+//
+// For the first VM in a shared-disk group, pass create=true so vcsim creates
+// the VMDK at sharedPath (1 GiB by default). For each additional VM that
+// should participate in the same multi-writer group, call again with the
+// same sharedPath and create=false so the existing backing is attached
+// (object.diskFileOperation treats zero capacity as attach).
+//
+// After that, VirtualMachine.FetchVmGroupForMultiwriterDisks on vcsim will
+// return peers that share the same backing FileName string.
+// The fetch request's diskIds field is ignored by vcsim (real VC filters by it).
+//
+// sharedPath is typically "[LocalDS_0] name.vmdk" at the datastore root. If you
+// use nested segments (e.g. "[LocalDS_0] dir/name.vmdk"), dir must already exist;
+// vcsim does not create parent directories when create is true.
+func AttachMultiWriterDisk(ctx context.Context, vm *object.VirtualMachine, sharedPath string, create bool) (diskKey int32, err error) {
+	devs, err := vm.Device(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("device list: %w", err)
+	}
+	scsiList := devs.SelectByType((*types.ParaVirtualSCSIController)(nil))
+	if len(scsiList) == 0 {
+		return 0, fmt.Errorf("vm %s has no ParaVirtualSCSIController", vm.Reference().Value)
+	}
+	scsi := scsiList[0].(types.BaseVirtualController)
+
+	var capKB int64
+	if create {
+		capKB = int64(units.GB) / units.KB
+	}
+	disk := &types.VirtualDisk{
+		CapacityInKB: capKB,
+		VirtualDevice: types.VirtualDevice{
+			Backing: &types.VirtualDiskFlatVer2BackingInfo{
+				VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
+					FileName: sharedPath,
+				},
+				DiskMode:        string(types.VirtualDiskModePersistent),
+				ThinProvisioned: types.NewBool(true),
+				Sharing:         string(types.VirtualDiskSharingSharingMultiWriter),
+			},
+		},
+	}
+	(object.VirtualDeviceList{disk}).AssignController(disk, scsi)
+
+	cs, err := (object.VirtualDeviceList{disk}).ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+	if err != nil {
+		return 0, fmt.Errorf("config spec: %w", err)
+	}
+
+	task, err := vm.Reconfigure(ctx, types.VirtualMachineConfigSpec{DeviceChange: cs})
+	if err != nil {
+		return 0, fmt.Errorf("reconfigure: %w", err)
+	}
+	if err := task.Wait(ctx); err != nil {
+		return 0, fmt.Errorf("reconfigure task: %w", err)
+	}
+
+	devs, err = vm.Device(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("device list after reconfigure: %w", err)
+	}
+	wantSharing := string(types.VirtualDiskSharingSharingMultiWriter)
+	for _, d := range devs.SelectByType((*types.VirtualDisk)(nil)) {
+		vd := d.(*types.VirtualDisk)
+		b, ok := vd.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+		if !ok {
+			continue
+		}
+		if b.FileName == sharedPath && b.Sharing == wantSharing {
+			return vd.Key, nil
+		}
+	}
+	return 0, fmt.Errorf("multi-writer disk with path %q not found on vm %s", sharedPath, vm.Reference().Value)
+}

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -3529,3 +3529,124 @@ func (vm *VirtualMachine) updateTagSpec(
 
 	return nil
 }
+
+// multiWriterDiskShareKey returns the normalized backing identity for a
+// VirtualDisk that uses sharingMultiWriter. Two attachments (on any VMs)
+// that produce the same key are treated as referring to the same shared
+// multi-writer disk. Mirrors vCenter's URL-based grouping in
+// vpx/vpxd/vm/moVm.cpp::VmMo::GetSharedVmDisks; vcsim does not normalize
+// to a URL so the backing file name from config is used directly.
+func multiWriterDiskShareKey(d *types.VirtualDisk) (shareKey string, ok bool) {
+	const want = string(types.VirtualDiskSharingSharingMultiWriter)
+	var name, sharing string
+	switch b := d.Backing.(type) {
+	case *types.VirtualDiskFlatVer2BackingInfo:
+		name = b.FileName
+		sharing = b.Sharing
+	case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
+		name = b.FileName
+		sharing = b.Sharing
+	case *types.VirtualDiskRawDiskVer2BackingInfo:
+		name = b.DescriptorFileName
+		sharing = b.Sharing
+	default:
+		return "", false
+	}
+	if sharing != want || name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+// vmMultiWriterDisks returns (deviceKey, shareKey) for every multi-writer
+// disk on the given VM, in device order. Mirrors VC's
+// VmMo::GetAllMultiwriterDiskUrls.
+func vmMultiWriterDisks(vm *VirtualMachine) []struct {
+	Key      int32
+	ShareKey string
+} {
+	var out []struct {
+		Key      int32
+		ShareKey string
+	}
+	for _, dev := range vm.Config.Hardware.Device {
+		d, ok := dev.(*types.VirtualDisk)
+		if !ok {
+			continue
+		}
+		sk, ok := multiWriterDiskShareKey(d)
+		if !ok {
+			continue
+		}
+		out = append(out, struct {
+			Key      int32
+			ShareKey string
+		}{Key: d.Key, ShareKey: sk})
+	}
+	return out
+}
+
+// FetchVmGroupForMultiwriterDisks is a vcsim implementation of
+// VirtualMachine.fetchVmGroupForMultiwriterDisks (see
+// vpx/vpxd/vm/moVm.cpp::VmMo::FetchVmGroupForMultiwriterDisks).
+//
+// vcsim behavior (aligned with VC where noted):
+//
+//  1. Enumerate THIS VM's multi-writer disks: FlatVer2, RawDiskVer2, or
+//     RawDiskMappingVer1 backing with sharing=sharingMultiWriter (same
+//     backing families as VpxdVmprovUtil::IsMultiWriterDisk).
+//
+//  2. For each such disk, emit one SharedDiskVmInfo with DiskKey set to the
+//     caller's device key and VirtualDiskId listing every OTHER VM (caller
+//     excluded) that has a multi-writer disk on the same backing share key
+//
+//     Peer discovery in vcsim is implemented as a full scan of every
+//     VirtualMachine in the simulator map and each VM's in-memory device
+//     list (config.hardware.device), comparing multiWriterDiskShareKey to the
+//     caller disk's share key. Real VC runs a VCDB query per disk and applies
+//     session privilege checks; vcsim does neither.
+//
+//  3. A row is emitted for every multi-writer disk on the caller, even when
+//     no peer shares that backing (empty VirtualDiskId), matching VC.
+//
+// Simplification: req.DiskIds is ignored. Real VC de-duplicates diskIds,
+// restricts to those keys, and faults with InvalidArgument(diskIds) if any
+// id is not a multi-writer disk on this VM. vcsim always reports all MW disks
+// on the VM so tests and clients do not need to pass diskIds.
+func (vm *VirtualMachine) FetchVmGroupForMultiwriterDisks(ctx *Context, req *types.FetchVmGroupForMultiwriterDisks) soap.HasFault {
+	body := new(methods.FetchVmGroupForMultiwriterDisksBody)
+	_ = req
+
+	mw := vmMultiWriterDisks(vm)
+
+	rows := make([]types.SharedDiskVmGroupInfoSharedDiskVmInfo, 0, len(mw))
+	for _, e := range mw {
+		var peers []types.VirtualDiskId
+		for _, ent := range ctx.Map.All("VirtualMachine") {
+			ovm, ok := ent.(*VirtualMachine)
+			if !ok || ovm.Self.Value == vm.Self.Value {
+				continue
+			}
+			for _, dev := range ovm.Config.Hardware.Device {
+				od, ok := dev.(*types.VirtualDisk)
+				if !ok {
+					continue
+				}
+				osk, ok := multiWriterDiskShareKey(od)
+				if !ok || osk != e.ShareKey {
+					continue
+				}
+				peers = append(peers, types.VirtualDiskId{Vm: ovm.Self, DiskId: od.Key})
+			}
+		}
+		rows = append(rows, types.SharedDiskVmGroupInfoSharedDiskVmInfo{
+			DiskKey:       e.Key,
+			VirtualDiskId: peers,
+		})
+	}
+
+	body.Res = &types.FetchVmGroupForMultiwriterDisksResponse{
+		Returnval: &types.SharedDiskVmGroupInfo{SharedDiskVmInfo: rows},
+	}
+	return body
+}

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware/govmomi/simulator/esx"
 	"github.com/vmware/govmomi/task"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vmdk"
@@ -4396,6 +4397,105 @@ func TestVirtualDiskUUIDAssignment(t *testing.T) {
 		assert.True(t, ok, "found disk backing should be VirtualDiskFlatVer2BackingInfo")
 		assert.Equal(t, explicitUUID, foundDiskBacking.Uuid, "disk UUID should match the explicitly set UUID")
 	})
+}
+
+func TestFetchVmGroupForMultiwriterDisks(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name  string
+		model *Model
+	}{
+		{"ESX", ESX()},
+		{"VPX", VPX()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			model := tc.model
+			defer model.Remove()
+			if err := model.Create(); err != nil {
+				t.Fatal(err)
+			}
+
+			s := model.Service.NewServer()
+			defer s.Close()
+
+			c, err := govmomi.NewClient(ctx, s.URL, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			finder := find.NewFinder(c.Client, false)
+			dc, err := finder.DefaultDatacenter(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			finder.SetDatacenter(dc)
+
+			vms, err := finder.VirtualMachineList(ctx, "*")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(vms) < 2 {
+				t.Fatalf("need at least 2 VMs, got %d", len(vms))
+			}
+
+			vmA, vmB := vms[0], vms[1]
+			sharedPath := "[LocalDS_0] shared-mw.vmdk"
+
+			keyA, err := AttachMultiWriterDisk(ctx, vmA, sharedPath, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			keyB, err := AttachMultiWriterDisk(ctx, vmB, sharedPath, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Run("PeerListedForMWDisk", func(t *testing.T) {
+				res, err := methods.FetchVmGroupForMultiwriterDisks(ctx, c.Client, &types.FetchVmGroupForMultiwriterDisks{
+					This: vmA.Reference(),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if res == nil || res.Returnval == nil {
+					t.Fatal("nil response or Returnval")
+				}
+
+				var row *types.SharedDiskVmGroupInfoSharedDiskVmInfo
+				for i := range res.Returnval.SharedDiskVmInfo {
+					if res.Returnval.SharedDiskVmInfo[i].DiskKey == keyA {
+						row = &res.Returnval.SharedDiskVmInfo[i]
+						break
+					}
+				}
+				if row == nil {
+					t.Fatalf("no row for caller diskKey %d in %#v", keyA, res.Returnval.SharedDiskVmInfo)
+				}
+				wantPeers := []types.VirtualDiskId{{Vm: vmB.Reference(), DiskId: keyB}}
+				if !reflect.DeepEqual(row.VirtualDiskId, wantPeers) {
+					t.Fatalf("peers: got %#v want %#v", row.VirtualDiskId, wantPeers)
+				}
+			})
+
+			t.Run("CallerExcludedFromPeers", func(t *testing.T) {
+				res, err := methods.FetchVmGroupForMultiwriterDisks(ctx, c.Client, &types.FetchVmGroupForMultiwriterDisks{
+					This: vmA.Reference(),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, row := range res.Returnval.SharedDiskVmInfo {
+					for _, p := range row.VirtualDiskId {
+						if p.Vm.Value == vmA.Reference().Value {
+							t.Fatalf("caller VM listed as a peer in %#v", row)
+						}
+					}
+				}
+			})
+
+		})
+	}
 }
 
 func createTestVM(

--- a/vim25/methods/unreleased.go
+++ b/vim25/methods/unreleased.go
@@ -50,3 +50,23 @@ func UpdatePodVMProperty(ctx context.Context, r soap.RoundTripper, req *types.Up
 
 	return reqBody.Res, nil
 }
+
+type FetchVmGroupForMultiwriterDisksBody struct {
+	Req    *types.FetchVmGroupForMultiwriterDisks         `xml:"urn:vim25 FetchVmGroupForMultiwriterDisks,omitempty"`
+	Res    *types.FetchVmGroupForMultiwriterDisksResponse `xml:"FetchVmGroupForMultiwriterDisksResponse,omitempty"`
+	Fault_ *soap.Fault                                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FetchVmGroupForMultiwriterDisksBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FetchVmGroupForMultiwriterDisks(ctx context.Context, r soap.RoundTripper, req *types.FetchVmGroupForMultiwriterDisks) (*types.FetchVmGroupForMultiwriterDisksResponse, error) {
+	var reqBody, resBody FetchVmGroupForMultiwriterDisksBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/vim25/types/unreleased.go
+++ b/vim25/types/unreleased.go
@@ -202,3 +202,46 @@ func init() {
 	t["ClusterClusterInitialPlacementAction"] = reflect.TypeOf((*ClusterClusterInitialPlacementAction)(nil)).Elem()
 	t["BaseClusterClusterInitialPlacementAction"] = reflect.TypeOf((*ClusterClusterInitialPlacementAction)(nil)).Elem()
 }
+
+// SharedDiskVmGroupInfoSharedDiskVmInfo is a row in SharedDiskVmGroupInfo (vim.vm.SharedDiskVmGroupInfo.SharedDiskVmInfo).
+type SharedDiskVmGroupInfoSharedDiskVmInfo struct {
+	DynamicData
+
+	DiskKey       int32           `xml:"diskKey" json:"diskKey"`
+	VirtualDiskId []VirtualDiskId `xml:"virtualDiskId,omitempty" json:"virtualDiskId,omitempty"`
+}
+
+func init() {
+	t["SharedDiskVmGroupInfoSharedDiskVmInfo"] = reflect.TypeOf((*SharedDiskVmGroupInfoSharedDiskVmInfo)(nil)).Elem()
+}
+
+// SharedDiskVmGroupInfo describes VMs sharing multi-writer or SCSI bus-sharing disks (vim.vm.SharedDiskVmGroupInfo).
+type SharedDiskVmGroupInfo struct {
+	DynamicData
+
+	SharedDiskVmInfo []SharedDiskVmGroupInfoSharedDiskVmInfo `xml:"sharedDiskVmInfo,omitempty" json:"sharedDiskVmInfo,omitempty"`
+}
+
+func init() {
+	t["SharedDiskVmGroupInfo"] = reflect.TypeOf((*SharedDiskVmGroupInfo)(nil)).Elem()
+}
+
+type FetchVmGroupForMultiwriterDisksRequestType struct {
+	This    ManagedObjectReference `xml:"_this" json:"-"`
+	DiskIds *ArrayOfInt            `xml:"diskIds,omitempty" json:"diskIds,omitempty"`
+}
+
+func init() {
+	t["FetchVmGroupForMultiwriterDisksRequestType"] = reflect.TypeOf((*FetchVmGroupForMultiwriterDisksRequestType)(nil)).Elem()
+}
+
+// FetchVmGroupForMultiwriterDisks is VirtualMachine#fetchVmGroupForMultiwriterDisks (MultiwriterDiskVMotion).
+type FetchVmGroupForMultiwriterDisks FetchVmGroupForMultiwriterDisksRequestType
+
+func init() {
+	t["FetchVmGroupForMultiwriterDisks"] = reflect.TypeOf((*FetchVmGroupForMultiwriterDisks)(nil)).Elem()
+}
+
+type FetchVmGroupForMultiwriterDisksResponse struct {
+	Returnval *SharedDiskVmGroupInfo `xml:"returnval,omitempty" json:"returnval,omitempty"`
+}


### PR DESCRIPTION
## Description

This patch extends the vim25 API bindings to support VirtualMachine.FetchVmGroupForMultiwriterDisks.

Multi-writer (MW) import work uses that vSphere call to obtain the shared-disk VM group (peer VMs). The change adds the Go types/methods wiring for FetchVmGroupForMultiwriterDisks and a vcsim VirtualMachine handler so MW import flows can be covered in tests without a live vCenter.

Closes: N/A

## How Has This Been Tested?

yz038067@H22PYP9YLC govmomi % go test -count=1 -v -run TestFetchVmGroupForMultiwriterDisks ./simulator
=== RUN   TestFetchVmGroupForMultiwriterDisks
=== RUN   TestFetchVmGroupForMultiwriterDisks/ESX
=== RUN   TestFetchVmGroupForMultiwriterDisks/ESX/PeerListedForMWDisk
=== RUN   TestFetchVmGroupForMultiwriterDisks/ESX/CallerExcludedFromPeers
=== RUN   TestFetchVmGroupForMultiwriterDisks/VPX
=== RUN   TestFetchVmGroupForMultiwriterDisks/VPX/PeerListedForMWDisk
=== RUN   TestFetchVmGroupForMultiwriterDisks/VPX/CallerExcludedFromPeers
--- PASS: TestFetchVmGroupForMultiwriterDisks (0.47s)
    --- PASS: TestFetchVmGroupForMultiwriterDisks/ESX (0.11s)
        --- PASS: TestFetchVmGroupForMultiwriterDisks/ESX/PeerListedForMWDisk (0.00s)
        --- PASS: TestFetchVmGroupForMultiwriterDisks/ESX/CallerExcludedFromPeers (0.00s)
    --- PASS: TestFetchVmGroupForMultiwriterDisks/VPX (0.36s)
        --- PASS: TestFetchVmGroupForMultiwriterDisks/VPX/PeerListedForMWDisk (0.00s)
        --- PASS: TestFetchVmGroupForMultiwriterDisks/VPX/CallerExcludedFromPeers (0.00s)
PASS
ok  	github.com/vmware/govmomi/simulator	0.903s