### PR TITLE
Use AutoUpdate for container-backed VM

### DIFF
--- a/simulator/container.go
+++ b/simulator/container.go
@@ -704,7 +704,7 @@ func (c *container) updated() {
 // returns:
 //
 //	err - uninitializedContainer error - if c.id is empty
-func (c *container) watchContainer(ctx *Context, updateFn func(*Context, *containerDetails, *container) error) error {
+func (c *container) watchContainer(ctx *Context, updateFn func(*Context, []byte, *containerDetails, *container) error) error {
 	c.Lock()
 	defer c.Unlock()
 
@@ -727,7 +727,7 @@ func (c *container) watchContainer(ctx *Context, updateFn func(*Context, *contai
 		ticker := time.NewTicker(inspectInterval)
 
 		update := func() {
-			_, details, err := c.inspect()
+			out, details, err := c.inspect()
 			var rmErr error
 			var removing bool
 			if _, ok := err.(uninitializedContainer); ok {
@@ -735,7 +735,7 @@ func (c *container) watchContainer(ctx *Context, updateFn func(*Context, *contai
 				rmErr = c.remove(ctx)
 			}
 
-			updateErr := updateFn(ctx, &details, c)
+			updateErr := updateFn(ctx, out, &details, c)
 			// if we don't succeed we want to re-try
 			if removing && rmErr == nil && updateErr == nil {
 				ticker.Stop()

--- a/simulator/container_virtual_machine.go
+++ b/simulator/container_virtual_machine.go
@@ -61,137 +61,134 @@ func createSimulationVM(vm *VirtualMachine) *simVM {
 	return nil
 }
 
-// applies container network settings to vm.Guest properties.
-// If ctx is provided, property change notifications will be triggered for all modified properties.
-func (svm *simVM) syncNetworkConfigToVMGuestProperties(ctx *Context) error {
-	if svm == nil {
+// syncNetworkConfigToVMGuestProperties applies container network settings to
+// vm.Guest properties and triggers granular property-change notifications.
+//
+// out and detail are an optional docker/podman inspect result (e.g.
+// from watchContainer's update loop, which must inspect anyway to detect
+// container removal). If detail is nil this function perform its own inspect().
+//
+// The inspect() call, when performed here, happens outside the lock to avoid
+// holding it during I/O. ctx.AutoUpdate acquires the VM lock once for the
+// whole checkpoint → modify → diff → update sequence, preventing races with
+// concurrent SOAP handlers (e.g. DestroyTask) that also hold the VM lock.
+func (svm *simVM) syncNetworkConfigToVMGuestProperties(ctx *Context, out []byte, detail *containerDetails) error {
+	if svm == nil || ctx == nil {
 		return nil
 	}
 
-	out, detail, err := svm.c.inspect()
-	if err != nil {
-		return err
+	if detail == nil {
+		o, d, err := svm.c.inspect()
+		if err != nil {
+			return err
+		}
+		out = o
+		detail = &d
 	}
 
-	svm.vm.Config.Annotation = "inspect"
-	svm.vm.logPrintf("%s: %s", svm.vm.Config.Annotation, string(out))
-
-	netS := detail.NetworkSettings.networkSettings
-
-	// ? Why is this valid - we're taking the first entry while iterating over a MAP
+	// Precompute values that don't need the VM lock.
+	//
+	// primaryNet is chosen by taking an arbitrary entry from Go's randomized
+	// map iteration over multi-network containers. This is intentional instability
+	// until we've verified the real VC algo for selecting "primary" network.
+	primaryNet := detail.NetworkSettings.networkSettings
 	for _, n := range detail.NetworkSettings.Networks {
-		netS = n
+		primaryNet = n
 		break
 	}
 
-	// Collect property changes as we modify the VM state
-	var changes []types.PropertyChange
+	ctx.AutoUpdate(svm.vm, func() {
+		svm.vm.Config.Annotation = "inspect"
+		svm.vm.logPrintf("%s: %s", svm.vm.Config.Annotation, string(out))
 
-	// Update power state based on container state
-	var oldPowerState types.VirtualMachinePowerState
-	if detail.State.Paused {
-		svm.vm.Runtime.PowerState = types.VirtualMachinePowerStateSuspended
-	} else if detail.State.Running {
-		svm.vm.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOn
-	} else {
-		svm.vm.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOff
-	}
-	if svm.vm.Runtime.PowerState != oldPowerState {
-		changes = append(changes, types.PropertyChange{
-			Name: "runtime.powerState",
-			Val:  svm.vm.Runtime.PowerState,
-			Op:   types.PropertyChangeOpAssign,
-		})
-	}
-
-	// Update IP address
-	newIP := netS.IPAddress
-	if svm.vm.Guest.IpAddress != newIP {
-		svm.vm.Guest.IpAddress = newIP
-		changes = append(changes, types.PropertyChange{
-			Name: "guest.ipAddress",
-			Val:  newIP,
-			Op:   types.PropertyChangeOpAssign,
-		})
-	}
-	if svm.vm.Summary.Guest.IpAddress != newIP {
-		svm.vm.Summary.Guest.IpAddress = newIP
-		changes = append(changes, types.PropertyChange{
-			Name: "summary.guest.ipAddress",
-			Val:  newIP,
-			Op:   types.PropertyChangeOpAssign,
-		})
-	}
-
-	// Update hostname
-	if svm.vm.Guest.HostName == "" && detail.Config.Hostname != "" {
-		svm.vm.Guest.HostName = detail.Config.Hostname
-		changes = append(changes, types.PropertyChange{
-			Name: "guest.hostName",
-			Val:  detail.Config.Hostname,
-			Op:   types.PropertyChangeOpAssign,
-		})
-	}
-
-	// Update network info if we have a NIC configured
-	if len(svm.vm.Guest.Net) != 0 {
-		net := &svm.vm.Guest.Net[0]
-		net.IpAddress = []string{newIP}
-		net.MacAddress = netS.MacAddress
-		net.IpConfig = &types.NetIpConfigInfo{
-			IpAddress: []types.NetIpConfigInfoIpAddress{{
-				IpAddress:    newIP,
-				PrefixLength: int32(netS.IPPrefixLen),
-				State:        string(types.NetIpConfigInfoIpAddressStatusPreferred),
-			}},
+		if detail.State.Paused {
+			svm.vm.Runtime.PowerState = types.VirtualMachinePowerStateSuspended
+		} else if detail.State.Running {
+			svm.vm.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOn
+		} else {
+			svm.vm.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOff
 		}
 
-		gsi := types.GuestStackInfo{
-			DnsConfig: &types.NetDnsConfigInfo{
-				Dhcp:         false,
-				HostName:     svm.vm.Guest.HostName,
-				DomainName:   detail.Config.Domainname,
-				IpAddress:    detail.Config.DNS,
-				SearchDomain: nil,
-			},
-			IpRouteConfig: &types.NetIpRouteConfigInfo{
-				IpRoute: []types.NetIpRouteConfigInfoIpRoute{{
-					Network:      "0.0.0.0",
-					PrefixLength: 0,
-					Gateway: types.NetIpRouteConfigInfoGateway{
-						IpAddress: netS.Gateway,
-						Device:    "0",
-					},
-				}},
-			},
+		svm.vm.Guest.IpAddress = primaryNet.IPAddress
+		svm.vm.Summary.Guest.IpAddress = primaryNet.IPAddress
+
+		if detail.Config.Hostname != "" {
+			svm.vm.Guest.HostName = detail.Config.Hostname
+			svm.vm.Summary.Guest.HostName = detail.Config.Hostname
 		}
-		svm.vm.Guest.IpStack = []types.GuestStackInfo{gsi}
 
-		// guest.net is a complex structure, trigger update for the whole thing
-		changes = append(changes, types.PropertyChange{
-			Name: "guest.net",
-			Val:  svm.vm.Guest.Net,
-			Op:   types.PropertyChangeOpAssign,
-		})
-		changes = append(changes, types.PropertyChange{
-			Name: "guest.ipStack",
-			Val:  svm.vm.Guest.IpStack,
-			Op:   types.PropertyChangeOpAssign,
-		})
-	}
-
-	// Update MAC address on virtual ethernet card
-	for _, d := range svm.vm.Config.Hardware.Device {
-		if eth, ok := d.(types.BaseVirtualEthernetCard); ok {
-			eth.GetVirtualEthernetCard().MacAddress = netS.MacAddress
-			break
+		var guestNics []types.GuestNicInfo
+		nicIndex := int32(0)
+		for networkName, netSettings := range detail.NetworkSettings.Networks {
+			if netSettings.IPAddress == "" {
+				continue
+			}
+			nic := types.GuestNicInfo{
+				Network:        networkName,
+				IpAddress:      []string{netSettings.IPAddress},
+				MacAddress:     netSettings.MacAddress,
+				Connected:      true,
+				DeviceConfigId: nicIndex,
+				IpConfig: &types.NetIpConfigInfo{
+					IpAddress: []types.NetIpConfigInfoIpAddress{{
+						IpAddress:    netSettings.IPAddress,
+						PrefixLength: int32(netSettings.IPPrefixLen),
+						State:        string(types.NetIpConfigInfoIpAddressStatusPreferred),
+					}},
+				},
+			}
+			guestNics = append(guestNics, nic)
+			nicIndex++
 		}
-	}
 
-	// Trigger property change notifications if we have changes and context is available
-	if ctx != nil && len(changes) > 0 {
-		ctx.Update(svm.vm, changes)
-	}
+		if len(guestNics) == 0 && primaryNet.IPAddress != "" {
+			guestNics = append(guestNics, types.GuestNicInfo{
+				Network:        "default",
+				IpAddress:      []string{primaryNet.IPAddress},
+				MacAddress:     primaryNet.MacAddress,
+				Connected:      true,
+				DeviceConfigId: 0,
+				IpConfig: &types.NetIpConfigInfo{
+					IpAddress: []types.NetIpConfigInfoIpAddress{{
+						IpAddress:    primaryNet.IPAddress,
+						PrefixLength: int32(primaryNet.IPPrefixLen),
+						State:        string(types.NetIpConfigInfoIpAddressStatusPreferred),
+					}},
+				},
+			})
+		}
+
+		svm.vm.Guest.Net = guestNics
+
+		if primaryNet.IPAddress != "" {
+			svm.vm.Guest.IpStack = []types.GuestStackInfo{{
+				DnsConfig: &types.NetDnsConfigInfo{
+					Dhcp:         false,
+					HostName:     svm.vm.Guest.HostName,
+					DomainName:   detail.Config.Domainname,
+					IpAddress:    detail.Config.DNS,
+					SearchDomain: nil,
+				},
+				IpRouteConfig: &types.NetIpRouteConfigInfo{
+					IpRoute: []types.NetIpRouteConfigInfoIpRoute{{
+						Network:      "0.0.0.0",
+						PrefixLength: 0,
+						Gateway: types.NetIpRouteConfigInfoGateway{
+							IpAddress: primaryNet.Gateway,
+							Device:    "0",
+						},
+					}},
+				},
+			}}
+		}
+
+		for _, d := range svm.vm.Config.Hardware.Device {
+			if eth, ok := d.(types.BaseVirtualEthernetCard); ok {
+				eth.GetVirtualEthernetCard().MacAddress = primaryNet.MacAddress
+				break
+			}
+		}
+	})
 
 	return nil
 }
@@ -368,7 +365,7 @@ func (svm *simVM) start(ctx *Context) error {
 	// Sync network config, retrying a few times to allow the container to get an IP
 	// Container runtimes may take a moment to assign an IP address after start
 	for i := 0; i < 5; i++ {
-		if err = svm.syncNetworkConfigToVMGuestProperties(ctx); err != nil {
+		if err = svm.syncNetworkConfigToVMGuestProperties(ctx, nil, nil); err != nil {
 			log.Printf("%s inspect %s: %s", svm.vm.Name, svm.c.id, err)
 			break
 		}
@@ -378,8 +375,13 @@ func (svm *simVM) start(ctx *Context) error {
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	callback := func(callbackCtx *Context, details *containerDetails, c *container) error {
-		if c.id == "" && svm.vm != nil {
+	callback := func(callbackCtx *Context, out []byte, details *containerDetails, c *container) error {
+		// c.id is written under c.Lock() in container.remove().
+		c.Lock()
+		containerGone := c.id == ""
+		c.Unlock()
+
+		if containerGone && svm.vm != nil {
 			// If the container cannot be found then destroy this VM unless the VM is no longer configured for container backing (svm.vm == nil)
 			taskRef := svm.vm.DestroyTask(callbackCtx, &types.Destroy_Task{This: svm.vm.Self}).(*methods.Destroy_TaskBody).Res.Returnval
 			task, ok := callbackCtx.Map.Get(taskRef).(*Task)
@@ -396,14 +398,14 @@ func (svm *simVM) start(ctx *Context) error {
 			}
 		}
 
-		return svm.syncNetworkConfigToVMGuestProperties(callbackCtx)
+		return svm.syncNetworkConfigToVMGuestProperties(callbackCtx, out, details)
 	}
 
 	// Start watching the container resource.
 	err = svm.c.watchContainer(ctx, callback)
 	if _, ok := err.(uninitializedContainer); ok {
 		// the container has been deleted before we could watch, despite successful launch so clean up.
-		callback(ctx, nil, svm.c)
+		callback(ctx, nil, nil, svm.c)
 
 		// successful launch so nil the error
 		return nil

--- a/simulator/container_virtual_machine_test.go
+++ b/simulator/container_virtual_machine_test.go
@@ -24,10 +24,13 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-// takes a content string to serve from the container and returns ExtraConfig options
-// to construct container
-// content - the contents of index.html
-// port - the port to forward to the container port 80
+// constructNginxBacking returns ExtraConfig options for a container-backed nginx VM.
+// Runtime-specific defaults (e.g. RUN.mountdmi, RUN.network on rootless podman)
+// are NOT included here; call test.ApplyContainerRuntimeDefaults on the resulting
+// spec to add them.
+//
+// content - the contents of index.html served by nginx
+// port - the host port forwarded to container port 80
 func constructNginxBacking(t *testing.T, content string, port int) []types.BaseOptionValue {
 	dir := t.TempDir()
 	// experience shows that a parent directory created as part of the TempDir call may not have
@@ -55,13 +58,20 @@ func constructNginxBacking(t *testing.T, content string, port int) []types.BaseO
 	}
 }
 
-// validates the VM is serving the expected content on the expected ports
-// pairs with constructNginxBacking
-func validateNginxContainer(t *testing.T, vm *object.VirtualMachine, expected string, port int) error {
+// validateNginxContainer checks that vm is serving expected content via both
+// the container IP (direct bridge access) and the host port-mapped endpoint.
+// network is the bridge to join for the curlimages/curl probe; pass "" to use
+// the runtime default bridge (appropriate for root Docker).  On rootless
+// podman pass test.ContainerNetworkFromSpec(&spec) so the probe shares the VM
+// container's network.
+func validateNginxContainer(t *testing.T, vm *object.VirtualMachine, expected string, port int, network string) error {
 	ip, _ := vm.WaitForIP(context.Background(), true) // Returns the docker container's IP
 
-	// Count the number of bytes in feature_test.go via nginx going direct to the container
-	cmd := exec.Command("docker", "run", "--rm", "curlimages/curl", "curl", "-f", fmt.Sprintf("http://%s:80", ip))
+	// Verify direct container IP access.  Join the same bridge as the nginx
+	// container so the probe can reach it; omit --network on runtimes where
+	// the default bridge provides connectivity.
+	probeArgs := test.ContainerCurlProbeArgs(network, fmt.Sprintf("http://%s:80", ip))
+	cmd := exec.Command("docker", probeArgs...)
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	err := cmd.Run()
@@ -74,7 +84,7 @@ func validateNginxContainer(t *testing.T, vm *object.VirtualMachine, expected st
 		fmt.Printf("%d diff", buf.Len()-len(expected))
 	}
 
-	// Count the number of bytes in feature_test.go via nginx going via port remap on host
+	// Verify port-mapped access via host loopback.
 	cmd = exec.Command("curl", "-f", fmt.Sprintf("http://localhost:%d", port))
 	buf.Reset()
 	cmd.Stdout = &buf
@@ -116,6 +126,7 @@ func TestCreateVMWithContainerBacking(t *testing.T) {
 			},
 			ExtraConfig: constructNginxBacking(t, content, port),
 		}
+		require.NoError(t, test.ApplyContainerRuntimeDefaults(&spec))
 
 		f, _ := dc.Folders(ctx)
 		// Create a new VM
@@ -137,7 +148,7 @@ func TestCreateVMWithContainerBacking(t *testing.T) {
 			log.Fatal(err)
 		}
 
-		err = validateNginxContainer(t, vm, content, port)
+		err = validateNginxContainer(t, vm, content, port, test.ContainerNetworkFromSpec(&spec))
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -218,6 +229,7 @@ func TestUpdateVMAddContainerBacking(t *testing.T) {
 		spec2 := types.VirtualMachineConfigSpec{
 			ExtraConfig: constructNginxBacking(t, content, port),
 		}
+		require.NoError(t, test.ApplyContainerRuntimeDefaults(&spec2))
 
 		task, err = vm.Reconfigure(ctx, spec2)
 		if err != nil {
@@ -229,7 +241,7 @@ func TestUpdateVMAddContainerBacking(t *testing.T) {
 			log.Fatal(info, err)
 		}
 
-		err = validateNginxContainer(t, vm, content, port)
+		err = validateNginxContainer(t, vm, content, port, test.ContainerNetworkFromSpec(&spec2))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/simulator/feature_test.go
+++ b/simulator/feature_test.go
@@ -142,11 +142,7 @@ func Example_runContainer() {
 		// Count the number of bytes in feature_test.go via nginx going direct to the container.
 		// Join the same bridge so the probe can reach the nginx container IP on rootless podman;
 		// omit --network on runtimes where the default bridge provides connectivity.
-		probeArgs := []string{"run", "--rm"}
-		if network != "" {
-			probeArgs = append(probeArgs, "--network", network)
-		}
-		probeArgs = append(probeArgs, "curlimages/curl", "curl", "-f", fmt.Sprintf("http://%s", ip))
+		probeArgs := test.ContainerCurlProbeArgs(network, fmt.Sprintf("http://%s", ip))
 		cmd := exec.Command("docker", probeArgs...)
 		var buf bytes.Buffer
 		cmd.Stdout = &buf

--- a/simulator/property_diff.go
+++ b/simulator/property_diff.go
@@ -61,7 +61,7 @@ func diffFields(prefix string, oldVal, newVal reflect.Value, rtype reflect.Type,
 		}
 
 		// Compare the field values
-		if !reflect.DeepEqual(oldField.Interface(), newField.Interface()) {
+		if !fieldsEqual(oldField, newField) {
 			change := types.PropertyChange{
 				Name: path,
 				Op:   determineChangeOp(oldField, newField),
@@ -75,6 +75,21 @@ func diffFields(prefix string, oldVal, newVal reflect.Value, rtype reflect.Type,
 			*changes = append(*changes, change)
 		}
 	}
+}
+
+// fieldsEqual reports whether oldField and newField hold equal values for the
+// purpose of change detection. A nil slice and a non-nil, zero-length slice
+// of the same element type are treated as equal: neither carries observable
+// content, so reflect.DeepEqual's usual nil-vs-empty distinction (which would
+// otherwise report a change here) would produce a spurious PropertyChange for
+// a transition that changed nothing a consumer can observe.
+func fieldsEqual(oldField, newField reflect.Value) bool {
+	if oldField.Kind() == reflect.Slice && newField.Kind() == reflect.Slice {
+		if oldField.Len() == 0 && newField.Len() == 0 {
+			return true
+		}
+	}
+	return reflect.DeepEqual(oldField.Interface(), newField.Interface())
 }
 
 // determineChangeOp determines the appropriate PropertyChangeOp based on old and new values.

--- a/simulator/property_diff_test.go
+++ b/simulator/property_diff_test.go
@@ -7,13 +7,18 @@ package simulator
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/test"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 
@@ -76,23 +81,27 @@ func TestPropertyDiff_NestedFields(t *testing.T) {
 	// Get the diff
 	changes := PropertyDiff(checkpoint, vm)
 
-	// We should have changes for guest and summary.guest
-	require.Len(t, changes, 2, "expected at least 2 changes, got %d: %+v", len(changes), changes)
+	// Guest is an anonymous-free pointer field, so its change is reported
+	// under its own path ("guest"). Summary is a non-anonymous value-typed
+	// field that diffFields does not recurse into, so any change inside it
+	// -- including this one, nested under Summary.Guest -- is reported as a
+	// single opaque "summary" change, not a fine-grained "summary.guest" path.
+	require.Len(t, changes, 2, "expected 2 changes, got %d: %+v", len(changes), changes)
 
 	// Check that we have the expected property paths
 	foundGuest := false
-	foundSummaryGuest := false
+	foundSummary := false
 	for _, c := range changes {
 		if c.Name == "guest" {
 			foundGuest = true
 		}
 		if c.Name == "summary" {
-			foundSummaryGuest = true
+			foundSummary = true
 		}
 	}
 
 	assert.True(t, foundGuest, "expected change for 'guest' property")
-	assert.True(t, foundSummaryGuest, "expected change for 'summary' property")
+	assert.True(t, foundSummary, "expected change for 'summary' property")
 }
 
 func TestPropertyDiff_AddRemove(t *testing.T) {
@@ -176,6 +185,32 @@ func TestPropertyDiff_SliceFields(t *testing.T) {
 	}
 
 	t.Error("expected change for 'guest' property containing network changes")
+}
+
+// TestPropertyDiff_NilVsEmptySlice verifies that a nil slice and a non-nil,
+// zero-length slice of the same field are treated as equal (no
+// PropertyChange), even though reflect.DeepEqual alone would consider them
+// different. Without this, a transition like the one
+// syncNetworkConfigToVMGuestProperties performs -- assigning a nil
+// []types.GuestNicInfo when a container has no NICs -- would report a
+// spurious "guest" change against a checkpoint whose Net field happened to
+// be a non-nil empty slice, even though nothing observable changed.
+func TestPropertyDiff_NilVsEmptySlice(t *testing.T) {
+	vm := &mo.VirtualMachine{
+		Guest: &types.GuestInfo{
+			Net: []types.GuestNicInfo{}, // non-nil, empty
+		},
+	}
+	vm.Self = types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-1"}
+
+	checkpoint := Checkpoint(vm)
+
+	vm.Guest.Net = nil // nil, empty
+
+	changes := PropertyDiff(checkpoint, vm)
+
+	require.Len(t, changes, 0,
+		"nil slice and non-nil empty slice must not produce a change, got %d: %+v", len(changes), changes)
 }
 
 func TestCheckpoint(t *testing.T) {
@@ -433,10 +468,10 @@ func TestContext_Checkpoint(t *testing.T) {
 	})
 }
 
-// TestContext_PropertyDiff verifies that ctx.PropertyDiff computes changes from an old
+// TestContext_UpdateDiff verifies that ctx.UpdateDiff computes changes from an old
 // snapshot to the current live state and applies them so they are visible via the
 // PropertyCollector.
-func TestContext_PropertyDiff(t *testing.T) {
+func TestContext_UpdateDiff(t *testing.T) {
 	goCtx := context.Background()
 
 	m := VPX()
@@ -617,7 +652,10 @@ func TestPropertyDiff_GuestNetInfo(t *testing.T) {
 	assert.True(t, foundGuest, "expected change for 'guest' property")
 }
 
-// TestPropertyDiff_SummaryGuest tests that summary.guest changes are tracked
+// TestPropertyDiff_SummaryGuest tests that a change nested under
+// Summary.Guest is tracked, reported as a single opaque "summary" change
+// (Summary is a non-anonymous value-typed field that diffFields does not
+// recurse into).
 func TestPropertyDiff_SummaryGuest(t *testing.T) {
 	vm := &mo.VirtualMachine{
 		Summary: types.VirtualMachineSummary{
@@ -641,6 +679,175 @@ func TestPropertyDiff_SummaryGuest(t *testing.T) {
 	}
 
 	t.Error("expected change for 'summary' property")
+}
+
+// TestContainerVMNetworkPropertyChanges tests that a container-backed VM produces
+// the expected network property changes when powered on, including detailed Guest.Net info.
+func TestContainerVMNetworkPropertyChanges(t *testing.T) {
+	Test(func(ctx context.Context, c *vim25.Client) {
+		if !test.HasDocker() {
+			t.Skip("requires docker on linux")
+			return
+		}
+
+		finder := find.NewFinder(c)
+		pool, err := finder.ResourcePool(ctx, "DC0_H0/Resources")
+		require.NoError(t, err, "expected no error retrieving resource pool")
+		dc, err := finder.Datacenter(ctx, "DC0")
+		require.NoError(t, err, "expected no error retrieving datacenter")
+
+		// Use busybox with a simple sleep command to keep the container running
+		busybox := os.Getenv("VCSIM_BUSYBOX")
+		if busybox == "" {
+			busybox = "busybox"
+		}
+
+		spec := types.VirtualMachineConfigSpec{
+			Name: "busybox-network-test",
+			Files: &types.VirtualMachineFileInfo{
+				VmPathName: "[LocalDS_0] busybox-test",
+			},
+			ExtraConfig: []types.BaseOptionValue{
+				&types.OptionValue{Key: ContainerBackingOptionKey, Value: busybox + " sleep 300"},
+			},
+		}
+		require.NoError(t, test.ApplyContainerRuntimeDefaults(&spec), "expected no error applying container runtime defaults")
+
+		f, err := dc.Folders(ctx)
+		require.NoError(t, err, "expected no error retrieving folders")
+
+		// Create a new VM
+		task, err := f.VmFolder.CreateVM(ctx, spec, pool, nil)
+		require.NoError(t, err, "expected no error creating VM")
+
+		info, err := task.WaitForResult(ctx, nil)
+		require.NoError(t, err, "expected no error waiting for task result")
+
+		vmRef := info.Result.(types.ManagedObjectReference)
+		vm := object.NewVirtualMachine(c, vmRef)
+		defer func() {
+			task, _ = vm.PowerOff(ctx)
+			_ = task.Wait(ctx)
+			task, _ = vm.Destroy(ctx)
+			_ = task.Wait(ctx)
+		}()
+
+		// Get initial state before power on
+		pc := property.DefaultCollector(c)
+		var initialVM mo.VirtualMachine
+		err = pc.RetrieveOne(ctx, vmRef, []string{"runtime.powerState", "guest"}, &initialVM)
+		require.NoError(t, err, "expected no error retrieving initial VM state")
+		assert.Equal(t, types.VirtualMachinePowerStatePoweredOff, initialVM.Runtime.PowerState, "expected initial power state PoweredOff")
+
+		// Verify Guest.Net is empty before power on
+		require.NotNil(t, initialVM.Guest, "expected Guest to be set")
+		require.Equal(t, 0, len(initialVM.Guest.Net), "expected Guest.Net to be empty before power on")
+
+		// Power on the VM
+		task, err = vm.PowerOn(ctx)
+		require.NoError(t, err, "expected no error powering on VM")
+
+		err = task.Wait(ctx)
+		require.NoError(t, err, "expected no error waiting for task result")
+
+		// Wait for IP to be assigned with a timeout
+		waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		ip, err := vm.WaitForIP(waitCtx, false)
+		if err != nil {
+			t.Logf("WaitForIP error (may be expected with rootless podman): %v", err)
+		}
+
+		// Retrieve the updated VM state with all guest properties
+		var updatedVM mo.VirtualMachine
+		err = pc.RetrieveOne(ctx, vmRef, []string{
+			"runtime.powerState",
+			"guest.ipAddress",
+			"guest.hostName",
+			"guest.net",
+			"guest.ipStack",
+			"summary.guest.ipAddress",
+			"summary.guest.hostName",
+		}, &updatedVM)
+		require.NoError(t, err, "expected no error retrieving updated VM state")
+
+		// Verify power state changed
+		assert.Equal(t, types.VirtualMachinePowerStatePoweredOn, updatedVM.Runtime.PowerState, "expected power state PoweredOn")
+
+		// If we got an IP, verify detailed guest properties
+		if ip == "" {
+			t.Log("No IP assigned (rootless podman without bridge network)")
+			return
+		}
+
+		t.Logf("Container IP: %s", ip)
+
+		require.NotNil(t, updatedVM.Guest, "expected Guest to be populated")
+
+		// Verify Guest.IpAddress
+		if assert.NotEqual(t, "", updatedVM.Guest.IpAddress, "expected Guest.IpAddress to be set") {
+			t.Logf("Guest.IpAddress: %s", updatedVM.Guest.IpAddress)
+		}
+
+		// Verify Guest.HostName
+		if assert.NotEqual(t, "", updatedVM.Guest.HostName, "expected Guest.HostName to be set") {
+			t.Logf("Guest.HostName: %s", updatedVM.Guest.HostName)
+		}
+
+		// Verify Guest.Net is now populated with detailed NIC info
+		if assert.Greater(t, len(updatedVM.Guest.Net), 0, "expected Guest.Net to be populated after power on") {
+			t.Logf("Guest.Net has %d entries", len(updatedVM.Guest.Net))
+			for i, nic := range updatedVM.Guest.Net {
+				t.Logf("  NIC %d:", i)
+				t.Logf("    Network: %s", nic.Network)
+				t.Logf("    MacAddress: %s", nic.MacAddress)
+				t.Logf("    IpAddress: %v", nic.IpAddress)
+				t.Logf("    Connected: %v", nic.Connected)
+
+				// Verify NIC has expected fields populated
+				assert.NotEqual(t, "", nic.Network, "expected Network to be set")
+				assert.Greater(t, len(nic.IpAddress), 0, "expected IpAddress to be set")
+				assert.NotEqual(t, "", nic.MacAddress, "expected MacAddress to be set")
+				assert.True(t, nic.Connected, "expected Connected to be true")
+
+				// Verify IpConfig is populated
+				if assert.NotNil(t, nic.IpConfig, "expected IpConfig to be set (nic %d)", i) {
+					t.Logf("    IpConfig.IpAddress: %+v", nic.IpConfig.IpAddress)
+					if assert.Greater(t, len(nic.IpConfig.IpAddress), 0, "expected IpConfig.IpAddress to be set") {
+						ipAddr := nic.IpConfig.IpAddress[0]
+						assert.NotEqual(t, "", ipAddr.IpAddress, "expected IpConfig.IpAddress[0].IpAddress to be set")
+						assert.NotEqual(t, int32(0), ipAddr.PrefixLength, "expected PrefixLength to be set")
+					}
+				}
+			}
+		}
+
+		// Verify Guest.IpStack is populated
+		if assert.Greater(t, len(updatedVM.Guest.IpStack), 0, "expected Guest.IpStack to be populated") {
+			t.Logf("Guest.IpStack has %d entries", len(updatedVM.Guest.IpStack))
+			for i, stack := range updatedVM.Guest.IpStack {
+				if stack.DnsConfig != nil {
+					t.Logf("  Stack %d DnsConfig: HostName=%s, DomainName=%s, DNS=%v",
+						i, stack.DnsConfig.HostName, stack.DnsConfig.DomainName, stack.DnsConfig.IpAddress)
+				}
+				if stack.IpRouteConfig != nil && len(stack.IpRouteConfig.IpRoute) > 0 {
+					route := stack.IpRouteConfig.IpRoute[0]
+					t.Logf("  Stack %d DefaultRoute: Gateway=%s", i, route.Gateway.IpAddress)
+				}
+			}
+		}
+
+		// Verify Summary.Guest
+		if updatedVM.Summary.Guest != nil {
+			if assert.NotEqual(t, "", updatedVM.Summary.Guest.IpAddress, "expected Summary.Guest.IpAddress to be set") {
+				t.Logf("Summary.Guest.IpAddress: %s", updatedVM.Summary.Guest.IpAddress)
+			}
+			if updatedVM.Summary.Guest.HostName != "" {
+				t.Logf("Summary.Guest.HostName: %s", updatedVM.Summary.Guest.HostName)
+			}
+		}
+
+	})
 }
 
 // TestPropertyDiff_ConcurrentAccess is a race regression test for the pattern used in

--- a/test/helper.go
+++ b/test/helper.go
@@ -7,11 +7,13 @@ package test
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/vmware/govmomi/vim25"
@@ -30,16 +32,38 @@ func HasDocker() bool {
 	return true
 }
 
+var (
+	isRootlessPodmanOnce   sync.Once
+	isRootlessPodmanResult bool
+)
+
 // IsRootlessPodman returns true when the docker CLI is backed by rootless podman.
 // Rootless podman has restrictions such as the inability to bind-mount system
 // paths like /sys/class/dmi/id.
+//
+// The detection result is memoized (sync.Once): the underlying runtime does
+// not change within a test binary's lifetime, and each call otherwise spawns
+// up to two subprocesses, which adds up across the many container-backed
+// tests that call this indirectly via ApplyContainerRuntimeDefaults.
 func IsRootlessPodman() bool {
+	isRootlessPodmanOnce.Do(func() {
+		isRootlessPodmanResult = detectRootlessPodman()
+	})
+	return isRootlessPodmanResult
+}
+
+func detectRootlessPodman() bool {
 	out, err := exec.Command("docker", "--version").Output()
-	if err != nil || !strings.Contains(string(out), "podman") {
+	if err != nil {
+		log.Printf("test: docker --version: %v", err)
+		return false
+	}
+	if !strings.Contains(string(out), "podman") {
 		return false
 	}
 	out, err = exec.Command("podman", "info", "--format", "{{.Host.Security.Rootless}}").Output()
 	if err != nil {
+		log.Printf("test: docker CLI reports podman, but podman info failed (rootless-podman detection assuming false): %v", err)
 		return false
 	}
 	return strings.TrimSpace(string(out)) == "true"
@@ -111,6 +135,19 @@ func ContainerNetworkFromSpec(spec *types.VirtualMachineConfigSpec) string {
 		}
 	}
 	return ""
+}
+
+// ContainerCurlProbeArgs returns the "docker run" argument list for probing
+// targetURL from a curlimages/curl container, joining network (if non-empty,
+// typically the result of ContainerNetworkFromSpec) so the probe can reach a
+// container-backed VM that is not on the runtime's default bridge (e.g.
+// rootless podman).
+func ContainerCurlProbeArgs(network, targetURL string) []string {
+	args := []string{"run", "--rm"}
+	if network != "" {
+		args = append(args, "--network", network)
+	}
+	return append(args, "curlimages/curl", "curl", "-f", targetURL)
 }
 
 // ApplyContainerRuntimeDefaults adds runtime-appropriate ExtraConfig defaults


### PR DESCRIPTION
## Description

This shifts container backed sim VMs to using AutoUpdate to populate PropertyCollector updates for network info.

It also:
* corrects the reflection based diff to equate nil and empty slices
* allows use of an existing result from container inspect to be passed into the network info diff, both for efficiency (only one inspect call) and result consistency.
* refactors setup of containers to support curl probes into a helper
* corrects docstrings where they're imprecise or incorrect.
* adds tests for the above

## How Has This Been Tested?

vcsim testing
