### PR TITLE
Adds govc commads for checking interoperability of components

### DIFF
--- a/cli/lcm/interop/check.go
+++ b/cli/lcm/interop/check.go
@@ -1,0 +1,97 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package interop
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/cli"
+	"github.com/vmware/govmomi/cli/flags"
+	"github.com/vmware/govmomi/vapi/lcm"
+)
+
+type check struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	product    string
+	version    string
+	identifier string
+	wait       bool
+}
+
+func init() {
+	cli.Register("lcm.interop.check", &check{}, true)
+}
+
+func (cmd *check) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.product, "product", "com.vmware.vcenter.supervisor", "Product name to validate")
+	f.StringVar(&cmd.version, "version", "", "Target version to validate (required)")
+	f.StringVar(&cmd.identifier, "identifier", "", "Component instance identifier (optional)")
+	f.BoolVar(&cmd.wait, "wait", false, "Wait for task completion and print the report")
+}
+
+func (cmd *check) Description() string {
+	return `Submit an LCM interoperability validation task.
+
+Prints the task ID on success. Use lcm.interop.result to retrieve the report,
+or pass -wait to block until completion and print it immediately.
+
+Examples:
+  govc lcm.interop.check -version 8.0.3
+  govc lcm.interop.check -product com.vmware.vcenter.supervisor -version 8.0.3 -identifier my-instance
+  govc lcm.interop.check -version 8.0.3 -wait`
+}
+
+func (cmd *check) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *check) Run(ctx context.Context, f *flag.FlagSet) error {
+	if cmd.version == "" {
+		return fmt.Errorf("-version is required")
+	}
+
+	m := newManager(cmd.ClientFlag)
+
+	component := lcm.InteropComponent{
+		ProductName: cmd.product,
+		Version:     cmd.version,
+		Identifier:  cmd.identifier,
+	}
+
+	taskID, err := m.CreateInteropTask(ctx, component)
+	if err != nil {
+		return err
+	}
+
+	if !cmd.wait {
+		fmt.Fprintln(cmd.OutputFlag.Out, taskID)
+		return nil
+	}
+
+	info, err := m.WaitForCompletion(ctx, taskID)
+	if err != nil {
+		return err
+	}
+
+	interopResult, err := lcm.ParseResult(info)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(&reportOutput{result: interopResult})
+}

--- a/cli/lcm/interop/common.go
+++ b/cli/lcm/interop/common.go
@@ -1,0 +1,36 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package interop
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	"github.com/vmware/govmomi/cli/flags"
+	"github.com/vmware/govmomi/vapi/lcm"
+)
+
+// newManager builds an lcm.Manager from the standard govc client flags.
+// The LCM REST API uses HTTP Basic Auth; credentials and the base URL are
+// taken directly from the session configuration.
+func newManager(f *flags.ClientFlag) *lcm.Manager {
+	u := f.Session.URL
+	baseURL := "https://" + u.Host
+
+	username := ""
+	password := ""
+	if u.User != nil {
+		username = u.User.Username()
+		password, _ = u.User.Password()
+	}
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: f.Session.Insecure}, //nolint:gosec
+		},
+	}
+
+	return lcm.NewManager(baseURL, username, password, httpClient)
+}

