### PR TITLE
Add simulator methods for eam2 cluster solutions api

### DIFF
--- a/vapi/esx/settings/clusters/vms/simulator/simulator.go
+++ b/vapi/esx/settings/clusters/vms/simulator/simulator.go
@@ -1,0 +1,255 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/esx/settings/clusters/vms"
+	vapi "github.com/vmware/govmomi/vapi/simulator"
+)
+
+func init() {
+	simulator.RegisterEndpoint(func(s *simulator.Service, r *simulator.Registry) {
+		New(s.Listen).Register(s, r)
+	})
+}
+
+// Handler implements the EAM vms API simulator.
+type Handler struct {
+	URL       *url.URL
+	Solutions map[string]map[string]vms.SolutionInfo        // clusterID → solutionID → info
+	Hooks     map[string]map[string][]vms.LifecycleHookInfo // clusterID → solutionID → hooks
+	Tasks     map[string]json.RawMessage                    // taskID → task JSON
+	taskCount int
+}
+
+// New creates a Handler instance.
+func New(u *url.URL) *Handler {
+	return &Handler{
+		URL:       u,
+		Solutions: make(map[string]map[string]vms.SolutionInfo),
+		Hooks:     make(map[string]map[string][]vms.LifecycleHookInfo),
+		Tasks:     make(map[string]json.RawMessage),
+	}
+}
+
+// Register adds all VMS API paths to the simulator's HTTP mux.
+func (h *Handler) Register(s *simulator.Service, r *simulator.Registry) {
+	if r.IsVPX() {
+		s.HandleFunc("/api/esx/settings/clusters/{cluster}/vms/solutions", h.solutions)
+		s.HandleFunc("/api/esx/settings/clusters/{cluster}/vms/solutions/{solution}", h.solution)
+		s.HandleFunc("/api/esx/settings/clusters/{cluster}/vms/lifecycle-hooks", h.hooksCollection)
+		s.HandleFunc("/api/esx/settings/clusters/{cluster}/vms/lifecycle-hooks/{solution}", h.hooksSolution)
+		s.HandleFunc("/api/esx/settings/clusters/{cluster}/vms/transition/{solution}", h.transition)
+		s.HandleFunc("/api/cis/tasks/{task}", h.taskGet)
+	}
+}
+
+// newTask stores a SUCCEEDED task and returns its ID.
+func (h *Handler) newTask() string {
+	h.taskCount++
+	id := fmt.Sprintf("vms-task-%d", h.taskCount)
+	h.Tasks[id] = json.RawMessage(`{"status":"SUCCEEDED","result":null}`)
+	return id
+}
+
+// clusterSolutions returns (and lazily initialises) the solution map for a cluster.
+func (h *Handler) clusterSolutions(cluster string) map[string]vms.SolutionInfo {
+	if h.Solutions[cluster] == nil {
+		h.Solutions[cluster] = make(map[string]vms.SolutionInfo)
+	}
+	return h.Solutions[cluster]
+}
+
+// solutions handles the solutions collection endpoint.
+//
+//	GET  /api/esx/settings/clusters/{cluster}/vms/solutions
+//	POST /api/esx/settings/clusters/{cluster}/vms/solutions?action=apply&vmw-task=true
+//	POST /api/esx/settings/clusters/{cluster}/vms/solutions?action=check-compliance&vmw-task=true
+func (h *Handler) solutions(w http.ResponseWriter, r *http.Request) {
+	cluster := r.PathValue("cluster")
+	action := r.URL.Query().Get("action")
+
+	switch r.Method {
+	case http.MethodGet:
+		vapi.StatusOK(w, vms.ListResult{Solutions: h.clusterSolutions(cluster)})
+
+	case http.MethodPost:
+		switch action {
+		case "apply":
+			var spec vms.ApplySpec
+			if vapi.Decode(r, w, &spec) {
+				vapi.StatusOK(w, h.newTask())
+			}
+		case "check-compliance":
+			var spec vms.CheckComplianceFilterSpec
+			if vapi.Decode(r, w, &spec) {
+				vapi.StatusOK(w, h.newTask())
+			}
+		default:
+			vapi.ApiErrorInvalidArgument(w)
+		}
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// solution handles the per-solution endpoint.
+//
+//	GET    /api/esx/settings/clusters/{cluster}/vms/solutions/{solution}
+//	PUT    /api/esx/settings/clusters/{cluster}/vms/solutions/{solution}?vmw-task=true
+//	DELETE /api/esx/settings/clusters/{cluster}/vms/solutions/{solution}?vmw-task=true
+func (h *Handler) solution(w http.ResponseWriter, r *http.Request) {
+	cluster := r.PathValue("cluster")
+	solution := r.PathValue("solution")
+	sols := h.clusterSolutions(cluster)
+
+	switch r.Method {
+	case http.MethodGet:
+		info, ok := sols[solution]
+		if !ok {
+			vapi.ApiErrorNotFound(w)
+			return
+		}
+		vapi.StatusOK(w, info)
+
+	case http.MethodPut:
+		var spec vms.SolutionSpec
+		if !vapi.Decode(r, w, &spec) {
+			return
+		}
+		// Round-trip through JSON to populate the overlapping SolutionInfo fields.
+		data, _ := json.Marshal(spec)
+		var info vms.SolutionInfo
+		_ = json.Unmarshal(data, &info)
+		sols[solution] = info
+		vapi.StatusOK(w, h.newTask())
+
+	case http.MethodDelete:
+		if _, ok := sols[solution]; !ok {
+			vapi.ApiErrorNotFound(w)
+			return
+		}
+		delete(sols, solution)
+		vapi.StatusOK(w, h.newTask())
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// hooksCollection handles POST actions on the lifecycle-hooks collection.
+//
+//	POST /api/esx/settings/clusters/{cluster}/vms/lifecycle-hooks?action=mark-as-processed
+//	POST /api/esx/settings/clusters/{cluster}/vms/lifecycle-hooks?action=process-dynamic-update
+func (h *Handler) hooksCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	action := r.URL.Query().Get("action")
+	switch action {
+	case "mark-as-processed":
+		var spec vms.ProcessedHookSpec
+		if vapi.Decode(r, w, &spec) {
+			vapi.StatusOK(w, nil)
+		}
+	case "process-dynamic-update":
+		var spec vms.DynamicUpdateSpec
+		if vapi.Decode(r, w, &spec) {
+			vapi.StatusOK(w, nil)
+		}
+	default:
+		vapi.ApiErrorInvalidArgument(w)
+	}
+}
+
+// hooksSolution handles GET on a per-solution hooks endpoint.
+//
+//	GET /api/esx/settings/clusters/{cluster}/vms/lifecycle-hooks/{solution}
+func (h *Handler) hooksSolution(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	cluster := r.PathValue("cluster")
+	solution := r.PathValue("solution")
+
+	var hooks []vms.LifecycleHookInfo
+	if clusterHooks, ok := h.Hooks[cluster]; ok {
+		hooks = clusterHooks[solution]
+	}
+	if hooks == nil {
+		hooks = []vms.LifecycleHookInfo{}
+	}
+	vapi.StatusOK(w, vms.HookListResult{Hooks: hooks})
+}
+
+// transition handles transition actions for a solution.
+//
+//	POST /api/esx/settings/clusters/{cluster}/vms/transition/{solution}?action=enable&vmw-task=true
+//	POST /api/esx/settings/clusters/{cluster}/vms/transition/{solution}?action=multi-source-enable&vmw-task=true
+//	POST /api/esx/settings/clusters/{cluster}/vms/transition/{solution}?action=transition&vmw-task=true
+//	POST /api/esx/settings/clusters/{cluster}/vms/transition/{solution}?action=delete-solution-only
+func (h *Handler) transition(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	cluster := r.PathValue("cluster")
+	solution := r.PathValue("solution")
+	action := r.URL.Query().Get("action")
+
+	switch action {
+	case "enable":
+		var spec vms.EnableSpec
+		if vapi.Decode(r, w, &spec) {
+			vapi.StatusOK(w, h.newTask())
+		}
+	case "multi-source-enable":
+		var spec vms.MultiSourceEnableSpec
+		if vapi.Decode(r, w, &spec) {
+			vapi.StatusOK(w, h.newTask())
+		}
+	case "transition":
+		var spec vms.TransitionSpec
+		if vapi.Decode(r, w, &spec) {
+			vapi.StatusOK(w, h.newTask())
+		}
+	case "delete-solution-only":
+		sols := h.clusterSolutions(cluster)
+		if _, ok := sols[solution]; !ok {
+			vapi.ApiErrorNotFound(w)
+			return
+		}
+		delete(sols, solution)
+		vapi.StatusOK(w)
+	default:
+		vapi.ApiErrorInvalidArgument(w)
+	}
+}
+
+// taskGet handles task status polls from the task manager.
+//
+//	GET /api/cis/tasks/{task}
+func (h *Handler) taskGet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	result, ok := h.Tasks[r.PathValue("task")]
+	if !ok {
+		vapi.ApiErrorNotFound(w)
+		return
+	}
+	vapi.StatusOK(w, result)
+}

--- a/vapi/esx/settings/clusters/vms/simulator/simulator_test.go
+++ b/vapi/esx/settings/clusters/vms/simulator/simulator_test.go
@@ -1,0 +1,231 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/esx/settings/clusters/vms"
+	"github.com/vmware/govmomi/vapi/rest"
+	_ "github.com/vmware/govmomi/vapi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// testSetup returns a logged-in vms.Manager and a cluster MOR from the simulator.
+func testSetup(ctx context.Context, vc *vim25.Client, t *testing.T) (*vms.Manager, types.ManagedObjectReference) {
+	t.Helper()
+
+	c := rest.NewClient(vc)
+	if err := c.Login(ctx, simulator.DefaultLogin); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = c.Logout(ctx) })
+
+	m := &vms.Manager{Client: c}
+
+	ccr := simulator.Map(ctx).Any("ClusterComputeResource")
+	if ccr == nil {
+		t.Fatal("no ClusterComputeResource found in simulator")
+	}
+	return m, ccr.Reference()
+}
+
+// minimalSpec returns a SolutionSpec with the minimum fields populated.
+func minimalSpec(name string) *vms.SolutionSpec {
+	return &vms.SolutionSpec{
+		DeploymentType:     vms.EveryHostPinned,
+		DisplayName:        name,
+		DisplayVersion:     "1.0.0",
+		VmNameTemplate:     vms.VmNameTemplate{Prefix: name + "-vm", Suffix: vms.Uuid},
+		VmCloneConfig:      vms.NoClones,
+		VmStoragePolicy:    vms.Default,
+		VmDiskType:         vms.DiskTypeDefault,
+		RedeploymentPolicy: vms.ReCreate,
+		OvfResource:        vms.OvfResource{LocationType: vms.RemoteFile},
+	}
+}
+
+// TestSetGetDelete exercises the basic CRUD lifecycle via task-based operations.
+func TestSetGetDelete(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		m, cluster := testSetup(ctx, vc, t)
+
+		const id = "sol-a"
+		spec := minimalSpec(id)
+
+		if err := m.Set(ctx, cluster, id, spec); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+
+		info, err := m.Get(ctx, cluster, id)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if info.DisplayName != spec.DisplayName {
+			t.Errorf("DisplayName: got %q, want %q", info.DisplayName, spec.DisplayName)
+		}
+
+		if err := m.Delete(ctx, cluster, id); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+
+		if _, err := m.Get(ctx, cluster, id); err == nil {
+			t.Fatal("Get after Delete: expected error, got nil")
+		}
+	})
+}
+
+// TestList verifies that List returns an accurate count of known solutions.
+func TestList(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		m, cluster := testSetup(ctx, vc, t)
+
+		result, err := m.List(ctx, cluster)
+		if err != nil {
+			t.Fatalf("List (empty): %v", err)
+		}
+		if len(result.Solutions) != 0 {
+			t.Fatalf("expected 0 solutions initially, got %d", len(result.Solutions))
+		}
+
+		for _, id := range []string{"sol-1", "sol-2"} {
+			if err := m.Set(ctx, cluster, id, minimalSpec(id)); err != nil {
+				t.Fatalf("Set %s: %v", id, err)
+			}
+		}
+
+		result, err = m.List(ctx, cluster)
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(result.Solutions) != 2 {
+			t.Fatalf("expected 2 solutions, got %d", len(result.Solutions))
+		}
+	})
+}
+
+// TestApply verifies that Apply returns a task ID and the task completes.
+func TestApply(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		m, cluster := testSetup(ctx, vc, t)
+
+		taskID, err := m.Apply(ctx, cluster, &vms.ApplySpec{})
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		if taskID == "" {
+			t.Fatal("Apply: empty task ID")
+		}
+		if _, err := m.ApplyWaitForCompletion(ctx, taskID); err != nil {
+			t.Fatalf("ApplyWaitForCompletion: %v", err)
+		}
+	})
+}
+
+// TestCheckCompliance verifies that CheckCompliance completes without error.
+func TestCheckCompliance(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		m, cluster := testSetup(ctx, vc, t)
+
+		if _, err := m.CheckCompliance(ctx, cluster, &vms.CheckComplianceFilterSpec{}); err != nil {
+			t.Fatalf("CheckCompliance: %v", err)
+		}
+	})
+}
+
+// TestListHooks verifies that ListHooks returns a non-nil hooks slice.
+func TestListHooks(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		m, cluster := testSetup(ctx, vc, t)
+
+		result, err := m.ListHooks(ctx, cluster, "any-solution")
+		if err != nil {
+			t.Fatalf("ListHooks: %v", err)
+		}
+		if result.Hooks == nil {
+			t.Fatal("ListHooks: expected non-nil hooks slice")
+		}
+	})
+}
+
+// TestMarkAsProcessed verifies that MarkAsProcessed succeeds.
+func TestMarkAsProcessed(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		m, cluster := testSetup(ctx, vc, t)
+
+		spec := &vms.ProcessedHookSpec{
+			Vm:                    "vm-1",
+			LifecycleState:        vms.PostPowerOn,
+			ProcessedSuccessfully: true,
+		}
+		if _, err := m.MarkAsProcessed(ctx, cluster, spec); err != nil {
+			t.Fatalf("MarkAsProcessed: %v", err)
+		}
+	})
+}
+
+// TestProcessDynamicUpdate verifies that ProcessDynamicUpdate succeeds.
+func TestProcessDynamicUpdate(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		m, cluster := testSetup(ctx, vc, t)
+
+		spec := &vms.DynamicUpdateSpec{
+			Vm:             "vm-1",
+			Solution:       "sol-a",
+			LifecycleState: vms.PostPowerOn,
+		}
+		if err := m.ProcessDynamicUpdate(ctx, cluster, spec); err != nil {
+			t.Fatalf("ProcessDynamicUpdate: %v", err)
+		}
+	})
+}
+
+// TestEnable verifies that Enable (transition from EAM-managed to vLCM) succeeds.
+func TestEnable(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		m, cluster := testSetup(ctx, vc, t)
+
+		spec := &vms.EnableSpec{
+			EamAgencyID: "agency-1",
+			Solution:    minimalSpec("sol-enable"),
+		}
+		if err := m.Enable(ctx, cluster, "sol-enable", spec); err != nil {
+			t.Fatalf("Enable: %v", err)
+		}
+	})
+}
+
+// TestMultiSourceEnable verifies that MultiSourceEnable succeeds.
+func TestMultiSourceEnable(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		m, cluster := testSetup(ctx, vc, t)
+
+		spec := &vms.MultiSourceEnableSpec{
+			EamAgencyIDs: []string{"agency-1", "agency-2"},
+			Solution:     minimalSpec("sol-multi"),
+		}
+		if err := m.MultiSourceEnable(ctx, cluster, "sol-multi", spec); err != nil {
+			t.Fatalf("MultiSourceEnable: %v", err)
+		}
+	})
+}
+
+// TestTransition verifies that Transition (move solution to another cluster) succeeds.
+func TestTransition(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		m, cluster := testSetup(ctx, vc, t)
+
+		spec := &vms.TransitionSpec{
+			SourceCluster: "domain-c8",
+			Solution:      minimalSpec("sol-transition"),
+		}
+		if err := m.Transition(ctx, cluster, "sol-transition", spec); err != nil {
+			t.Fatalf("Transition: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Description

Adds simulator methods for the eam2 esx/settings/clusters/vms api

Please include a summary of the change.

The clusters/vms api lacked simulator methods.  This change introduces the handlers for those methods in vcsim.

Closes: #(issue-number)

## How Has This Been Tested?

`go test -v vapi/esx/settings/clusters/vms/...  && make lint` pass.

Please describe any manual tests done to verify your changes.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
