### PR TITLE
vcsim: respect tag name for setCustomValueResponse

### DIFF
--- a/object/host_certificate_manager.go
+++ b/object/host_certificate_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -97,20 +98,24 @@ func (m HostCertificateManager) InstallServerCertificate(ctx context.Context, ce
 
 	// NotifyAffectedService is internal, not exposing as we don't have a use case other than with InstallServerCertificate
 	// Without this call, hostd needs to be restarted to use the updated certificate
-	// Note: using Refresh as it has the same struct/signature, we just need to use different xml name tags
-	body := struct {
-		Req *types.Refresh         `xml:"urn:vim25 NotifyAffectedServices,omitempty"`
-		Res *types.RefreshResponse `xml:"urn:vim25 NotifyAffectedServicesResponse,omitempty"`
-		methods.RefreshBody
-	}{
-		Req: &types.Refresh{This: m.Reference()},
-	}
+	var body notifyAffectedServicesBody
+	body.Req = &types.Refresh{This: m.Reference()}
 
 	err = m.Client().RoundTrip(ctx, &body, &body)
 	if err != nil && fault.Is(err, &types.MethodNotFound{}) {
 		return nil
 	}
 	return err
+}
+
+type notifyAffectedServicesBody struct {
+	Req    *types.Refresh         `xml:"urn:vim25 NotifyAffectedServices,omitempty"`
+	Res    *types.RefreshResponse `xml:"urn:vim25 NotifyAffectedServicesResponse,omitempty"`
+	Fault_ *soap.Fault            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *notifyAffectedServicesBody) Fault() *soap.Fault {
+	return b.Fault_
 }
 
 // ListCACertificateRevocationLists returns the SSL CRLs of Certificate Authorities that are trusted by the host system.

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -1179,3 +1179,7 @@ func (f *Folder) PlaceVmsXCluster(ctx *Context, req *types.PlaceVmsXCluster) soa
 	body.Fault_ = Fault("", &types.InvalidArgument{InvalidProperty: "placementType"})
 	return body
 }
+
+func (f *Folder) SetCustomValue(ctx *Context, req *types.SetCustomValue) soap.HasFault {
+	return SetCustomValue(ctx, req)
+}

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -382,26 +382,28 @@ func (r *response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	}
 
 	// Default response namespace
-	ns := "urn:" + r.Namespace
-	// Override namespace from struct tag if defined
-	field, _ := body.Type().FieldByName("Res")
-	if tag := field.Tag.Get("xml"); tag != "" {
-		tags := strings.Split(tag, " ")
-		if len(tags) > 0 && strings.HasPrefix(tags[0], "urn") {
-			ns = tags[0]
-		}
-	}
-
 	res := xml.StartElement{
 		Name: xml.Name{
-			Space: ns,
+			Space: "urn:" + r.Namespace,
 			Local: val.Elem().Type().Name(),
 		},
 	}
