### PR TITLE
fix case-sensitive api call - enable supervisor cluster

### DIFF
--- a/vapi/namespace/namespace.go
+++ b/vapi/namespace/namespace.go
@@ -213,7 +213,7 @@ type HAProxy struct {
 // https://developer.broadcom.com/xapis/vsphere-automation-api/latest/data-structures/Vcenter%20NamespaceManagement%20Networks%20Edges%20NSXConfig
 // Since 8.0.0.1
 type EdgeNSX struct {
-	EdgeClusterID                *string    `json:"edge_cluster_id,omitempty"`
+	EdgeClusterID                *string    `json:"edge_cluster_ID,omitempty"`
 	DefaultIngressTLSCertificate *string    `json:"default_ingress_tls_certificate,omitempty"`
 	RoutingMode                  *string    `json:"routing_mode,omitempty"`
 	EgressIPRanges               *[]IPRange `json:"egress_ip_ranges,omitempty"`


### PR DESCRIPTION
## Description

Structure VcenterNamespaceManagementNetworksEdgesNSXConfig is case sensitive.
Using edge_cluster_id instead of edge_cluster_ID is returning the error:

~~~
{"messages":[{"args":[],"default_message":"The nsxEdgeCluster field in NCPClusterNetworkInfo is required.","localized":"The nsxEdgeCluster field in NCPClusterNetworkInfo is required.","id":"vcenter.wcp.cluster.empty.nsx_edge_cluster"}]}
~~~

Changing the string to edge_cluster_ID

## How Has This Been Tested?

Tested by using terraform-provider-vsphere (vsphere_supervisor_v2)

