### PR TITLE
vcsim: support parsing both xs: and xsd: type prefixes

### DIFF
--- a/vim25/soap/soap_test.go
+++ b/vim25/soap/soap_test.go
@@ -5,8 +5,10 @@
 package soap
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vim25/xml"
 )
 
@@ -47,5 +49,61 @@ func TestNonEmptyHeader(t *testing.T) {
 
 	if env.Header.ID != "foo" {
 		t.Errorf("ID=%s", env.Header.ID)
+	}
+}
+
+func TestDecodeEnvelopeWithXsPrefix(t *testing.T) {
+	data := []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        <ReconfigVM_Task xmlns="urn:vim25" xmlns:ns2="urn:vsan">
+            <_this type="VirtualMachine">vm-1518</_this>
+            <spec>
+                <extraConfig>
+                    <key>SET.guest.customizationInfo.customizationStatus</key>
+                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:string">TEST_STATUS</value>
+                </extraConfig>
+            </spec>
+        </ReconfigVM_Task>
+    </soap:Body>
+</soap:Envelope>`)
+
+	var req types.ReconfigVM_Task
+	var body struct {
+		Req *types.ReconfigVM_Task `xml:"urn:vim25 ReconfigVM_Task"`
+	}
+	body.Req = &req
+	env := Envelope{Body: &body}
+
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	dec.TypeFunc = types.TypeFunc()
+	err := dec.Decode(&env)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(req.Spec.ExtraConfig) == 0 {
+		t.Fatal("ExtraConfig is empty")
+	}
+
+	opt := req.Spec.ExtraConfig[0].GetOptionValue()
+	if opt == nil {
+		t.Fatal("ExtraConfig element is not an OptionValue")
+	}
+
+	if opt.Key != "SET.guest.customizationInfo.customizationStatus" {
+		t.Errorf("Unexpected key: %s", opt.Key)
+	}
+
+	if opt.Value == nil {
+		t.Fatal("Value is nil")
+	}
+
+	val, ok := opt.Value.(string)
+	if !ok {
+		t.Fatalf("Unexpected value type: %T (expected string)", opt.Value)
+	}
+
+	if val != "TEST_STATUS" {
+		t.Errorf("Unexpected value: %s", val)
 	}
 }

--- a/vim25/types/base_test.go
+++ b/vim25/types/base_test.go
@@ -28,6 +28,10 @@ func TestAnyType(t *testing.T) {
 			Value: "test",
 		},
 		{
+			Input: x(`<name xsi:type="xs:string" xmlns:xs="http://www.w3.org/2001/XMLSchema">test</name>`),
+			Value: "test",
+		},
+		{
 			Input: x(`<name xsi:type="ArrayOfString"><string>AA</string><string>BB</string></name>`),
 			Value: ArrayOfString{String: []string{"AA", "BB"}},
 		},

--- a/vim25/xml/extras.go
+++ b/vim25/xml/extras.go
@@ -6,6 +6,7 @@ package xml
 
 import (
 	"reflect"
+	"strings"
 	"time"
 )
 
@@ -14,24 +15,29 @@ var xmlSchemaInstance = Name{Space: "http://www.w3.org/2001/XMLSchema-instance",
 var xsiType = Name{Space: "xsi", Local: "type"}
 
 var stringToTypeMap = map[string]reflect.Type{
-	"xsd:boolean":       reflect.TypeOf((*bool)(nil)).Elem(),
-	"xsd:byte":          reflect.TypeOf((*int8)(nil)).Elem(),
-	"xsd:short":         reflect.TypeOf((*int16)(nil)).Elem(),
-	"xsd:int":           reflect.TypeOf((*int32)(nil)).Elem(),
-	"xsd:long":          reflect.TypeOf((*int64)(nil)).Elem(),
-	"xsd:unsignedByte":  reflect.TypeOf((*uint8)(nil)).Elem(),
-	"xsd:unsignedShort": reflect.TypeOf((*uint16)(nil)).Elem(),
-	"xsd:unsignedInt":   reflect.TypeOf((*uint32)(nil)).Elem(),
-	"xsd:unsignedLong":  reflect.TypeOf((*uint64)(nil)).Elem(),
-	"xsd:float":         reflect.TypeOf((*float32)(nil)).Elem(),
-	"xsd:double":        reflect.TypeOf((*float64)(nil)).Elem(),
-	"xsd:string":        reflect.TypeOf((*string)(nil)).Elem(),
-	"xsd:dateTime":      reflect.TypeOf((*time.Time)(nil)).Elem(),
-	"xsd:base64Binary":  reflect.TypeOf((*[]byte)(nil)).Elem(),
+	"boolean":       reflect.TypeOf((*bool)(nil)).Elem(),
+	"byte":          reflect.TypeOf((*int8)(nil)).Elem(),
+	"short":         reflect.TypeOf((*int16)(nil)).Elem(),
+	"int":           reflect.TypeOf((*int32)(nil)).Elem(),
+	"long":          reflect.TypeOf((*int64)(nil)).Elem(),
+	"unsignedByte":  reflect.TypeOf((*uint8)(nil)).Elem(),
+	"unsignedShort": reflect.TypeOf((*uint16)(nil)).Elem(),
+	"unsignedInt":   reflect.TypeOf((*uint32)(nil)).Elem(),
+	"unsignedLong":  reflect.TypeOf((*uint64)(nil)).Elem(),
+	"float":         reflect.TypeOf((*float32)(nil)).Elem(),
+	"double":        reflect.TypeOf((*float64)(nil)).Elem(),
+	"string":        reflect.TypeOf((*string)(nil)).Elem(),
+	"dateTime":      reflect.TypeOf((*time.Time)(nil)).Elem(),
+	"base64Binary":  reflect.TypeOf((*[]byte)(nil)).Elem(),
 }
 
 // Return a reflect.Type for the specified type. Nil if unknown.
 func stringToType(s string) reflect.Type {
+	if strings.HasPrefix(s, "xs:") {
+		s = s[3:]
+	} else if strings.HasPrefix(s, "xsd:") {
+		s = s[4:]
+	}
 	return stringToTypeMap[s]
 }
 
@@ -67,7 +73,7 @@ func typeToString(typ reflect.Type) string {
 		}
 		return name
 	case reflect.Struct:
-		if typ == stringToTypeMap["xsd:dateTime"] {
+		if typ == stringToTypeMap["dateTime"] {
 			return "xsd:dateTime"
 		}
 


### PR DESCRIPTION
## Description

Update XML parser to support the`xs:` type prefix used by the Java SDK.

Closes: #4041 

