### PR TITLE
vcsim: Support VM.PutUsbScanCodes

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -3507,6 +3507,28 @@ func (vm *VirtualMachine) MarkAsVirtualMachine(req *types.MarkAsVirtualMachine) 
 	return r
 }
 
+// PutUsbScanCodes sends USB HID scan codes to the VM's virtual keyboard, as
+// real vSphere does to support tools such as the Packer vSphere-ISO builder
+// that type boot-time commands without a console/VNC connection. Real
+// vSphere requires the VM to be powered on for this to succeed.
+func (vm *VirtualMachine) PutUsbScanCodes(req *types.PutUsbScanCodes) soap.HasFault {
+	r := &methods.PutUsbScanCodesBody{}
+
+	if vm.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
+		r.Fault_ = Fault("", &types.InvalidPowerState{
+			RequestedState: types.VirtualMachinePowerStatePoweredOn,
+			ExistingState:  vm.Runtime.PowerState,
+		})
+		return r
+	}
+
+	r.Res = &types.PutUsbScanCodesResponse{
+		Returnval: int32(len(req.Spec.KeyEvents)),
+	}
+
+	return r
+}
+
 func findSnapshotInTree(tree []types.VirtualMachineSnapshotTree, ref types.ManagedObjectReference) *types.VirtualMachineSnapshotTree {
 	if tree == nil {
 		return nil

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -2338,6 +2338,71 @@ func TestShutdownGuest(t *testing.T) {
 	})
 }
 
+func TestPutUsbScanCodes(t *testing.T) {
+	Test(func(ctx context.Context, c *vim25.Client) {
+		vm := object.NewVirtualMachine(c, Map(ctx).Any("VirtualMachine").Reference())
+
+		state, err := vm.PowerState(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if state != types.VirtualMachinePowerStatePoweredOn {
+			t.Fatalf("expected fixture VM to be poweredOn, state=%s", state)
+		}
+
+		spec := types.UsbScanCodeSpec{
+			KeyEvents: []types.UsbScanCodeSpecKeyEvent{
+				{UsbHidCode: 0x07<<16 | 7}, // 'd' (USB HID usage 0x07), no modifier
+				{
+					UsbHidCode: 0x12<<16 | 7, // 'o' (USB HID usage 0x12) with left-shift held
+					Modifiers: &types.UsbScanCodeSpecModifierType{
+						LeftShift: types.NewBool(true),
+					},
+				},
+			},
+		}
+
+		n, err := vm.PutUsbScanCodes(ctx, spec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != int32(len(spec.KeyEvents)) {
+			t.Errorf("expected Returnval=%d, got %d", len(spec.KeyEvents), n)
+		}
+
+		// An empty batch of key events is a no-op, not an error.
+		n, err = vm.PutUsbScanCodes(ctx, types.UsbScanCodeSpec{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 0 {
+			t.Errorf("expected Returnval=0 for an empty spec, got %d", n)
+		}
+
+		task, err := vm.PowerOff(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = task.Wait(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		// PutUsbScanCodes on a powered off VM should fail.
+		_, err = vm.PutUsbScanCodes(ctx, spec)
+		if !fault.Is(err, &types.InvalidPowerState{}) {
+			t.Errorf("expected InvalidPowerState fault, got: %v", err)
+		}
+
+		task, err = vm.PowerOn(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = task.Wait(ctx); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestVmSnapshot(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION


## Description

This patch adds support for the VM PutUsbScanCodes API to vC Sim.

Closes: `NA`

## How Has This Been Tested?

By running the new unit tests.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
