### PR TITLE
feat(marshal): Implement new Marshal Function 

### DIFF
--- a/vapi/namespace/namespace.go
+++ b/vapi/namespace/namespace.go
@@ -1128,32 +1128,11 @@ type StorageSpec struct {
 	Limit  int64  `json:"limit,omitempty"`
 }
 
-// NamespacesInstanceUpdateSpec https://developer.vmware.com/apis/vsphere-automation/v7.0U3/vcenter/data-structures/Namespaces/Instances/UpdateSpec/
+// NamespacesInstanceUpdateSpec https://developer.broadcom.com/xapis/vsphere-automation-api/v7.0U3/vcenter/api/vcenter/namespaces/instances/namespace/patch/
 type NamespacesInstanceUpdateSpec struct {
 	VmServiceSpec VmServiceSpec            `json:"vm_service_spec,omitempty"`
-	StorageSpecs  []StorageSpec            `json:"storage_specs,omitempty"`
+	StorageSpecs  []StorageSpec            `json:"storage_specs"`
 	NetworkSpec   *NetworkConfigUpdateSpec `json:"network_spec,omitempty"`
-}
-
-// MarshalJSON is implemented to handle the case where StorageSpecs is explicitly set to an empty slice vs nil.
-func (spec NamespacesInstanceUpdateSpec) MarshalJSON() ([]byte, error) {
-	type Alias NamespacesInstanceUpdateSpec
-
-	// Check if StorageSpecs is explicitly set to empty slice vs nil
-	if spec.StorageSpecs != nil && len(spec.StorageSpecs) == 0 {
-		// Force inclusion of empty storage_specs array
-		aux := struct {
-			VmServiceSpec VmServiceSpec `json:"vm_service_spec,omitempty"`
-			StorageSpecs  []StorageSpec `json:"storage_specs"` // No omitempty
-		}{
-			VmServiceSpec: spec.VmServiceSpec,
-			StorageSpecs:  spec.StorageSpecs,
-		}
-		return json.Marshal(aux)
-	}
-
-	// Use default marshalling for all other cases (nil or non-empty StorageSpecs)
-	return json.Marshal((Alias)(spec))
 }
 
 // NetworkConfigUpdateSpec

--- a/vapi/namespace/namespace.go
+++ b/vapi/namespace/namespace.go
@@ -1135,6 +1135,27 @@ type NamespacesInstanceUpdateSpec struct {
 	NetworkSpec   *NetworkConfigUpdateSpec `json:"network_spec,omitempty"`
 }
 
+// MarshalJSON is implemented to handle the case where StorageSpecs is explicitly set to an empty slice vs nil.
+func (spec NamespacesInstanceUpdateSpec) MarshalJSON() ([]byte, error) {
+	type Alias NamespacesInstanceUpdateSpec
+
+	// Check if StorageSpecs is explicitly set to empty slice vs nil
+	if spec.StorageSpecs != nil && len(spec.StorageSpecs) == 0 {
+		// Force inclusion of empty storage_specs array
+		aux := struct {
+			VmServiceSpec VmServiceSpec `json:"vm_service_spec,omitempty"`
+			StorageSpecs  []StorageSpec `json:"storage_specs"` // No omitempty
+		}{
+			VmServiceSpec: spec.VmServiceSpec,
+			StorageSpecs:  spec.StorageSpecs,
+		}
+		return json.Marshal(aux)
+	}
+
+	// Use default marshalling for all other cases (nil or non-empty StorageSpecs)
+	return json.Marshal((Alias)(spec))
+}
+
 // NetworkConfigUpdateSpec
 // https://developer.broadcom.com/xapis/vsphere-automation-api/latest/data-structures/Vcenter%20Namespaces%20Instances%20NetworkConfigUpdateSpec/
 // Since 9.0.0.0


### PR DESCRIPTION
## Description

This PR removes the omitempty JSON tag from the namespace field in the request/response model.

The field must always be serialized so the API receives it explicitly.
With omitempty present, zero-value data could be dropped from the payload, which can cause validation or behavior mismatches on the vSphere API side.

Closes: #4007 

##  What changed

Removed omitempty from the target struct tag in the namespace model.
No behavioral logic changes, only JSON serialization behavior.

