### PR TITLE
refactor: modernize for loops to use range

### DIFF
--- a/cli/dvs/create.go
+++ b/cli/dvs/create.go
@@ -89,7 +89,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	if numUplinkPorts > 0 {
 		var policy types.DVSNameArrayUplinkPortPolicy
-		for i := 0; i < numUplinkPorts; i++ {
+		for i := range numUplinkPorts {
 			policy.UplinkPortName = append(policy.UplinkPortName, fmt.Sprintf("Uplink %d", i+1))
 		}
 		cmd.configSpec.UplinkPortPolicy = &policy

--- a/cli/flags/version.go
+++ b/cli/flags/version.go
@@ -40,7 +40,7 @@ func (v version) Lte(u version) bool {
 	lv := len(v)
 	lu := len(u)
 
-	for i := 0; i < lv; i++ {
+	for i := range lv {
 		// Everything up to here has been equal and v has more elements than u.
 		if i >= lu {
 			return false

--- a/eam/object/agency_test.go
+++ b/eam/object/agency_test.go
@@ -153,7 +153,7 @@ func TestAgency(t *testing.T) {
 			waitIntervalSecs = time.Duration(1) * time.Second
 		)
 		hasIssues := false
-		for i := 0; i < waitTotalSecs; i++ {
+		for range waitTotalSecs {
 			runtime, err := agency.Runtime(client.ctx)
 			if err != nil {
 				t.Fatal(err)

--- a/guest/file_manager_test.go
+++ b/guest/file_manager_test.go
@@ -26,7 +26,7 @@ func TestTranferURL(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		for i := 0; i < 2; i++ { // 2nd time is to validate the cached value
+		for range 2 { // 2nd time is to validate the cached value
 			turl := "https://esx:443/foo/bar"
 			u, err := m.TransferURL(ctx, turl)
 			if err != nil {
@@ -55,7 +55,7 @@ func TestTranferURL(t *testing.T) {
 			}
 		}
 
-		for i := 0; i < 2; i++ { // 2nd time is to validate the cached value
+		for range 2 { // 2nd time is to validate the cached value
 			turl := "https://esx2:443/foo/bar"
 			u, err := m.TransferURL(ctx, turl)
 			if err != nil {

--- a/object/virtual_device_list.go
+++ b/object/virtual_device_list.go
@@ -480,7 +480,7 @@ func (l VirtualDeviceList) PickController(kind types.BaseVirtualController) type
 func (l VirtualDeviceList) newUnitNumber(c types.BaseVirtualController, offset int) int32 {
 	units := make([]bool, 30)
 
-	for i := 0; i < offset; i++ {
+	for i := range offset {
 		units[i] = true
 	}
 

--- a/session/cache/example_test.go
+++ b/session/cache/example_test.go
@@ -25,7 +25,7 @@ func ExampleSession_Login() {
 		// Login() each client twice
 		// 1) creates a new authenticated session
 		// 2) uses a cached session (proved by removing the password)
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			s := &cache.Session{
 				URL:      u,
 				Insecure: true,

--- a/session/keepalive/example_test.go
+++ b/session/keepalive/example_test.go
@@ -42,7 +42,7 @@ func ExampleHandlerSOAP() {
 
 		// check twice if session is valid, sleeping > SessionIdleTimeout in between
 		check := func() {
-			for i := 0; i < 2; i++ {
+			for i := range 2 {
 				s, err := m.UserSession(ctx)
 				if err != nil {
 					log.Fatal(err)
@@ -101,7 +101,7 @@ func ExampleHandlerREST() {
 
 		// check twice if session is valid, sleeping > SessionIdleTimeout in between.
 		check := func() {
-			for i := 0; i < 2; i++ {
+			for i := range 2 {
 				s, err := c.Session(ctx)
 				if err != nil {
 					log.Fatal(err)

--- a/simulator/authorization_manager_test.go
+++ b/simulator/authorization_manager_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAuthorizationManager(t *testing.T) {
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		model := VPX()
 		ctx := NewContext()
 		_ = New(NewServiceInstance(ctx, model.ServiceContent, model.RootFolder)) // 2nd pass panics w/o copying RoleList

--- a/simulator/container_virtual_machine.go
+++ b/simulator/container_virtual_machine.go
@@ -364,7 +364,7 @@ func (svm *simVM) start(ctx *Context) error {
 
 	// Sync network config, retrying a few times to allow the container to get an IP
 	// Container runtimes may take a moment to assign an IP address after start
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		if err = svm.syncNetworkConfigToVMGuestProperties(ctx, nil, nil); err != nil {
 			log.Printf("%s inspect %s: %s", svm.vm.Name, svm.c.id, err)
 			break
@@ -554,7 +554,7 @@ func productSerial(id uuid.UUID) string {
 	var dst [len(id)*2 + len(id) - 1]byte
 
 	j := 0
-	for i := 0; i < len(id); i++ {
+	for i := range len(id) {
 		hex.Encode(dst[j:j+2], id[i:i+1])
 		j += 3
 		if j < len(dst) {

--- a/simulator/fault_injection_test.go
+++ b/simulator/fault_injection_test.go
@@ -85,7 +85,7 @@ func TestFaultInjection(t *testing.T) {
 		// Run multiple times to test probability
 		failures := 0
 		attempts := 100
-		for i := 0; i < attempts; i++ {
+		for range attempts {
 			vm.PowerOff(ctx) // Reset state
 			taskResult, err := vm.PowerOn(ctx)
 			if err != nil {
@@ -193,7 +193,7 @@ func TestFaultInjectionMaxCount(t *testing.T) {
 		require.NoError(t, err)
 
 		// First two attempts should fail
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			vm.PowerOff(ctx)
 			_, err := vm.PowerOn(ctx)
 			require.Error(t, err, "expected error on attempt %d", i+1)
@@ -276,7 +276,7 @@ func TestFaultInjectionSkipCount(t *testing.T) {
 		require.NoError(t, err)
 
 		// First two attempts should succeed (skipped)
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			vm.PowerOff(ctx)
 			taskResult, err := vm.PowerOn(ctx)
 			require.NoError(t, err, "expected success on attempt %d (should be skipped)", i+1)
@@ -329,7 +329,7 @@ func TestFaultInjectionSkipCountWithMaxCount(t *testing.T) {
 		}
 
 		// Second and third attempts should fail (after skip, max 2 injections)
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			vm.PowerOff(ctx)
 			_, err = vm.PowerOn(ctx)
 			require.Error(t, err, "expected error on attempt %d", i+2)

--- a/simulator/internal/server.go
+++ b/simulator/internal/server.go
@@ -236,7 +236,7 @@ func (s *Server) CloseClientConnections() {
 	// in tests.
 	timer := time.NewTimer(5 * time.Second)
 	defer timer.Stop()
-	for i := 0; i < nconn; i++ {
+	for range nconn {
 		select {
 		case <-ch:
 		case <-timer.C:

--- a/simulator/ip_pool_manager.go
+++ b/simulator/ip_pool_manager.go
@@ -269,7 +269,7 @@ func (p *IpPool) init() error {
 				return err
 			}
 
-			for i := 0; i < length; i++ {
+			for i := range length {
 				p.ipv4Pool = append(p.ipv4Pool, net.IPv4(ip[0], ip[1], ip[2], ip[3]+byte(i)).String())
 			}
 		}
@@ -294,7 +294,7 @@ func (p *IpPool) init() error {
 				return err
 			}
 
-			for i := 0; i < length; i++ {
+			for i := range length {
 				var ipv6 [16]byte
 				copy(ipv6[:], ip)
 				ipv6[15] += byte(i)

--- a/simulator/performance_manager.go
+++ b/simulator/performance_manager.go
@@ -105,7 +105,7 @@ func (p *PerformanceManager) buildAvailablePerfMetricsQueryResponse(ids []types.
 	for _, id := range ids {
 		switch id.Instance {
 		case "$cpu":
-			for i := 0; i < numCPU; i++ {
+			for i := range numCPU {
 				r.Returnval = append(r.Returnval, types.PerfMetricId{CounterId: id.CounterId, Instance: strconv.Itoa(i)})
 			}
 		case "$physDisk":

--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -1485,7 +1485,7 @@ func TestPropertyCollectorSession(t *testing.T) { // aka issue-923
 		t.Fatal(err)
 	}
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if err = c.Login(ctx, u); err != nil {
 			t.Fatal(err)
 		}
@@ -1792,7 +1792,7 @@ func TestPageUpdateSet(t *testing.T) {
 
 			for i := 0; i < test.filters; i++ {
 				f := types.PropertyFilterUpdate{}
-				for j := 0; j < 156; j++ {
+				for range 156 {
 					f.ObjectSet = append(f.ObjectSet, types.ObjectUpdate{})
 				}
 				update.FilterSet = append(update.FilterSet, f)

--- a/simulator/property_diff_test.go
+++ b/simulator/property_diff_test.go
@@ -554,13 +554,13 @@ func TestContext_AutoUpdate(t *testing.T) {
 
 	const iters = 100
 	var wg sync.WaitGroup
-	for g := 0; g < 2; g++ {
+	for g := range 2 {
 		wg.Add(1)
 		g := g
 		go func() {
 			defer wg.Done()
 			ctx := newCtx()
-			for i := 0; i < iters; i++ {
+			for i := range iters {
 				ctx.AutoUpdate(obj, func() {
 					if obj.Guest == nil {
 						obj.Guest = &types.GuestInfo{}
@@ -890,7 +890,7 @@ func TestPropertyDiff_ConcurrentAccess(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		ctx := newCtx()
-		for i := 0; i < iters; i++ {
+		for i := range iters {
 			ctx.AutoUpdate(obj, func() {
 				if obj.Guest == nil {
 					obj.Guest = &types.GuestInfo{}
@@ -906,7 +906,7 @@ func TestPropertyDiff_ConcurrentAccess(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		ctx := newCtx()
-		for i := 0; i < iters; i++ {
+		for i := range iters {
 			ctx.WithLock(obj, func() {
 				if obj.Guest == nil {
 					obj.Guest = &types.GuestInfo{}

--- a/simulator/race_test.go
+++ b/simulator/race_test.go
@@ -132,7 +132,7 @@ func TestRace(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		spec := types.VirtualMachineConfigSpec{
 			Name:    fmt.Sprintf("race-test-%d", i),
 			GuestId: string(types.VirtualMachineGuestOsIdentifierOtherGuest),
@@ -164,7 +164,7 @@ func TestRace(t *testing.T) {
 				t.Error(err)
 			}
 
-			for j := 0; j < 2; j++ {
+			for j := range 2 {
 				cspec := spec // copy spec and give it a unique name
 				cspec.Name += fmt.Sprintf("-%d", j)
 
@@ -345,7 +345,7 @@ func TestRaceVmRelocate(t *testing.T) {
 		var failed atomic.Int32
 		var wg sync.WaitGroup
 
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			spec := types.VirtualMachineRelocateSpec{
 				Folder: types.NewReference(vmFolder.Reference()),
 			}

--- a/simulator/registry_test.go
+++ b/simulator/registry_test.go
@@ -43,7 +43,7 @@ func TestRegistry(t *testing.T) {
 func TestRemoveReference(t *testing.T) {
 	var refs []types.ManagedObjectReference
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		refs = append(refs, types.ManagedObjectReference{Type: "any", Value: fmt.Sprintf("%d", i)})
 	}
 

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -109,7 +109,7 @@ func NewVirtualMachine(ctx *Context, parent types.ManagedObjectReference, spec *
 		// Create VM directory, renaming if already exists
 		name := dir
 
-		for i := 0; i < 1024; /* just in case */ i++ {
+		for i := range 1024 {
 			err := os.Mkdir(name, 0700)
 			if err != nil {
 				if os.IsExist(err) {

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -4327,7 +4327,7 @@ func TestEncryptDecryptVM(t *testing.T) {
 				if err := tsk.Wait(ctx); err != nil {
 					return err
 				}
-				for i := 0; i < 2; i++ {
+				for i := range 2 {
 					tsk, err := vm.CreateSnapshot(
 						ctx,
 						fmt.Sprintf("snap-%d", i),

--- a/toolbox/hgfs/archive_test.go
+++ b/toolbox/hgfs/archive_test.go
@@ -168,7 +168,7 @@ func TestWriteArchive(t *testing.T) {
 	gz := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gz)
 
-	for i := 0; i < nfiles; i++ {
+	for i := range nfiles {
 		data := bytes.NewBufferString(strings.Repeat("X", i+1024))
 
 		header := &tar.Header{

--- a/vapi/tags/categories_test.go
+++ b/vapi/tags/categories_test.go
@@ -50,7 +50,7 @@ func TestManager_GetCategories(t *testing.T) {
 			created = append(created, cat)
 		}
 
-		for i := 0; i < deleteCount; i++ {
+		for i := range deleteCount {
 			tr.deleted = append(tr.deleted, created[i])
 		}
 

--- a/vim25/debug/debug_test.go
+++ b/vim25/debug/debug_test.go
@@ -30,7 +30,7 @@ func TestSetProvider(t *testing.T) {
 		rc := rest.NewClient(c)
 
 		// hit the debug package with some concurrency (see PR #2469)
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/vim25/json/encode.go
+++ b/vim25/json/encode.go
@@ -943,7 +943,7 @@ type arrayEncoder struct {
 func (ae arrayEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 	e.WriteByte('[')
 	n := v.Len()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if i > 0 {
 			e.WriteByte(',')
 		}

--- a/vim25/json/indent.go
+++ b/vim25/json/indent.go
@@ -62,7 +62,7 @@ func compact(dst *bytes.Buffer, src []byte, escape bool) error {
 func newline(dst *bytes.Buffer, prefix, indent string, depth int) {
 	dst.WriteByte('\n')
 	dst.WriteString(prefix)
-	for i := 0; i < depth; i++ {
+	for range depth {
 		dst.WriteString(indent)
 	}
 }

--- a/vim25/progress/aggregator_test.go
+++ b/vim25/progress/aggregator_test.go
@@ -24,7 +24,7 @@ func TestAggregatorMultipleSinks(t *testing.T) {
 	ch := make(chan Report)
 	a := NewAggregator(dummySinker{ch})
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		go func(ch chan<- Report) {
 			ch <- dummyReport{}
 			ch <- dummyReport{}

--- a/vim25/progress/scale_test.go
+++ b/vim25/progress/scale_test.go
@@ -14,7 +14,7 @@ func TestScaleMany(t *testing.T) {
 	s := Scale(a, 5)
 
 	go func() {
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			go func(ch chan<- Report) {
 				ch <- dummyReport{p: 0.0}
 				ch <- dummyReport{p: 50.0}

--- a/vim25/retry_test.go
+++ b/vim25/retry_test.go
@@ -106,7 +106,7 @@ func TestRetryNetworkError(t *testing.T) {
 
 		simulator.StatusSDK = http.StatusBadGateway
 		// beyond max retry attempts, should result in an erro
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			_, err = vm.PowerState(ctx)
 		}
 

--- a/vim25/types/helpers.go
+++ b/vim25/types/helpers.go
@@ -217,7 +217,7 @@ func (ci VirtualMachineConfigInfo) ToConfigSpec() VirtualMachineConfigSpec {
 
 	if l := len(ci.CpuFeatureMask); l > 0 {
 		cs.CpuFeatureMask = make([]VirtualMachineCpuIdInfoSpec, l)
-		for i := 0; i < l; i++ {
+		for i := range l {
 			cs.CpuFeatureMask[i] = VirtualMachineCpuIdInfoSpec{
 				ArrayUpdateSpec: ArrayUpdateSpec{
 					Operation: ArrayUpdateOperationAdd,
@@ -236,7 +236,7 @@ func (ci VirtualMachineConfigInfo) ToConfigSpec() VirtualMachineConfigSpec {
 
 	if l := len(ci.Hardware.Device); l > 0 {
 		cs.DeviceChange = make([]BaseVirtualDeviceConfigSpec, l)
-		for i := 0; i < l; i++ {
+		for i := range l {
 			cs.DeviceChange[i] = &VirtualDeviceConfigSpec{
 				Operation:     VirtualDeviceConfigSpecOperationAdd,
 				FileOperation: VirtualDeviceConfigSpecFileOperationCreate,

--- a/vim25/xml/marshal.go
+++ b/vim25/xml/marshal.go
@@ -643,7 +643,7 @@ func (p *printer) marshalAttr(start *StartElement, name Name, val reflect.Value)
 	// Walk slices.
 	if val.Kind() == reflect.Slice && val.Type().Elem().Kind() != reflect.Uint8 {
 		n := val.Len()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			if err := p.marshalAttr(start, name, val.Index(i)); err != nil {
 				return err
 			}
@@ -1110,7 +1110,7 @@ func (s *parentStack) trim(parents []string) error {
 
 // push adds parent elements to the stack and writes open tags.
 func (s *parentStack) push(parents []string) error {
-	for i := 0; i < len(parents); i++ {
+	for i := range parents {
 		if err := s.p.writeStart(&StartElement{Name: Name{Local: parents[i]}}); err != nil {
 			return err
 		}

--- a/vim25/xml/marshal_test.go
+++ b/vim25/xml/marshal_test.go
@@ -2393,7 +2393,7 @@ func TestRace9796(t *testing.T) {
 		C []A `xml:"X>Y"`
 	}
 	var wg sync.WaitGroup
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		wg.Add(1)
 		go func() {
 			Marshal(B{[]A{{}}})

--- a/vim25/xml/read.go
+++ b/vim25/xml/read.go
@@ -346,7 +346,7 @@ func (d *Decoder) unmarshal(val reflect.Value, start *StartElement, depth int) e
 				return err
 			}
 
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				if typ.Implements(val.Type()) {
 					val.Set(pval)
 					return nil

--- a/vim25/xml/typeinfo.go
+++ b/vim25/xml/typeinfo.go
@@ -62,7 +62,7 @@ func GetTypeInfo(typ reflect.Type) (*TypeInfo, error) {
 	}
 	if typ.Kind() == reflect.Struct && typ != nameType {
 		n := typ.NumField()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			f := typ.Field(i)
 			if (!f.IsExported() && !f.Anonymous) || f.Tag.Get("xml") == "-" {
 				continue // Private field
@@ -278,7 +278,7 @@ Loop:
 			continue
 		}
 		minl := min(len(newf.parents), len(oldf.parents))
-		for p := 0; p < minl; p++ {
+		for p := range minl {
 			if oldf.parents[p] != newf.parents[p] {
 				continue Loop
 			}

--- a/vim25/xml/xml.go
+++ b/vim25/xml/xml.go
@@ -695,7 +695,7 @@ func (d *Decoder) rawToken() (Token, error) {
 
 		case '[': // <![
 			// Probably <![CDATA[.
-			for i := 0; i < 6; i++ {
+			for i := range 6 {
 				if b, ok = d.mustgetc(); !ok {
 					return nil, d.err
 				}

--- a/vmdk/writer_test.go
+++ b/vmdk/writer_test.go
@@ -239,7 +239,7 @@ func TestCalculateGrainTableLocations_TableDriven(t *testing.T) {
 		{"0 bytes", 0, []uint64{}},
 		{"1TB", 1099511627776, func() []uint64 {
 			locations := make([]uint64, 32768)
-			for i := uint64(0); i < 32768; i++ {
+			for i := range uint64(32768) {
 				locations[i] = 277 + (i * 4)
 			}
 			return locations


### PR DESCRIPTION
## Description

Tech Debt: Replace classic C-style loops with Go's modern range-over-integer syntax introduced in Go 1.22.
