### PR TITLE
api: add ConcurrentAccess to IsTransientError

### DIFF
--- a/fault/meta_types.go
+++ b/fault/meta_types.go
@@ -45,5 +45,6 @@ func IsTransientError(err any) bool {
 		Is(err, &types.NetworkDisruptedAndConfigRolledBack{}) ||
 		Is(err, &types.VAppTaskInProgress{}) ||
 		Is(err, &types.FailToLockFaultToleranceVMs{}) ||
-		Is(err, &types.HostCommunication{})
+		Is(err, &types.HostCommunication{}) ||
+		Is(err, &types.ConcurrentAccess{})
 }

--- a/fault/meta_types_test.go
+++ b/fault/meta_types_test.go
@@ -14,6 +14,28 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+func TestIsTransientErrorConcurrentAccess(t *testing.T) {
+	var (
+		errFalse any
+		errTrue  any
+	)
+
+	errFalse = task.Error{
+		LocalizedMethodFault: &types.LocalizedMethodFault{
+			Fault: &types.SystemError{},
+		},
+	}
+
+	errTrue = task.Error{
+		LocalizedMethodFault: &types.LocalizedMethodFault{
+			Fault: &types.ConcurrentAccess{},
+		},
+	}
+
+	assert.False(t, fault.IsTransientError(errFalse))
+	assert.True(t, fault.IsTransientError(errTrue))
+}
+
 func TestAlreadyPoweredOff(t *testing.T) {
 	var (
 		errFalse any


### PR DESCRIPTION
## Description

`ConcurrentAccess` is thrown when an operation fails because another concurrent operation modified the datastructure. Like `TaskInProgress` (already in the list), the contention is transient and the operation is expected to succeed on retry once the competing operation completes.

vSphere HA itself treats `ConcurrentAccess` this way — when the fault is encountered during VM failover placement, HA sets an internal timeout and retries placement rather than failing immediately.

This change ensures clients using `IsTransientError` as the canonical retry-check do not need to add this fault type themselves, which was the stated goal of the function (see #3824).

Closes: #4017

## How Has This Been Tested?

Added `TestIsTransientErrorConcurrentAccess` to `fault/meta_types_test.go` verifying both the positive case (`ConcurrentAccess` → `true`) and a negative case (`SystemError` → `false`).

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md