### PR TITLE
api: add ExtensionCompatibilityConstraint bindings

### DIFF
--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -89579,7 +89579,7 @@ type VirtualMachineConfigInfo struct {
 	// The full set of extension compatibility constraints registered on this
 	// virtual machine by its managing extension. When unset, no extension
 	// compatibility constraints are registered on the virtual machine.
-	ExtensionCompatibilityConstraint *VirtualMachineExtensionCompatibilityConstraintSet `xml:"extensionCompatibilityConstraint,omitempty" json:"extensionCompatibilityConstraint,omitempty"`
+	ExtensionCompatibilityConstraint *VirtualMachineExtensionCompatibilityConstraintSet `xml:"extensionCompatibilityConstraint,omitempty" json:"extensionCompatibilityConstraint,omitempty" vim:"9.1.0.0"`
 }
 
 func init() {
@@ -90366,13 +90366,13 @@ type VirtualMachineConfigSpec struct {
 	// change them. At create time the constraints are persisted atomically with
 	// the VM; at reconfigure time the set fully replaces the existing set
 	// (an empty constraint array clears it).
-	ExtensionCompatibilityConstraint *VirtualMachineExtensionCompatibilityConstraintSet `xml:"extensionCompatibilityConstraint,omitempty" json:"extensionCompatibilityConstraint,omitempty"`
+	ExtensionCompatibilityConstraint *VirtualMachineExtensionCompatibilityConstraintSet `xml:"extensionCompatibilityConstraint,omitempty" json:"extensionCompatibilityConstraint,omitempty" vim:"9.1.0.0"`
 	// Whether to skip enforcement of the extensionCompatibilityConstraint set.
 	// Honored only when the caller holds the
 	// VirtualMachine.ExtensionCompatibility.Bypass privilege on the virtual
 	// machine; otherwise the operation is rejected. When unset, the value is
 	// treated as false and the registered constraints are enforced.
-	SkipExtensionCompatibilityChecks *bool `xml:"skipExtensionCompatibilityChecks" json:"skipExtensionCompatibilityChecks,omitempty"`
+	SkipExtensionCompatibilityChecks *bool `xml:"skipExtensionCompatibilityChecks" json:"skipExtensionCompatibilityChecks,omitempty" vim:"9.1.0.0"`
 }
 
 func init() {
@@ -92442,7 +92442,7 @@ type VirtualMachineRelocateSpec struct {
 	// VirtualMachine.ExtensionCompatibility.Bypass privilege on the virtual
 	// machine; otherwise the operation is rejected. Built-in compatibility
 	// checks (host compatibility, SPBM, and so on) are still enforced.
-	SkipExtensionCompatibilityChecks *bool `xml:"skipExtensionCompatibilityChecks" json:"skipExtensionCompatibilityChecks,omitempty"`
+	SkipExtensionCompatibilityChecks *bool `xml:"skipExtensionCompatibilityChecks" json:"skipExtensionCompatibilityChecks,omitempty" vim:"9.1.0.0"`
 }
 
 func init() {

--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -89576,6 +89576,10 @@ type VirtualMachineConfigInfo struct {
 	//
 	// SEV-SNP is enabled when set to true, and disabled otherwise.
 	SevSnpEnabled *bool `xml:"sevSnpEnabled" json:"sevSnpEnabled,omitempty" vim:"9.0.0.0"`
+	// The full set of extension compatibility constraints registered on this
+	// virtual machine by its managing extension. When unset, no extension
+	// compatibility constraints are registered on the virtual machine.
+	ExtensionCompatibilityConstraint *VirtualMachineExtensionCompatibilityConstraintSet `xml:"extensionCompatibilityConstraint,omitempty" json:"extensionCompatibilityConstraint,omitempty"`
 }
 
 func init() {
@@ -90356,6 +90360,19 @@ type VirtualMachineConfigSpec struct {
 	// existing vSphere compute-policies or affinity rules, then they will still
 	// be considered during this VM's placement.
 	VmPlacementPolicies []BaseVmPlacementPolicy `xml:"vmPlacementPolicies,omitempty,typeattr" json:"vmPlacementPolicies,omitempty" vim:"9.1.0.0"`
+	// The full set of extension compatibility constraints for this virtual
+	// machine, declared by its managing extension (see ManagedBy) so that
+	// vCenter can protect the VM's properties during operations that would
+	// change them. At create time the constraints are persisted atomically with
+	// the VM; at reconfigure time the set fully replaces the existing set
+	// (an empty constraint array clears it).
+	ExtensionCompatibilityConstraint *VirtualMachineExtensionCompatibilityConstraintSet `xml:"extensionCompatibilityConstraint,omitempty" json:"extensionCompatibilityConstraint,omitempty"`
+	// Whether to skip enforcement of the extensionCompatibilityConstraint set.
+	// Honored only when the caller holds the
+	// VirtualMachine.ExtensionCompatibility.Bypass privilege on the virtual
+	// machine; otherwise the operation is rejected. When unset, the value is
+	// treated as false and the registered constraints are enforced.
+	SkipExtensionCompatibilityChecks *bool `xml:"skipExtensionCompatibilityChecks" json:"skipExtensionCompatibilityChecks,omitempty"`
 }
 
 func init() {
@@ -92418,6 +92435,14 @@ type VirtualMachineRelocateSpec struct {
 	// on the placement constraints defined in Supervisor. This field will be
 	// ignored except when set by Supervisor.
 	VmPlacementPolicies []BaseVmPlacementPolicy `xml:"vmPlacementPolicies,omitempty,typeattr" json:"vmPlacementPolicies,omitempty" vim:"9.1.0.0"`
+	// Whether to skip enforcement of the extension compatibility constraints
+	// registered on the virtual machine (see
+	// VirtualMachineConfigInfo.ExtensionCompatibilityConstraint) for this
+	// relocate. Honored only when the caller holds the
+	// VirtualMachine.ExtensionCompatibility.Bypass privilege on the virtual
+	// machine; otherwise the operation is rejected. Built-in compatibility
+	// checks (host compatibility, SPBM, and so on) are still enforced.
+	SkipExtensionCompatibilityChecks *bool `xml:"skipExtensionCompatibilityChecks" json:"skipExtensionCompatibilityChecks,omitempty"`
 }
 
 func init() {

--- a/vim25/types/unreleased.go
+++ b/vim25/types/unreleased.go
@@ -354,3 +354,119 @@ type InsufficientResourcesQuotaFault InsufficientResourcesQuota
 func init() {
 	t["InsufficientResourcesQuotaFault"] = reflect.TypeOf((*InsufficientResourcesQuotaFault)(nil)).Elem()
 }
+
+// VirtualMachineExtensionCompatibilityConstraintType enumerates the set of
+// constraintType values defined in this release. The value is carried as an
+// open string on the wire; these are the named constants.
+type VirtualMachineExtensionCompatibilityConstraintType string
+
+const (
+	// VirtualMachineExtensionCompatibilityConstraintTypeSERVICE is the virtual machine's vCenter service (cross-vCenter move).
+	VirtualMachineExtensionCompatibilityConstraintTypeSERVICE = VirtualMachineExtensionCompatibilityConstraintType("SERVICE")
+	// VirtualMachineExtensionCompatibilityConstraintTypeFOLDER is the virtual machine's folder.
+	VirtualMachineExtensionCompatibilityConstraintTypeFOLDER = VirtualMachineExtensionCompatibilityConstraintType("FOLDER")
+	// VirtualMachineExtensionCompatibilityConstraintTypePOOL is the virtual machine's resource pool.
+	VirtualMachineExtensionCompatibilityConstraintTypePOOL = VirtualMachineExtensionCompatibilityConstraintType("POOL")
+	// VirtualMachineExtensionCompatibilityConstraintTypeVM_STORAGE_POLICY is the virtual machine-level storage policy.
+	VirtualMachineExtensionCompatibilityConstraintTypeVM_STORAGE_POLICY = VirtualMachineExtensionCompatibilityConstraintType("VM_STORAGE_POLICY")
+	// VirtualMachineExtensionCompatibilityConstraintTypeDISK_STORAGE_POLICY is per-disk storage policies.
+	VirtualMachineExtensionCompatibilityConstraintTypeDISK_STORAGE_POLICY = VirtualMachineExtensionCompatibilityConstraintType("DISK_STORAGE_POLICY")
+	// VirtualMachineExtensionCompatibilityConstraintTypeDEVICE is virtual device configuration (for example, device backings).
+	VirtualMachineExtensionCompatibilityConstraintTypeDEVICE = VirtualMachineExtensionCompatibilityConstraintType("DEVICE")
+)
+
+func (e VirtualMachineExtensionCompatibilityConstraintType) Values() []VirtualMachineExtensionCompatibilityConstraintType {
+	return []VirtualMachineExtensionCompatibilityConstraintType{
+		VirtualMachineExtensionCompatibilityConstraintTypeSERVICE,
+		VirtualMachineExtensionCompatibilityConstraintTypeFOLDER,
+		VirtualMachineExtensionCompatibilityConstraintTypePOOL,
+		VirtualMachineExtensionCompatibilityConstraintTypeVM_STORAGE_POLICY,
+		VirtualMachineExtensionCompatibilityConstraintTypeDISK_STORAGE_POLICY,
+		VirtualMachineExtensionCompatibilityConstraintTypeDEVICE,
+	}
+}
+
+func (e VirtualMachineExtensionCompatibilityConstraintType) Strings() []string {
+	return EnumValuesAsStrings(e.Values())
+}
+
+func init() {
+	t["VirtualMachineExtensionCompatibilityConstraintType"] = reflect.TypeOf((*VirtualMachineExtensionCompatibilityConstraintType)(nil)).Elem()
+}
+
+// VirtualMachineExtensionCompatibilityConstraintKind enumerates the set of
+// constraintKind values defined in this release. The value is carried as an
+// open string on the wire; these are the named constants.
+type VirtualMachineExtensionCompatibilityConstraintKind string
+
+const (
+	// VirtualMachineExtensionCompatibilityConstraintKindINVARIANT asserts the constrained property must not change from the virtual machine's current value.
+	VirtualMachineExtensionCompatibilityConstraintKindINVARIANT = VirtualMachineExtensionCompatibilityConstraintKind("INVARIANT")
+)
+
+func (e VirtualMachineExtensionCompatibilityConstraintKind) Values() []VirtualMachineExtensionCompatibilityConstraintKind {
+	return []VirtualMachineExtensionCompatibilityConstraintKind{
+		VirtualMachineExtensionCompatibilityConstraintKindINVARIANT,
+	}
+}
+
+func (e VirtualMachineExtensionCompatibilityConstraintKind) Strings() []string {
+	return EnumValuesAsStrings(e.Values())
+}
+
+func init() {
+	t["VirtualMachineExtensionCompatibilityConstraintKind"] = reflect.TypeOf((*VirtualMachineExtensionCompatibilityConstraintKind)(nil)).Elem()
+}
+
+type ArrayOfVirtualMachineExtensionCompatibilityConstraint struct {
+	VirtualMachineExtensionCompatibilityConstraint []VirtualMachineExtensionCompatibilityConstraint `xml:"VirtualMachineExtensionCompatibilityConstraint,omitempty" json:"_value"`
+}
+
+func init() {
+	t["ArrayOfVirtualMachineExtensionCompatibilityConstraint"] = reflect.TypeOf((*ArrayOfVirtualMachineExtensionCompatibilityConstraint)(nil)).Elem()
+}
+
+// VirtualMachineExtensionCompatibilityConstraint is a compatibility constraint
+// declared by a managing extension on a virtual machine it manages. A
+// constraint has two orthogonal dimensions: ConstraintType identifies what
+// property is constrained and ConstraintKind identifies how it is evaluated.
+// Within a single VM a constraint's identity is the (ConstraintType,
+// ConstraintKind) pair; ConstraintName is descriptive only.
+type VirtualMachineExtensionCompatibilityConstraint struct {
+	DynamicData
+
+	// ConstraintName is an optional descriptive label for the constraint,
+	// chosen by the managing extension (for example, "pool-invariant"). It is
+	// not required to be unique and is not used to evaluate or identify the
+	// constraint.
+	ConstraintName string `xml:"constraintName,omitempty" json:"constraintName,omitempty"`
+	// ConstraintType is the property that this constraint protects. The values
+	// defined today are enumerated by
+	// VirtualMachineExtensionCompatibilityConstraintType. An unrecognized value
+	// causes the create or reconfigure operation that registers the constraint
+	// to fail.
+	ConstraintType string `xml:"constraintType" json:"constraintType"`
+	// ConstraintKind is how the constraint is evaluated. The only kind defined
+	// today is
+	// VirtualMachineExtensionCompatibilityConstraintKindINVARIANT. This field is
+	// required and must be set explicitly.
+	ConstraintKind string `xml:"constraintKind" json:"constraintKind"`
+}
+
+func init() {
+	t["VirtualMachineExtensionCompatibilityConstraint"] = reflect.TypeOf((*VirtualMachineExtensionCompatibilityConstraint)(nil)).Elem()
+}
+
+// VirtualMachineExtensionCompatibilityConstraintSet represents the set of
+// VirtualMachineExtensionCompatibilityConstraint objects declared on a virtual
+// machine. An empty Constraint array means no constraints are declared.
+type VirtualMachineExtensionCompatibilityConstraintSet struct {
+	DynamicData
+
+	// Constraint is the extension compatibility constraints in this set.
+	Constraint []VirtualMachineExtensionCompatibilityConstraint `xml:"constraint,omitempty" json:"constraint,omitempty"`
+}
+
+func init() {
+	t["VirtualMachineExtensionCompatibilityConstraintSet"] = reflect.TypeOf((*VirtualMachineExtensionCompatibilityConstraintSet)(nil)).Elem()
+}

--- a/vim25/types/unreleased_test.go
+++ b/vim25/types/unreleased_test.go
@@ -6,6 +6,8 @@ package types_test
 
 import (
 	"context"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/vmware/govmomi/property"
@@ -13,6 +15,7 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
 )
 
 func TestPodVMInfo(t *testing.T) {
@@ -38,4 +41,60 @@ func TestPodVMInfo(t *testing.T) {
 			t.Errorf("%#v", props.Runtime.PodVMInfo)
 		}
 	})
+}
+
+// TestExtensionCompatibilityConstraint verifies the read-back property
+// config.extensionCompatibilityConstraint round-trips through the
+// PropertyCollector (as config.managedBy does), and that the request-side
+// write/bypass fields on ConfigSpec and RelocateSpec serialize.
+func TestExtensionCompatibilityConstraint(t *testing.T) {
+	set := &types.VirtualMachineExtensionCompatibilityConstraintSet{
+		Constraint: []types.VirtualMachineExtensionCompatibilityConstraint{
+			{
+				ConstraintName: "pool-invariant",
+				ConstraintType: string(types.VirtualMachineExtensionCompatibilityConstraintTypePOOL),
+				ConstraintKind: string(types.VirtualMachineExtensionCompatibilityConstraintKindINVARIANT),
+			},
+		},
+	}
+
+	// Read-back path via PropertyCollector.
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		vm := simulator.Map(ctx).Any("VirtualMachine").(*simulator.VirtualMachine)
+		vm.Config.ExtensionCompatibilityConstraint = set
+
+		var props mo.VirtualMachine
+		pc := property.DefaultCollector(c)
+		if err := pc.RetrieveOne(ctx, vm.Self, []string{"config"}, &props); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(props.Config.ExtensionCompatibilityConstraint, set) {
+			t.Errorf("config.extensionCompatibilityConstraint: %#v", props.Config.ExtensionCompatibilityConstraint)
+		}
+	})
+
+	// Request-side write + bypass fields (vcsim does not persist these); assert
+	// they serialize.
+	skip := true
+	b, err := xml.Marshal(types.VirtualMachineConfigSpec{
+		ExtensionCompatibilityConstraint: set,
+		SkipExtensionCompatibilityChecks: &skip,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"extensionCompatibilityConstraint", "skipExtensionCompatibilityChecks",
+		"pool-invariant", "POOL", "INVARIANT",
+	} {
+		if !strings.Contains(string(b), want) {
+			t.Errorf("expected %q in marshaled ConfigSpec:\n%s", want, b)
+		}
+	}
+
+	if b, err = xml.Marshal(types.VirtualMachineRelocateSpec{SkipExtensionCompatibilityChecks: &skip}); err != nil {
+		t.Fatal(err)
+	} else if !strings.Contains(string(b), "skipExtensionCompatibilityChecks") {
+		t.Errorf("expected skipExtensionCompatibilityChecks in RelocateSpec:\n%s", b)
+	}
 }


### PR DESCRIPTION
## Description

Adds vim25 bindings for the extension compatibility constraint API. A managing
extension can declare compatibility constraints on a VM it manages so vCenter's
compatibility-check pipeline rejects operations that would change protected
properties (for example, moving the VM out of its resource pool); a bypass flag
lets privileged callers holding the bypass privilege skip enforcement.

These VMODL types are feature-gated and not yet part of a released WSDL, so the
new types are hand-added under the `unreleased.go` convention and will migrate
into the generated files when the version's WSDL is next generated:

- `VirtualMachineExtensionCompatibilityConstraint` and its `...ConstraintSet`
  wrapper, plus the `ConstraintType` / `ConstraintKind` constant holders
  (`vim25/types/unreleased.go`).
- New optional fields on existing types (`vim25/types/types.go`):
  `VirtualMachineConfigSpec` and `VirtualMachineConfigInfo` gain
  `extensionCompatibilityConstraint`; `VirtualMachineConfigSpec` and
  `VirtualMachineRelocateSpec` gain `skipExtensionCompatibilityChecks`.

## How Has This Been Tested?

- `go build ./...` — clean.
- `go test ./vim25/types/` — 786 tests pass, including a new
  `TestExtensionCompatibilityConstraint` that:
  - sets `config.extensionCompatibilityConstraint` on a vcsim VM and retrieves
    it back through the PropertyCollector, asserting a deep-equal round-trip
    (the read-back path);
  - marshals a `VirtualMachineConfigSpec` and `VirtualMachineRelocateSpec` and
    asserts the `extensionCompatibilityConstraint` set and the
    `skipExtensionCompatibilityChecks` flag serialize (the request-side path).
- `go vet ./vim25/types/` and `make check` (goimports + govet) — clean.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