--- a/cli/lcm/interop/common.go
+++ b/cli/lcm/interop/common.go
@@ -7,6 +7,7 @@ package interop
 import (
 	"crypto/tls"
 	"net/http"
+	"net/url"
 
 	"github.com/vmware/govmomi/cli/flags"
 	"github.com/vmware/govmomi/vapi/lcm"
@@ -17,7 +18,7 @@ import (
 // taken directly from the session configuration.
 func newManager(f *flags.ClientFlag) *lcm.Manager {
 	u := f.Session.URL
-	baseURL := "https://" + u.Host
+	baseURL := &url.URL{Scheme: "https", Host: u.Host}
 
 	username := ""
 	password := ""

--- a/cli/lcm/interop/report.go
+++ b/cli/lcm/interop/report.go
@@ -1,0 +1,180 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package interop
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/cli"
+	"github.com/vmware/govmomi/cli/flags"
+	"github.com/vmware/govmomi/vapi/lcm"
+)
+
+type report struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("lcm.interop.report", &report{}, true)
+}
+
+func (cmd *report) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *report) Description() string {
+	return `Fetch and display the interoperability report created for a task.
+
+The task must have been created by lcm.interop.check. If the task is not yet
+complete, the current status is printed and the command exits with an error.
+
+Examples:
+  govc lcm.interop.report <task-id>
+  govc lcm.interop.report -json <task-id>`
+}
+
+func (cmd *report) Usage() string {
+	return "TASK_ID"
+}
+
+func (cmd *report) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.OutputFlag.Process(ctx)
+}
+
+func (cmd *report) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+	taskID := f.Arg(0)
+
+	m := newManager(cmd.ClientFlag)
+
+	info, err := m.GetTask(ctx, taskID)
+	if err != nil {
+		return err
+	}
+
+	if !info.IsDone() {
+		return fmt.Errorf("task %s is not yet complete (status: %s, progress: %d/%d)",
+			taskID, info.Status, info.Progress.Completed, info.Progress.Total)
+	}
+
+	if err := info.Err(); err != nil {
+		return fmt.Errorf("task %s failed: %w", taskID, err)
+	}
+
+	interopResult, err := lcm.ParseResult(info)
+	if err != nil {
+		return err
+	}
+
+	return cmd.WriteResult(&reportOutput{result: interopResult})
+}
+
+// reportOutput implements OutputWriter for JSON/text rendering.
+// JSON output is scoped to the report object only.
+type reportOutput struct {
+	result *lcm.InteropResult
+}
+
+func (o *reportOutput) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.result)
+}
+
+func (o *reportOutput) Write(w io.Writer) error {
+	return printReport(w, o.result)
+}
+
+// printReport writes a human-readable interop report table.
+func printReport(w io.Writer, r *lcm.InteropResult) error {
+	if r == nil {
+		fmt.Fprintln(w, "No result payload in task.")
+		return nil
+	}
+
+	if r.Issues != nil {
+		printIssues(w, "ERROR", r.Issues.Errors)
+		printIssues(w, "WARNING", r.Issues.Warnings)
+		printIssues(w, "INFO", r.Issues.Info)
+		if len(r.Issues.Errors)+len(r.Issues.Warnings)+len(r.Issues.Info) > 0 {
+			fmt.Fprintln(w)
+		}
+	}
+
+	fmt.Fprintf(w, "Report date: %s\n\n", r.Report.DateCreated.Format("2006-01-02 15:04:05 UTC"))
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	for _, row := range r.Report.Rows {
+		target := row.TargetComponent
+		fmt.Fprintf(tw, "Target:\t%s %s\n", target.Product.DisplayName, target.Version)
+		fmt.Fprintf(tw, "  Compatible:\t%d\tIncompatible:\t%d\tUnknown:\t%d\n",
+			row.Summary.CompatibleCount,
+			row.Summary.IncompatibleCount,
+			row.Summary.UnknownCount,
+		)
+
+		if len(row.AssociatedComponents) > 0 {
+			fmt.Fprintln(tw)
+			fmt.Fprintf(tw, "  %-40s\t%-15s\t%s\n", "Component", "Status", "Compatible Releases")
+			fmt.Fprintf(tw, "  %-40s\t%-15s\t%s\n", "---------", "------", "-------------------")
+			printAssociatedComponents(tw, row.AssociatedComponents, "  ")
+		}
+		fmt.Fprintln(tw)
+	}
+
+	return tw.Flush()
+}
+
+func printIssues(w io.Writer, level string, notifications []lcm.InteropNotification) {
+	for _, n := range notifications {
+		fmt.Fprintf(w, "[%s] %s (id: %s)\n", level, n.Message.DefaultMessage, n.Id)
+		if n.Resolution != nil {
+			fmt.Fprintf(w, "         Resolution: %s\n", n.Resolution.DefaultMessage)
+		}
+	}
+}
+
+func printAssociatedComponents(w io.Writer, components []lcm.InteropAssociatedComponent, indent string) {
+	for _, assoc := range components {
+		version := ""
+		if assoc.Component.Version != nil {
+			version = *assoc.Component.Version
+		}
+
+		releases := make([]string, 0, len(assoc.CompatibleReleases))
+		for _, r := range assoc.CompatibleReleases {
+			releases = append(releases, r.Version)
+		}
+		compatStr := "-"
+		if len(releases) > 0 {
+			compatStr = fmt.Sprintf("%v", releases)
+		}
+
+		name := assoc.Component.Product.DisplayName
+		if version != "" {
+			name = fmt.Sprintf("%s %s", name, version)
+		}
+
+		fmt.Fprintf(w, "%s%-40s\t%-15s\t%s\n", indent, name, assoc.Status, compatStr)
+
+		if len(assoc.LinkedComponents) > 0 {
+			printAssociatedComponents(w, assoc.LinkedComponents, indent+"  ")
+		}
+	}
+}

