### PR TITLE
types: add InsufficientResourcesQuota fault type

### DIFF
--- a/simulator/fault_injection_test.go
+++ b/simulator/fault_injection_test.go
@@ -449,6 +449,90 @@ func TestFaultInjectionInclusionExclusionFilter(t *testing.T) {
 	})
 }
 
+func TestInsufficientResourcesQuotaFaultInjection(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		resourceType            string
+		resourceQuotaType       string
+		available               int64
+		requested               int64
+		entity                  string
+		resourceEnvelope        string
+		failureNotificationMode string
+	}{
+		{
+			name:                    "cpu reservation quota exceeded (transient)",
+			resourceType:            string(types.InsufficientResourcesQuotaResourceTypeCpu),
+			resourceQuotaType:       string(types.InsufficientResourcesQuotaResourceQuotaTypeReservation),
+			available:               100,
+			requested:               500,
+			entity:                  "vm-42",
+			resourceEnvelope:        "envelope-1",
+			failureNotificationMode: string(types.InsufficientResourcesQuotaFailureNotificationModeFailureModeTransient),
+		},
+		{
+			name:                    "memory configured-size quota exceeded (permanent)",
+			resourceType:            string(types.InsufficientResourcesQuotaResourceTypeMemory),
+			resourceQuotaType:       string(types.InsufficientResourcesQuotaResourceQuotaTypeConfiguredSize),
+			available:               0,
+			requested:               1 << 30,
+			entity:                  "envelope-99",
+			resourceEnvelope:        "envelope-99",
+			failureNotificationMode: string(types.InsufficientResourcesQuotaFailureNotificationModeFailureModePermanent),
+		},
+	}
+
+	Test(func(ctx context.Context, c *vim25.Client) {
+		service := ServiceFromContext(ctx)
+
+		finder := find.NewFinder(c)
+		vm, err := finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
+		require.NoError(t, err)
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				service.ClearFaultRules()
+				vm.PowerOff(ctx)
+
+				rule := &FaultInjectionRule{
+					MethodName:  "PowerOnVM_Task",
+					ObjectType:  "*",
+					ObjectName:  "*",
+					Probability: 1.0,
+					FaultType:   FaultTypeCustom,
+					Fault: &types.InsufficientResourcesQuota{
+						ResourceType:            tc.resourceType,
+						ResourceQuotaType:       tc.resourceQuotaType,
+						Available:               tc.available,
+						Requested:               tc.requested,
+						Entity:                  tc.entity,
+						ResourceEnvelope:        tc.resourceEnvelope,
+						FailureNotificationMode: tc.failureNotificationMode,
+					},
+					Enabled: true,
+				}
+				service.AddFaultRule(rule)
+
+				_, err := vm.PowerOn(ctx)
+				require.Error(t, err)
+
+				var quotaFault *types.InsufficientResourcesQuota
+				_, ok := fault.As(err, &quotaFault)
+				require.True(t, ok, "expected InsufficientResourcesQuota fault, got: %T", err)
+				require.Equal(t, tc.resourceType, quotaFault.ResourceType)
+				require.Equal(t, tc.resourceQuotaType, quotaFault.ResourceQuotaType)
+				require.Equal(t, tc.available, quotaFault.Available)
+				require.Equal(t, tc.requested, quotaFault.Requested)
+				require.Equal(t, tc.entity, quotaFault.Entity)
+				require.Equal(t, tc.resourceEnvelope, quotaFault.ResourceEnvelope)
+				require.Equal(t, tc.failureNotificationMode, quotaFault.FailureNotificationMode)
+			})
+		}
+
+		service.ClearFaultRules()
+	})
+}
+
 func TestFaultInjectionIncorrectFilterSpecifications(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/vim25/types/unreleased.go
+++ b/vim25/types/unreleased.go
@@ -245,3 +245,112 @@ func init() {
 type FetchVmGroupForMultiwriterDisksResponse struct {
 	Returnval *SharedDiskVmGroupInfo `xml:"returnval,omitempty" json:"returnval,omitempty"`
 }
+
+// InsufficientResourcesQuotaResourceType identifies the type of resource whose quota was exceeded.
+type InsufficientResourcesQuotaResourceType string
+
+const (
+	// InsufficientResourcesQuotaResourceTypeCpu indicates CPU quota was exceeded (unit: MHz).
+	InsufficientResourcesQuotaResourceTypeCpu = InsufficientResourcesQuotaResourceType("cpu")
+	// InsufficientResourcesQuotaResourceTypeMemory indicates memory quota was exceeded (unit: bytes).
+	InsufficientResourcesQuotaResourceTypeMemory = InsufficientResourcesQuotaResourceType("memory")
+)
+
+func (e InsufficientResourcesQuotaResourceType) Values() []InsufficientResourcesQuotaResourceType {
+	return []InsufficientResourcesQuotaResourceType{
+		InsufficientResourcesQuotaResourceTypeCpu,
+		InsufficientResourcesQuotaResourceTypeMemory,
+	}
+}
+
+func (e InsufficientResourcesQuotaResourceType) Strings() []string {
+	return EnumValuesAsStrings(e.Values())
+}
+
+func init() {
+	t["InsufficientResourcesQuotaResourceType"] = reflect.TypeOf((*InsufficientResourcesQuotaResourceType)(nil)).Elem()
+}
+
+// InsufficientResourcesQuotaResourceQuotaType identifies the type of quota that was violated.
+type InsufficientResourcesQuotaResourceQuotaType string
+
+const (
+	// InsufficientResourcesQuotaResourceQuotaTypeReservation indicates a violation against reservation capacity.
+	InsufficientResourcesQuotaResourceQuotaTypeReservation = InsufficientResourcesQuotaResourceQuotaType("reservation")
+	// InsufficientResourcesQuotaResourceQuotaTypeConfiguredSize indicates a violation against configured size capacity.
+	InsufficientResourcesQuotaResourceQuotaTypeConfiguredSize = InsufficientResourcesQuotaResourceQuotaType("configuredSize")
+)
+
+func (e InsufficientResourcesQuotaResourceQuotaType) Values() []InsufficientResourcesQuotaResourceQuotaType {
+	return []InsufficientResourcesQuotaResourceQuotaType{
+		InsufficientResourcesQuotaResourceQuotaTypeReservation,
+		InsufficientResourcesQuotaResourceQuotaTypeConfiguredSize,
+	}
+}
+
+func (e InsufficientResourcesQuotaResourceQuotaType) Strings() []string {
+	return EnumValuesAsStrings(e.Values())
+}
+
+func init() {
+	t["InsufficientResourcesQuotaResourceQuotaType"] = reflect.TypeOf((*InsufficientResourcesQuotaResourceQuotaType)(nil)).Elem()
+}
+
+// InsufficientResourcesQuotaFailureNotificationMode indicates whether the failure is transient or permanent.
+type InsufficientResourcesQuotaFailureNotificationMode string
+
+const (
+	// InsufficientResourcesQuotaFailureNotificationModeFailureModeTransient indicates the failure is temporary and may be resolved through reallocation.
+	InsufficientResourcesQuotaFailureNotificationModeFailureModeTransient = InsufficientResourcesQuotaFailureNotificationMode("failureModeTransient")
+	// InsufficientResourcesQuotaFailureNotificationModeFailureModePermanent indicates the failure cannot be resolved.
+	InsufficientResourcesQuotaFailureNotificationModeFailureModePermanent = InsufficientResourcesQuotaFailureNotificationMode("failureModePermanent")
+)
+
+func (e InsufficientResourcesQuotaFailureNotificationMode) Values() []InsufficientResourcesQuotaFailureNotificationMode {
+	return []InsufficientResourcesQuotaFailureNotificationMode{
+		InsufficientResourcesQuotaFailureNotificationModeFailureModeTransient,
+		InsufficientResourcesQuotaFailureNotificationModeFailureModePermanent,
+	}
+}
+
+func (e InsufficientResourcesQuotaFailureNotificationMode) Strings() []string {
+	return EnumValuesAsStrings(e.Values())
+}
+
+func init() {
+	t["InsufficientResourcesQuotaFailureNotificationMode"] = reflect.TypeOf((*InsufficientResourcesQuotaFailureNotificationMode)(nil)).Elem()
+}
+
+// InsufficientResourcesQuota is thrown when an operation exceeds the quota in an associated resource envelope.
+type InsufficientResourcesQuota struct {
+	InsufficientResourcesFault
+
+	// ResourceType identifies the type of resource whose quota was exceeded.
+	// See InsufficientResourcesQuotaResourceType for supported values.
+	ResourceType string `xml:"resourceType" json:"resourceType"`
+	// ResourceQuotaType identifies the type of quota that was violated.
+	// See InsufficientResourcesQuotaResourceQuotaType for supported values.
+	ResourceQuotaType string `xml:"resourceQuotaType" json:"resourceQuotaType"`
+	// Available is the amount of the resource still available under the quota
+	// (MHz for CPU, bytes for memory).
+	Available int64 `xml:"available" json:"available"`
+	// Requested is the amount of the resource requested in the failed operation.
+	Requested int64 `xml:"requested" json:"requested"`
+	// Entity is the identifier of the entity that violated the quota (e.g., a VM or resource envelope).
+	Entity string `xml:"entity" json:"entity"`
+	// ResourceEnvelope is the identifier of the resource envelope whose quota was exceeded.
+	ResourceEnvelope string `xml:"resourceEnvelope" json:"resourceEnvelope"`
+	// FailureNotificationMode indicates whether the failure is transient or permanent.
+	// See InsufficientResourcesQuotaFailureNotificationMode for supported values.
+	FailureNotificationMode string `xml:"failureNotificationMode" json:"failureNotificationMode"`
+}
+
+func init() {
+	t["InsufficientResourcesQuota"] = reflect.TypeOf((*InsufficientResourcesQuota)(nil)).Elem()
+}
+
+type InsufficientResourcesQuotaFault InsufficientResourcesQuota
+
+func init() {
+	t["InsufficientResourcesQuotaFault"] = reflect.TypeOf((*InsufficientResourcesQuotaFault)(nil)).Elem()
+}


### PR DESCRIPTION
## Description

- Adds `InsufficientResourcesQuota` to `vim25/types/unreleased.go`,
  mapping `vim.fault.InsufficientResourcesQuota` from the
  vmodl definition. The fault extends `InsufficientResourcesFault` and
  carries resource type, quota type, available/requested amounts, entity
  and envelope identifiers, and a failure notification mode.
- Adds three string enum types with `Values()` helpers, following the
  pattern in `vim25/types/enum.go`.
- Adds `TestInsufficientResourcesQuotaFaultInjection` to
  `simulator/fault_injection_test.go` — table-driven, covers CPU
  reservation (transient) and memory configured-size (permanent) cases,
  verifies all fault fields via `fault.As`.


## How Has This Been Tested?

##### Run just the new test
go test -v ./simulator/... -run TestInsufficientResourcesQuotaFaultInjection
##### Run all fault injection tests
go test -v ./simulator/... -run TestFaultInjection
##### Run all simulator tests
go test ./simulator/...
##### Build types package only
go build ./vim25/types/...


## Guidelines

Compliant.
