### PR TITLE
Make VirtualDevice.NumaNode a pointer to allow node 0

### DIFF
--- a/cli/gpu/vm/info.go
+++ b/cli/gpu/vm/info.go
@@ -58,7 +58,7 @@ type gpuInfo struct {
 	Index    int    `json:"index"`
 	Label    string `json:"label"`
 	Summary  string `json:"summary"`
-	NumaNode int32  `json:"numaNode"`
+	NumaNode *int32 `json:"numaNode"`
 	Key      int32  `json:"key"`
 }
 
@@ -72,7 +72,11 @@ func (r *infoResult) Write(w io.Writer) error {
 		fmt.Fprintf(tw, "GPU %d:\n", gpu.Index)
 		fmt.Fprintf(tw, "  Label: %s\n", gpu.Label)
 		fmt.Fprintf(tw, "  Summary: %s\n", gpu.Summary)
-		fmt.Fprintf(tw, "  Numa Node: %d\n", gpu.NumaNode)
+		if gpu.NumaNode != nil {
+			fmt.Fprintf(tw, "  Numa Node: %d\n", *gpu.NumaNode)
+		} else {
+			fmt.Fprintf(tw, "  Numa Node: unset\n")
+		}
 		fmt.Fprintf(tw, "  Key: %d\n", gpu.Key)
 	}
 	return tw.Flush()

--- a/gen/vim_wsdl.rb
+++ b/gen/vim_wsdl.rb
@@ -252,7 +252,7 @@ class Simple
 
   def pointer_type?
     ["UnitNumber"].include?(var_name) or
-      optional? && ["CoresPerNumaNode", "IpPoolId", "OwnerId", "GroupId", "MaxWaitSeconds", "Reservation", "Limit", "OverheadLimit", "ResourceReductionToToleratePercent"].include?(var_name)
+      optional? && ["CoresPerNumaNode", "IpPoolId", "OwnerId", "GroupId", "MaxWaitSeconds", "NumaNode", "Reservation", "Limit", "OverheadLimit", "ResourceReductionToToleratePercent"].include?(var_name)
   end
 
   def var_type

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -85943,7 +85943,7 @@ type VirtualDevice struct {
 	// An unset value of numaNode is status-quo during Reconfigure time.
 	// If numaNode is unset during ConfigInfo, then it means there is no
 	// affinity for the device.
-	NumaNode int32 `xml:"numaNode,omitempty" json:"numaNode,omitempty" vim:"8.0.0.1"`
+	NumaNode *int32 `xml:"numaNode" json:"numaNode,omitempty" vim:"8.0.0.1"`
 	// Information about device group device is part of.
 	//
 	// Devices in the device group cannot be added/removed individually,


### PR DESCRIPTION
## Description

`VirtualDevice.NumaNode` was generated as `int32` with an `xml:"numaNode,omitempty"` tag. Go's XML encoder drops zero-valued `omitempty` fields, so writing `NumaNode = 0` into a `VirtualDeviceConfigSpec` was silently omitted from the SOAP payload and never reached vSphere. This made NUMA node 0 (a valid zero-indexed assignment) unreachable from Go, and made a cleared assignment read back as `0`, indistinguishable from a device that was never assigned.

This change makes `NumaNode` a `*int32` with an `xml:"numaNode"` tag (no `omitempty`) and `json:"numaNode,omitempty"`, mirroring the existing `CoresPerNumaNode *int32` pattern. A non-nil `*int32(0)` now marshals `<numaNode>0</numaNode>` (node 0 is assignable), and a nil pointer is omitted entirely (never-set / cleared state is distinguishable on read-back).

The field comment already documents this semantic: "An unset value of numaNode is status-quo during Reconfigure time."

Changes:
- `gen/vim_wsdl.rb`: add `"NumaNode"` to the optional-int pointer override list in `pointer_type?` (the same list that already contains `CoresPerNumaNode`, `IpPoolId`, `Reservation`, etc.), so the pointer shape survives the next WSDL regeneration.
- `vim25/types/types.go`: the regenerated `VirtualDevice.NumaNode` field (`*int32`, XML tag without `omitempty`).
- `cli/gpu/vm/info.go`: the only internal consumer of the field; updated to carry the pointer through `gpu.vm.info` output so an unassigned device prints `unset` instead of an ambiguous `0`.

The generator runs via `make generate-types` inside a container against VMware's proprietary WSDL/SDK bundle and regenerates every package while bumping the VIM version, which is not reproducible in a standard contributor environment. The single `types.go` field was therefore edited by hand to exactly match the shape the generator emits for the entries already in the `pointer_type?` list (e.g. `CoresPerNumaNode`); the generator entry is the source-of-truth change and was added so a full regeneration produces the same result.

Maintainer @dougm confirmed the fix on 2026-06-19, pointing at the generator's pointer-field override list in `gen/vim_wsdl.rb` as the place to add `NumaNode`.

Closes: #4049

## How Has This Been Tested?

- `go build ./vim25/types/... ./cli/gpu/...` and `go vet ./vim25/... ./cli/gpu/...` pass cleanly.
- `go test ./vim25/types/...` passes (XML and JSON round-trip fixtures).
- Verified marshalling behavior: a device with `NumaNode = types.NewInt32(0)` now emits `<numaNode>0</numaNode>`; a device with `NumaNode = nil` omits the element entirely.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md

Fixes #4049