--- a/cli/lcm/interop/report_test.go
+++ b/cli/lcm/interop/report_test.go
@@ -1,0 +1,436 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package interop
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vmware/govmomi/cli/flags"
+	"github.com/vmware/govmomi/vapi/cis/tasks"
+	"github.com/vmware/govmomi/vapi/lcm"
+)
+
+func TestPrintReportNil(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printReport(&buf, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No result payload") {
+		t.Errorf("expected 'No result payload' message, got: %q", buf.String())
+	}
+}
+
+func TestPrintReport(t *testing.T) {
+	r := &lcm.InteropResult{
+		Report: lcm.InteropReport{
+			DateCreated: time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC),
+			Rows: []lcm.InteropReportRow{
+				{
+					TargetComponent: lcm.InteropTargetComponent{
+						Product: lcm.InteropProductInfo{DisplayName: "vCenter Server"},
+						Version: "8.0.3",
+					},
+					Summary: lcm.InteropSummary{
+						CompatibleCount:   3,
+						IncompatibleCount: 1,
+						UnknownCount:      2,
+					},
+					AssociatedComponents: []lcm.InteropAssociatedComponent{
+						{
+							Component: lcm.InteropComponentInstance{
+								Product: lcm.InteropProductInfo{DisplayName: "NSX"},
+								Name:    "nsx",
+							},
+							Status:             "COMPATIBLE",
+							CompatibleReleases: []lcm.InteropReleaseInfo{{Version: "4.1"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := printReport(&buf, r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"2026-06-26",
+		"vCenter Server",
+		"8.0.3",
+		"NSX",
+		"COMPATIBLE",
+		"4.1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintReportWithIssues(t *testing.T) {
+	resolution := "Upgrade to version 2.0"
+	r := &lcm.InteropResult{
+		Report: lcm.InteropReport{
+			DateCreated: time.Now(),
+			Rows:        []lcm.InteropReportRow{},
+		},
+		Issues: &lcm.InteropNotifications{
+			Errors: []lcm.InteropNotification{
+				{
+					Id:      "err-001",
+					Message: lcm.InteropLocalizableMessage{DefaultMessage: "Component X is incompatible"},
+				},
+			},
+			Warnings: []lcm.InteropNotification{
+				{
+					Id:      "warn-001",
+					Message: lcm.InteropLocalizableMessage{DefaultMessage: "Component Y status unknown"},
+					Resolution: &lcm.InteropLocalizableMessage{
+						DefaultMessage: resolution,
+					},
+				},
+			},
+			Info: []lcm.InteropNotification{
+				{
+					Id:      "info-001",
+					Message: lcm.InteropLocalizableMessage{DefaultMessage: "Validation completed"},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := printReport(&buf, r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"[ERROR]", "Component X is incompatible", "err-001",
+		"[WARNING]", "Component Y status unknown", "warn-001", resolution,
+		"[INFO]", "Validation completed", "info-001",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintIssuesNoResolution(t *testing.T) {
+	notifications := []lcm.InteropNotification{
+		{
+			Id:      "n-001",
+			Message: lcm.InteropLocalizableMessage{DefaultMessage: "something happened"},
+		},
+	}
+
+	var buf bytes.Buffer
+	printIssues(&buf, "WARNING", notifications)
+	out := buf.String()
+
+	if !strings.Contains(out, "[WARNING]") {
+		t.Errorf("missing level prefix: %q", out)
+	}
+	if !strings.Contains(out, "something happened") {
+		t.Errorf("missing message: %q", out)
+	}
+	if strings.Contains(out, "Resolution") {
+		t.Errorf("unexpected Resolution line when none set: %q", out)
+	}
+}
+
+func TestReportOutputMarshalJSON(t *testing.T) {
+	csvReport := "col1,col2\nval1,val2"
+	r := &lcm.InteropResult{
+		Report: lcm.InteropReport{
+			DateCreated: time.Date(2026, 6, 26, 0, 0, 0, 0, time.UTC),
+			Rows:        []lcm.InteropReportRow{},
+		},
+		CsvReport: &csvReport,
+		Issues: &lcm.InteropNotifications{
+			Errors: []lcm.InteropNotification{
+				{Id: "e1", Message: lcm.InteropLocalizableMessage{DefaultMessage: "bad"}},
+			},
+		},
+	}
+
+	o := &reportOutput{result: r}
+	data, err := o.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+
+	var decoded lcm.InteropResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if decoded.CsvReport == nil || *decoded.CsvReport != csvReport {
+		t.Errorf("csv_report not preserved: got %v", decoded.CsvReport)
+	}
+	if decoded.Issues == nil || len(decoded.Issues.Errors) != 1 {
+		t.Errorf("issues not preserved: got %+v", decoded.Issues)
+	}
+	if decoded.Issues.Errors[0].Id != "e1" {
+		t.Errorf("issue id not preserved: got %q", decoded.Issues.Errors[0].Id)
+	}
+	if len(decoded.Report.Rows) != 0 {
+		t.Errorf("expected empty rows, got %d", len(decoded.Report.Rows))
+	}
+}
+
+func TestReportOutputMarshalJSONNilResult(t *testing.T) {
+	o := &reportOutput{result: nil}
+	data, err := o.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	if string(data) != "null" {
+		t.Errorf("expected null for nil result, got %q", data)
+	}
+}
+
+func TestCheckDescription(t *testing.T) {
+	cmd := &check{}
+	if !strings.Contains(cmd.Description(), "Submit") {
+		t.Errorf("unexpected description: %q", cmd.Description())
+	}
+}
+
+func TestCheckRunMissingVersion(t *testing.T) {
+	cmd := &check{}
+	f := flag.NewFlagSet("", flag.ContinueOnError)
+	err := cmd.Run(context.Background(), f)
+	if err == nil || err.Error() != "-version is required" {
+		t.Errorf("got err %v, want '-version is required'", err)
+	}
+}
+
+func TestReportDescription(t *testing.T) {
+	cmd := &report{}
+	if !strings.Contains(cmd.Description(), "Fetch") {
+		t.Errorf("unexpected description: %q", cmd.Description())
+	}
+}
+
+func TestReportUsage(t *testing.T) {
+	cmd := &report{}
+	if cmd.Usage() != "TASK_ID" {
+		t.Errorf("got usage %q, want 'TASK_ID'", cmd.Usage())
+	}
+}
+
+func TestReportRunMissingArgs(t *testing.T) {
+	cmd := &report{}
+	f := flag.NewFlagSet("", flag.ContinueOnError)
+	err := cmd.Run(context.Background(), f)
+	if err != flag.ErrHelp {
+		t.Errorf("got err %v, want flag.ErrHelp", err)
+	}
+}
+
+func TestReportWrite(t *testing.T) {
+	r := &lcm.InteropResult{
+		Report: lcm.InteropReport{
+			DateCreated: time.Date(2026, 6, 26, 0, 0, 0, 0, time.UTC),
+			Rows:        []lcm.InteropReportRow{},
+		},
+	}
+	o := &reportOutput{result: r}
+	var buf bytes.Buffer
+	if err := o.Write(&buf); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !strings.Contains(buf.String(), "2026-06-26") {
+		t.Errorf("output missing date: %q", buf.String())
+	}
+}
+
+func TestPrintAssociatedComponentsLinked(t *testing.T) {
+	version := "3.0"
+	components := []lcm.InteropAssociatedComponent{
+		{
+			Component: lcm.InteropComponentInstance{
+				Product: lcm.InteropProductInfo{DisplayName: "NSX"},
+				Version: &version,
+			},
+			Status: "COMPATIBLE",
+			LinkedComponents: []lcm.InteropAssociatedComponent{
+				{
+					Component: lcm.InteropComponentInstance{
+						Product: lcm.InteropProductInfo{DisplayName: "NSX Edge"},
+					},
+					Status: "COMPATIBLE",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printAssociatedComponents(&buf, components, "  ")
+	out := buf.String()
+
+	if !strings.Contains(out, "NSX 3.0") {
+		t.Errorf("missing parent component: %q", out)
+	}
+	if !strings.Contains(out, "NSX Edge") {
+		t.Errorf("missing linked component: %q", out)
+	}
+}
+
+func TestNewManagerHelper(t *testing.T) {
+	f := &flags.ClientFlag{}
+	f.Session.URL = &url.URL{
+		Host: "vcenter.example.com",
+		User: url.UserPassword("admin", "secret"),
+	}
+	f.Session.Insecure = true
+	m := newManager(f)
+	if m == nil {
+		t.Fatal("expected non-nil manager from newManager")
+	}
+}
+
+func TestCheckRegister(t *testing.T) {
+	cmd := &check{}
+	f := flag.NewFlagSet("", flag.ContinueOnError)
+	cmd.Register(context.Background(), f)
+	if cmd.ClientFlag == nil {
+		t.Fatal("ClientFlag should be non-nil after Register")
+	}
+	if cmd.OutputFlag == nil {
+		t.Fatal("OutputFlag should be non-nil after Register")
+	}
+	if f.Lookup("version") == nil {
+		t.Fatal("expected -version flag to be registered")
+	}
+	if f.Lookup("product") == nil {
+		t.Fatal("expected -product flag to be registered")
+	}
+}
+
+func TestReportRegister(t *testing.T) {
+	cmd := &report{}
+	f := flag.NewFlagSet("", flag.ContinueOnError)
+	cmd.Register(context.Background(), f)
+	if cmd.ClientFlag == nil {
+		t.Fatal("ClientFlag should be non-nil after Register")
+	}
+	if cmd.OutputFlag == nil {
+		t.Fatal("OutputFlag should be non-nil after Register")
+	}
+}
+
+// newTLSTestServer creates an HTTPS test server. newManager always builds
+// "https://host", so we use TLS + Insecure to let the test client through.
+func newTLSTestServer(t *testing.T, h http.HandlerFunc) (*httptest.Server, *url.URL) {
+	t.Helper()
+	ts := httptest.NewTLSServer(h)
+	t.Cleanup(ts.Close)
+	u, _ := url.Parse(ts.URL)
+	u.User = url.UserPassword("user", "pass")
+	return ts, u
+}
+
+func registeredCheck(t *testing.T, tsURL *url.URL) (*check, *flag.FlagSet) {
+	t.Helper()
+	cmd := &check{}
+	f := flag.NewFlagSet("", flag.ContinueOnError)
+	cmd.Register(context.Background(), f)
+	cmd.ClientFlag.Session.URL = tsURL
+	cmd.ClientFlag.Session.Insecure = true
+	return cmd, f
+}
+
+func registeredReport(t *testing.T, tsURL *url.URL) (*report, *flag.FlagSet) {
+	t.Helper()
+	cmd := &report{}
+	f := flag.NewFlagSet("", flag.ContinueOnError)
+	cmd.Register(context.Background(), f)
+	cmd.ClientFlag.Session.URL = tsURL
+	cmd.ClientFlag.Session.Insecure = true
+	return cmd, f
+}
+
+func TestCheckRunPrintsTaskID(t *testing.T) {
+	const wantTaskID = "task-check-run"
+	_, tsURL := newTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(wantTaskID)
+	})
+
+	cmd, f := registeredCheck(t, tsURL)
+	cmd.version = "8.0.3"
+
+	if err := cmd.Run(context.Background(), f); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestCheckRunWait(t *testing.T) {
+	const wantTaskID = "task-wait-run"
+	calls := 0
+	_, tsURL := newTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			_ = json.NewEncoder(w).Encode(wantTaskID)
+			return
+		}
+		calls++
+		info := tasks.Info{}
+		if calls < 2 {
+			info.Status = tasks.Running
+		} else {
+			info.Status = tasks.Succeeded
+			result, _ := json.Marshal(lcm.InteropResult{
+				Report: lcm.InteropReport{DateCreated: time.Now(), Rows: []lcm.InteropReportRow{}},
+			})
+			info.Result = result
+		}
+		_ = json.NewEncoder(w).Encode(info)
+	})
+
+	cmd, f := registeredCheck(t, tsURL)
+	cmd.version = "8.0.3"
+	cmd.wait = true
+	cmd.ClientFlag.Session.Insecure = true
+
+	if err := cmd.Run(context.Background(), f); err != nil {
+		t.Fatalf("Run -wait: %v", err)
+	}
+}
+
+func TestReportRunFetchesTask(t *testing.T) {
+	result, _ := json.Marshal(lcm.InteropResult{
+		Report: lcm.InteropReport{DateCreated: time.Now(), Rows: []lcm.InteropReportRow{}},
+	})
+	info := tasks.Info{Status: tasks.Succeeded, Result: result}
+
+	_, tsURL := newTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(info)
+	})
+
+	cmd, f := registeredReport(t, tsURL)
+	if err := f.Parse([]string{"task-123"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmd.Run(context.Background(), f); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}

--- a/govc/main.go
+++ b/govc/main.go
@@ -65,6 +65,7 @@ import (
 	_ "github.com/vmware/govmomi/cli/importx"
 	_ "github.com/vmware/govmomi/cli/kms"
 	_ "github.com/vmware/govmomi/cli/kms/key"
+	_ "github.com/vmware/govmomi/cli/lcm/interop"
 	_ "github.com/vmware/govmomi/cli/library"
 	_ "github.com/vmware/govmomi/cli/library/policy"
 	_ "github.com/vmware/govmomi/cli/library/session"

--- a/vapi/lcm/interop.go
+++ b/vapi/lcm/interop.go
@@ -1,0 +1,284 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package lcm
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/vmware/govmomi/vapi/cis/tasks"
+)
+
+const (
+	interopTasksPath = "/lcm/rest/cis/tasks/"
+	interopPath      = "/lcm/rest/vcenter/lcm/interop"
+)
+
+// InteropComponent specifies the component to validate interoperability for.
+type InteropComponent struct {
+	ProductName string
+	Version     string
+	Identifier  string // optional instance identifier
+}
+
+// InteropResult is the decoded payload returned by a completed interop task.
+type InteropResult struct {
+	Report    InteropReport         `json:"report"`
+	Issues    *InteropNotifications `json:"issues,omitempty"`
+	CsvReport *string               `json:"csv_report,omitempty"`
+}
+
+// InteropNotifications groups info, warning, and error notifications from the API.
+type InteropNotifications struct {
+	Info     []InteropNotification `json:"info,omitempty"`
+	Warnings []InteropNotification `json:"warnings,omitempty"`
+	Errors   []InteropNotification `json:"errors,omitempty"`
+}
+
+// InteropNotification is a single notification entry returned alongside the report.
+type InteropNotification struct {
+	Id         string                     `json:"id"`
+	Time       *time.Time                 `json:"time,omitempty"`
+	Message    InteropLocalizableMessage  `json:"message"`
+	Resolution *InteropLocalizableMessage `json:"resolution,omitempty"`
+}
+
+// InteropLocalizableMessage carries a human-readable message from the API.
+type InteropLocalizableMessage struct {
+	Id             string  `json:"id"`
+	DefaultMessage string  `json:"default_message"`
+	Localized      *string `json:"localized,omitempty"`
+}
+
+// InteropReport is the top-level report container.
+type InteropReport struct {
+	DateCreated time.Time          `json:"date_created"`
+	Rows        []InteropReportRow `json:"rows"`
+}
+
+// InteropReportRow is one row of the interoperability report.
+type InteropReportRow struct {
+	TargetComponent      InteropTargetComponent       `json:"target_component"`
+	Summary              InteropSummary               `json:"summary"`
+	AssociatedComponents []InteropAssociatedComponent `json:"associated_components"`
+}
+
+// InteropTargetComponent describes the component being validated.
+type InteropTargetComponent struct {
+	Identifier *string            `json:"identifier,omitempty"`
+	Product    InteropProductInfo `json:"product"`
+	Version    string             `json:"version"`
+	Name       *string            `json:"name,omitempty"`
+}
+
+// InteropProductInfo holds product metadata.
+type InteropProductInfo struct {
+	DisplayName string `json:"display_name"`
+	Name        string `json:"name"`
+	Category    string `json:"category"`
+}
+
+// InteropSummary holds compatibility counts for a row.
+type InteropSummary struct {
+	CompatibleCount   int64 `json:"compatible_count"`
+	IncompatibleCount int64 `json:"incompatible_count"`
+	UnknownCount      int64 `json:"unknown_count"`
+}
+
+// InteropAssociatedComponent describes a component's interoperability status.
+type InteropAssociatedComponent struct {
+	Component          InteropComponentInstance     `json:"component"`
+	Status             string                       `json:"status"`
+	CompatibleReleases []InteropReleaseInfo         `json:"compatible_releases"`
+	LinkedComponents   []InteropAssociatedComponent `json:"linked_components"`
+}
+
+// InteropComponentInstance is an instantiated component in the environment.
+type InteropComponentInstance struct {
+	Identifier string             `json:"identifier"`
+	Product    InteropProductInfo `json:"product"`
+	Version    *string            `json:"version,omitempty"`
+	Name       string             `json:"name"`
+	Auto       bool               `json:"auto"`
+}
+
+// InteropReleaseInfo describes a compatible release for an associated component.
+type InteropReleaseInfo struct {
+	Version string  `json:"version"`
+	Note    *string `json:"note,omitempty"`
+}
+
+// interopRequestBody is the JSON body for POST /lcm/rest/vcenter/lcm/interop.
+type interopRequestBody struct {
+	Spec interopSpecBody `json:"spec"`
+}
+
+type interopSpecBody struct {
+	Components []interopComponentBody `json:"components"`
+}
+
+type interopComponentBody struct {
+	ProductName string  `json:"product_name"`
+	Version     *string `json:"version,omitempty"`
+	Identifier  *string `json:"identifier,omitempty"`
+}
+
+// Manager provides access to the LCM interoperability REST API using a plain
+// net/http client with HTTP Basic Auth. The LCM REST endpoint (/lcm/rest/...)
+// is a separate service from the vSphere vAPI and does not accept VAPI session tokens.
+type Manager struct {
+	client          *http.Client
+	baseURL         string
+	username        string
+	password        string
+	pollingInterval time.Duration
+}
+
+// NewManager creates a Manager. client handles TLS and transport; baseURL is
+// the scheme+host of the vCenter (e.g. "https://vcenter.example.com").
+// Interop APIs support Basic Auth only.
+func NewManager(baseURL, username, password string, client *http.Client) *Manager {
+	return &Manager{
+		client:          client,
+		baseURL:         baseURL,
+		username:        username,
+		password:        password,
+		pollingInterval: time.Second,
+	}
+}
+
+// WithPollingInterval overrides the interval between WaitForCompletion polls.
+func (m *Manager) WithPollingInterval(d time.Duration) *Manager {
+	m.pollingInterval = d
+	return m
+}
+
+// NewInsecureManager is a convenience constructor that creates its own
+// http.Client with TLS verification disabled.
+func NewInsecureManager(baseURL, username, password string) *Manager {
+	return NewManager(baseURL, username, password, &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		},
+	})
+}
+
+func (m *Manager) lcmURL(path string, params url.Values) string {
+	u, _ := url.Parse(m.baseURL + path)
+	if len(params) > 0 {
+		u.RawQuery = params.Encode()
+	}
+	return u.String()
+}
+
+func (m *Manager) do(ctx context.Context, method, rawURL string, reqBody, resBody any) error {
+	var buf bytes.Buffer
+	if reqBody != nil {
+		if err := json.NewEncoder(&buf).Encode(reqBody); err != nil {
+			return err
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.SetBasicAuth(m.username, m.password)
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s %s: %s: %s", method, rawURL, resp.Status, body)
+	}
+	if resBody != nil {
+		return json.Unmarshal(body, resBody)
+	}
+	return nil
+}
+
+// CreateInteropTask submits an interop validation request and returns the task ID.
+func (m *Manager) CreateInteropTask(ctx context.Context, component InteropComponent) (string, error) {
+	body := interopRequestBody{
+		Spec: interopSpecBody{
+			Components: []interopComponentBody{toComponentBody(component)},
+		},
+	}
+	rawURL := m.lcmURL(interopPath, url.Values{"vmw-task": {"true"}})
+	var taskID string
+	if err := m.do(ctx, http.MethodPost, rawURL, body, &taskID); err != nil {
+		return "", err
+	}
+	return taskID, nil
+}
+
+// GetTask fetches the current state of an interop task.
+func (m *Manager) GetTask(ctx context.Context, taskID string) (*tasks.Info, error) {
+	rawURL := m.lcmURL(interopTasksPath+taskID, nil)
+	var info tasks.Info
+	if err := m.do(ctx, http.MethodGet, rawURL, nil, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// WaitForCompletion polls GetTask until the task reaches a terminal state.
+func (m *Manager) WaitForCompletion(ctx context.Context, taskID string) (*tasks.Info, error) {
+	for {
+		info, err := m.GetTask(ctx, taskID)
+		if err != nil {
+			return nil, err
+		}
+		if info.IsDone() {
+			return info, info.Err()
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(m.pollingInterval):
+		}
+	}
+}
+
+// ParseResult extracts the InteropResult from a completed task's result field.
+// Returns nil if the result field is empty.
+func ParseResult(info *tasks.Info) (*InteropResult, error) {
+	if len(info.Result) == 0 {
+		return nil, nil
+	}
+	var r InteropResult
+	if err := json.Unmarshal(info.Result, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func toComponentBody(c InteropComponent) interopComponentBody {
+	body := interopComponentBody{ProductName: c.ProductName}
+	if c.Version != "" {
+		v := c.Version
+		body.Version = &v
+	}
+	if c.Identifier != "" {
+		id := c.Identifier
+		body.Identifier = &id
+	}
+	return body
+}

--- a/vapi/lcm/interop.go
+++ b/vapi/lcm/interop.go
@@ -137,16 +137,16 @@ type interopComponentBody struct {
 // is a separate service from the vSphere vAPI and does not accept VAPI session tokens.
 type Manager struct {
 	client          *http.Client
-	baseURL         string
+	baseURL         *url.URL
 	username        string
 	password        string
 	pollingInterval time.Duration
 }
 
 // NewManager creates a Manager. client handles TLS and transport; baseURL is
-// the scheme+host of the vCenter (e.g. "https://vcenter.example.com").
+// the scheme+host of the vCenter (e.g. &url.URL{Scheme: "https", Host: "vcenter.example.com"}).
 // Interop APIs support Basic Auth only.
-func NewManager(baseURL, username, password string, client *http.Client) *Manager {
+func NewManager(baseURL *url.URL, username, password string, client *http.Client) *Manager {
 	return &Manager{
 		client:          client,
 		baseURL:         baseURL,
@@ -164,7 +164,7 @@ func (m *Manager) WithPollingInterval(d time.Duration) *Manager {
 
 // NewInsecureManager is a convenience constructor that creates its own
 // http.Client with TLS verification disabled.
-func NewInsecureManager(baseURL, username, password string) *Manager {
+func NewInsecureManager(baseURL *url.URL, username, password string) *Manager {
 	return NewManager(baseURL, username, password, &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
@@ -173,10 +173,9 @@ func NewInsecureManager(baseURL, username, password string) *Manager {
 }
 
 func (m *Manager) lcmURL(path string, params url.Values) string {
-	u, _ := url.Parse(m.baseURL + path)
-	if len(params) > 0 {
-		u.RawQuery = params.Encode()
-	}
+	u := *m.baseURL
+	u.Path = path
+	u.RawQuery = params.Encode()
 	return u.String()
 }
 

--- a/vapi/lcm/interop_test.go
+++ b/vapi/lcm/interop_test.go
@@ -1,0 +1,362 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package lcm_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vmware/govmomi/vapi/cis/tasks"
+	"github.com/vmware/govmomi/vapi/lcm"
+)
+
+// newTestManager builds a Manager pointed at ts with no polling delay.
+func newTestManager(ts *httptest.Server) *lcm.Manager {
+	return lcm.NewManager(ts.URL, "user", "pass", ts.Client()).
+		WithPollingInterval(0)
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	return b
+}
+
+func TestCreateInteropTask(t *testing.T) {
+	const wantTaskID = "interop-task-abc"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("got method %s, want POST", r.Method)
+		}
+		if !strings.HasPrefix(r.URL.Path, "/lcm/rest/vcenter/lcm/interop") {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("vmw-task") != "true" {
+			t.Errorf("missing vmw-task=true query param")
+		}
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "user" || pass != "pass" {
+			t.Errorf("unexpected auth: user=%q pass=%q ok=%v", user, pass, ok)
+		}
+
+		var body struct {
+			Spec struct {
+				Components []struct {
+					ProductName string  `json:"product_name"`
+					Version     *string `json:"version,omitempty"`
+					Identifier  *string `json:"identifier,omitempty"`
+				} `json:"components"`
+			} `json:"spec"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding request body: %v", err)
+		}
+		if len(body.Spec.Components) != 1 {
+			t.Errorf("expected 1 component, got %d", len(body.Spec.Components))
+		}
+		if body.Spec.Components[0].ProductName != "com.vmware.vcenter" {
+			t.Errorf("unexpected product_name %q", body.Spec.Components[0].ProductName)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(wantTaskID)
+	}))
+	defer ts.Close()
+
+	m := newTestManager(ts)
+	taskID, err := m.CreateInteropTask(context.Background(), lcm.InteropComponent{
+		ProductName: "com.vmware.vcenter",
+		Version:     "8.0.3",
+	})
+	if err != nil {
+		t.Fatalf("CreateInteropTask: %v", err)
+	}
+	if taskID != wantTaskID {
+		t.Errorf("got taskID %q, want %q", taskID, wantTaskID)
+	}
+}
+
+func TestGetTask(t *testing.T) {
+	const taskID = "interop-task-xyz"
+
+	want := tasks.Info{
+		Status:   tasks.Succeeded,
+		Progress: tasks.Progress{Total: 100, Completed: 100},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("got method %s, want GET", r.Method)
+		}
+		wantPath := "/lcm/rest/cis/tasks/" + taskID
+		if r.URL.Path != wantPath {
+			t.Errorf("got path %q, want %q", r.URL.Path, wantPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer ts.Close()
+
+	m := newTestManager(ts)
+	got, err := m.GetTask(context.Background(), taskID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.Status != tasks.Succeeded {
+		t.Errorf("got status %q, want %q", got.Status, tasks.Succeeded)
+	}
+}
+
+func TestWaitForCompletion(t *testing.T) {
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		info := tasks.Info{}
+		if calls < 3 {
+			info.Status = tasks.Running
+			info.Progress = tasks.Progress{Total: 100, Completed: uint64(calls * 30)}
+		} else {
+			info.Status = tasks.Succeeded
+			info.Progress = tasks.Progress{Total: 100, Completed: 100}
+			info.Result = mustJSON(t, lcm.InteropResult{
+				Report: lcm.InteropReport{
+					DateCreated: time.Now(),
+					Rows:        []lcm.InteropReportRow{},
+				},
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(info)
+	}))
+	defer ts.Close()
+
+	m := newTestManager(ts)
+	info, err := m.WaitForCompletion(context.Background(), "task-999")
+	if err != nil {
+		t.Fatalf("WaitForCompletion: %v", err)
+	}
+	if info.Status != tasks.Succeeded {
+		t.Errorf("got status %q, want %q", info.Status, tasks.Succeeded)
+	}
+	if calls < 3 {
+		t.Errorf("expected at least 3 polls, got %d", calls)
+	}
+}
+
+func TestWaitForCompletionContextCancel(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		info := tasks.Info{Status: tasks.Running}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(info)
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	m := newTestManager(ts)
+	_, err := m.WaitForCompletion(ctx, "task-999")
+	if err == nil {
+		t.Fatal("expected context cancellation error, got nil")
+	}
+}
+
+func TestParseResult(t *testing.T) {
+	note := "upgrade required"
+	interopResult := lcm.InteropResult{
+		Report: lcm.InteropReport{
+			DateCreated: time.Date(2026, 6, 26, 0, 0, 0, 0, time.UTC),
+			Rows: []lcm.InteropReportRow{
+				{
+					TargetComponent: lcm.InteropTargetComponent{
+						Product: lcm.InteropProductInfo{DisplayName: "vCenter Server", Name: "vcenter"},
+						Version: "8.0.3",
+					},
+					Summary: lcm.InteropSummary{CompatibleCount: 5, IncompatibleCount: 1},
+				},
+			},
+		},
+		Issues: &lcm.InteropNotifications{
+			Warnings: []lcm.InteropNotification{
+				{
+					Id:      "warn-001",
+					Message: lcm.InteropLocalizableMessage{DefaultMessage: "check compatibility"},
+					Resolution: &lcm.InteropLocalizableMessage{
+						DefaultMessage: note,
+					},
+				},
+			},
+		},
+	}
+
+	info := &tasks.Info{Result: mustJSON(t, interopResult)}
+
+	got, err := lcm.ParseResult(info)
+	if err != nil {
+		t.Fatalf("ParseResult: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(got.Report.Rows) != 1 {
+		t.Errorf("got %d rows, want 1", len(got.Report.Rows))
+	}
+	if got.Report.Rows[0].Summary.CompatibleCount != 5 {
+		t.Errorf("got compatible_count %d, want 5", got.Report.Rows[0].Summary.CompatibleCount)
+	}
+	if got.Issues == nil || len(got.Issues.Warnings) != 1 {
+		t.Errorf("expected 1 warning")
+	}
+	if got.Issues.Warnings[0].Resolution.DefaultMessage != note {
+		t.Errorf("got resolution %q, want %q", got.Issues.Warnings[0].Resolution.DefaultMessage, note)
+	}
+}
+
+func TestParseResultEmpty(t *testing.T) {
+	info := &tasks.Info{}
+	got, err := lcm.ParseResult(info)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil result for empty task, got %+v", got)
+	}
+}
+
+func TestCreateInteropTask_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	m := newTestManager(ts)
+	_, err := m.CreateInteropTask(context.Background(), lcm.InteropComponent{
+		ProductName: "com.vmware.vcenter",
+		Version:     "8.0.3",
+	})
+	if err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+}
+
+func TestCreateInteropTaskWithIdentifier(t *testing.T) {
+	const wantID = "inst-abc-123"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Spec struct {
+				Components []struct {
+					Identifier *string `json:"identifier,omitempty"`
+				} `json:"components"`
+			} `json:"spec"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if len(body.Spec.Components) == 0 || body.Spec.Components[0].Identifier == nil {
+			t.Errorf("expected identifier in request body")
+		} else if *body.Spec.Components[0].Identifier != wantID {
+			t.Errorf("got identifier %q, want %q", *body.Spec.Components[0].Identifier, wantID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode("task-with-id")
+	}))
+	defer ts.Close()
+
+	m := newTestManager(ts)
+	_, err := m.CreateInteropTask(context.Background(), lcm.InteropComponent{
+		ProductName: "com.vmware.vcenter",
+		Version:     "8.0.3",
+		Identifier:  wantID,
+	})
+	if err != nil {
+		t.Fatalf("CreateInteropTask: %v", err)
+	}
+}
+
+func TestNewInsecureManager(t *testing.T) {
+	m := lcm.NewInsecureManager("https://vcenter.example.com", "admin", "secret")
+	if m == nil {
+		t.Fatal("expected non-nil manager from NewInsecureManager")
+	}
+}
+
+func TestWaitForCompletionFailedTask(t *testing.T) {
+	const failedJSON = `{"status":"FAILED","progress":{"total":100,"completed":50},` +
+		`"error":{"error_type":"com.vmware.vapi.std.errors.error"}}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(failedJSON))
+	}))
+	defer ts.Close()
+
+	m := newTestManager(ts)
+	_, err := m.WaitForCompletion(context.Background(), "task-fail")
+	if err == nil {
+		t.Fatal("expected error for failed task, got nil")
+	}
+}
+
+func TestWaitForCompletionContextCancelDuringPoll(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cancel() // cancel before returning so ctx.Done fires in the select
+		info := tasks.Info{Status: tasks.Running}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(info)
+	}))
+	defer ts.Close()
+
+	// Long polling interval so time.After loses to the already-closed ctx.Done.
+	m := lcm.NewManager(ts.URL, "user", "pass", ts.Client()).
+		WithPollingInterval(time.Hour)
+
+	_, err := m.WaitForCompletion(ctx, "task-999")
+	if err == nil {
+		t.Fatal("expected context cancellation error, got nil")
+	}
+}
+
+func TestGetTaskNetworkError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	m := newTestManager(ts)
+	ts.Close() // close before the request is made
+
+	_, err := m.GetTask(context.Background(), "task-123")
+	if err == nil {
+		t.Fatal("expected network error after server close, got nil")
+	}
+}
+
+func TestGetTaskInvalidJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not-valid-json"))
+	}))
+	defer ts.Close()
+
+	m := newTestManager(ts)
+	_, err := m.GetTask(context.Background(), "task-123")
+	if err == nil {
+		t.Fatal("expected unmarshal error for invalid JSON, got nil")
+	}
+}
+
+func TestParseResultInvalidJSON(t *testing.T) {
+	info := &tasks.Info{Result: []byte("not-valid-json")}
+	_, err := lcm.ParseResult(info)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}

--- a/vapi/lcm/interop_test.go
+++ b/vapi/lcm/interop_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -19,7 +20,8 @@ import (
 
 // newTestManager builds a Manager pointed at ts with no polling delay.
 func newTestManager(ts *httptest.Server) *lcm.Manager {
-	return lcm.NewManager(ts.URL, "user", "pass", ts.Client()).
+	u, _ := url.Parse(ts.URL)
+	return lcm.NewManager(u, "user", "pass", ts.Client()).
 		WithPollingInterval(0)
 }
 
@@ -284,7 +286,7 @@ func TestCreateInteropTaskWithIdentifier(t *testing.T) {
 }
 
 func TestNewInsecureManager(t *testing.T) {
-	m := lcm.NewInsecureManager("https://vcenter.example.com", "admin", "secret")
+	m := lcm.NewInsecureManager(&url.URL{Scheme: "https", Host: "vcenter.example.com"}, "admin", "secret")
 	if m == nil {
 		t.Fatal("expected non-nil manager from NewInsecureManager")
 	}
@@ -319,7 +321,8 @@ func TestWaitForCompletionContextCancelDuringPoll(t *testing.T) {
 	defer ts.Close()
 
 	// Long polling interval so time.After loses to the already-closed ctx.Done.
-	m := lcm.NewManager(ts.URL, "user", "pass", ts.Client()).
+	u, _ := url.Parse(ts.URL)
+	m := lcm.NewManager(u, "user", "pass", ts.Client()).
 		WithPollingInterval(time.Hour)
 
 	_, err := m.WaitForCompletion(ctx, "task-999")


### PR DESCRIPTION
## Description

Use vcenter paths /lcm/rest/cis/tasks/ and /lcm/rest/vcenter/lcm/interop to submit interop check request and get inerop report. These API endpoints support basic auth only, hence we only use net/http client. Added mirror implementations of interop task response content objects. These commands are marked as unreleased.
Use GOVC_SHOW_UNRELEASED=true to use them.

The two commands are as described below:

% GOVC_SHOW_UNRELEASED=true govc lcm.interop.check -h Usage: govc lcm.interop.check [OPTIONS]

Submit an LCM interoperability validation task.

Prints the task ID on success. Use lcm.interop.result to retrieve the report, or pass -wait to block until completion and print it immediately.

Examples:
  govc lcm.interop.check -version 8.0.3
  govc lcm.interop.check -product com.vmware.vcenter.supervisor -version 8.0.3 -identifier my-instance
  govc lcm.interop.check -version 8.0.3 -wait

govc lcm.interop.report -h
Usage: govc lcm.interop.report [OPTIONS] TASK_ID

Fetch and display the interoperability report for a task.

The task must have been created by lcm.interop.check. If the task is not yet complete, the current status is printed and the command exits with an error.

Examples:
  govc lcm.interop.report <task-id>
  govc lcm.interop.report -json <task-id

Closes: #(issue-number)

## How Has This Been Tested?

Unit and integration testing.
