### PR TITLE
Add functionality to import.vmdk for entity name derivation

### DIFF
--- a/vmdk/import.go
+++ b/vmdk/import.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -240,17 +239,14 @@ func Import(ctx context.Context, c *vim25.Client, name string, datastore *object
 		return err
 	}
 
-	var rename string
-
-	p.Path = strings.TrimSuffix(p.Path, "/")
-	if p.Path != "" {
-		disk.ImportName = p.Path
-		rename = path.Join(disk.ImportName, disk.Name)
+	// derive targets using shared helper so tests exercise actual behavior
+	entityName, target, err := deriveImportTargets(p, disk)
+	if err != nil {
+		return err
 	}
 
-	// "target" is the path that will be created by ImportVApp()
-	// ImportVApp uses the same name for the VM and the disk.
-	target := fmt.Sprintf("%s/%s.vmdk", disk.ImportName, disk.ImportName)
+	// set ImportName used by OVF template
+	disk.ImportName = entityName
 
 	if _, err = datastore.Stat(ctx, target); err == nil {
 		if p.Force {
@@ -260,13 +256,6 @@ func Import(ctx context.Context, c *vim25.Client, name string, datastore *object
 			}
 		} else {
 			return fmt.Errorf("%s: %s", os.ErrExist, datastore.Path(target))
-		}
-	}
-
-	// If we need to rename at the end, check if the file exists early unless Force.
-	if !p.Force && rename != "" {
-		if _, err = datastore.Stat(ctx, rename); err == nil {
-			return fmt.Errorf("%s: %s", os.ErrExist, datastore.Path(rename))
 		}
 	}
 
@@ -286,7 +275,7 @@ func Import(ctx context.Context, c *vim25.Client, name string, datastore *object
 
 	params := types.OvfCreateImportSpecParams{
 		DiskProvisioning: string(kind),
-		EntityName:       disk.ImportName,
+		EntityName:       entityName,
 	}
 
 	spec, err := m.CreateImportSpec(ctx, descriptor, pool, datastore, &params)
@@ -360,9 +349,5 @@ func Import(ctx context.Context, c *vim25.Client, name string, datastore *object
 		return err
 	}
 
-	if rename == "" {
-		return nil
-	}
-
-	return fm.Move(ctx, target, rename)
+	return nil
 }

--- a/vmdk/import.go
+++ b/vmdk/import.go
@@ -240,17 +240,14 @@ func Import(ctx context.Context, c *vim25.Client, name string, datastore *object
 		return err
 	}
 
-	var rename string
-
-	p.Path = strings.TrimSuffix(p.Path, "/")
-	if p.Path != "" {
-		disk.ImportName = p.Path
-		rename = path.Join(disk.ImportName, disk.Name)
+	// derive targets using shared helper so tests exercise actual behavior
+	entityName, target, err := deriveImportTargets(p, disk)
+	if err != nil {
+		return err
 	}
 
-	// "target" is the path that will be created by ImportVApp()
-	// ImportVApp uses the same name for the VM and the disk.
-	target := fmt.Sprintf("%s/%s.vmdk", disk.ImportName, disk.ImportName)
+	// set ImportName used by OVF template
+	disk.ImportName = entityName
 
 	if _, err = datastore.Stat(ctx, target); err == nil {
 		if p.Force {
@@ -260,13 +257,6 @@ func Import(ctx context.Context, c *vim25.Client, name string, datastore *object
 			}
 		} else {
 			return fmt.Errorf("%s: %s", os.ErrExist, datastore.Path(target))
-		}
-	}
-
-	// If we need to rename at the end, check if the file exists early unless Force.
-	if !p.Force && rename != "" {
-		if _, err = datastore.Stat(ctx, rename); err == nil {
-			return fmt.Errorf("%s: %s", os.ErrExist, datastore.Path(rename))
 		}
 	}
 
@@ -286,7 +276,7 @@ func Import(ctx context.Context, c *vim25.Client, name string, datastore *object
 
 	params := types.OvfCreateImportSpecParams{
 		DiskProvisioning: string(kind),
-		EntityName:       disk.ImportName,
+		EntityName:       entityName,
 	}
 
 	spec, err := m.CreateImportSpec(ctx, descriptor, pool, datastore, &params)
@@ -295,6 +285,16 @@ func Import(ctx context.Context, c *vim25.Client, name string, datastore *object
 	}
 	if spec.Error != nil {
 		return errors.New(spec.Error[0].LocalizedMessage)
+	}
+
+	// CreateImportSpec places the VM (and its vmdk) in a datastore folder named
+	// after entityName by default, ignoring any directory component of p.Path.
+	// Override the config file path so the vmdk ends up in the requested folder.
+	if vmSpec, ok := spec.ImportSpec.(*types.VirtualMachineImportSpec); ok {
+		uploadFolder := path.Dir(target)
+		vmSpec.ConfigSpec.Files = &types.VirtualMachineFileInfo{
+			VmPathName: datastore.Path(fmt.Sprintf("%s/%s.vmx", uploadFolder, entityName)),
+		}
 	}
 
 	lease, err := pool.ImportVApp(ctx, spec.ImportSpec, folder, p.Host)
@@ -360,9 +360,5 @@ func Import(ctx context.Context, c *vim25.Client, name string, datastore *object
 		return err
 	}
 
-	if rename == "" {
-		return nil
-	}
-
-	return fm.Move(ctx, target, rename)
+	return nil
 }

--- a/vmdk/import_helpers.go
+++ b/vmdk/import_helpers.go
@@ -1,0 +1,51 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmdk
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// deriveImportTargets centralizes logic for choosing the OVF entity name (no slashes),
+// upload folder, upload target, and final rename destination based on ImportParams
+// and the local disk info. It mirrors the behavior used in Import.
+func deriveImportTargets(p ImportParams, disk *Info) (entityName, target string, err error) {
+	// original import name derived from local file (base name without .vmdk)
+	origImport := disk.ImportName
+
+	// If no remote path provided, fall back to original behavior where entityName
+	// is derived from the local vmdk base name and upload folder == entityName.
+	if strings.TrimSpace(p.Path) == "" {
+		entityName = origImport
+		target = fmt.Sprintf("%s/%s.vmdk", origImport, origImport)
+		return
+	}
+
+	// remotePath is the provided target path (should include the vmdk filename)
+	remotePath := strings.TrimSuffix(p.Path, "/")
+	base := path.Base(remotePath)
+
+	if path.Ext(base) != ".vmdk" {
+		err = fmt.Errorf("remote target must end with .vmdk; the last element will be the vmdk name (e.g. windows/win2019/mydisk.vmdk)")
+		return
+	}
+
+	// entityName is the vmdk file name without extension
+	entityName = strings.TrimSuffix(base, ".vmdk")
+
+	// dir is the folder portion of the provided path. If none, we implicitly create a folder named after the vmdk
+	dir := path.Dir(remotePath)
+	uploadFolder := dir
+	if dir == "." || dir == "" {
+		uploadFolder = entityName
+	}
+
+	// target is where ImportVApp will place the uploaded disk (uploadFolder/entityName.vmdk).
+	target = fmt.Sprintf("%s/%s.vmdk", uploadFolder, entityName)
+
+	return
+}

--- a/vmdk/import_helpers_test.go
+++ b/vmdk/import_helpers_test.go
@@ -1,0 +1,60 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmdk
+
+import (
+	"testing"
+)
+
+func TestDeriveImportTargets(t *testing.T) {
+	// common local disk info
+	disk := &Info{
+		Name:       "local.vmdk",
+		ImportName: "local",
+	}
+
+	tests := []struct {
+		name       string
+		params     ImportParams
+		wantEntity string
+		wantTarget string
+		wantError  bool
+	}{
+		{
+			name:       "Full Path",
+			params:     ImportParams{Path: "windows/win2019/win2019.vmdk"},
+			wantEntity: "win2019",
+			wantTarget: "windows/win2019/win2019.vmdk",
+			wantError:  false,
+		},
+		{
+			name:       "Only vmdk name",
+			params:     ImportParams{Path: "win2019.vmdk"},
+			wantEntity: "win2019",
+			wantTarget: "win2019/win2019.vmdk",
+			wantError:  false,
+		},
+		{
+			name:      "Only target path",
+			params:    ImportParams{Path: "windows"},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entity, target, err := deriveImportTargets(tt.params, disk)
+			if tt.wantError && err == nil {
+				t.Fatalf("error: got %v want %v", err, tt.wantError)
+			}
+			if entity != tt.wantEntity {
+				t.Fatalf("entity: got %q want %q", entity, tt.wantEntity)
+			}
+			if target != tt.wantTarget {
+				t.Fatalf("target: got %q want %q", target, tt.wantTarget)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Changed the upload target path and name calculation to properly interpret nested directory structures and allow setting the name of the vmdk.

Closes: #4061

## How Has This Been Tested?

Ran unit tests.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
