### PR TITLE
simulator: add SubnetId and SubnetInfo support

### DIFF
--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -92,6 +92,7 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.Add
 				VmVnicNetworkResourcePoolKey: spec.VmVnicNetworkResourcePoolKey,
 				LogicalSwitchUuid:            spec.LogicalSwitchUuid,
 				SegmentId:                    spec.SegmentId,
+				SubnetId:                     spec.SubnetId,
 				BackingType:                  spec.BackingType,
 			}
 

--- a/simulator/environment_browser.go
+++ b/simulator/environment_browser.go
@@ -244,6 +244,7 @@ func (b *EnvironmentBrowser) QueryConfigTarget(ctx *Context, req *types.QueryCon
 	}
 
 	seen := make(map[types.ManagedObjectReference]bool)
+	seenSubnets := make(map[string]bool)
 
 	for i := range hosts {
 		host := ctx.Map.Get(hosts[i]).(*HostSystem)
@@ -294,7 +295,24 @@ func (b *EnvironmentBrowser) QueryConfigTarget(ctx *Context, req *types.QueryCon
 					UplinkPortgroup:             false,
 					Portgroup:                   n.Self,
 					NetworkReservationSupported: types.NewBool(false),
+					SubnetId:                    n.Config.SubnetId,
 				})
+
+				if n.Config.SubnetId != "" && !seenSubnets[n.Config.SubnetId] {
+					seenSubnets[n.Config.SubnetId] = true
+					target.SubnetInfo = append(target.SubnetInfo, types.SubnetInfo{
+						Id: n.Config.SubnetId,
+						SubnetFolderInfo: types.SubnetInfoFolderInfo{
+							Name: "Subnet Folder",
+						},
+						VpcFolderInfo: types.SubnetInfoFolderInfo{
+							Name: "VPC Folder",
+						},
+						RootFolderInfo: types.SubnetInfoFolderInfo{
+							Name: "Root Folder",
+						},
+					})
+				}
 			case *DistributedVirtualSwitch:
 				target.DistributedVirtualSwitch = append(target.DistributedVirtualSwitch, types.DistributedVirtualSwitchInfo{
 					SwitchName:                  n.Name,

--- a/simulator/portgroup.go
+++ b/simulator/portgroup.go
@@ -51,6 +51,7 @@ func (s *DistributedVirtualPortgroup) ReconfigureDVPortgroupTask(ctx *Context, r
 		s.Config.PortNameFormat = req.Spec.PortNameFormat
 		s.Config.VmVnicNetworkResourcePoolKey = req.Spec.VmVnicNetworkResourcePoolKey
 		s.Config.LogicalSwitchUuid = req.Spec.LogicalSwitchUuid
+		s.Config.SubnetId = req.Spec.SubnetId
 		s.Config.BackingType = req.Spec.BackingType
 
 		return nil, nil

--- a/simulator/portgroup_test.go
+++ b/simulator/portgroup_test.go
@@ -145,3 +145,190 @@ func TestPortgroupBackingWithNSX(t *testing.T) {
 		}
 	}, model)
 }
