### PR TITLE
govmomi: Add HostDistributedVirtualSwitchManager MO

### DIFF
--- a/vim25/mo/registry.go
+++ b/vim25/mo/registry.go
@@ -39,3 +39,16 @@ func (m TransitGateway) Reference() types.ManagedObjectReference {
 func init() {
 	t["TransitGateway"] = reflect.TypeOf((*TransitGateway)(nil)).Elem()
 }
+
+type HostDistributedVirtualSwitchManager struct {
+	Self                     types.ManagedObjectReference `json:"self"`
+	DistributedVirtualSwitch []string                     `json:"distributedVirtualSwitch"`
+}
+
+func (d HostDistributedVirtualSwitchManager) Reference() types.ManagedObjectReference {
+	return d.Self
+}
+
+func init() {
+	t["HostDistributedVirtualSwitchManager"] = reflect.TypeOf((*HostDistributedVirtualSwitchManager)(nil)).Elem()
+}


### PR DESCRIPTION
## Description

This change adds the HostDistributedVirtualSwitchManager managed object into govmomi for the internal object implementation being added in [1] to use the manager to fetch the list of distributed virtual switches on the host.

This is needed for ESXi infravisord to fetch the list of distributed virtual switches on a host and get their port information for the CRXs that it manages.

1. https://github-vcf.devops.broadcom.net/vcf/govmomi-internal/pull/44

## How Has This Been Tested?

- Consumed this logic in infravisord and able to use the added FetchPortState and DistributedVirtualSwitches APIs.
