### PR TITLE
vcsim: Fix data race via shared default device templates

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -179,6 +179,15 @@ func (o VirtualMachine) addDefaultDevices(
 		existingDefaultDeviceMap = map[int32]struct{}{}
 	)
 
+	// Copy the package-level default devices so each VM gets its own
+	// instances. Sharing them across VMs would mean a device mutation on
+	// one VM, e.g. object.VirtualDeviceList.AssignController appending to
+	// the PCI controller's Device list, is visible on every other VM and
+	// races with concurrent readers of those VMs.
+	defaults := types.ArrayOfVirtualDevice{}
+	deepCopy(types.ArrayOfVirtualDevice{VirtualDevice: esx.VirtualDevice}, &defaults)
+	defaultDevices := object.VirtualDeviceList(defaults.VirtualDevice)
+
 	for i := range src.DeviceChange {
 		var (
 			dc     = src.DeviceChange[i]
@@ -201,36 +210,36 @@ func (o VirtualMachine) addDefaultDevices(
 		case *types.VirtualIDEController:
 			switch td.BusNumber {
 			case 0:
-				fn(esx.VirtualMachineDefaultDeviceIDEControllerBus0)
+				fn(defaultDevices.FindByKey(esx.VirtualMachineDefaultDeviceIDEControllerBus0.Key))
 			case 1:
-				fn(esx.VirtualMachineDefaultDeviceIDEControllerBus1)
+				fn(defaultDevices.FindByKey(esx.VirtualMachineDefaultDeviceIDEControllerBus1.Key))
 			}
 		case *types.VirtualPS2Controller:
-			fn(esx.VirtualMachineDefaultDevicePS2Controller)
+			fn(defaultDevices.FindByKey(esx.VirtualMachineDefaultDevicePS2Controller.Key))
 		case *types.VirtualPCIController:
-			fn(esx.VirtualMachineDefaultDevicePCIController)
+			fn(defaultDevices.FindByKey(esx.VirtualMachineDefaultDevicePCIController.Key))
 		case *types.VirtualSIOController:
-			fn(esx.VirtualMachineDefaultDeviceSIOController)
+			fn(defaultDevices.FindByKey(esx.VirtualMachineDefaultDeviceSIOController.Key))
 		case *types.VirtualKeyboard:
-			fn(esx.VirtualMachineDefaultDeviceVirtualKeyboard)
+			fn(defaultDevices.FindByKey(esx.VirtualMachineDefaultDeviceVirtualKeyboard.Key))
 		case *types.VirtualPointingDevice:
-			fn(esx.VirtualMachineDefaultDeviceVirtualPointingDevice)
+			fn(defaultDevices.FindByKey(esx.VirtualMachineDefaultDeviceVirtualPointingDevice.Key))
 		case *types.VirtualMachineVideoCard:
-			fn(esx.VirtualMachineDefaultDeviceVideoCard)
+			fn(defaultDevices.FindByKey(esx.VirtualMachineDefaultDeviceVideoCard.Key))
 		case *types.VirtualMachineVMCIDevice:
-			fn(esx.VirtualMachineDefaultDeviceVMCIDevice)
+			fn(defaultDevices.FindByKey(esx.VirtualMachineDefaultDeviceVMCIDevice.Key))
 		}
 	}
 
 	// Add any of the missing default devices.
-	for i := range esx.VirtualDevice {
-		vd := esx.VirtualDevice[i].GetVirtualDevice()
+	for i := range defaultDevices {
+		vd := defaultDevices[i].GetVirtualDevice()
 		if _, ok := existingDefaultDeviceMap[vd.Key]; !ok {
 			dst.DeviceChange = append(
 				dst.DeviceChange,
 				&types.VirtualDeviceConfigSpec{
 					Operation: types.VirtualDeviceConfigSpecOperationAdd,
-					Device:    esx.VirtualDevice[i],
+					Device:    defaultDevices[i],
 				})
 		}
 	}

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -734,6 +734,90 @@ func TestReconfigVmDevice(t *testing.T) {
 	}
 }
 
+func TestReconfigVmDefaultDevicesNotShared(t *testing.T) {
+	Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c, false)
+		dc, err := finder.DefaultDatacenter(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		finder.SetDatacenter(dc)
+
+		folders, err := dc.Folders(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pool, err := finder.ResourcePool(ctx, "DC0_H0/Resources")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create powered off VMs, so that the device list is not cloned by
+		// a power state change (see powerVMTask.Run).
+		create := func(name string) *object.VirtualMachine {
+			spec := types.VirtualMachineConfigSpec{
+				Name:    name,
+				GuestId: string(types.VirtualMachineGuestOsIdentifierOtherGuest),
+				Files: &types.VirtualMachineFileInfo{
+					VmPathName: "[LocalDS_0]",
+				},
+			}
+			task, err := folders.VmFolder.CreateVM(ctx, spec, pool, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			info, err := task.WaitForResult(ctx, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return object.NewVirtualMachine(c, info.Result.(types.ManagedObjectReference))
+		}
+
+		vm1 := create(t.Name() + "-vm1")
+		vm2 := create(t.Name() + "-vm2")
+
+		templateDevices := len(esx.VirtualMachineDefaultDevicePCIController.Device)
+
+		devices, err := vm2.Device(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pci, ok := devices.FindByKey(esx.VirtualMachineDefaultDevicePCIControllerKey).(*types.VirtualPCIController)
+		if !ok {
+			t.Fatal("vm2 PCI controller not found")
+		}
+		vm2Devices := len(pci.Device)
+
+		// Add a NIC without a UnitNumber so the simulator assigns it to the
+		// PCI controller (object.VirtualDeviceList.AssignController).
+		nic := &types.VirtualE1000{}
+		nic.Backing = &types.VirtualEthernetCardNetworkBackingInfo{
+			VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
+				DeviceName: "VM Network",
+			},
+		}
+		if err := vm1.AddDevice(ctx, nic); err != nil {
+			t.Fatal(err)
+		}
+
+		if n := len(esx.VirtualMachineDefaultDevicePCIController.Device); n != templateDevices {
+			t.Errorf("esx.VirtualMachineDefaultDevicePCIController.Device count changed: %d -> %d", templateDevices, n)
+		}
+
+		devices, err = vm2.Device(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pci, ok = devices.FindByKey(esx.VirtualMachineDefaultDevicePCIControllerKey).(*types.VirtualPCIController)
+		if !ok {
+			t.Fatal("vm2 PCI controller not found")
+		}
+		if n := len(pci.Device); n != vm2Devices {
+			t.Errorf("vm2 PCI controller device count changed: %d -> %d", vm2Devices, n)
+		}
+	})
+}
+
 func TestConnectVmDevice(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Description

`addDefaultDevices` added the package-level `esx.VirtualDevice` template devices directly to each VM's device list, so every VM created via `CreateVM_Task`/`RegisterVM_Task` shared the same device instances (until a power state change happened to clone the list via `powerVMTask.Run`).

Reconfiguring a powered off VM, e.g. adding an ethernet card, calls `object.VirtualDeviceList.AssignController`, which appends the new device key to the shared PCI controller's `Device` slice. The mutation:

- is visible in every other VM's `config.hardware.device` (and in the package-level templates themselves), and
- races with the XML marshaling of concurrent requests reading another VM, failing tests that run vcsim under the Go race detector:

```
WARNING: DATA RACE
Write:  object.VirtualDeviceList.AssignController (object/virtual_device_list.go)
        <- simulator.(*VirtualMachine).configureDevice <- ReconfigVM_Task
Previous read: vim25/xml.(*printer).marshalValue (response marshaling)
```

This change copies the default devices per VM in `addDefaultDevices` so a VM never aliases the package-level templates.

## How Has This Been Tested?

- Added `TestReconfigVmDefaultDevicesNotShared`: creates two powered off VMs, adds a NIC to one, and asserts neither the `esx` templates nor the other VM's PCI controller changed. Fails before this fix (both counts go 2 -> 3), passes after.
- `go test -race -count=1 ./simulator/...` passes, except the pre-existing unrelated flake in `TestVirtualDiskUUIDAssignment` (`Registry.AppendReference` on `ds.Vm` vs `Datastore.resolve`), which reproduces identically on a clean `main` checkout (3 of 20 runs on both).

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md