### PR TITLE
Add govc Relocate Volume command

### DIFF
--- a/cli/volume/relocate.go
+++ b/cli/volume/relocate.go
@@ -1,18 +1,6 @@
-/*
-Copyright (c) 2020 VMware, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package volume
 
@@ -24,9 +12,9 @@ import (
 	"io"
 	"text/tabwriter"
 
+	"github.com/vmware/govmomi/cli"
+	"github.com/vmware/govmomi/cli/flags"
 	cnstypes "github.com/vmware/govmomi/cns/types"
-	"github.com/vmware/govmomi/govc/cli"
-	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
@@ -62,7 +50,7 @@ func (cmd *relocate) Process(ctx context.Context) error {
 }
 
 func (cmd *relocate) Usage() string {
-	return "ID [ID...]"
+	return "ID..."
 }
 
 func (cmd *relocate) Description() string {

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -437,6 +437,7 @@ but appear via `govc $cmd -h`:
  - [vm.vnc](#vmvnc)
  - [volume.extend](#volumeextend)
  - [volume.ls](#volumels)
+ - [volume.relocate](#volumerelocate)
  - [volume.rm](#volumerm)
  - [volume.snapshot.create](#volumesnapshotcreate)
  - [volume.snapshot.ls](#volumesnapshotls)
@@ -7816,6 +7817,25 @@ Options:
   -label=[]              List volumes with labels
   -n=[]                  List volumes with names
   -profile=[]            Storage profile name or ID
+```
+
+## volume.relocate
+
+```
+Usage: govc volume.relocate [OPTIONS] ID...
+
+Relocate one or more CNS volumes to the target datastore.
+
+All IDs are submitted in a single batch RelocateVolume call.
+Per-volume results are printed; the command exits non-zero if any relocation failed.
+
+Examples:
+  govc volume.relocate -ds vsanDatastore f75989dc-95b9-4db7-af96-8583f24bc59d
+  govc volume.relocate -ds vsanDatastore id1 id2 id3
+  govc volume.relocate -ds vsanDatastore -json id1 id2 | jq .
+
+Options:
+  -ds=                   Datastore [GOVC_DATASTORE]
 ```
 
 ## volume.rm

--- a/govc/volume/relocate.go
+++ b/govc/volume/relocate.go
@@ -1,0 +1,179 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type relocate struct {
+	*flags.ClientFlag
+	*flags.DatastoreFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("volume.relocate", &relocate{})
+}
+
+func (cmd *relocate) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *relocate) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *relocate) Usage() string {
+	return "ID [ID...]"
+}
+
+func (cmd *relocate) Description() string {
+	return `Relocate one or more CNS volumes to the target datastore.
+
+All IDs are submitted in a single batch RelocateVolume call.
+Per-volume results are printed; the command exits non-zero if any relocation failed.
+
+Examples:
+  govc volume.relocate -ds vsanDatastore f75989dc-95b9-4db7-af96-8583f24bc59d
+  govc volume.relocate -ds vsanDatastore id1 id2 id3
+  govc volume.relocate -ds vsanDatastore -json id1 id2 | jq .`
+}
+
+// relocateResult holds the per-volume outcomes of a batch relocation and
+// implements flags.OutputWriter for both text and JSON rendering.
+type relocateResult struct {
+	Results []relocateVolumeResult `json:"results"`
+}
+
+type relocateVolumeResult struct {
+	VolumeID string `json:"volumeId"`
+	Status   string `json:"status"`
+	Error    string `json:"error,omitempty"`
+}
+
+func (r *relocateResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+	for _, res := range r.Results {
+		if res.Error != "" {
+			fmt.Fprintf(tw, "%s\tFAILED\t%s\n", res.VolumeID, res.Error)
+		} else {
+			fmt.Fprintf(tw, "%s\tOK\n", res.VolumeID)
+		}
+	}
+	return tw.Flush()
+}
+
+func (cmd *relocate) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	c, err := cmd.CnsClient()
+	if err != nil {
+		return err
+	}
+
+	out := new(relocateResult)
+	var firstErr error
+
+	for _, id := range f.Args() {
+		spec := cnstypes.CnsBlockVolumeRelocateSpec{
+			CnsVolumeRelocateSpec: cnstypes.CnsVolumeRelocateSpec{
+				VolumeId:  cnstypes.CnsVolumeId{Id: id},
+				Datastore: ds.Reference(),
+			},
+		}
+
+		entry := relocateVolumeResult{VolumeID: id, Status: "OK"}
+
+		task, err := c.RelocateVolume(ctx, spec)
+		if err != nil {
+			entry.Status = "FAILED"
+			entry.Error = err.Error()
+			if firstErr == nil {
+				firstErr = err
+			}
+			out.Results = append(out.Results, entry)
+			continue
+		}
+
+		info, err := task.WaitForResult(ctx, nil)
+		if err != nil {
+			entry.Status = "FAILED"
+			entry.Error = err.Error()
+			if firstErr == nil {
+				firstErr = err
+			}
+			out.Results = append(out.Results, entry)
+			continue
+		}
+
+		if batchRes, ok := info.Result.(cnstypes.CnsVolumeOperationBatchResult); ok {
+			for _, r := range batchRes.VolumeResults {
+				opRes := r.GetCnsVolumeOperationResult()
+				if opRes.Fault != nil {
+					entry.Status = "FAILED"
+					entry.Error = opRes.Fault.LocalizedMessage
+					if firstErr == nil {
+						if opRes.Fault.Fault != nil {
+							firstErr = soap.WrapVimFault(opRes.Fault.Fault)
+						} else {
+							firstErr = errors.New(opRes.Fault.LocalizedMessage)
+						}
+					}
+				}
+			}
+		}
+
+		out.Results = append(out.Results, entry)
+	}
+
+	if wErr := cmd.WriteResult(out); wErr != nil {
+		return wErr
+	}
+
+	return firstErr
+}


### PR DESCRIPTION
## Description

A new govc sub-command that relocates one or more CNS block volumes to a target datastore in a single CLI command

- Accepts one or more volume IDs as positional arguments.
- Target datastore is specified via -ds (falls back to GOVC_DATASTORE).
- All volumes are sent together in one CnsRelocateVolume request.
- Per-volume success/failure is printed to stdout; the command exits non-zero if any relocation fails.
- Supports -json output for scripting.

```
# Relocate a single volume
govc volume.relocate -ds vsanDatastore f75989dc-95b9-4db7-af96-8583f24bc59d

# Relocate multiple volumes in one call
govc volume.relocate -ds vsanDatastore id1 id2 id3

# JSON output for scripting
govc volume.relocate -ds vsanDatastore -json id1 id2 | jq .
```

Closes: #(issue-number)

## How Has This Been Tested?

A standalone integration test that exercises the batch path of cnsClient.RelocateVolume:

- Creates N block volumes (default 2, configurable via CNS_BATCH_RELOCATE_COUNT).
- Sends all relocation specs in a single RelocateVolume call.
- Iterates GetTaskResultArray results and logs [SUCCEEDED] / [FAILED] per volume.
- Prints a batch summary line (X/N succeeded, Y/N failed).
- Registers a t.Cleanup handler to delete all created volumes regardless of test outcome.

```
volume.relocate -ds vsanDatastore 68eb8587-2900-4365-af06-3fe5eb9a18d5 ebb395b1-d678-4239-8f1c-c1bfbccab4df
68eb8587-2900-4365-af06-3fe5eb9a18d5  OK
ebb395b1-d678-4239-8f1c-c1bfbccab4df  OK
```
<img width="1915" height="157" alt="Screenshot 2026-05-28 at 3 53 43 PM" src="https://github.com/user-attachments/assets/8d8fc238-07ba-401d-9778-5571532eb069" />


## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
