### PR TITLE
add host-local storage support to CnsVolumeCreateSpec and CnsPlacementResult

### DIFF
--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -32,6 +32,7 @@ import (
 const VSphere70u3VersionInt = 703
 const VSphere80u3VersionInt = 803
 const VSphere91VersionInt = 910
+const VSphere912VersionInt = 912
 const VSphere92VersionInt = 920
 
 func TestClient(t *testing.T) {
@@ -61,6 +62,7 @@ func TestClient(t *testing.T) {
 
 	// set CNS_RUN_HOST_LOCAL_STORAGE_TESTS to true to run host-local datastore volume creation tests.
 	// The SPBM policy (CNS_SPBM_PROFILE_NAME) must have the hostLocalStorage capability.
+	// This test is applicable for vCenter 9.1.2 and above.
 	// example: export CNS_RUN_HOST_LOCAL_STORAGE_TESTS='true'
 	run_host_local_storage_tests := os.Getenv("CNS_RUN_HOST_LOCAL_STORAGE_TESTS")
 
@@ -198,7 +200,7 @@ func TestClient(t *testing.T) {
 				ProfileId: storagePolicyID,
 			},
 		}
-	} else if run_host_local_storage_tests == "true" {
+	} else if run_host_local_storage_tests == "true" && isvSphereVersion912orAbove(ctx, c.ServiceContent.About) {
 		hostSystems, err := finder.HostSystemList(ctx, "*")
 		if err != nil {
 			t.Fatal(err)
@@ -279,7 +281,7 @@ func TestClient(t *testing.T) {
 		}
 	}
 
-	if run_host_local_storage_tests == "true" {
+	if run_host_local_storage_tests == "true" && isvSphereVersion912orAbove(ctx, c.ServiceContent.About) {
 		if volumeCreateResult.PlacementResults[0].Host == nil {
 			t.Fatalf("host in the placement result cannot be nil for host-local storage. "+
 				"volumeCreateResult.PlacementResults :%q", pretty.Sprint(volumeCreateResult.PlacementResults))
@@ -2552,6 +2554,23 @@ func isvSphereVersion91orAbove(ctx context.Context, aboutInfo vim25types.AboutIn
 		}
 	}
 	// For all other versions
+	return false
+}
+
+// isvSphereVersion912orAbove checks if specified version is 9.1.2 or higher.
+// Host-local storage support in CNS was introduced in vCenter 9.1.2.
+func isvSphereVersion912orAbove(ctx context.Context, aboutInfo vim25types.AboutInfo) bool {
+	items := strings.Split(aboutInfo.Version, ".")
+	version := strings.Join(items[:], "")
+	if len(version) >= 3 {
+		vSphereVersionInt, err := strconv.Atoi(version[0:3])
+		if err != nil {
+			return false
+		}
+		if vSphereVersionInt >= VSphere912VersionInt {
+			return true
+		}
+	}
 	return false
 }
 

--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -59,6 +59,11 @@ func TestClient(t *testing.T) {
 	// example: export CNS_RUN_MULTICLUSTER_PER_ZONE_TESTS='true'
 	run_cns_multicluster_per_zone_tests := os.Getenv("CNS_RUN_MULTICLUSTER_PER_ZONE_TESTS")
 
+	// set CNS_RUN_HOST_LOCAL_STORAGE_TESTS to true to run host-local datastore volume creation tests.
+	// The SPBM policy (CNS_SPBM_PROFILE_NAME) must have the hostLocalStorage capability.
+	// example: export CNS_RUN_HOST_LOCAL_STORAGE_TESTS='true'
+	run_host_local_storage_tests := os.Getenv("CNS_RUN_HOST_LOCAL_STORAGE_TESTS")
+
 	// set CNS_RUN_FILESHARE_TESTS environment to true, if your setup has vsanfileshare enabled.
 	// when CNS_RUN_FILESHARE_TESTS is not set to true, vsan file share related tests are skipped.
 	// example: export CNS_RUN_FILESHARE_TESTS='true'
@@ -193,6 +198,32 @@ func TestClient(t *testing.T) {
 				ProfileId: storagePolicyID,
 			},
 		}
+	} else if run_host_local_storage_tests == "true" {
+		hostSystems, err := finder.HostSystemList(ctx, "*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var hosts []vim25types.ManagedObjectReference
+		for _, h := range hostSystems {
+			hosts = append(hosts, h.Reference())
+		}
+		t.Logf("set cnsVolumeCreateSpec.Hosts=%v", hosts)
+		cnsVolumeCreateSpec.Hosts = hosts
+
+		pbmclient, err := pbm.NewClient(ctx, c.Client)
+		if err != nil {
+			t.Fatal(err)
+		}
+		storagePolicyID, err := pbmclient.ProfileIDByName(ctx, spbmProfileName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("set cnsVolumeCreateSpec.Profile=%s", storagePolicyID)
+		cnsVolumeCreateSpec.Profile = []vim25types.BaseVirtualMachineProfileSpec{
+			&vim25types.VirtualMachineDefinedProfileSpec{
+				ProfileId: storagePolicyID,
+			},
+		}
 	} else {
 		cnsVolumeCreateSpec.Datastores = dsList
 	}
@@ -246,6 +277,14 @@ func TestClient(t *testing.T) {
 			t.Fatalf("clusters in the placement result in createvolumeresult can not be empty. "+
 				"volumeCreateResult.PlacementResults :%q", pretty.Sprint(volumeCreateResult.PlacementResults))
 		}
+	}
+
+	if run_host_local_storage_tests == "true" {
+		if volumeCreateResult.PlacementResults[0].Host == nil {
+			t.Fatalf("host in the placement result cannot be nil for host-local storage. "+
+				"volumeCreateResult.PlacementResults :%q", pretty.Sprint(volumeCreateResult.PlacementResults))
+		}
+		t.Logf("host-local storage placement host: %+v", volumeCreateResult.PlacementResults[0].Host)
 	}
 
 	// Creating Volume with same ID again on different datastore

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -85,6 +85,7 @@ type CnsVolumeCreateSpec struct {
 	BackingObjectDetails BaseCnsBackingObjectDetails           `xml:"backingObjectDetails,typeattr" json:"backingObjectDetails"`
 	Profile              []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr" json:"profile"`
 	ActiveClusters       []types.ManagedObjectReference        `xml:"activeClusters,omitempty,typeattr" json:"activeClusters"`
+	Hosts                []types.ManagedObjectReference        `xml:"hosts,omitempty" json:"hosts"`
 	CreateSpec           BaseCnsBaseCreateSpec                 `xml:"createSpec,omitempty,typeattr" json:"createSpec"`
 	VolumeSource         BaseCnsVolumeSource                   `xml:"volumeSource,omitempty,typeattr" json:"volumeSource"`
 }
@@ -341,7 +342,8 @@ func init() {
 type CnsPlacementResult struct {
 	Datastore       types.ManagedObjectReference   `xml:"datastore,omitempty" json:"datastore"`
 	PlacementFaults []*types.LocalizedMethodFault  `xml:"placementFaults,omitempty" json:"placementFaults"`
-	Clusters        []types.ManagedObjectReference `xml:"clusters,omitempty" json:"clusters"`
+	Clusters        []types.ManagedObjectReference  `xml:"clusters,omitempty" json:"clusters"`
+	Host            *types.ManagedObjectReference  `xml:"host,omitempty" json:"host,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

Add Hosts field to CnsVolumeCreateSpec for specifying target hosts when creating host-local datastore volumes, and add Host field to CnsPlacementResult to surface the selected host after placement. Add test coverage via the CNS_RUN_HOST_LOCAL_STORAGE_TESTS env var that validates host is non-nil in the placement result.