## Impact

Requests now always include the field, even when empty/zero-valued.
Improves API compatibility where explicit presence is required.
Low risk change, scoped to marshaling output only.

## How Has This Been Tested?

```go
package main

import (
	"context"
	"fmt"
	"log"
	"net/url"

	"github.com/vmware/govmomi"
	"github.com/vmware/govmomi/pbm"
	"github.com/vmware/govmomi/pbm/types"
	"github.com/vmware/govmomi/vapi/namespace"

	"github.com/vmware/govmomi/vapi/rest"
)

func main() {
	ctx := context.Background()

	// vCenter connection details (update these with your actual credentials)
	vcenterURL := "host"
	username := "user"
	password := "password"

	storagePolicyName := "sp-vks-global"

	namespaceName := "test-sp-deletion"
	IngressNet := "10.11.1.0"
	namespaceNet := "192.168.101.0"
	gw := "lab-t0-gw-01"
	provider := "NSXT_CONTAINER_PLUGIN"

	log.Println("=== Creating vSphere Client ===")
	client, err := NewVSphereClient(ctx, vcenterURL, username, password)
	if err != nil {
		log.Fatalf("Failed to create vSphere client: %v", err)
	}

	log.Println("=== Finding Supervisors ===")
	// Find supervisors using the namespace manager
	supervisors, err := client.NamespaceManager.GetSupervisorSummaries(ctx)
	if err != nil {
		log.Fatalf("Failed to list supervisors: %v", err)
	}

	if len(supervisors.Items) == 0 {
		log.Fatalf("No supervisors found")
	}

	if len(supervisors.Items) != 1 {
		log.Fatalf("Expected exactly one supervisor, found %d supervisors:", len(supervisors.Items))
	}

	supervisor := supervisors.Items[0]
	log.Printf("Found exactly one supervisor: %s (ID: %s)", supervisor.Supervisor, supervisor.Info.Name)

	log.Println("=== Creating Namespace Network Specification ===")
	// Define CIDR blocks
	namespaceCidrs := []namespace.CidrBlock{
		{Address: namespaceNet, Prefix: 24},
	}
	ingressCidrs := []namespace.CidrBlock{
		{Address: IngressNet, Prefix: 24},
	}
	// Only on NAT Mode
	// egressCidrs := []namespace.CidrBlock{
	// 	{Address: "10.10.2.0", Prefix: 24},
	// }

	log.Printf("=== Creating Namespace: %s ===", namespaceName)
	description := "Test namespace with network override"

	storagePolicyId, err := getStoragePolicyByName(ctx, client.StorageManager, storagePolicyName)
	if err != nil {
		log.Printf("Warning: Could not find storage policy '%s': %v", storagePolicyName, err)
	}

	namespaceSpec := namespace.NamespaceInstanceCreateSpecV2{
		// Standard govmomi fields
		Namespace:   namespaceName,
		Supervisor:  supervisor.Supervisor,
		Description: &description,
		StorageSpecs: &[]namespace.StorageSpec{
			{
				Policy: storagePolicyId.ID,
			},
		},
		NamespaceNetwork: &namespace.NamespaceNetworkCreateSpec{
			NetworkProvider: provider, // or another valid network provider
			Network: &namespace.NamespaceNetworkConfig{
				NamespaceNetworkCidrs: namespaceCidrs,
				IngressCidrs:          ingressCidrs,
				// EgressCidrs:           egressCidrs,
				NsxTier0Gateway:    gw, // Update with your actual NSX-T Tier-0 Gateway name
				SubnetPrefixLength: 24,
				RoutedMode:         true,
				LoadBalancerSize:   "SMALL",
			},
		},
	}

	// Test the extended struct with vSphere API
	err = client.NamespaceManager.CreateNamespaceV2(ctx, namespaceSpec)
	if err != nil {
		log.Printf("Warning: Failed to create namespace: %v", err)
	}

	time.Sleep(10 * time.Second) // Wait for a bit to allow namespace creation to propagate before verification

	// log.Printf("Namespace '%s' created successfully with network override!", namespaceSpec.Namespace)

	// Verify the namespace was created
	log.Println("=== Verifying Namespace Creation ===")
	nsInfo, err := client.NamespaceManager.GetNamespaceV2(ctx, namespaceSpec.Namespace)
	if err != nil {
		log.Printf("Warning: Could not verify namespace creation: %v", err)
	} else {
		log.Printf("Namespace verified: %s on supervisor: %s", namespaceSpec.Namespace, nsInfo.Supervisor)
		log.Printf("   Status: %s", nsInfo.ConfigStatus)
		log.Printf("   Policies:")
		for _, spec := range nsInfo.StorageSpecs {
			log.Printf("   -  %s", spec.Policy)
		}
	}

	// ------------------------------------------------------------------------
	// 	Update Namespace - Remove Storage Policy (all policies)
	// ------------------------------------------------------------------------
	log.Println("================================================================================ ")
	log.Println("================================================================================ ")

	// Patch Namespace with empty Storage Spec to verify that empty storage Spec is respevted and removes all specified storage policies from the namespace
	log.Printf("=== Patching Namespace '%s' with empty storage spec to remove all storage policies ===", namespaceSpec.Namespace)
	updateSpec := namespace.NamespacesInstanceUpdateSpec{
		StorageSpecs: []namespace.StorageSpec{}, // Set to empty slice to remove all storage policies
	}

	err = client.NamespaceManager.UpdateNamespace(ctx, namespaceName, updateSpec)
	if err != nil {
		log.Printf("Warning: Failed to update namespace: %v", err)
	}

	time.Sleep(10 * time.Second) // Wait for a bit to allow namespace creation to propagate before verification

	// Verify the namespace was updated
	log.Println("=== Verifying Namespace Update ===")
	nsInfo, err = client.NamespaceManager.GetNamespaceV2(ctx, namespaceSpec.Namespace)
	if err != nil {
		log.Printf("Warning: Could not verify namespace update: %v", err)
	} else {
		log.Printf("Namespace verified after update: %s on supervisor: %s", namespaceSpec.Namespace, nsInfo.Supervisor)
		log.Printf("   Status: %s", nsInfo.ConfigStatus)
		log.Printf("   Policies:")
		if len(nsInfo.StorageSpecs) == 0 {
			log.Printf("   - No storage policies assigned to this namespace")
		} else {
			for _, spec := range nsInfo.StorageSpecs {
				log.Printf("   -  %s", spec.Policy)
			}
		}
	}

	// ------------------------------------------------------------------------
	// Re-Add Storage Policy to Namespace
	// ------------------------------------------------------------------------
	log.Println("================================================================================ ")
	log.Println("================================================================================ ")
	// Patch Namespace with a Storage Spec to verify that the new storage policy is added
	// should have same output as the create operation and the storage policy should be added back to the namespace
	log.Printf("=== Patching Namespace '%s' with old storage spec ===", namespaceSpec.Namespace)
	updateSpec = namespace.NamespacesInstanceUpdateSpec{
		StorageSpecs: []namespace.StorageSpec{
			{
				Policy: storagePolicyId.ID,
			},
		}, // Set to empty slice to remove all storage policies
	}

	err = client.NamespaceManager.UpdateNamespace(ctx, namespaceName, updateSpec)
	if err != nil {
		log.Printf("Warning: Failed to update namespace: %v", err)
	}

	time.Sleep(10 * time.Second) // Wait for a bit to allow namespace creation to propagate before verification

	// Verify the namespace was updated
	log.Println("=== Verifying Namespace Update ===")
	nsInfo, err = client.NamespaceManager.GetNamespaceV2(ctx, namespaceSpec.Namespace)
	if err != nil {
		log.Printf("Warning: Could not verify namespace update: %v", err)
	} else {
		log.Printf("Namespace verified after update: %s on supervisor: %s", namespaceSpec.Namespace, nsInfo.Supervisor)
		log.Printf("   Status: %s", nsInfo.ConfigStatus)
		log.Printf("   Policies:")
		if len(nsInfo.StorageSpecs) == 0 {
			log.Printf("   - No storage policies assigned to this namespace")
		} else {
			for _, spec := range nsInfo.StorageSpecs {
				log.Printf("   -  %s", spec.Policy)
			}
		}
	}

	// ------------------------------------------------------------------------
	// 	Update Namespace without touching the StorageSpec
	// ------------------------------------------------------------------------
	log.Println("================================================================================ ")
	log.Println("================================================================================ ")
	log.Printf("=== Patching Namespace '%s' with new vmClass without touching storage spec ===", namespaceSpec.Namespace)
	updateSpec = namespace.NamespacesInstanceUpdateSpec{
		VmServiceSpec: namespace.VmServiceSpec{
			VmClasses: []string{
				"best-effort-small",
			},
		},
	}

	err = client.NamespaceManager.UpdateNamespace(ctx, namespaceName, updateSpec)
	if err != nil {
		log.Printf("Warning: Failed to update namespace: %v", err)
	}
	time.Sleep(10 * time.Second) // Wait for a bit to allow namespace creation to propagate before verification
	// Verify the namespace was updated
	log.Println("=== Verifying Namespace Update ===")
	nsInfo, err = client.NamespaceManager.GetNamespaceV2(ctx, namespaceSpec.Namespace)
	if err != nil {
		log.Printf("Warning: Could not verify namespace update: %v", err)
	} else {
		log.Printf("Namespace verified after update: %s on supervisor: %s", namespaceSpec.Namespace, nsInfo.Supervisor)
		log.Printf("   Status: %s", nsInfo.ConfigStatus)
		log.Printf("   Policies:")
		if len(nsInfo.StorageSpecs) == 0 {
			log.Printf("   - No storage policies assigned to this namespace")
		} else {
			for _, spec := range nsInfo.StorageSpecs {
				log.Printf("   -  %s", spec.Policy)
			}
		}
		log.Printf("   VM Classes:")
		if len(nsInfo.VmServiceSpec.VmClasses) == 0 {
			log.Printf("   - No VM classes assigned to this namespace")
		} else {
			for _, vmClass := range nsInfo.VmServiceSpec.VmClasses {
				log.Printf("   -  %s", vmClass)
			}
		}
	}

	// ------------------------------------------------------------------------
	// 	Update Namespace without touching the StorageSpec 2
	// ------------------------------------------------------------------------
	log.Println("================================================================================ ")
	log.Println("================================================================================ ")
	log.Printf("=== Patching Namespace '%s' with new vmClass without touching storage spec ===", namespaceSpec.Namespace)

	err = client.NamespaceManager.UpdateNamespace(ctx, namespaceName, namespace.NamespacesInstanceUpdateSpec{
		VmServiceSpec: namespace.VmServiceSpec{
			VmClasses: []string{
				"best-effort-small",
				"best-effort-medium",
			},
		},
	})
	if err != nil {
		log.Printf("Warning: Failed to update namespace: %v", err)
	}
	time.Sleep(10 * time.Second) // Wait for a bit to allow namespace creation to propagate before verification
	// Verify the namespace was updated
	log.Println("=== Verifying Namespace Update ===")
	nsInfo, err = client.NamespaceManager.GetNamespaceV2(ctx, namespaceSpec.Namespace)
	if err != nil {
		log.Printf("Warning: Could not verify namespace update: %v", err)
	} else {
		log.Printf("Namespace verified after update: %s on supervisor: %s", namespaceSpec.Namespace, nsInfo.Supervisor)
		log.Printf("   Status: %s", nsInfo.ConfigStatus)
		log.Printf("   Policies:")
		if len(nsInfo.StorageSpecs) == 0 {
			log.Printf("   - No storage policies assigned to this namespace")
		} else {
			for _, spec := range nsInfo.StorageSpecs {
				log.Printf("   -  %s", spec.Policy)
			}
		}
		log.Printf("   VM Classes:")
		if len(nsInfo.VmServiceSpec.VmClasses) == 0 {
			log.Printf("   - No VM classes assigned to this namespace")
		} else {
			for _, vmClass := range nsInfo.VmServiceSpec.VmClasses {
				log.Printf("   -  %s", vmClass)
			}
		}
	}

	// ------------------------------------------------------------------------
	// 								Cleanup - Delete Namespace
	// ------------------------------------------------------------------------

	// Verify by key press enter to continue to deletion
	fmt.Println("Press Enter to continue to namespace deletion...")
	fmt.Scanln()
	// Cleanup
	log.Printf("=== Deleting Namespace: %s ===", namespaceName)
	err = client.NamespaceManager.DeleteNamespace(ctx, namespaceName)
	if err != nil {
		log.Fatalf("Failed to delete namespace: %v", err)
	}
	log.Printf("Namespace '%s' deleted successfully!", namespaceName)
}

func NewVSphereClient(ctx context.Context, vcenterURL, username, password string) (*VSphereClient, error) {

	client, err := newGovmomiClient(ctx, vcenterURL, username, password)
	if err != nil {
		return nil, fmt.Errorf("failed to create vSphere client: %w", err)
	}

	// Create REST client for namespace management
	restClient := rest.NewClient(client.Client)

	// Login to REST API with the same credentials
	err = restClient.Login(ctx, url.UserPassword(username, password))
	if err != nil {
		return nil, fmt.Errorf("error logging into REST API: %w", err)
	}

	// Get namespace manager
	namespaceManager := namespace.NewManager(restClient)

	storageManager, err := NewStorageManager(client, restClient)
	if err != nil {
		return nil, fmt.Errorf("failed to create storage manager: %w", err)
	}

	return &VSphereClient{
		Client:           client,
		NamespaceManager: namespaceManager,
		StorageManager:   storageManager,
	}, nil
}

type VSphereClient struct {
	Client           *govmomi.Client
	NamespaceManager *namespace.Manager
	StorageManager   *StorageManager
}

func newGovmomiClient(ctx context.Context, vcenterURL, username, password string) (*govmomi.Client, error) {
	vCenterURL := fmt.Sprintf("https://%s:%s@%s/sdk", username, password, vcenterURL)

	// Parse the vCenter URL
	u, err := url.Parse(vCenterURL)
	if err != nil {
		return nil, fmt.Errorf("error parsing URL: %w", err)
	}

	u.User = url.UserPassword(username, password)

	// Create the client
	client, err := govmomi.NewClient(ctx, u, true)
	if err != nil {
		return nil, fmt.Errorf("error creating client: %w", err)
	}
	if !client.IsVC() {
		return nil, fmt.Errorf("not connected to vCenter Server")
	}
	if !client.Client.IsVC() {
		return nil, fmt.Errorf("not connected to vCenter Server")
	}

	return client, nil

}

// NewStorageManager creates a new storage manager
func NewStorageManager(client *govmomi.Client, restClient *rest.Client) (*StorageManager, error) {
	// Create PBM (Policy Based Management) client for storage policies
	pbmClient, err := pbm.NewClient(context.Background(), client.Client)
	if err != nil {
		return nil, fmt.Errorf("failed to create PBM client: %w", err)
	}

	return &StorageManager{
		PBMClient:  pbmClient,
		RestClient: restClient,
	}, nil
}

func listVirtualMachineClasses(ctx context.Context, mgr *namespace.Manager) ([]string, error) {
	// List all virtual machine classes
	vmClasses, err := mgr.ListVmClasses(ctx)
	if err != nil {
		return nil, fmt.Errorf("failed to list virtual machine classes: %w", err)
	}

	var classNames []string
	for _, class := range vmClasses {
		classNames = append(classNames, class.Id)
	}

	return classNames, nil
}

func (v *VSphereClient) ListNamespaces(ctx context.Context) ([]string, error) {
	// List all supervisor namespaces
	nsList, err := v.NamespaceManager.ListNamespaces(ctx)
	if err != nil {
		return nil, fmt.Errorf("failed to list namespaces: %w", err)
	}

	var namespaceNames []string
	for _, ns := range nsList {
		namespaceNames = append(namespaceNames, ns.Namespace)
	}

	return namespaceNames, nil
}

type StoragePolicy struct {
	Name        string
	ID          string
	Description string
	ProfileID   string
}

func getStoragePolicyByName(ctx context.Context, storageManager *StorageManager, storagePolicyName string) (*StoragePolicy, error) { // List all storage policies (equivalent to your curl command)
	list, err := storageManager.ListStoragePolicies(ctx)
	if err != nil {
		return nil, fmt.Errorf("error listing storage policies: %v", err)
	}

	storagePolicy := StoragePolicy{}

	for _, policy := range list {
		if policy.Name == storagePolicyName {
			fmt.Printf("Using storage policy: %s (ID: %s)\n", policy.Name, policy.ID)
			storagePolicy = policy
			break
		}

	}

	if storagePolicy.Name == "" {
		fmt.Printf("Storage policy '%s' not found - aborting\n", storagePolicyName)
		return nil, fmt.Errorf("storage policy '%s' not found", storagePolicyName)
	}

	return &storagePolicy, nil
}

// StorageManager handles storage policy operations
type StorageManager struct {
	PBMClient  *pbm.Client
	RestClient *rest.Client
}

// ListStoragePolicies lists all storage policies using PBM client
func (sm *StorageManager) ListStoragePolicies(ctx context.Context) ([]StoragePolicy, error) {
	var policies []StoragePolicy

	// Using PBM client to list storage policies
	pbmPolicies, err := sm.listPBMPolicies(ctx)
	if err != nil {
		return nil, fmt.Errorf("failed to list storage policies: %w", err)
	}

	policies = append(policies, pbmPolicies...)
	return policies, nil
}

// listPBMPolicies lists storage policies using PBM client
func (sm *StorageManager) listPBMPolicies(ctx context.Context) ([]StoragePolicy, error) {
	var policies []StoragePolicy

	// category := types.PbmProfileCategoryEnumREQUIREMENT
	// Query all storage profiles - using nil for category to get all types
	profileIDs, err := sm.PBMClient.QueryProfile(ctx, types.PbmProfileResourceType{
		ResourceType: string(types.PbmProfileResourceTypeEnumSTORAGE),
	}, "") // Pass empty filter string to get all categories
	if err != nil {
		return nil, fmt.Errorf("failed to query storage profiles: %w", err)
	}

	if len(profileIDs) == 0 {
		fmt.Println("No storage profiles found")
		return policies, nil
	}

	// Retrieve profile content
	profiles, err := sm.PBMClient.RetrieveContent(ctx, profileIDs)
	if err != nil {
		return nil, fmt.Errorf("failed to retrieve profile content: %w", err)
	}

	// Convert to our storage policy format
	for _, profileContent := range profiles {
		// Get the base profile interface
		profile := profileContent.GetPbmProfile()
		if profile == nil {
			fmt.Printf("Warning: profile content is nil for profile")
			continue
		}

		// Create our storage policy from the PBM profile
		policy := StoragePolicy{
			ID:          profile.ProfileId.UniqueId,
			Name:        profile.Name,
			Description: profile.Description,
			ProfileID:   profile.ProfileId.UniqueId,
		}
		policies = append(policies, policy)
	}

	return policies, nil
}

```