+
+func TestPortgroupSubnetId(t *testing.T) {
+	m := VPX()
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer m.Remove()
+
+	c := m.Service.client()
+	ctx := m.Service.Context
+
+	dvs := object.NewDistributedVirtualSwitch(c,
+		ctx.Map.Any("DistributedVirtualSwitch").Reference())
+
+	spec := []types.DVPortgroupConfigSpec{
+		{
+			Name:     "subnet-pg",
+			NumPorts: 10,
+			SubnetId: "subnet-12345",
+		},
+	}
+
+	task, err := dvs.AddPortgroup(ctx, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Find the network folder from the datacenter to search for the portgroup
+	dc := ctx.Map.Any("Datacenter").(*Datacenter)
+	netFolderRef := dc.NetworkFolder
+	netFolder := ctx.Map.Get(netFolderRef).(*Folder)
+	pgRef := ctx.Map.FindByName("subnet-pg", netFolder.ChildEntity)
+	if pgRef == nil {
+		t.Fatal("subnet-pg portgroup not found")
+	}
+
+	pge := ctx.Map.Get(pgRef.Reference()).(*DistributedVirtualPortgroup)
+	if pge.Config.SubnetId != "subnet-12345" {
+		t.Fatalf("expected pg SubnetId==subnet-12345; got %q", pge.Config.SubnetId)
+	}
+
+	// Reconfigure the SubnetId
+	pg := object.NewDistributedVirtualPortgroup(c, pgRef.Reference())
+	pgspec := types.DVPortgroupConfigSpec{
+		Name:     "subnet-pg",
+		SubnetId: "subnet-67890",
+	}
+
+	task, err = pg.Reconfigure(ctx, pgspec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pge.Config.SubnetId != "subnet-67890" {
+		t.Fatalf("expected reconfigured pg SubnetId==subnet-67890; got %q", pge.Config.SubnetId)
+	}
+
+	// Now query config target via environment browser to check SubnetInfo
+	vm := ctx.Map.Any("VirtualMachine").(*VirtualMachine)
+	browser := object.NewEnvironmentBrowser(c, vm.EnvironmentBrowser)
+
+	target, err := browser.QueryConfigTarget(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foundSubnet := false
+	for _, subnet := range target.SubnetInfo {
+		if subnet.Id == "subnet-67890" {
+			foundSubnet = true
+			break
+		}
+	}
+
+	if !foundSubnet {
+		t.Error("expected subnet-67890 in QueryConfigTarget SubnetInfo")
+	}
+
+	foundPGSubnet := false
+	for _, pgInfo := range target.DistributedVirtualPortgroup {
+		if pgInfo.PortgroupKey == pge.Key && pgInfo.SubnetId == "subnet-67890" {
+			foundPGSubnet = true
+			break
+		}
+	}
+
+	if !foundPGSubnet {
+		t.Error("expected portgroup to have SubnetId==subnet-67890 in QueryConfigTarget")
+	}
+
+	// Now test virtual machine ethernet card inheriting SubnetId
+	// Add an ethernet card backing to the newly created portgroup
+	backing, err := pg.EthernetCardBackingInfo(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientVM := object.NewVirtualMachine(c, vm.Reference())
+
+	devices, err := clientVM.Device(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	card, err := devices.CreateEthernetCard("vmxnet3", backing)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = clientVM.AddDevice(ctx, card)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Retrieve devices again and check if SubnetId was inherited from the portgroup
+	devices, err = clientVM.Device(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cards := devices.SelectByType((*types.VirtualEthernetCard)(nil))
+	foundInheritedSubnet := false
+	for _, dev := range cards {
+		nic := dev.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+		if nic.SubnetId == "subnet-67890" {
+			foundInheritedSubnet = true
+			break
+		}
+	}
+
+	if !foundInheritedSubnet {
+		t.Error("expected newly added VirtualEthernetCard to inherit SubnetId from its portgroup backing")
+	}
+
+	// Now test creating an ethernet card specifying ONLY SubnetId and NO backing
+	devices, err = clientVM.Device(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a raw VirtualVmxnet3 card without specifying a backing, but setting SubnetId
+	rawCard := &types.VirtualVmxnet3{}
+	rawCard.SubnetId = "subnet-67890"
+
+	err = clientVM.AddDevice(ctx, rawCard)
+	if err != nil {
+		t.Fatalf("failed to add device with only SubnetId: %s", err)
+	}
+
+	// Retrieve devices again to check if vCenter resolved and populated the backing
+	devices, err = clientVM.Device(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cards = devices.SelectByType((*types.VirtualEthernetCard)(nil))
+	foundAutoResolvedBacking := false
+	for _, dev := range cards {
+		nic := dev.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+		if nic.SubnetId == "subnet-67890" && nic.Backing != nil {
+			// Check if the backing points to our portgroup
+			if b, ok := nic.Backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo); ok {
+				if b.Port.PortgroupKey == pge.Key {
+					foundAutoResolvedBacking = true
+					break
+				}
+			}
+		}
+	}
+
+	if !foundAutoResolvedBacking {
+		t.Error("expected VirtualEthernetCard with only SubnetId to auto-resolve its backing to the matching Portgroup")
+	}
+}

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1428,6 +1428,32 @@ func (vm *VirtualMachine) configureDevice(
 		var net types.ManagedObjectReference
 		var name string
 
+		if card := x.GetVirtualEthernetCard(); card.SubnetId != "" && d.Backing == nil {
+			var dvpg *DistributedVirtualPortgroup
+
+			var find func(types.ManagedObjectReference)
+			find = func(child types.ManagedObjectReference) {
+				d, ok := ctx.Map.Get(child).(*DistributedVirtualPortgroup)
+				if ok && d.Config.SubnetId == card.SubnetId {
+					dvpg = d
+					return
+				}
+				walk(ctx.Map.Get(child), find)
+			}
+			f := ctx.Map.getEntityDatacenter(vm).NetworkFolder
+			walk(ctx.Map.Get(f), find) // search in NetworkFolder and any sub folders
+
+			if dvpg != nil {
+				dvs := ctx.Map.Get(*dvpg.Config.DistributedVirtualSwitch).(*DistributedVirtualSwitch)
+				d.Backing = &types.VirtualEthernetCardDistributedVirtualPortBackingInfo{
+					Port: types.DistributedVirtualSwitchPortConnection{
+						PortgroupKey: dvpg.Key,
+						SwitchUuid:   dvs.Uuid,
+					},
+				}
+			}
+		}
+
 		if b, ok := d.Backing.(*types.VirtualEthernetCardOpaqueNetworkBackingInfo); ok &&
 			b.OpaqueNetworkType == "nsx.LogicalSwitch" {
 
@@ -1481,6 +1507,12 @@ func (vm *VirtualMachine) configureDevice(
 			net.Value = b.Port.PortgroupKey
 			if err := vm.validateSwitchMembers(ctx, b.Port.SwitchUuid); err != nil {
 				return err
+			}
+			pgRef := types.ManagedObjectReference{Type: "DistributedVirtualPortgroup", Value: b.Port.PortgroupKey}
+			if pgObj := ctx.Map.Get(pgRef); pgObj != nil {
+				if pg, ok := pgObj.(*DistributedVirtualPortgroup); ok {
+					x.GetVirtualEthernetCard().SubnetId = pg.Config.SubnetId
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
This PR implements support for `SubnetId` on `VirtualEthernetCard` and `DistributedVirtualPortgroup` in `vcsim` (vCenter Simulator). It also adds `SubnetInfo` and updated portgroup info inside `QueryConfigTarget` of the `EnvironmentBrowser`.

## Test Plan
Added a comprehensive integration test `TestPortgroupSubnetId` in `simulator/portgroup_test.go` verifying the entire lifecycle (adding portgroup with SubnetId, reconfiguring it, querying it via EnvironmentBrowser, and card inheritance).