### PR TITLE
vcsim: align interval counter on inventory load

### DIFF
--- a/simulator/model.go
+++ b/simulator/model.go
@@ -466,6 +466,10 @@ func (m *Model) Load(dir string) error {
 
 	m.Service = New(ctx, s)
 
+	if err = ctx.Map.AlignCounter(); err != nil {
+		return err
+	}
+
 	return m.resolveReferences(ctx)
 }
 

--- a/simulator/model_test.go
+++ b/simulator/model_test.go
@@ -5,9 +5,13 @@
 package simulator
 
 import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/vmware/govmomi/simulator/vpx"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 func compareModel(t *testing.T, m *Model) {
@@ -149,4 +153,53 @@ func TestModelWithFolders(t *testing.T) {
 	}
 
 	compareModel(t, m)
+}
+
+func TestModelLoadAlignCounter(t *testing.T) {
+	dir, err := os.MkdirTemp("", "vcsim-load-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Create a Datacenter XML file to prevent resolveReferences from creating a default one
+	dcContent := types.ObjectContent{
+		Obj: types.ManagedObjectReference{Type: "Datacenter", Value: "datacenter-10"},
+	}
+	dcData, err := xml.Marshal(dcContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "datacenter-10.xml"), dcData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a VirtualMachine XML file with vm-500
+	vmContent := types.ObjectContent{
+		Obj: types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-500"},
+	}
+	vmData, err := xml.Marshal(vmContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "vm-500.xml"), vmData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load the model from the directory using the VPX baseline configuration
+	m := VPX()
+	defer m.Remove()
+
+	if err := m.Load(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the model registry counter was aligned to 500
+	reg := m.Map()
+	if reg.counter != 500 {
+		for k, _ := range reg.objects {
+			t.Logf("Registry object: %s:%s", k.Type, k.Value)
+		}
+		t.Errorf("expected registry counter to be 500, got %d", reg.counter)
+	}
 }

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -142,6 +143,24 @@ func (r *Registry) newReference(item mo.Reference) types.ManagedObjectReference 
 	}
 
 	return ref
+}
+
+func (r *Registry) AlignCounter() error {
+	maxN := int64(0)
+	for ref, _ := range r.objects {
+		prefix := valuePrefix(ref.Type)
+		suffix := strings.TrimPrefix(ref.Value, prefix)
+		n, err := strconv.ParseInt(suffix, 10, 64)
+		if err != nil {
+			continue
+		}
+		if n > maxN {
+			maxN = n
+		}
+	}
+
+	r.counter = maxN
+	return nil
 }
 
 func (r *Registry) setReference(item mo.Reference, ref types.ManagedObjectReference) {

--- a/simulator/registry_test.go
+++ b/simulator/registry_test.go
@@ -55,3 +55,59 @@ func TestRemoveReference(t *testing.T) {
 		t.Errorf("%d", len(refs))
 	}
 }
+
+func TestAlignCounter(t *testing.T) {
+	r := NewRegistry()
+
+	// 1. Empty registry AlignCounter should result in counter 0
+	if err := r.AlignCounter(); err != nil {
+		t.Fatalf("AlignCounter failed: %v", err)
+	}
+	if r.counter != 0 {
+		t.Errorf("expected counter 0, got %d", r.counter)
+	}
+
+	// 2. Add some entities with specific types and references
+	vm1 := &mo.VirtualMachine{}
+	vm1.Self = types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-42"}
+	r.Put(vm1)
+
+	host1 := &mo.HostSystem{}
+	host1.Self = types.ManagedObjectReference{Type: "HostSystem", Value: "host-10"}
+	r.Put(host1)
+
+	rp1 := &mo.ResourcePool{}
+	rp1.Self = types.ManagedObjectReference{Type: "ResourcePool", Value: "resgroup-250"}
+	r.Put(rp1)
+
+	// Non-conforming/invalid suffix formats should be skipped
+	vmInvalid := &mo.VirtualMachine{}
+	vmInvalid.Self = types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-abc"}
+	r.Put(vmInvalid)
+
+	vmNonNumeric := &mo.VirtualMachine{}
+	vmNonNumeric.Self = types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-v50"}
+	r.Put(vmNonNumeric)
+
+	// Another valid one but smaller than max
+	vmSmall := &mo.VirtualMachine{}
+	vmSmall.Self = types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-100"}
+	r.Put(vmSmall)
+
+	if err := r.AlignCounter(); err != nil {
+		t.Fatalf("AlignCounter failed: %v", err)
+	}
+
+	// Max numeric suffix should be 250 (from resgroup-250)
+	if r.counter != 250 {
+		t.Errorf("expected counter 250, got %d", r.counter)
+	}
+
+	// 3. Verify next allocated reference uses the aligned counter + 1 (251)
+	newVM := &mo.VirtualMachine{}
+	ref := r.reference(newVM)
+	expectedValue := "vm-251"
+	if ref.Value != expectedValue {
+		t.Errorf("expected new reference value %q, got %q", expectedValue, ref.Value)
+	}
+}


### PR DESCRIPTION
## Description

Update the internal counter used for new object references when inventory is loaded from disk. This ensures that if new objects are added, they do not overwrite existing objects.

Closes: #4029

## How Has This Been Tested?

See #4029 for steps to reproduce.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
