### PR TITLE
api(cns): add ActiveClusters to CnsVolumePolicyReconfigSpec

### DIFF
--- a/cns/types/activeclusters_test.go
+++ b/cns/types/activeclusters_test.go
@@ -1,0 +1,52 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
+)
+
+// TestCnsVolumePolicyReconfigSpecActiveClusters verifies that the
+// ActiveClusters field serializes into the CNS ReconfigPolicy request, so CNS
+// can auto-relocate a volume whose target profile differs. It mirrors the
+// existing CnsVolumeCreateSpec.ActiveClusters serialization.
+func TestCnsVolumePolicyReconfigSpecActiveClusters(t *testing.T) {
+	spec := CnsVolumePolicyReconfigSpec{
+		VolumeId: CnsVolumeId{Id: "vol-1"},
+		Profile: []types.BaseVirtualMachineProfileSpec{
+			&types.VirtualMachineDefinedProfileSpec{ProfileId: "policy-1"},
+		},
+		ActiveClusters: []types.ManagedObjectReference{
+			{Type: "ClusterComputeResource", Value: "domain-c1"},
+		},
+	}
+
+	b, err := xml.Marshal(spec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	out := string(b)
+	if !strings.Contains(out, "activeClusters") {
+		t.Errorf("expected activeClusters element in:\n%s", out)
+	}
+	if !strings.Contains(out, "domain-c1") {
+		t.Errorf("expected cluster moref value domain-c1 in:\n%s", out)
+	}
+
+	// omitempty: no ActiveClusters -> no element (an in-place reconfigure).
+	spec.ActiveClusters = nil
+	b, err = xml.Marshal(spec)
+	if err != nil {
+		t.Fatalf("marshal (empty): %v", err)
+	}
+	if strings.Contains(string(b), "activeClusters") {
+		t.Errorf("expected no activeClusters element when empty, got:\n%s", string(b))
+	}
+}

--- a/cns/types/types.go
+++ b/cns/types/types.go
@@ -986,8 +986,9 @@ type CnsReconfigVolumePolicyResponse struct {
 type CnsVolumePolicyReconfigSpec struct {
 	types.DynamicData
 
-	VolumeId CnsVolumeId                           `xml:"volumeId" json:"volumeId"`
-	Profile  []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr" json:"profile"`
+	VolumeId       CnsVolumeId                           `xml:"volumeId" json:"volumeId"`
+	Profile        []types.BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr" json:"profile"`
+	ActiveClusters []types.ManagedObjectReference        `xml:"activeClusters,omitempty,typeattr" json:"activeClusters"`
 }
 
 func init() {


### PR DESCRIPTION
## Description

Adds an optional `ActiveClusters` field to `CnsVolumePolicyReconfigSpec`.

`CnsReconfigVolumePolicy` can auto-relocate a volume to a compatible datastore
when the target storage profile differs from the volume's current profile, but
only when the caller supplies the set of active `ClusterComputeResource`s to
relocate within — the same input already carried by
`CnsVolumeCreateSpec.ActiveClusters`.

This change adds the field to `CnsVolumePolicyReconfigSpec`, mirroring the
create spec's type and XML serialization (`omitempty` + `typeattr`), so a policy
reconfigure can request a relocate. Without it, `ReconfigPolicy` can only perform
an in-place profile change. The field is optional and backward compatible:
existing callers that omit it serialize the same request as before.

## How Has This Been Tested?

`go test -race ./cns/types/...` and `make go-test` pass.

A new unit test (`TestCnsVolumePolicyReconfigSpecActiveClusters`) verifies that
`ActiveClusters` serializes into the `ReconfigPolicy` request XML when set, and
is omitted (via `omitempty`) when nil — i.e. an in-place reconfigure.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
