### PR TITLE
vcsim: power on and customize VM when cloning

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -2257,6 +2257,7 @@ func (c *powerVMTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	}
 
 	event := c.event(c.ctx)
+	var customizationFault types.BaseMethodFault
 	switch c.state {
 	case types.VirtualMachinePowerStatePoweredOn:
 		if c.VirtualMachine.hostInMM(c.ctx) {
@@ -2277,7 +2278,7 @@ func (c *powerVMTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 			&types.VmStartingEvent{VmEvent: event},
 			&types.VmPoweredOnEvent{VmEvent: event},
 		)
-		c.customize(c.ctx)
+		customizationFault = c.customize(c.ctx)
 	case types.VirtualMachinePowerStatePoweredOff:
 		c.svm.stop(c.ctx)
 		c.ctx.postEvent(
@@ -2322,7 +2323,7 @@ func (c *powerVMTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 		{Name: "config.hardware.device", Val: devices},
 	})
 
-	return nil, nil
+	return nil, customizationFault
 }
 
 func (vm *VirtualMachine) PowerOnVMTask(ctx *Context, c *types.PowerOnVM_Task) soap.HasFault {
@@ -2805,12 +2806,25 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 
 		if req.Spec.Template {
 			_ = clone.MarkAsTemplate(&types.MarkAsTemplate{This: clone.Self})
+		} else {
+			if err := clone.setPendingCustomization(ctx, req.Spec.Customization); err != nil {
+				return nil, err
+			}
 		}
 
 		ctx.postEvent(&types.VmClonedEvent{
 			VmCloneEvent: types.VmCloneEvent{VmEvent: clone.event(ctx)},
 			SourceVm:     *event.Vm,
 		})
+
+		if !req.Spec.Template && req.Spec.PowerOn {
+			res := clone.PowerOnVMTask(ctx, &types.PowerOnVM_Task{This: clone.Self})
+			ctask := ctx.Map.Get(res.(*methods.PowerOnVM_TaskBody).Res.Returnval).(*Task)
+			ctask.Wait()
+			if ctask.Info.Error != nil {
+				return nil, ctask.Info.Error.Fault
+			}
+		}
 
 		return ref, nil
 	})
@@ -2898,19 +2912,30 @@ func (vm *VirtualMachine) RelocateVMTask(ctx *Context, req *types.RelocateVM_Tas
 	}
 }
 
