### PR TITLE
chore: bump ClientVersion

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,5 +9,5 @@ const (
 	ClientName = "govmomi"
 
 	// ClientVersion is the version of this SDK
-	ClientVersion = "0.44.0"
+	ClientVersion = "0.55.0"
 )


### PR DESCRIPTION
Unlike the generated/injected govc version, the ClientVersion is manually updated. And is way out of date.