Temporary edit on upateFunc to print rendered request:

```go
// UpdateNamespace https://developer.vmware.com/apis/vsphere-automation/v7.0U3/vcenter/api/vcenter/namespaces/instances/namespace/patch/
func (c *Manager) UpdateNamespace(ctx context.Context, namespace string, spec NamespacesInstanceUpdateSpec) error {
	resource := c.Resource(internal.NamespacesPath).WithSubpath(namespace)
	request := resource.Request(http.MethodPatch, spec)
	command, _ := http2curl.GetCurlCommand(request)
	fmt.Println("Equivalent curl command:")
	fmt.Println(command)
	return c.Do(ctx, request, nil)
}
```

### Output

```log
2026/05/08 08:51:04 === Creating vSphere Client ===
2026/05/08 08:51:05 === Finding Supervisors ===
2026/05/08 08:51:06 Found exactly one supervisor: 0b5781e9-9089-4922-b8a6-1f72ac8eb26a (ID: cl-lab-e3)
2026/05/08 08:51:06 === Creating Namespace Network Specification ===
2026/05/08 08:51:06 === Creating Namespace: test-sp-deletion ===
Using storage policy: sp-vks-global (ID: f9e82f63-6988-4139-9b0d-b201740ba943)
2026/05/08 08:51:16 === Verifying Namespace Creation ===
2026/05/08 08:51:16 Namespace verified: test-sp-deletion on supervisor: 0b5781e9-9089-4922-b8a6-1f72ac8eb26a
2026/05/08 08:51:16    Status: RUNNING
2026/05/08 08:51:16    Policies:
2026/05/08 08:51:16    -  f9e82f63-6988-4139-9b0d-b201740ba943
2026/05/08 08:51:16 ================================================================================ 
2026/05/08 08:51:16 ================================================================================ 
2026/05/08 08:51:16 === Patching Namespace 'test-sp-deletion' with empty storage spec to remove all storage policies ===
Equivalent curl command:
curl -X 'PATCH' -d '{"vm_service_spec":{},"storage_specs":[]}
' 'https://labvce3.soultec.lab/api/vcenter/namespaces/instances/test-sp-deletion'
2026/05/08 08:51:26 === Verifying Namespace Update ===
2026/05/08 08:51:26 Namespace verified after update: test-sp-deletion on supervisor: 0b5781e9-9089-4922-b8a6-1f72ac8eb26a
2026/05/08 08:51:26    Status: RUNNING
2026/05/08 08:51:26    Policies:
2026/05/08 08:51:26    - No storage policies assigned to this namespace
2026/05/08 08:51:26 ================================================================================ 
2026/05/08 08:51:26 ================================================================================ 
2026/05/08 08:51:26 === Patching Namespace 'test-sp-deletion' with old storage spec ===
Equivalent curl command:
curl -X 'PATCH' -d '{"vm_service_spec":{},"storage_specs":[{"policy":"f9e82f63-6988-4139-9b0d-b201740ba943"}]}
' 'https://labvce3.soultec.lab/api/vcenter/namespaces/instances/test-sp-deletion'
2026/05/08 08:51:36 === Verifying Namespace Update ===
2026/05/08 08:51:37 Namespace verified after update: test-sp-deletion on supervisor: 0b5781e9-9089-4922-b8a6-1f72ac8eb26a
2026/05/08 08:51:37    Status: RUNNING
2026/05/08 08:51:37    Policies:
2026/05/08 08:51:37    -  f9e82f63-6988-4139-9b0d-b201740ba943
2026/05/08 08:51:37 ================================================================================ 
2026/05/08 08:51:37 ================================================================================ 
2026/05/08 08:51:37 === Patching Namespace 'test-sp-deletion' with new vmClass without touching storage spec ===
Equivalent curl command:
curl -X 'PATCH' -d '{"vm_service_spec":{"vm_classes":["best-effort-small"]},"storage_specs":null}
' 'https://labvce3.soultec.lab/api/vcenter/namespaces/instances/test-sp-deletion'
2026/05/08 08:51:47 === Verifying Namespace Update ===
2026/05/08 08:51:47 Namespace verified after update: test-sp-deletion on supervisor: 0b5781e9-9089-4922-b8a6-1f72ac8eb26a
2026/05/08 08:51:47    Status: RUNNING
2026/05/08 08:51:47    Policies:
2026/05/08 08:51:47    -  f9e82f63-6988-4139-9b0d-b201740ba943
2026/05/08 08:51:47    VM Classes:
2026/05/08 08:51:47    -  best-effort-small
2026/05/08 08:51:47 ================================================================================ 
2026/05/08 08:51:47 ================================================================================ 
2026/05/08 08:51:47 === Patching Namespace 'test-sp-deletion' with new vmClass without touching storage spec ===
Equivalent curl command:
curl -X 'PATCH' -d '{"vm_service_spec":{"vm_classes":["best-effort-small","best-effort-medium"]},"storage_specs":null}
' 'https://labvce3.soultec.lab/api/vcenter/namespaces/instances/test-sp-deletion'
2026/05/08 08:51:57 === Verifying Namespace Update ===
2026/05/08 08:51:57 Namespace verified after update: test-sp-deletion on supervisor: 0b5781e9-9089-4922-b8a6-1f72ac8eb26a
2026/05/08 08:51:57    Status: RUNNING
2026/05/08 08:51:57    Policies:
2026/05/08 08:51:57    -  f9e82f63-6988-4139-9b0d-b201740ba943
2026/05/08 08:51:57    VM Classes:
2026/05/08 08:51:57    -  best-effort-small
2026/05/08 08:51:57    -  best-effort-medium
Press Enter to continue to namespace deletion...

2026/05/08 08:54:50 === Deleting Namespace: test-sp-deletion ===
2026/05/08 08:54:50 Namespace 'test-sp-deletion' deleted successfully!
```


## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