-func (vm *VirtualMachine) customize(ctx *Context) {
+func (vm *VirtualMachine) customize(ctx *Context) types.BaseMethodFault {
 	if vm.imc == nil {
-		return
+		return nil
 	}
 
 	event := types.CustomizationEvent{VmEvent: vm.event(ctx)}
 	ctx.postEvent(&types.CustomizationStartedEvent{CustomizationEvent: event})
+	ctx.Update(vm, []types.PropertyChange{
+		{
+			Name: "guest.customizationInfo",
+			Val:  vm.customizationInfo(types.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_RUNNING, ""),
+		},
+	})
 
 	changes := []types.PropertyChange{
 		{Name: "config.tools.pendingCustomization", Val: ""},
 	}
 
 	if len(vm.Guest.Net) != len(vm.imc.NicSettingMap) {
+		fault := &types.NicSettingMismatch{
+			NumberOfNicsInSpec: int32(len(vm.imc.NicSettingMap)),
+			NumberOfNicsInVM:   int32(len(vm.Guest.Net)),
+		}
+
 		ctx.postEvent(&types.CustomizationNetworkSetupFailed{
 			CustomizationFailed: types.CustomizationFailed{
 				CustomizationEvent: event,
@@ -2919,8 +2944,12 @@ func (vm *VirtualMachine) customize(ctx *Context) {
 		})
 
 		vm.imc = nil
+		changes = append(changes, types.PropertyChange{
+			Name: "guest.customizationInfo",
+			Val:  vm.customizationInfo(types.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_FAILED, "NicSettingMismatch"),
+		})
 		ctx.Update(vm, changes)
-		return
+		return fault
 	}
 
 	hostname := ""
@@ -2990,8 +3019,66 @@ func (vm *VirtualMachine) customize(ctx *Context) {
 	}
 
 	vm.imc = nil
+	changes = append(changes, types.PropertyChange{
+		Name: "guest.customizationInfo",
+		Val:  vm.customizationInfo(types.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_SUCCEEDED, ""),
+	})
 	ctx.Update(vm, changes)
 	ctx.postEvent(&types.CustomizationSucceeded{CustomizationEvent: event})
+	return nil
+}
+
+func (vm *VirtualMachine) customizationInfo(status types.GuestInfoCustomizationStatus, err string) *types.GuestInfoCustomizationInfo {
+	info := &types.GuestInfoCustomizationInfo{
+		CustomizationStatus: string(status),
+		ErrorMsg:            err,
+	}
+
+	now := time.Now()
+	switch status {
+	case types.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_RUNNING:
+		info.StartTime = &now
+	case types.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_SUCCEEDED, types.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_FAILED:
+		if vm.Guest != nil && vm.Guest.CustomizationInfo != nil && vm.Guest.CustomizationInfo.StartTime != nil {
+			info.StartTime = vm.Guest.CustomizationInfo.StartTime
+		} else {
+			info.StartTime = &now
+		}
+		info.EndTime = &now
+	}
+
+	return info
+}
+
+func (vm *VirtualMachine) setPendingCustomization(ctx *Context, spec *types.CustomizationSpec) types.BaseMethodFault {
+	if spec == nil {
+		return nil
+	}
+
+	if vm.Config.Tools == nil {
+		vm.Config.Tools = new(types.ToolsConfigInfo)
+	}
+
+	if vm.Config.Tools.PendingCustomization != "" {
+		return new(types.CustomizationPending)
+	}
+	if len(vm.Guest.Net) != len(spec.NicSettingMap) {
+		return &types.NicSettingMismatch{
+			NumberOfNicsInSpec: int32(len(spec.NicSettingMap)),
+			NumberOfNicsInVM:   int32(len(vm.Guest.Net)),
+		}
+	}
+
+	vm.imc = spec
+	ctx.Update(vm, []types.PropertyChange{
+		{Name: "config.tools.pendingCustomization", Val: uuid.New().String()},
+		{
+			Name: "guest.customizationInfo",
+			Val:  vm.customizationInfo(types.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_PENDING, ""),
+		},
+	})
+
+	return nil
 }
 
 func (vm *VirtualMachine) CustomizeVMTask(ctx *Context, req *types.CustomizeVM_Task) soap.HasFault {
@@ -3006,20 +3093,8 @@ func (vm *VirtualMachine) CustomizeVMTask(ctx *Context, req *types.CustomizeVM_T
 				ExistingState:  vm.Runtime.PowerState,
 			}
 		}
-		if vm.Config.Tools.PendingCustomization != "" {
-			return nil, new(types.CustomizationPending)
-		}
-		if len(vm.Guest.Net) != len(req.Spec.NicSettingMap) {
-			return nil, &types.NicSettingMismatch{
-				NumberOfNicsInSpec: int32(len(req.Spec.NicSettingMap)),
-				NumberOfNicsInVM:   int32(len(vm.Guest.Net)),
-			}
-		}
 
-		vm.imc = &req.Spec
-		vm.Config.Tools.PendingCustomization = uuid.New().String()
-
-		return nil, nil
+		return nil, vm.setPendingCustomization(ctx, &req.Spec)
 	})
 
 	return &methods.CustomizeVM_TaskBody{

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -2236,8 +2236,9 @@ func (vm *VirtualMachine) configureDevices(ctx *Context, spec *types.VirtualMach
 type powerVMTask struct {
 	*VirtualMachine
 
-	state types.VirtualMachinePowerState
-	ctx   *Context
+	state                       types.VirtualMachinePowerState
+	ctx                         *Context
+	propagateCustomizationFault bool
 }
 
 func (c *powerVMTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
@@ -2323,7 +2324,11 @@ func (c *powerVMTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 		{Name: "config.hardware.device", Val: devices},
 	})
 
-	return nil, customizationFault
+	if c.propagateCustomizationFault {
+		return nil, customizationFault
+	}
+
+	return nil, nil
 }
 
 func (vm *VirtualMachine) PowerOnVMTask(ctx *Context, c *types.PowerOnVM_Task) soap.HasFault {
@@ -2333,7 +2338,11 @@ func (vm *VirtualMachine) PowerOnVMTask(ctx *Context, c *types.PowerOnVM_Task) s
 		}
 	}
 
-	runner := &powerVMTask{vm, types.VirtualMachinePowerStatePoweredOn, ctx}
+	runner := &powerVMTask{
+		VirtualMachine: vm,
+		state:          types.VirtualMachinePowerStatePoweredOn,
+		ctx:            ctx,
+	}
 	task := CreateTask(runner.Reference(), "powerOn", runner.Run)
 
 	return &methods.PowerOnVM_TaskBody{
@@ -2344,7 +2353,11 @@ func (vm *VirtualMachine) PowerOnVMTask(ctx *Context, c *types.PowerOnVM_Task) s
 }
 
 func (vm *VirtualMachine) PowerOffVMTask(ctx *Context, c *types.PowerOffVM_Task) soap.HasFault {
-	runner := &powerVMTask{vm, types.VirtualMachinePowerStatePoweredOff, ctx}
+	runner := &powerVMTask{
+		VirtualMachine: vm,
+		state:          types.VirtualMachinePowerStatePoweredOff,
+		ctx:            ctx,
+	}
 	task := CreateTask(runner.Reference(), "powerOff", runner.Run)
 
 	return &methods.PowerOffVM_TaskBody{
@@ -2355,7 +2368,11 @@ func (vm *VirtualMachine) PowerOffVMTask(ctx *Context, c *types.PowerOffVM_Task)
 }
 
 func (vm *VirtualMachine) SuspendVMTask(ctx *Context, req *types.SuspendVM_Task) soap.HasFault {
-	runner := &powerVMTask{vm, types.VirtualMachinePowerStateSuspended, ctx}
+	runner := &powerVMTask{
+		VirtualMachine: vm,
+		state:          types.VirtualMachinePowerStateSuspended,
+		ctx:            ctx,
+	}
 	task := CreateTask(runner.Reference(), "suspend", runner.Run)
 
 	return &methods.SuspendVM_TaskBody{
@@ -2818,8 +2835,14 @@ func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soa
 		})
 
 		if !req.Spec.Template && req.Spec.PowerOn {
-			res := clone.PowerOnVMTask(ctx, &types.PowerOnVM_Task{This: clone.Self})
-			ctask := ctx.Map.Get(res.(*methods.PowerOnVM_TaskBody).Res.Returnval).(*Task)
+			runner := &powerVMTask{
+				VirtualMachine:              clone,
+				state:                       types.VirtualMachinePowerStatePoweredOn,
+				ctx:                         ctx,
+				propagateCustomizationFault: true,
+			}
+			task := CreateTask(runner.Reference(), "powerOn", runner.Run)
+			ctask := ctx.Map.Get(task.Run(ctx)).(*Task)
 			ctask.Wait()
 			if ctask.Info.Error != nil {
 				return nil, ctask.Info.Error.Fault

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -528,6 +528,393 @@ func TestCloneVm(t *testing.T) {
 	}
 }
 
+func testCloneCustomizationSpec(hostname, ip string) *types.CustomizationSpec {
+	return &types.CustomizationSpec{
+		NicSettingMap: []types.CustomizationAdapterMapping{
+			{
+				Adapter: types.CustomizationIPSettings{
+					Ip: &types.CustomizationFixedIp{
+						IpAddress: ip,
+					},
+					SubnetMask:    "255.255.255.0",
+					DnsServerList: []string{"192.168.1.1"},
+					DnsDomain:     "ad.domain",
+				},
+			},
+		},
+		Identity: &types.CustomizationLinuxPrep{
+			HostName: &types.CustomizationFixedName{
+				Name: hostname,
+			},
+			Domain:     "ad.domain",
+			TimeZone:   "Etc/UTC",
+			HwClockUTC: types.NewBool(true),
+		},
+		GlobalIPSettings: types.CustomizationGlobalIPSettings{
+			DnsSuffixList: []string{"ad.domain"},
+			DnsServerList: []string{"192.168.1.1"},
+		},
+	}
+}
+
+func assertCloneCustomizationApplied(ctx context.Context, t *testing.T, vm *object.VirtualMachine, hostname, ip string) {
+	t.Helper()
+
+	var moVM mo.VirtualMachine
+	if err := vm.Properties(ctx, vm.Reference(), []string{
+		"runtime.powerState",
+		"guest",
+		"config.tools",
+	}, &moVM); err != nil {
+		t.Fatal(err)
+	}
+
+	if moVM.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
+		t.Fatalf("expected clone to be powered on; got %s", moVM.Runtime.PowerState)
+	}
+	if moVM.Guest == nil {
+		t.Fatal("nil guest info")
+	}
+	if moVM.Guest.HostName != hostname {
+		t.Fatalf("expected guest hostname %q; got %q", hostname, moVM.Guest.HostName)
+	}
+	if moVM.Guest.IpAddress != ip {
+		t.Fatalf("expected guest IP %q; got %q", ip, moVM.Guest.IpAddress)
+	}
+	assertGuestCustomizationInfo(ctx, t, vm, types.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_SUCCEEDED, true, true)
+	if moVM.Config == nil || moVM.Config.Tools == nil {
+		t.Fatal("nil tools config")
+	}
+	if moVM.Config.Tools.PendingCustomization != "" {
+		t.Fatalf("expected pending customization to be cleared; got %q", moVM.Config.Tools.PendingCustomization)
+	}
+}
+
+func assertGuestCustomizationInfo(ctx context.Context, t *testing.T, vm *object.VirtualMachine, status types.GuestInfoCustomizationStatus, wantStart, wantEnd bool) {
+	t.Helper()
+
+	var moVM mo.VirtualMachine
+	if err := vm.Properties(ctx, vm.Reference(), []string{"guest"}, &moVM); err != nil {
+		t.Fatal(err)
+	}
+	if moVM.Guest == nil {
+		t.Fatal("nil guest info")
+	}
+	info := moVM.Guest.CustomizationInfo
+	if info == nil {
+		t.Fatal("nil guest customization info")
+	}
+	if got := info.CustomizationStatus; got != string(status) {
+		t.Fatalf("expected customization status %q; got %q", status, got)
+	}
+	if (info.StartTime != nil) != wantStart {
+		t.Fatalf("expected startTime presence %t; got %t", wantStart, info.StartTime != nil)
+	}
+	if (info.EndTime != nil) != wantEnd {
+		t.Fatalf("expected endTime presence %t; got %t", wantEnd, info.EndTime != nil)
+	}
+}
+
+func TestCloneVmPowerOnAndCustomization(t *testing.T) {
+	m := VPX()
+	defer m.Remove()
+
+	Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c, false)
+		dc, err := finder.DefaultDatacenter(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		folders, err := dc.Folders(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
+		vm := object.NewVirtualMachine(c, vmm.Reference())
+
+		hostname := "clone-host"
+		ip := "192.168.1.100"
+		config := types.VirtualMachineCloneSpec{
+			PowerOn:       true,
+			Customization: testCloneCustomizationSpec(hostname, ip),
+		}
+
+		task, err := vm.Clone(ctx, folders.VmFolder, "cloned-vm-power-on-customization", config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err := task.WaitForResult(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		clone := object.NewVirtualMachine(c, info.Result.(types.ManagedObjectReference))
+		assertCloneCustomizationApplied(ctx, t, clone, hostname, ip)
+	}, m)
+}
+
+func TestCustomizeVmCustomizationInfo(t *testing.T) {
+	m := VPX()
+	defer m.Remove()
+
+	Test(func(ctx context.Context, c *vim25.Client) {
+		vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
+		vm := object.NewVirtualMachine(c, vmm.Reference())
+
+		var moVM mo.VirtualMachine
+		if err := vm.Properties(ctx, vm.Reference(), []string{"runtime.powerState"}, &moVM); err != nil {
+			t.Fatal(err)
+		}
+		if moVM.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
+			task, err := vm.PowerOff(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err = task.Wait(ctx); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		hostname := "customized-vm-host"
+		ip := "192.168.1.110"
+		task, err := vm.Customize(ctx, *testCloneCustomizationSpec(hostname, ip))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = task.Wait(ctx); err != nil {
+			t.Fatal(err)
+		}
+		assertGuestCustomizationInfo(ctx, t, vm, types.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_PENDING, false, false)
+
+		task, err = vm.PowerOn(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = task.Wait(ctx); err != nil {
+			t.Fatal(err)
+		}
+		assertCloneCustomizationApplied(ctx, t, vm, hostname, ip)
+	}, m)
+}
+
+func TestPowerOnReturnsCustomizationFault(t *testing.T) {
+	m := VPX()
+	defer m.Remove()
+
+	Test(func(ctx context.Context, c *vim25.Client) {
+		vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
+		vm := object.NewVirtualMachine(c, vmm.Reference())
+
+		var moVM mo.VirtualMachine
+		if err := vm.Properties(ctx, vm.Reference(), []string{"runtime.powerState"}, &moVM); err != nil {
+			t.Fatal(err)
+		}
+		if moVM.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
+			task, err := vm.PowerOff(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err = task.Wait(ctx); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		customizeTask, err := vm.Customize(ctx, *testCloneCustomizationSpec("mismatch-host", "192.168.1.130"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = customizeTask.Wait(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		devices, err := vm.Device(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		nics := devices.SelectByType((*types.VirtualEthernetCard)(nil))
+		if len(nics) == 0 {
+			t.Fatal("expected VM to have at least one NIC")
+		}
+		if err = vm.RemoveDevice(ctx, false, nics...); err != nil {
+			t.Fatal(err)
+		}
+
+		powerTask, err := vm.PowerOn(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = powerTask.Wait(ctx)
+		if err == nil {
+			t.Fatal("expected power-on task to return customization fault")
+		}
+		taskErr, ok := err.(task.Error)
+		if !ok {
+			t.Fatalf("expected task.Error; got %T: %v", err, err)
+		}
+		fault := taskErr.Fault()
+		if _, ok = fault.(types.BaseCustomizationFault); !ok {
+			t.Fatalf("expected customization fault; got %T", fault)
+		}
+		mismatch, ok := fault.(*types.NicSettingMismatch)
+		if !ok {
+			t.Fatalf("expected NicSettingMismatch fault; got %T", fault)
+		}
+		if mismatch.NumberOfNicsInSpec != 1 || mismatch.NumberOfNicsInVM != 0 {
+			t.Fatalf("expected NIC counts spec=1 vm=0; got spec=%d vm=%d", mismatch.NumberOfNicsInSpec, mismatch.NumberOfNicsInVM)
+		}
+
+		if err := vm.Properties(ctx, vm.Reference(), []string{
+			"runtime.powerState",
+			"guest",
+			"config.tools",
+		}, &moVM); err != nil {
+			t.Fatal(err)
+		}
+		if moVM.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
+			t.Fatalf("expected VM to be powered on after customization fault; got %s", moVM.Runtime.PowerState)
+		}
+		if moVM.Config.Tools.PendingCustomization != "" {
+			t.Fatalf("expected pending customization to be cleared; got %q", moVM.Config.Tools.PendingCustomization)
+		}
+		if moVM.Guest.CustomizationInfo == nil {
+			t.Fatal("nil guest customization info")
+		}
+		if moVM.Guest.CustomizationInfo.CustomizationStatus != string(types.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_FAILED) {
+			t.Fatalf("expected failed customization status; got %q", moVM.Guest.CustomizationInfo.CustomizationStatus)
+		}
+		if moVM.Guest.CustomizationInfo.ErrorMsg != "NicSettingMismatch" {
+			t.Fatalf("expected NicSettingMismatch customization error; got %q", moVM.Guest.CustomizationInfo.ErrorMsg)
+		}
+	}, m)
+}
+
+func TestCloneVmCustomizationPendingUntilPowerOn(t *testing.T) {
+	m := VPX()
+	defer m.Remove()
+
+	Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c, false)
+		dc, err := finder.DefaultDatacenter(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		folders, err := dc.Folders(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
+		vm := object.NewVirtualMachine(c, vmm.Reference())
+
+		hostname := "clone-host-deferred"
+		ip := "192.168.1.101"
+		config := types.VirtualMachineCloneSpec{
+			Customization: testCloneCustomizationSpec(hostname, ip),
+		}
+
+		task, err := vm.Clone(ctx, folders.VmFolder, "cloned-vm-deferred-customization", config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err := task.WaitForResult(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		clone := object.NewVirtualMachine(c, info.Result.(types.ManagedObjectReference))
+
+		var moVM mo.VirtualMachine
+		if err := clone.Properties(ctx, clone.Reference(), []string{
+			"runtime.powerState",
+			"config.tools",
+		}, &moVM); err != nil {
+			t.Fatal(err)
+		}
+		if moVM.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOff {
+			t.Fatalf("expected clone to remain powered off; got %s", moVM.Runtime.PowerState)
+		}
+		if moVM.Config == nil || moVM.Config.Tools == nil {
+			t.Fatal("nil tools config")
+		}
+		if moVM.Config.Tools.PendingCustomization == "" {
+			t.Fatal("expected customization to be pending")
+		}
+		assertGuestCustomizationInfo(ctx, t, clone, types.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_PENDING, false, false)
+
+		task, err = clone.PowerOn(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = task.Wait(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		assertCloneCustomizationApplied(ctx, t, clone, hostname, ip)
+	}, m)
+}
+
+func TestCloneVmTemplateIgnoresPowerOnAndCustomization(t *testing.T) {
+	m := VPX()
+	defer m.Remove()
+
+	Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c, false)
+		dc, err := finder.DefaultDatacenter(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		folders, err := dc.Folders(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
+		vm := object.NewVirtualMachine(c, vmm.Reference())
+
+		config := types.VirtualMachineCloneSpec{
+			Template:      true,
+			PowerOn:       true,
+			Customization: testCloneCustomizationSpec("ignored-template-host", "192.168.1.102"),
+		}
+
+		task, err := vm.Clone(ctx, folders.VmFolder, "cloned-template", config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err := task.WaitForResult(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		clone := object.NewVirtualMachine(c, info.Result.(types.ManagedObjectReference))
+		var moVM mo.VirtualMachine
+		if err := clone.Properties(ctx, clone.Reference(), []string{
+			"config.template",
+			"runtime.powerState",
+			"config.tools",
+		}, &moVM); err != nil {
+			t.Fatal(err)
+		}
+
+		if moVM.Config == nil || !moVM.Config.Template {
+			t.Fatal("expected clone to be marked as a template")
+		}
+		if moVM.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOff {
+			t.Fatalf("expected template clone to remain powered off; got %s", moVM.Runtime.PowerState)
+		}
+		if moVM.Config.Tools == nil {
+			t.Fatal("nil tools config")
+		}
+		if moVM.Config.Tools.PendingCustomization != "" {
+			t.Fatalf("expected template clone customization to be ignored; got pending value %q", moVM.Config.Tools.PendingCustomization)
+		}
+	}, m)
+}
+
 func TestCloneVmExtraConfig(t *testing.T) {
 	m := VPX()
 	defer m.Remove()

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -699,7 +699,7 @@ func TestCustomizeVmCustomizationInfo(t *testing.T) {
 	}, m)
 }
 
-func TestPowerOnReturnsCustomizationFault(t *testing.T) {
+func TestPowerOnIgnoresCustomizationFault(t *testing.T) {
 	m := VPX()
 	defer m.Remove()
 
@@ -745,24 +745,8 @@ func TestPowerOnReturnsCustomizationFault(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = powerTask.Wait(ctx)
-		if err == nil {
-			t.Fatal("expected power-on task to return customization fault")
-		}
-		taskErr, ok := err.(task.Error)
-		if !ok {
-			t.Fatalf("expected task.Error; got %T: %v", err, err)
-		}
-		fault := taskErr.Fault()
-		if _, ok = fault.(types.BaseCustomizationFault); !ok {
-			t.Fatalf("expected customization fault; got %T", fault)
-		}
-		mismatch, ok := fault.(*types.NicSettingMismatch)
-		if !ok {
-			t.Fatalf("expected NicSettingMismatch fault; got %T", fault)
-		}
-		if mismatch.NumberOfNicsInSpec != 1 || mismatch.NumberOfNicsInVM != 0 {
-			t.Fatalf("expected NIC counts spec=1 vm=0; got spec=%d vm=%d", mismatch.NumberOfNicsInSpec, mismatch.NumberOfNicsInVM)
+		if err = powerTask.Wait(ctx); err != nil {
+			t.Fatal(err)
 		}
 
 		if err := vm.Properties(ctx, vm.Reference(), []string{
@@ -786,6 +770,81 @@ func TestPowerOnReturnsCustomizationFault(t *testing.T) {
 		}
 		if moVM.Guest.CustomizationInfo.ErrorMsg != "NicSettingMismatch" {
 			t.Fatalf("expected NicSettingMismatch customization error; got %q", moVM.Guest.CustomizationInfo.ErrorMsg)
+		}
+	}, m)
+}
+
+func TestCloneVmPowerOnReturnsCustomizationFault(t *testing.T) {
+	m := VPX()
+	defer m.Remove()
+
+	Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c, false)
+		dc, err := finder.DefaultDatacenter(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		folders, err := dc.Folders(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
+		vm := object.NewVirtualMachine(c, vmm.Reference())
+
+		config := types.VirtualMachineCloneSpec{
+			PowerOn: true,
+			Customization: &types.CustomizationSpec{
+				NicSettingMap: []types.CustomizationAdapterMapping{
+					{
+						Adapter: types.CustomizationIPSettings{
+							Ip: &types.CustomizationFixedIp{
+								IpAddress: "192.168.1.120",
+							},
+							SubnetMask: "255.255.255.0",
+						},
+					},
+					{
+						Adapter: types.CustomizationIPSettings{
+							Ip: &types.CustomizationFixedIp{
+								IpAddress: "192.168.1.121",
+							},
+							SubnetMask: "255.255.255.0",
+						},
+					},
+				},
+				Identity: &types.CustomizationLinuxPrep{
+					HostName: &types.CustomizationFixedName{
+						Name: "clone-host",
+					},
+				},
+			},
+		}
+
+		cloneTask, err := vm.Clone(ctx, folders.VmFolder, "cloned-vm-power-on-customization-fault", config)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = cloneTask.Wait(ctx)
+		if err == nil {
+			t.Fatal("expected clone task to return customization fault")
+		}
+		taskErr, ok := err.(task.Error)
+		if !ok {
+			t.Fatalf("expected task.Error; got %T: %v", err, err)
+		}
+		fault := taskErr.Fault()
+		if _, ok = fault.(types.BaseCustomizationFault); !ok {
+			t.Fatalf("expected customization fault; got %T", fault)
+		}
+		mismatch, ok := fault.(*types.NicSettingMismatch)
+		if !ok {
+			t.Fatalf("expected NicSettingMismatch fault; got %T", fault)
+		}
+		if mismatch.NumberOfNicsInSpec != 2 || mismatch.NumberOfNicsInVM != 1 {
+			t.Fatalf("expected NIC counts spec=2 vm=1; got spec=%d vm=%d", mismatch.NumberOfNicsInSpec, mismatch.NumberOfNicsInVM)
 		}
 	}, m)
 }


### PR DESCRIPTION
## Description

Power on and customize VMs cloned in vcsim.

## How Has This Been Tested?

- Create a VM in vcsim
- Clone the VM with `powerOn=true` and some customizations
  - If the customization fails, the error should be reported in the result of the clone task