-	if err := e.EncodeToken(start); err != nil {
+
+	// Override element namespace/name with struct tag if defined
+	tinfo, err := xml.GetTypeInfo(body.Type())
+	if resTinfo, ok := tinfo.Fields["Res"]; ok {
+		if resTinfo.Name != "" {
+			res.Name.Local = resTinfo.Name
+		}
+		if resTinfo.Xmlns != "" {
+			res.Name.Space = resTinfo.Xmlns
+		}
+	}
+
+	if err = e.EncodeToken(start); err != nil {
 		return err
 	}
-	if err := e.EncodeElement(val.Interface(), res); err != nil {
+	if err = e.EncodeElement(val.Interface(), res); err != nil {
 		return err
 	}
 	return e.EncodeToken(start.End())

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -7,6 +7,8 @@ package types
 import (
 	"reflect"
 	"time"
+
+	"github.com/vmware/govmomi/vim25/xml"
 )
 
 type AbandonHciWorkflow AbandonHciWorkflowRequestType
@@ -101481,6 +101483,7 @@ func init() {
 }
 
 type SetCustomValueResponse struct {
+	XMLName xml.Name `xml:"setCustomValueResponse"`
 }
 
 type StartDpuFailover StartDpuFailoverRequestType

--- a/vim25/xml/marshal.go
+++ b/vim25/xml/marshal.go
@@ -424,7 +424,7 @@ var (
 
 // marshalValue writes one or more XML elements representing val.
 // If val was obtained from a struct field, finfo must have its details.
-func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplate *StartElement) error {
+func (p *printer) marshalValue(val reflect.Value, finfo *FieldInfo, startTemplate *StartElement) error {
 	if startTemplate != nil && startTemplate.Name.Local == "" {
 		return fmt.Errorf("xml: EncodeElement of StartElement with missing name")
 	}
@@ -481,7 +481,7 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 		return nil
 	}
 
-	tinfo, err := getTypeInfo(typ)
+	tinfo, err := GetTypeInfo(typ)
 	if err != nil {
 		return err
 	}
@@ -497,10 +497,10 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 	if startTemplate != nil {
 		start.Name = startTemplate.Name
 		start.Attr = append(start.Attr, startTemplate.Attr...)
-	} else if tinfo.xmlname != nil {
-		xmlname := tinfo.xmlname
-		if xmlname.name != "" {
-			start.Name.Space, start.Name.Local = xmlname.xmlns, xmlname.name
+	} else if tinfo.XmlName != nil {
+		xmlname := tinfo.XmlName
+		if xmlname.Name != "" {
+			start.Name.Space, start.Name.Local = xmlname.Xmlns, xmlname.Name
 		} else {
 			fv := xmlname.value(val, dontInitNilPointers)
 			if v, ok := fv.Interface().(Name); ok && v.Local != "" {
@@ -509,7 +509,7 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 		}
 	}
 	if start.Name.Local == "" && finfo != nil {
-		start.Name.Space, start.Name.Local = finfo.xmlns, finfo.name
+		start.Name.Space, start.Name.Local = finfo.Xmlns, finfo.Name
 	}
 	if start.Name.Local == "" {
 		name := typ.Name()
@@ -524,8 +524,8 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 	}
 
 	// Attributes
-	for i := range tinfo.fields {
-		finfo := &tinfo.fields[i]
+	for _, fname := range tinfo.FieldNames {
+		finfo := tinfo.Fields[fname]
 		if finfo.flags&fAttr == 0 {
 			continue
 		}
@@ -539,7 +539,7 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 			continue
 		}
 
-		name := Name{Space: finfo.xmlns, Local: finfo.name}
+		name := Name{Space: finfo.Xmlns, Local: finfo.Name}
 		if err := p.marshalAttr(&start, name, fv); err != nil {
 			return err
 		}
@@ -551,8 +551,8 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 	}
 
 	// If an empty name was found, namespace is overridden with an empty space
-	if tinfo.xmlname != nil && start.Name.Space == "" &&
-		tinfo.xmlname.xmlns == "" && tinfo.xmlname.name == "" &&
+	if tinfo.XmlName != nil && start.Name.Space == "" &&
+		tinfo.XmlName.Xmlns == "" && tinfo.XmlName.Name == "" &&
 		len(p.tags) != 0 && p.tags[len(p.tags)-1].Space != "" {
 		start.Attr = append(start.Attr, Attr{Name{"", xmlnsPrefix}, ""})
 	}
@@ -669,16 +669,16 @@ func (p *printer) marshalAttr(start *StartElement, name Name, val reflect.Value)
 
 // defaultStart returns the default start element to use,
 // given the reflect type, field info, and start template.
-func defaultStart(typ reflect.Type, finfo *fieldInfo, startTemplate *StartElement) StartElement {
+func defaultStart(typ reflect.Type, finfo *FieldInfo, startTemplate *StartElement) StartElement {
 	var start StartElement
 	// Precedence for the XML element name is as above,
 	// except that we do not look inside structs for the first field.
 	if startTemplate != nil {
 		start.Name = startTemplate.Name
 		start.Attr = append(start.Attr, startTemplate.Attr...)
-	} else if finfo != nil && finfo.name != "" {
-		start.Name.Local = finfo.name
-		start.Name.Space = finfo.xmlns
+	} else if finfo != nil && finfo.Name != "" {
+		start.Name.Local = finfo.Name
+		start.Name.Space = finfo.Xmlns
 	} else if typ.Name() != "" {
 		start.Name.Local = typ.Name()
 	} else {
@@ -842,10 +842,10 @@ func indirect(vf reflect.Value) reflect.Value {
 	return vf
 }
 
-func (p *printer) marshalStruct(tinfo *typeInfo, val reflect.Value) error {
+func (p *printer) marshalStruct(tinfo *TypeInfo, val reflect.Value) error {
 	s := parentStack{p: p}
-	for i := range tinfo.fields {
-		finfo := &tinfo.fields[i]
+	for _, fname := range tinfo.FieldNames {
+		finfo := tinfo.Fields[fname]
 		if finfo.flags&fAttr != 0 {
 			continue
 		}
@@ -989,7 +989,7 @@ func (p *printer) marshalStruct(tinfo *typeInfo, val reflect.Value) error {
 				}
 			}
 		}
-		if err := p.marshalValue(vf, finfo, nil); err != nil {
+		if err := p.marshalValue(vf, &finfo, nil); err != nil {
 			return err
 		}
 	}

--- a/vim25/xml/read.go
+++ b/vim25/xml/read.go
@@ -411,7 +411,7 @@ func (d *Decoder) unmarshal(val reflect.Value, start *StartElement, depth int) e
 		saveXMLData  []byte
 		saveAny      reflect.Value
 		sv           reflect.Value
-		tinfo        *typeInfo
+		tinfo        *TypeInfo
 		err          error
 	)
 
@@ -457,19 +457,19 @@ func (d *Decoder) unmarshal(val reflect.Value, start *StartElement, depth int) e
 		}
 
 		sv = v
-		tinfo, err = getTypeInfo(typ)
+		tinfo, err = GetTypeInfo(typ)
 		if err != nil {
 			return err
 		}
 
 		// Validate and assign element name.
-		if tinfo.xmlname != nil {
-			finfo := tinfo.xmlname
-			if finfo.name != "" && finfo.name != start.Name.Local {
-				return UnmarshalError("expected element type <" + finfo.name + "> but have <" + start.Name.Local + ">")
+		if tinfo.XmlName != nil {
+			finfo := tinfo.XmlName
+			if finfo.Name != "" && finfo.Name != start.Name.Local {
+				return UnmarshalError("expected element type <" + finfo.Name + "> but have <" + start.Name.Local + ">")
 			}
-			if finfo.xmlns != "" && finfo.xmlns != start.Name.Space {
-				e := "expected element <" + finfo.name + "> in name space " + finfo.xmlns + " but have "
+			if finfo.Xmlns != "" && finfo.Xmlns != start.Name.Space {
+				e := "expected element <" + finfo.Name + "> in name space " + finfo.Xmlns + " but have "
 				if start.Name.Space == "" {
 					e += "no name space"
 				} else {
@@ -486,13 +486,13 @@ func (d *Decoder) unmarshal(val reflect.Value, start *StartElement, depth int) e
 		// Assign attributes.
 		for _, a := range start.Attr {
 			handled := false
-			any := -1
-			for i := range tinfo.fields {
-				finfo := &tinfo.fields[i]
+			any := ""
+			for _, name := range tinfo.FieldNames {
+				finfo := tinfo.Fields[name]
 				switch finfo.flags & fMode {
 				case fAttr:
 					strv := finfo.value(sv, initNilPointers)
-					if a.Name.Local == finfo.name && (finfo.xmlns == "" || finfo.xmlns == a.Name.Space) {
+					if a.Name.Local == finfo.Name && (finfo.Xmlns == "" || finfo.Xmlns == a.Name.Space) {
 						needTypeAttr := (finfo.flags & fTypeAttr) != 0
 						// HACK: avoid using xsi:type value for a "type" attribute, such as ManagedObjectReference.Type for example.
 						if needTypeAttr || (a.Name != xmlSchemaInstance && a.Name != xsiType) {
@@ -504,13 +504,13 @@ func (d *Decoder) unmarshal(val reflect.Value, start *StartElement, depth int) e
 					}
 
 				case fAny | fAttr:
-					if any == -1 {
-						any = i
+					if any == "" {
+						any = name
 					}
 				}
 			}
-			if !handled && any >= 0 {
-				finfo := &tinfo.fields[any]
+			if !handled && any != "" {
+				finfo := tinfo.Fields[any]
 				strv := finfo.value(sv, initNilPointers)
 				if err := d.unmarshalAttr(strv, a); err != nil {
 					return err
@@ -519,8 +519,8 @@ func (d *Decoder) unmarshal(val reflect.Value, start *StartElement, depth int) e
 		}
 
 		// Determine whether we need to save character data or comments.
-		for i := range tinfo.fields {
-			finfo := &tinfo.fields[i]
+		for _, name := range tinfo.FieldNames {
+			finfo := tinfo.Fields[name]
 			switch finfo.flags & fMode {
 			case fCDATA, fCharData:
 				if !saveData.IsValid() {
@@ -742,12 +742,12 @@ func copyValue(dst reflect.Value, src []byte) (err error) {
 // The consumed result tells whether XML elements have been consumed
 // from the Decoder until start's matching end element, or if it's
 // still untouched because start is uninteresting for sv's fields.
-func (d *Decoder) unmarshalPath(tinfo *typeInfo, sv reflect.Value, parents []string, start *StartElement, depth int) (consumed bool, err error) {
+func (d *Decoder) unmarshalPath(tinfo *TypeInfo, sv reflect.Value, parents []string, start *StartElement, depth int) (consumed bool, err error) {
 	recurse := false
 Loop:
-	for i := range tinfo.fields {
-		finfo := &tinfo.fields[i]
-		if finfo.flags&fElement == 0 || len(finfo.parents) < len(parents) || finfo.xmlns != "" && finfo.xmlns != start.Name.Space {
+	for _, name := range tinfo.FieldNames {
+		finfo := tinfo.Fields[name]
+		if finfo.flags&fElement == 0 || len(finfo.parents) < len(parents) || finfo.Xmlns != "" && finfo.Xmlns != start.Name.Space {
 			continue
 		}
 		for j := range parents {
@@ -755,7 +755,7 @@ Loop:
 				continue Loop
 			}
 		}
-		if len(finfo.parents) == len(parents) && finfo.name == start.Name.Local {
+		if len(finfo.parents) == len(parents) && finfo.Name == start.Name.Local {
 			// It's a perfect match, unmarshal the field.
 			return true, d.unmarshal(finfo.value(sv, initNilPointers), start, depth+1)
 		}

--- a/vim25/xml/typeinfo.go
+++ b/vim25/xml/typeinfo.go
@@ -11,17 +11,18 @@ import (
 	"sync"
 )
 
-// typeInfo holds details for the xml representation of a type.
-type typeInfo struct {
-	xmlname *fieldInfo
-	fields  []fieldInfo
+// TypeInfo holds details for the xml representation of a type.
+type TypeInfo struct {
+	XmlName    *FieldInfo
+	Fields     map[string]FieldInfo
+	FieldNames []string
 }
 
-// fieldInfo holds details for the xml representation of a single field.
-type fieldInfo struct {
+// FieldInfo holds details for the xml representation of a single field.
+type FieldInfo struct {
+	Name    string
+	Xmlns   string
 	idx     []int
-	name    string
-	xmlns   string
 	flags   fieldFlags
 	parents []string
 }
@@ -45,18 +46,20 @@ const (
 	xmlName = "XMLName"
 )
 
-var tinfoMap sync.Map // map[reflect.Type]*typeInfo
+var tinfoMap sync.Map // map[reflect.Type]*TypeInfo
 
 var nameType = reflect.TypeFor[Name]()
 
-// getTypeInfo returns the typeInfo structure with details necessary
+// GetTypeInfo returns the TypeInfo structure with details necessary
 // for marshaling and unmarshaling typ.
-func getTypeInfo(typ reflect.Type) (*typeInfo, error) {
+func GetTypeInfo(typ reflect.Type) (*TypeInfo, error) {
 	if ti, ok := tinfoMap.Load(typ); ok {
-		return ti.(*typeInfo), nil
+		return ti.(*TypeInfo), nil
 	}
 
-	tinfo := &typeInfo{}
+	tinfo := &TypeInfo{
+		Fields: make(map[string]FieldInfo),
+	}
 	if typ.Kind() == reflect.Struct && typ != nameType {
 		n := typ.NumField()
 		for i := 0; i < n; i++ {
@@ -72,14 +75,15 @@ func getTypeInfo(typ reflect.Type) (*typeInfo, error) {
 					t = t.Elem()
 				}
 				if t.Kind() == reflect.Struct {
-					inner, err := getTypeInfo(t)
+					inner, err := GetTypeInfo(t)
 					if err != nil {
 						return nil, err
 					}
-					if tinfo.xmlname == nil {
-						tinfo.xmlname = inner.xmlname
+					if tinfo.XmlName == nil {
+						tinfo.XmlName = inner.XmlName
 					}
-					for _, finfo := range inner.fields {
+					for _, name := range inner.FieldNames {
+						finfo := inner.Fields[name]
 						finfo.idx = append([]int{i}, finfo.idx...)
 						if err := addFieldInfo(typ, tinfo, &finfo); err != nil {
 							return nil, err
@@ -95,7 +99,7 @@ func getTypeInfo(typ reflect.Type) (*typeInfo, error) {
 			}
 
 			if f.Name == xmlName {
-				tinfo.xmlname = finfo
+				tinfo.XmlName = finfo
 				continue
 			}
 
@@ -107,17 +111,17 @@ func getTypeInfo(typ reflect.Type) (*typeInfo, error) {
 	}
 
 	ti, _ := tinfoMap.LoadOrStore(typ, tinfo)
-	return ti.(*typeInfo), nil
+	return ti.(*TypeInfo), nil
 }
 
-// structFieldInfo builds and returns a fieldInfo for f.
-func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, error) {
-	finfo := &fieldInfo{idx: f.Index}
+// structFieldInfo builds and returns a FieldInfo for f.
+func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*FieldInfo, error) {
+	finfo := &FieldInfo{idx: f.Index}
 
 	// Split the tag from the xml namespace if necessary.
 	tag := f.Tag.Get("xml")
 	if ns, t, ok := strings.Cut(tag, " "); ok {
-		finfo.xmlns, tag = ns, t
+		finfo.Xmlns, tag = ns, t
 	}
 
 	// Parse flags.
@@ -173,7 +177,7 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 	}
 
 	// Use of xmlns without a name is not allowed.
-	if finfo.xmlns != "" && tag == "" {
+	if finfo.Xmlns != "" && tag == "" {
 		return nil, fmt.Errorf("xml: namespace without name in field %s of type %s: %q",
 			f.Name, typ, f.Tag.Get("xml"))
 	}
@@ -182,7 +186,7 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 		// The XMLName field records the XML element name. Don't
 		// process it as usual because its name should default to
 		// empty rather than to the field name.
-		finfo.name = tag
+		finfo.Name = tag
 		return finfo, nil
 	}
 
@@ -191,9 +195,9 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 		// default from XMLName of underlying struct if feasible,
 		// or field name otherwise.
 		if xmlname := lookupXMLName(f.Type); xmlname != nil {
-			finfo.xmlns, finfo.name = xmlname.xmlns, xmlname.name
+			finfo.Xmlns, finfo.Name = xmlname.Xmlns, xmlname.Name
 		} else {
-			finfo.name = f.Name
+			finfo.Name = f.Name
 		}
 		return finfo, nil
 	}
@@ -206,7 +210,7 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 	if parents[len(parents)-1] == "" {
 		return nil, fmt.Errorf("xml: trailing '>' in field %s of type %s", f.Name, typ)
 	}
-	finfo.name = parents[len(parents)-1]
+	finfo.Name = parents[len(parents)-1]
 	if len(parents) > 1 {
 		if (finfo.flags & fElement) == 0 {
 			return nil, fmt.Errorf("xml: %s chain not valid with %s flag", tag, strings.Join(tokens[1:], ","))
@@ -220,18 +224,18 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 	if finfo.flags&fElement != 0 {
 		ftyp := f.Type
 		xmlname := lookupXMLName(ftyp)
-		if xmlname != nil && xmlname.name != finfo.name {
+		if xmlname != nil && xmlname.Name != finfo.Name {
 			return nil, fmt.Errorf("xml: name %q in tag of %s.%s conflicts with name %q in %s.XMLName",
-				finfo.name, typ, f.Name, xmlname.name, ftyp)
+				finfo.Name, typ, f.Name, xmlname.Name, ftyp)
 		}
 	}
 	return finfo, nil
 }
 
-// lookupXMLName returns the fieldInfo for typ's XMLName field
+// lookupXMLName returns the FieldInfo for typ's XMLName field
 // in case it exists and has a valid xml field tag, otherwise
 // it returns nil.
-func lookupXMLName(typ reflect.Type) (xmlname *fieldInfo) {
+func lookupXMLName(typ reflect.Type) (xmlname *FieldInfo) {
 	for typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
@@ -244,7 +248,7 @@ func lookupXMLName(typ reflect.Type) (xmlname *fieldInfo) {
 			continue
 		}
 		finfo, err := structFieldInfo(typ, &f)
-		if err == nil && finfo.name != "" {
+		if err == nil && finfo.Name != "" {
 			return finfo
 		}
 		// Also consider errors as a non-existent field tag
@@ -261,16 +265,16 @@ func lookupXMLName(typ reflect.Type) (xmlname *fieldInfo) {
 // A conflict occurs when the path (parent + name) to a field is
 // itself a prefix of another path, or when two paths match exactly.
 // It is okay for field paths to share a common, shorter prefix.
-func addFieldInfo(typ reflect.Type, tinfo *typeInfo, newf *fieldInfo) error {
-	var conflicts []int
+func addFieldInfo(typ reflect.Type, tinfo *TypeInfo, newf *FieldInfo) error {
+	var conflicts []string
 Loop:
 	// First, figure all conflicts. Most working code will have none.
-	for i := range tinfo.fields {
-		oldf := &tinfo.fields[i]
+	for _, name := range tinfo.FieldNames {
+		oldf := tinfo.Fields[name]
 		if oldf.flags&fMode != newf.flags&fMode {
 			continue
 		}
-		if oldf.xmlns != "" && newf.xmlns != "" && oldf.xmlns != newf.xmlns {
+		if oldf.Xmlns != "" && newf.Xmlns != "" && oldf.Xmlns != newf.Xmlns {
 			continue
 		}
 		minl := min(len(newf.parents), len(oldf.parents))
@@ -280,36 +284,40 @@ Loop:
 			}
 		}
 		if len(oldf.parents) > len(newf.parents) {
-			if oldf.parents[len(newf.parents)] == newf.name {
-				conflicts = append(conflicts, i)
+			if oldf.parents[len(newf.parents)] == newf.Name {
+				conflicts = append(conflicts, name)
 			}
 		} else if len(oldf.parents) < len(newf.parents) {
-			if newf.parents[len(oldf.parents)] == oldf.name {
-				conflicts = append(conflicts, i)
+			if newf.parents[len(oldf.parents)] == oldf.Name {
+				conflicts = append(conflicts, name)
 			}
 		} else {
-			if newf.name == oldf.name && newf.xmlns == oldf.xmlns {
-				conflicts = append(conflicts, i)
+			if newf.Name == oldf.Name && newf.Xmlns == oldf.Xmlns {
+				conflicts = append(conflicts, name)
 			}
 		}
 	}
+
+	newName := typ.FieldByIndex(newf.idx).Name
+
 	// Without conflicts, add the new field and return.
 	if conflicts == nil {
-		tinfo.fields = append(tinfo.fields, *newf)
+		tinfo.Fields[newName] = *newf
+		tinfo.FieldNames = append(tinfo.FieldNames, newName)
 		return nil
 	}
 
 	// If any conflict is shallower, ignore the new field.
 	// This matches the Go field resolution on embedding.
-	for _, i := range conflicts {
-		if len(tinfo.fields[i].idx) < len(newf.idx) {
+	for _, name := range conflicts {
+		if len(tinfo.Fields[name].idx) < len(newf.idx) {
 			return nil
 		}
 	}
 
 	// Otherwise, if any of them is at the same depth level, it's an error.
-	for _, i := range conflicts {
-		oldf := &tinfo.fields[i]
+	for _, name := range conflicts {
+		oldf := tinfo.Fields[name]
 		if len(oldf.idx) == len(newf.idx) {
 			f1 := typ.FieldByIndex(oldf.idx)
 			f2 := typ.FieldByIndex(newf.idx)
@@ -318,13 +326,21 @@ Loop:
 	}
 
 	// Otherwise, the new field is shallower, and thus takes precedence,
-	// so drop the conflicting fields from tinfo and append the new one.
-	for c := len(conflicts) - 1; c >= 0; c-- {
-		i := conflicts[c]
-		copy(tinfo.fields[i:], tinfo.fields[i+1:])
-		tinfo.fields = tinfo.fields[:len(tinfo.fields)-1]
+	// so drop the conflicting fields from tinfo and add the new one.
+	for _, name := range conflicts {
+		delete(tinfo.Fields, name)
 	}
-	tinfo.fields = append(tinfo.fields, *newf)
+
+	newNames := make([]string, 0, len(tinfo.FieldNames))
+	for _, name := range tinfo.FieldNames {
+		if _, ok := tinfo.Fields[name]; ok {
+			newNames = append(newNames, name)
+		}
+	}
+	tinfo.FieldNames = newNames
+
+	tinfo.Fields[newName] = *newf
+	tinfo.FieldNames = append(tinfo.FieldNames, newName)
 	return nil
 }
 
@@ -350,7 +366,7 @@ const (
 // initNilPointers, it initializes and dereferences pointers as necessary.
 // When passed dontInitNilPointers and a nil pointer is reached, the function
 // returns a zero reflect.Value.
-func (finfo *fieldInfo) value(v reflect.Value, shouldInitNilPointers bool) reflect.Value {
+func (finfo *FieldInfo) value(v reflect.Value, shouldInitNilPointers bool) reflect.Value {
 	for i, x := range finfo.idx {
 		if i > 0 {
 			t := v.Type()


### PR DESCRIPTION
## Description

- Expose `GetTypeInfo` utility to reflect the XML namespace/tag names
- Respect the tag name specified in response bodies passed to `MarshalXML`
- Add support for custom values in folders

Fixes #4038.

## How Has This Been Tested?

To test this, the `setCustomValue` SOAP method must be called directly on a folder.

