### PR TITLE
chore: build govc release with Go 1.26

### DIFF
--- a/.github/workflows/govmomi-release.yaml
+++ b/.github/workflows/govmomi-release.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go.mod
+          go-version: '1.26'
       - name: Update version.go
         run: |
           # strip semantic v


### PR DESCRIPTION
Commit e2054307 switched to using go.mod, which until recently was go 1.24

