### PR TITLE
vapi/library: tolerate spaces around '=' in ReadManifest

### DIFF
--- a/vapi/library/library_item_updatesession_file.go
+++ b/vapi/library/library_item_updatesession_file.go
@@ -163,17 +163,26 @@ func ReadManifest(m io.Reader) (map[string]*Checksum, error) {
 
 	scanner := bufio.NewScanner(m)
 	for scanner.Scan() {
-		line := strings.SplitN(scanner.Text(), ")=", 2)
-		if len(line) != 2 {
+		// Manifest lines look like "ALG(file name)= digest". Anchor on the
+		// last ")" (the digest separator's closing paren) so that "(" or ")"
+		// or "=" inside the file name don't confuse the parse, then require an
+		// "=" after it. Whitespace around the "=" (e.g. ") = ") is tolerated.
+		line := scanner.Text()
+		rparen := strings.LastIndex(line, ")")
+		if rparen < 0 {
 			continue
 		}
-		name := strings.SplitN(line[0], "(", 2)
+		value := strings.TrimSpace(line[rparen+1:])
+		if !strings.HasPrefix(value, "=") {
+			continue
+		}
+		name := strings.SplitN(line[:rparen], "(", 2)
 		if len(name) != 2 {
 			continue
 		}
 		sum := &Checksum{
 			Algorithm: strings.TrimSpace(name[0]),
-			Checksum:  strings.TrimSpace(line[1]),
+			Checksum:  strings.TrimSpace(strings.TrimPrefix(value, "=")),
 		}
 		c[name[1]] = sum
 	}

--- a/vapi/library/library_item_updatesession_file_test.go
+++ b/vapi/library/library_item_updatesession_file_test.go
@@ -10,15 +10,108 @@ import (
 )
 
 func TestReadManifest(t *testing.T) {
-	mf := `SHA1(ttylinux-pc_i486-16.1.ovf)= 344a536fab6782622b6beb923798e84134bd4cbd
-SHA1(ttylinux-pc_i486-16.1-disk1.vmdk)= ed64564a37366bfe1c93af80e2ead0cbd398c3d3`
-
-	sums, err := ReadManifest(strings.NewReader(mf))
-	if err != nil {
-		t.Error(err)
+	tests := []struct {
+		name     string
+		manifest string
+		want     map[string]Checksum
+	}{
+		{
+			name:     "compact",
+			manifest: "SHA1(name.vmdk)= 344a536fab6782622b6beb923798e84134bd4cbd",
+			want: map[string]Checksum{
+				"name.vmdk": {
+					Algorithm: "SHA1",
+					Checksum:  "344a536fab6782622b6beb923798e84134bd4cbd",
+				},
+			},
+		},
+		{
+			name:     "spaced",
+			manifest: "SHA1(name.vmdk) = 344a536fab6782622b6beb923798e84134bd4cbd",
+			want: map[string]Checksum{
+				"name.vmdk": {
+					Algorithm: "SHA1",
+					Checksum:  "344a536fab6782622b6beb923798e84134bd4cbd",
+				},
+			},
+		},
+		{
+			name: "mixed multi-line",
+			manifest: `SHA1(ttylinux-pc_i486-16.1.ovf)= 344a536fab6782622b6beb923798e84134bd4cbd
+SHA1(ttylinux-pc_i486-16.1-disk1.vmdk) = ed64564a37366bfe1c93af80e2ead0cbd398c3d3`,
+			want: map[string]Checksum{
+				"ttylinux-pc_i486-16.1.ovf": {
+					Algorithm: "SHA1",
+					Checksum:  "344a536fab6782622b6beb923798e84134bd4cbd",
+				},
+				"ttylinux-pc_i486-16.1-disk1.vmdk": {
+					Algorithm: "SHA1",
+					Checksum:  "ed64564a37366bfe1c93af80e2ead0cbd398c3d3",
+				},
+			},
+		},
+		{
+			name:     "sha256",
+			manifest: "SHA256(name.ovf) = 7437f1b90e40ced4f27a33997c15028204b72eb3",
+			want: map[string]Checksum{
+				"name.ovf": {
+					Algorithm: "SHA256",
+					Checksum:  "7437f1b90e40ced4f27a33997c15028204b72eb3",
+				},
+			},
+		},
+		{
+			name:     "filename with parens",
+			manifest: "SHA256(foo (1).ovf)= 7437f1b90e40ced4f27a33997c15028204b72eb3",
+			want: map[string]Checksum{
+				"foo (1).ovf": {
+					Algorithm: "SHA256",
+					Checksum:  "7437f1b90e40ced4f27a33997c15028204b72eb3",
+				},
+			},
+		},
+		{
+			name:     "filename with equals",
+			manifest: "SHA1(foo=bar.vmdk)= 344a536fab6782622b6beb923798e84134bd4cbd",
+			want: map[string]Checksum{
+				"foo=bar.vmdk": {
+					Algorithm: "SHA1",
+					Checksum:  "344a536fab6782622b6beb923798e84134bd4cbd",
+				},
+			},
+		},
+		{
+			name: "blank and malformed lines",
+			manifest: `
+SHA1(name.vmdk = 344a536fab6782622b6beb923798e84134bd4cbd
+`,
+			want: map[string]Checksum{},
+		},
 	}
 
-	if len(sums) != 2 {
-		t.Error(err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sums, err := ReadManifest(strings.NewReader(tc.manifest))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(sums) != len(tc.want) {
+				t.Fatalf("len(sums) = %d; want %d", len(sums), len(tc.want))
+			}
+
+			for name, want := range tc.want {
+				got, ok := sums[name]
+				if !ok {
+					t.Fatalf("missing checksum for %q", name)
+				}
+				if got.Algorithm != want.Algorithm {
+					t.Errorf("Algorithm = %q; want %q", got.Algorithm, want.Algorithm)
+				}
+				if got.Checksum != want.Checksum {
+					t.Errorf("Checksum = %q; want %q", got.Checksum, want.Checksum)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`library.ReadManifest` parsed each OVF manifest (`.mf`) line by splitting on the literal `")="`. Manifests written with whitespace around the equals sign (`") = "`) therefore produced a single-element slice, every line was skipped, and the function returned an empty checksum map.

This change anchors the parse on the closing paren of the algorithm group and tolerates optional whitespace around the `=`, so both `SHA1(name.vmdk)= <hash>` and `SHA1(name.vmdk) = <hash>` parse identically.

## Why this matters

Issue #3893 reports that real-world manifests (e.g. from `wazuh` OVAs) use the spaced `) = ` form, which has no strict `.mf` spec forbidding it. The old parser silently dropped every entry for such manifests, yielding an empty map with no error, so downstream import/verification lost all checksums. The new parse also handles file names containing `)` or `=` (anchored on the last `)` before the separator), which the prior `")="` split could mishandle.

## Testing

Rewrote `TestReadManifest` into a table-driven test covering:
- compact `)=` form (regression guard)
- spaced `) = ` form (the bug)
- mixed multi-line manifest (compact + spaced)
- `SHA256` algorithm name preserved
- file name containing parentheses
- file name containing `=`
- blank and malformed (no `)`) lines skipped without error

`go test ./vapi/library/...`, `go vet ./vapi/library/...`, and `gofmt -l` all pass.

Fixes #3893

AI was used for assistance.
