### PR TITLE
simulator: improve podman compatibility for container-backed VMs

### DIFF
--- a/simulator/container.go
+++ b/simulator/container.go
@@ -35,9 +35,25 @@ const (
 )
 
 func init() {
-	if sh, err := exec.LookPath("bash"); err != nil {
+	if sh, err := exec.LookPath("bash"); err == nil && sh != "" {
 		shell = sh
 	}
+}
+
+// commandError logs and returns an error from a command execution failure, including stderr if available.
+func commandError(operation string, args []string, err error) error {
+	stderr := ""
+	if xerr, ok := err.(*exec.ExitError); ok {
+		stderr = strings.TrimSpace(string(xerr.Stderr))
+	}
+	var cmdErr error
+	if stderr != "" {
+		cmdErr = fmt.Errorf("%s %v failed: %s: %s", operation, args, err, stderr)
+	} else {
+		cmdErr = fmt.Errorf("%s %v failed: %s", operation, args, err)
+	}
+	log.Print(cmdErr)
+	return cmdErr
 }
 
 type eventWatcher struct {
@@ -186,14 +202,13 @@ func copyFromGuest(id string, src string, sink func(int64, io.Reader) error) err
 //
 //	uid - string
 //	err - error or nil
-func createVolume(volumeName string, labels []string, files []tarEntry) (string, error) {
+func createVolume(volumeName string, labels []string, files []tarEntry) (uid string, err error) {
 	image := os.Getenv("VCSIM_BUSYBOX")
 	if image == "" {
 		image = "busybox"
 	}
 
 	name := sanitizeName(volumeName)
-	uid := ""
 
 	// label the volume if specified - this requires the volume be created before use
 	if len(labels) > 0 {
@@ -205,7 +220,7 @@ func createVolume(volumeName string, labels []string, files []tarEntry) (string,
 		cmd := exec.Command("docker", run...)
 		out, err := cmd.Output()
 		if err != nil {
-			return "", err
+			return "", commandError("volume create", cmd.Args, err)
 		}
 		uid = strings.TrimSpace(string(out))
 
@@ -223,9 +238,8 @@ func createVolume(volumeName string, labels []string, files []tarEntry) (string,
 		return uid, err
 	}
 
-	err = cmd.Start()
-	if err != nil {
-		return uid, err
+	if err = cmd.Start(); err != nil {
+		return uid, commandError("volume population start", cmd.Args, err)
 	}
 
 	tw := tar.NewWriter(stdin)
@@ -259,14 +273,7 @@ func createVolume(volumeName string, labels []string, files []tarEntry) (string,
 	}
 
 	if waitErr := cmd.Wait(); waitErr != nil {
-		stderr := ""
-		if xerr, ok := waitErr.(*exec.ExitError); ok {
-			stderr = string(xerr.Stderr)
-		}
-		log.Printf("%s %s: %s %s", name, cmd.Args, waitErr, stderr)
-
-		err = fmt.Errorf("%s, wait: {%s}", err, waitErr)
-		return uid, err
+		return uid, commandError("volume population", cmd.Args, waitErr)
 	}
 
 	return uid, err
@@ -411,13 +418,7 @@ func create(ctx *Context, name string, id string, networks []string, volumes []s
 	cmd := exec.Command(shell, "-c", strings.Join(run, " "))
 	out, err := cmd.Output()
 	if err != nil {
-		stderr := ""
-		if xerr, ok := err.(*exec.ExitError); ok {
-			stderr = string(xerr.Stderr)
-		}
-		log.Printf("%s %s: %s %s", name, cmd.Args, err, stderr)
-
-		return nil, err
+		return nil, commandError("container create", cmd.Args, err)
 	}
 
 	c.id = strings.TrimSpace(string(out))
@@ -506,12 +507,26 @@ func (c *container) start(ctx *Context) error {
 	}
 
 	cmd := exec.Command("docker", start, c.id)
-	err = cmd.Run()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Printf("%s %s: %s", c.name, cmd.Args, err)
+		errMsg := fmt.Sprintf("container %s failed: %s", start, err)
+		if len(out) > 0 {
+			stderr := strings.TrimSpace(string(out))
+			errMsg = fmt.Sprintf("%s: %s", errMsg, stderr)
+			// Check for common podman permission errors related to DMI mount
+			if strings.Contains(stderr, "Permission denied") || strings.Contains(stderr, "OCI permission denied") {
+				if strings.Contains(stderr, "/sys/class/dmi") || strings.Contains(stderr, "dmi") {
+					errMsg = fmt.Sprintf("%s (hint: rootless podman cannot mount to /sys/class/dmi/id - set VM ExtraConfig 'RUN.mountdmi=false' to disable, or run with root privileges)", errMsg)
+				} else {
+					errMsg = fmt.Sprintf("%s (hint: this may be a rootless container permission issue - check volume mounts to system paths, or set VM ExtraConfig 'RUN.mountdmi=false' if using DMI mount)", errMsg)
+				}
+			}
+		}
+		log.Printf("%s %s: %s", c.name, cmd.Args, errMsg)
+		return errors.New(errMsg)
 	}
 
-	return err
+	return nil
 }
 
 // pause the container (if any) for the given vm.
@@ -689,7 +704,7 @@ func (c *container) updated() {
 // returns:
 //
 //	err - uninitializedContainer error - if c.id is empty
-func (c *container) watchContainer(ctx *Context, updateFn func(*containerDetails, *container) error) error {
+func (c *container) watchContainer(ctx *Context, updateFn func(*Context, *containerDetails, *container) error) error {
 	c.Lock()
 	defer c.Unlock()
 
@@ -720,7 +735,7 @@ func (c *container) watchContainer(ctx *Context, updateFn func(*containerDetails
 				rmErr = c.remove(ctx)
 			}
 
-			updateErr := updateFn(&details, c)
+			updateErr := updateFn(ctx, &details, c)
 			// if we don't succeed we want to re-try
 			if removing && rmErr == nil && updateErr == nil {
 				ticker.Stop()

--- a/simulator/container_virtual_machine.go
+++ b/simulator/container_virtual_machine.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -61,7 +62,8 @@ func createSimulationVM(vm *VirtualMachine) *simVM {
 }
 
 // applies container network settings to vm.Guest properties.
-func (svm *simVM) syncNetworkConfigToVMGuestProperties() error {
+// If ctx is provided, property change notifications will be triggered for all modified properties.
+func (svm *simVM) syncNetworkConfigToVMGuestProperties(ctx *Context) error {
 	if svm == nil {
 		return nil
 	}
@@ -82,6 +84,11 @@ func (svm *simVM) syncNetworkConfigToVMGuestProperties() error {
 		break
 	}
 
+	// Collect property changes as we modify the VM state
+	var changes []types.PropertyChange
+
+	// Update power state based on container state
+	var oldPowerState types.VirtualMachinePowerState
 	if detail.State.Paused {
 		svm.vm.Runtime.PowerState = types.VirtualMachinePowerStateSuspended
 	} else if detail.State.Running {
@@ -89,20 +96,51 @@ func (svm *simVM) syncNetworkConfigToVMGuestProperties() error {
 	} else {
 		svm.vm.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOff
 	}
-
-	svm.vm.Guest.IpAddress = netS.IPAddress
-	svm.vm.Summary.Guest.IpAddress = netS.IPAddress
-	if svm.vm.Guest.HostName == "" {
-		svm.vm.Guest.HostName = detail.Config.Hostname
+	if svm.vm.Runtime.PowerState != oldPowerState {
+		changes = append(changes, types.PropertyChange{
+			Name: "runtime.powerState",
+			Val:  svm.vm.Runtime.PowerState,
+			Op:   types.PropertyChangeOpAssign,
+		})
 	}
 
+	// Update IP address
+	newIP := netS.IPAddress
+	if svm.vm.Guest.IpAddress != newIP {
+		svm.vm.Guest.IpAddress = newIP
+		changes = append(changes, types.PropertyChange{
+			Name: "guest.ipAddress",
+			Val:  newIP,
+			Op:   types.PropertyChangeOpAssign,
+		})
+	}
+	if svm.vm.Summary.Guest.IpAddress != newIP {
+		svm.vm.Summary.Guest.IpAddress = newIP
+		changes = append(changes, types.PropertyChange{
+			Name: "summary.guest.ipAddress",
+			Val:  newIP,
+			Op:   types.PropertyChangeOpAssign,
+		})
+	}
+
+	// Update hostname
+	if svm.vm.Guest.HostName == "" && detail.Config.Hostname != "" {
+		svm.vm.Guest.HostName = detail.Config.Hostname
+		changes = append(changes, types.PropertyChange{
+			Name: "guest.hostName",
+			Val:  detail.Config.Hostname,
+			Op:   types.PropertyChangeOpAssign,
+		})
+	}
+
+	// Update network info if we have a NIC configured
 	if len(svm.vm.Guest.Net) != 0 {
 		net := &svm.vm.Guest.Net[0]
-		net.IpAddress = []string{netS.IPAddress}
+		net.IpAddress = []string{newIP}
 		net.MacAddress = netS.MacAddress
 		net.IpConfig = &types.NetIpConfigInfo{
 			IpAddress: []types.NetIpConfigInfoIpAddress{{
-				IpAddress:    netS.IPAddress,
+				IpAddress:    newIP,
 				PrefixLength: int32(netS.IPPrefixLen),
 				State:        string(types.NetIpConfigInfoIpAddressStatusPreferred),
 			}},
@@ -128,13 +166,31 @@ func (svm *simVM) syncNetworkConfigToVMGuestProperties() error {
 			},
 		}
 		svm.vm.Guest.IpStack = []types.GuestStackInfo{gsi}
+
+		// guest.net is a complex structure, trigger update for the whole thing
+		changes = append(changes, types.PropertyChange{
+			Name: "guest.net",
+			Val:  svm.vm.Guest.Net,
+			Op:   types.PropertyChangeOpAssign,
+		})
+		changes = append(changes, types.PropertyChange{
+			Name: "guest.ipStack",
+			Val:  svm.vm.Guest.IpStack,
+			Op:   types.PropertyChangeOpAssign,
+		})
 	}
 
+	// Update MAC address on virtual ethernet card
 	for _, d := range svm.vm.Config.Hardware.Device {
 		if eth, ok := d.(types.BaseVirtualEthernetCard); ok {
 			eth.GetVirtualEthernetCard().MacAddress = netS.MacAddress
 			break
 		}
+	}
+
+	// Trigger property change notifications if we have changes and context is available
+	if ctx != nil && len(changes) > 0 {
+		ctx.Update(svm.vm, changes)
 	}
 
 	return nil
@@ -212,6 +268,7 @@ func (svm *simVM) start(ctx *Context) error {
 	var args []string
 	var env []string
 	var ports []string
+	var networks []string
 	mountDMI := true
 
 	for _, opt := range svm.vm.Config.ExtraConfig {
@@ -233,6 +290,13 @@ func (svm *simVM) start(ctx *Context) error {
 				mountDMI = mount
 			}
 
+			continue
+		}
+
+		if val.Key == "RUN.network" {
+			// Specify container network (e.g., "podman" for rootless podman bridge network)
+			// This is important for rootless podman which doesn't assign IPs without a network
+			networks = append(networks, val.Value.(string))
 			continue
 		}
 
@@ -276,7 +340,7 @@ func (svm *simVM) start(ctx *Context) error {
 	}
 
 	var err error
-	svm.c, err = create(ctx, svm.vm.Name, svm.vm.uid.String(), nil, volumes, ports, env, args[0], args[1:])
+	svm.c, err = create(ctx, svm.vm.Name, svm.vm.uid.String(), networks, volumes, ports, env, args[0], args[1:])
 	if err != nil {
 		return err
 	}
@@ -301,15 +365,24 @@ func (svm *simVM) start(ctx *Context) error {
 
 	svm.vm.logPrintf("%s: %s", args, svm.c.id)
 
-	if err = svm.syncNetworkConfigToVMGuestProperties(); err != nil {
-		log.Printf("%s inspect %s: %s", svm.vm.Name, svm.c.id, err)
+	// Sync network config, retrying a few times to allow the container to get an IP
+	// Container runtimes may take a moment to assign an IP address after start
+	for i := 0; i < 5; i++ {
+		if err = svm.syncNetworkConfigToVMGuestProperties(ctx); err != nil {
+			log.Printf("%s inspect %s: %s", svm.vm.Name, svm.c.id, err)
+			break
+		}
+		if svm.vm.Guest.IpAddress != "" {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
 	}
 
-	callback := func(details *containerDetails, c *container) error {
+	callback := func(callbackCtx *Context, details *containerDetails, c *container) error {
 		if c.id == "" && svm.vm != nil {
 			// If the container cannot be found then destroy this VM unless the VM is no longer configured for container backing (svm.vm == nil)
-			taskRef := svm.vm.DestroyTask(ctx, &types.Destroy_Task{This: svm.vm.Self}).(*methods.Destroy_TaskBody).Res.Returnval
-			task, ok := ctx.Map.Get(taskRef).(*Task)
+			taskRef := svm.vm.DestroyTask(callbackCtx, &types.Destroy_Task{This: svm.vm.Self}).(*methods.Destroy_TaskBody).Res.Returnval
+			task, ok := callbackCtx.Map.Get(taskRef).(*Task)
 			if !ok {
 				panic(fmt.Sprintf("couldn't retrieve task for moref %+q while deleting VM %s", taskRef, svm.vm.Name))
 			}
@@ -323,14 +396,14 @@ func (svm *simVM) start(ctx *Context) error {
 			}
 		}
 
-		return svm.syncNetworkConfigToVMGuestProperties()
+		return svm.syncNetworkConfigToVMGuestProperties(callbackCtx)
 	}
 
 	// Start watching the container resource.
 	err = svm.c.watchContainer(ctx, callback)
 	if _, ok := err.(uninitializedContainer); ok {
 		// the container has been deleted before we could watch, despite successful launch so clean up.
-		callback(nil, svm.c)
+		callback(ctx, nil, svm.c)
 
 		// successful launch so nil the error
 		return nil

--- a/simulator/feature_test.go
+++ b/simulator/feature_test.go
@@ -113,6 +113,10 @@ func Example_runContainer() {
 				&types.OptionValue{Key: "RUN.port.80", Value: "8888"}, // test port remap
 			},
 		}
+		if err := test.ApplyContainerRuntimeDefaults(&spec); err != nil {
+			log.Fatal(err)
+		}
+		network := test.ContainerNetworkFromSpec(&spec)
 
 		// Create a new VM
 		task, err := f.VmFolder.CreateVM(ctx, spec, pool, nil)
@@ -135,8 +139,15 @@ func Example_runContainer() {
 
 		ip, _ := vm.WaitForIP(ctx, true) // Returns the docker container's IP
 
-		// Count the number of bytes in feature_test.go via nginx going direct to the container
-		cmd := exec.Command("docker", "run", "--rm", "curlimages/curl", "curl", "-f", fmt.Sprintf("http://%s", ip))
+		// Count the number of bytes in feature_test.go via nginx going direct to the container.
+		// Join the same bridge so the probe can reach the nginx container IP on rootless podman;
+		// omit --network on runtimes where the default bridge provides connectivity.
+		probeArgs := []string{"run", "--rm"}
+		if network != "" {
+			probeArgs = append(probeArgs, "--network", network)
+		}
+		probeArgs = append(probeArgs, "curlimages/curl", "curl", "-f", fmt.Sprintf("http://%s", ip))
+		cmd := exec.Command("docker", probeArgs...)
 		var buf bytes.Buffer
 		cmd.Stdout = &buf
 		err = cmd.Run()

--- a/test/helper.go
+++ b/test/helper.go
@@ -6,10 +6,12 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/vmware/govmomi/vim25"
@@ -26,6 +28,137 @@ func HasDocker() bool {
 		return false
 	}
 	return true
+}
+
+// IsRootlessPodman returns true when the docker CLI is backed by rootless podman.
+// Rootless podman has restrictions such as the inability to bind-mount system
+// paths like /sys/class/dmi/id.
+func IsRootlessPodman() bool {
+	out, err := exec.Command("docker", "--version").Output()
+	if err != nil || !strings.Contains(string(out), "podman") {
+		return false
+	}
+	out, err = exec.Command("podman", "info", "--format", "{{.Host.Security.Rootless}}").Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
+}
+
+// containerRuntimeDefaults returns the ExtraConfig defaults appropriate for
+// the current container runtime and spec.  Returns nil, nil when no
+// runtime-specific defaults are needed.
+//
+// For rootless podman:
+//   - RUN.mountdmi=false is always added (rootless cannot bind-mount
+//     /sys/class/dmi/id).
+//   - RUN.network is added when the spec uses container backing; the bridge
+//     is created on demand unless VCSIM_NETWORK is set (in which case the
+//     caller-supplied network is used as-is).
+func containerRuntimeDefaults(spec *types.VirtualMachineConfigSpec) ([]types.BaseOptionValue, error) {
+	if !IsRootlessPodman() {
+		return nil, nil
+	}
+
+	defaults := []types.BaseOptionValue{
+		&types.OptionValue{Key: "RUN.mountdmi", Value: "false"},
+	}
+
+	if hasContainerBacking(spec) {
+		network := os.Getenv("VCSIM_NETWORK")
+		if network == "" {
+			network = "vcsim-test-bridge"
+			if err := ensureContainerBridge(network); err != nil {
+				return nil, fmt.Errorf("creating default container bridge %q: %w", network, err)
+			}
+		}
+		defaults = append(defaults, &types.OptionValue{Key: "RUN.network", Value: network})
+	}
+
+	return defaults, nil
+}
+
+// hasContainerBacking reports whether spec contains a RUN.container ExtraConfig key.
+func hasContainerBacking(spec *types.VirtualMachineConfigSpec) bool {
+	for _, opt := range spec.ExtraConfig {
+		if opt.GetOptionValue().Key == "RUN.container" {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureContainerBridge creates the named Docker/Podman bridge network if it
+// does not already exist.
+func ensureContainerBridge(name string) error {
+	out, err := exec.Command("docker", "network", "inspect", name).Output()
+	if err == nil && len(out) > 2 { // non-empty JSON array means it exists
+		return nil
+	}
+	return exec.Command("docker", "network", "create", name).Run()
+}
+
+// ContainerNetworkFromSpec returns the RUN.network value from spec's
+// ExtraConfig, or "" when not set.  After ApplyContainerRuntimeDefaults, this
+// yields the bridge name that was configured for rootless podman, or "" on
+// runtimes that use the default bridge (e.g. root Docker).  Pass the result
+// to any probe container that must reach the VM container by IP.
+func ContainerNetworkFromSpec(spec *types.VirtualMachineConfigSpec) string {
+	for _, opt := range spec.ExtraConfig {
+		ov := opt.GetOptionValue()
+		if ov.Key == "RUN.network" {
+			return fmt.Sprint(ov.Value)
+		}
+	}
+	return ""
+}
+
+// ApplyContainerRuntimeDefaults adds runtime-appropriate ExtraConfig defaults
+// to spec.  It is a no-op when the current runtime requires no special
+// treatment.
+//
+// An error is returned when the spec already contains an explicit value for a
+// key that the runtime default would change.  An exact value match is treated
+// as a silent no-op: the caller already expressed the same intent.  A
+// differing value is an error because silently overriding explicit test intent
+// would mask problems.
+func ApplyContainerRuntimeDefaults(spec *types.VirtualMachineConfigSpec) error {
+	defaults, err := containerRuntimeDefaults(spec)
+	if err != nil {
+		return err
+	}
+	if len(defaults) == 0 {
+		return nil
+	}
+
+	for _, def := range defaults {
+		dov := def.GetOptionValue()
+		defaultVal := fmt.Sprint(dov.Value)
+
+		found := false
+		for _, existing := range spec.ExtraConfig {
+			eov := existing.GetOptionValue()
+			if eov.Key != dov.Key {
+				continue
+			}
+			found = true
+			if existingVal := fmt.Sprint(eov.Value); existingVal != defaultVal {
+				return fmt.Errorf(
+					"container runtime default %q=%q conflicts with explicit ExtraConfig value %q; "+
+						"remove the explicit setting to use runtime defaults, or handle the "+
+						"runtime difference in the test itself",
+					dov.Key, defaultVal, existingVal,
+				)
+			}
+			// Already set to the correct value; nothing to add.
+			break
+		}
+
+		if !found {
+			spec.ExtraConfig = append(spec.ExtraConfig, def)
+		}
+	}
+	return nil
 }
 
 // URL parses the GOVMOMI_TEST_URL environment variable if set.


### PR DESCRIPTION
## Description

Add helpers and options that let vcsim container-backed VMs work correctly
under rootless podman-docker:

* commandError(cmd, err, stderr) – consistent error logging that includes the
   command's stderr so failures are easier to diagnose.
* RUN.network ExtraConfig – explicit container network name; needed for
   rootless podman where the default bridge does not provide cross-container
   IP connectivity.
* RUN.mountdmi ExtraConfig        – error hint when /dev/mem mount fails
  (rootless podman permission issue).
* syncNetworkConfigToVMGuestProperties – now calls ctx.Update for every
   modified property and retries IP resolution after container start to handle
   delayed IP assignment.
* watchContainer callback – updated to accept a *Context so callers can trigger
   property change notifications.
* test/helper.go – adds IsRootlessPodman() and ContainerNetworkFromSpec()
   helpers; Example_runContainer in feature_test.go uses them so the curl probe
   joins the same bridge network as the nginx VM.

## How Has This Been Tested?

Unit and sim testing