### PR TITLE
vcsim: Fix data race in PropertyFilter prefix match

### DIFF
--- a/simulator/property_filter.go
+++ b/simulator/property_filter.go
@@ -123,7 +123,20 @@ func (f *PropertyFilter) matches(ctx *Context, ref types.ManagedObjectReference,
 			if strings.HasPrefix(change.Name, name) {
 				if obj := ctx.Map.Get(ref); obj != nil { // object may have since been deleted
 					change.Name = name
-					change.Val, _ = fieldValue(reflect.ValueOf(obj), name)
+					// Hold the object's lock while reading its live state, as
+					// a task (e.g. ReconfigVM_Task) may be mutating the object.
+					// fieldValue does not copy nested data, so deep copy while
+					// still holding the lock, as the change is not encoded
+					// until after the lock is released.
+					ctx.WithLock(obj, func() {
+						val, _ := fieldValue(reflect.ValueOf(obj), name)
+						if val != nil {
+							var dst types.PropertyChange
+							deepCopy(types.PropertyChange{Val: val}, &dst)
+							val = dst.Val
+						}
+						change.Val = val
+					})
 				}
 
 				return true

--- a/simulator/race_test.go
+++ b/simulator/race_test.go
@@ -6,6 +6,7 @@ package simulator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -16,6 +17,7 @@ import (
 	"github.com/vmware/govmomi/event"
 	"github.com/vmware/govmomi/fault"
 	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25"
@@ -317,6 +319,149 @@ func TestRaceDestroy(t *testing.T) {
 	if !notFound {
 		t.Error("expected ManagedObjectNotFound")
 	}
+}
+
+// TestWaitForUpdatesPrefixMatchRace reproduces a data race in
+// PropertyFilter.matches: when a change name matches a parent prefix of the
+// filter's PathSet (e.g. PathSet ["config"] matching a "config.hardware.device"
+// update), the WaitForUpdatesEx goroutine re-reads the object's live property
+// state via fieldValue without holding the object's lock, racing with a
+// ReconfigVM_Task goroutine mutating the same VM under its lock.
+func TestWaitForUpdatesPrefixMatchRace(t *testing.T) {
+	Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c)
+
+		dc, err := finder.DefaultDatacenter(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		finder.SetDatacenter(dc)
+
+		folders, err := dc.Folders(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pool, err := finder.ResourcePool(ctx, "DC0_H0/Resources")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		spec := types.VirtualMachineConfigSpec{
+			Name:    "prefix-match-race",
+			GuestId: string(types.VirtualMachineGuestOsIdentifierOtherGuest),
+			Files: &types.VirtualMachineFileInfo{
+				VmPathName: "[LocalDS_0]",
+			},
+		}
+
+		task, err := folders.VmFolder.CreateVM(ctx, spec, pool, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		info, err := task.WaitForResult(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The VM is intentionally left powered off: ReconfigVM_Task then
+		// mutates the device list in place.
+		vm := object.NewVirtualMachine(c, info.Result.(types.ManagedObjectReference))
+
+		wctx, cancel := context.WithCancel(ctx)
+		var watcher sync.WaitGroup
+
+		watcher.Add(1)
+		go func() {
+			defer watcher.Done()
+
+			pc := property.DefaultCollector(c)
+			// The parent field "config" forces the PropertyFilter.matches
+			// prefix path to re-read the whole config subtree on every
+			// "config.*" update.
+			werr := property.Wait(wctx, pc, vm.Reference(), []string{"config"}, func([]types.PropertyChange) bool {
+				return false // consume updates until wctx is canceled
+			})
+			if werr != nil && !errors.Is(werr, context.Canceled) {
+				t.Error(werr)
+			}
+		}()
+
+		var writers sync.WaitGroup
+
+		// Add and remove a NIC in a loop; the simulator assigns the
+		// controller and MAC address, mutating config.hardware.device
+		// during the task, after property updates have been published.
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+
+			for i := 0; i < 100; i++ {
+				nic := &types.VirtualE1000{
+					VirtualEthernetCard: types.VirtualEthernetCard{
+						VirtualDevice: types.VirtualDevice{
+							Backing: &types.VirtualEthernetCardNetworkBackingInfo{
+								VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
+									DeviceName: "VM Network",
+								},
+							},
+						},
+					},
+				}
+
+				if err := vm.AddDevice(ctx, nic); err != nil {
+					t.Error(err)
+					return
+				}
+
+				devices, err := vm.Device(ctx)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+
+				cards := devices.SelectByType((*types.VirtualEthernetCard)(nil))
+				if len(cards) == 0 {
+					t.Error("no ethernet card found")
+					return
+				}
+
+				if err := vm.RemoveDevice(ctx, false, cards[len(cards)-1]); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}()
+
+		// Reconfig ExtraConfig in a loop, mutating config.extraConfig on
+		// the same VM.
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+
+			for i := 0; i < 100; i++ {
+				rtask, err := vm.Reconfigure(ctx, types.VirtualMachineConfigSpec{
+					ExtraConfig: []types.BaseOptionValue{
+						&types.OptionValue{Key: "race.test", Value: fmt.Sprintf("%d", i)},
+					},
+				})
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				if err := rtask.Wait(ctx); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}()
+
+		writers.Wait()
+		cancel()
+		watcher.Wait()
+	})
 }
 
 func TestRaceVmRelocate(t *testing.T) {


### PR DESCRIPTION
## Description

When a `PropertyChange` name matches a parent prefix of a filter's `PathSet` (e.g. a `config.hardware.device` update against `PathSet ["config"]`), `PropertyFilter.matches` re-reads the parent property from the object's **live** managed object state via `fieldValue`. This runs on the `WaitForUpdatesEx` goroutine without holding the object's registry lock, racing with task goroutines that mutate the same object under that lock (e.g. `ReconfigVM_Task` assigning a controller to a new device):

```
WARNING: DATA RACE
Read:  fieldValue <- PropertyFilter.matches (property_filter.go:126)
       <- PropertyFilter.apply <- PropertyCollector.WaitForUpdatesEx
Write: object.VirtualDeviceList.AssignController
       <- simulator.(*VirtualMachine).configureDevice <- ReconfigVM_Task
```

In addition, `fieldValue` does not copy nested data: the value it returns aliases the object's live slices and pointers, which the SOAP response encoder reads after the update set is returned, racing with subsequent mutations of the same object (read stack in `vim25/xml` `marshalValue` via `ServeSDK`).

Fix: take the object's lock while re-reading the property, and deep copy the value while still holding the lock so the encoded response no longer aliases live object state. This matches `retrieveResult.collect`, which already copies collected properties under the object's lock for the same reason. No lock-ordering cycle is introduced: at this point the goroutine holds only the PropertyCollector's own lock (reentrant per-context), and writers never acquire it while holding an object lock.

Known adjacent issue, intentionally out of scope: writers publish `ctx.Update` values that can also alias live pointers (e.g. `config.hardware.device` on an exact `PathSet` match forwards the live device slice); fixing that generally requires copying at the notification source across the update pipeline.

Related (same writer stack, different bug): #4069 fixes VMs sharing the package-level default device templates. The two changes are independent.

## How Has This Been Tested?

- Added `TestWaitForUpdatesPrefixMatchRace` (simulator/race_test.go): one powered off VM, a `property.Wait` watcher on `["config"]`, plus concurrent reconfig loops (NIC add/remove exercising `AssignController`, and `extraConfig` updates). Under `-race` it fails consistently without the fix (6/6 runs, ~30 race reports per run) and passes with it.
- Differential check: with only `simulator/property_filter.go` reverted to main and the same test binary, 30 race warnings; with the fix, zero.
- `go test -race -count=10 -run TestWaitForUpdatesPrefixMatchRace ./simulator/`: 10/10 pass.
- Full `go test -race -count=1 ./simulator/`: ok (265s).
- `gofmt` / `go vet` clean.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md