### PR TITLE
Vcsim nested containers and guestrpc

### DIFF
--- a/.github/workflows/govmomi-go-tests.yaml
+++ b/.github/workflows/govmomi-go-tests.yaml
@@ -42,6 +42,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.go-version }}-
 
+      - name: Build VMCI systemd-init test image
+        # Non-fatal by design (see the Makefile target's comment): a runner without
+        # docker, or a build failure, must not fail the job. continue-on-error is
+        # belt-and-suspenders on top of that; Run Tests below triggers the same
+        # target again via go-test's prerequisite, so this step is for CI visibility.
+        continue-on-error: true
+        run: make vmci-systemd-init-image
+
       - name: Run Tests
         env:
           TEST_COUNT: 1

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ dist/
 # Ignore editor temp files
 *~
 .vscode/
+.cursor/
+
+# Test binaries
+*.test
+
+# vmci simulation artifacts (built on-demand by simulator tests via go build)
+/vmci-guest
+/simulator/bin/

--- a/Makefile
+++ b/Makefile
@@ -143,8 +143,22 @@ ifeq (-timeout,$(findstring -timeout,$(TEST_OPTS)))
 $(error Use TEST_TIMEOUT to override this option)
 endif
 
+VMCI_SYSTEMD_INIT_IMAGE ?= docker.io/library/vmci-systemd-init:latest
+
+# Always attempts a fresh build rather than checking for an existing image first, so a
+# Dockerfile change can never be shadowed by a stale image the way a stale toolbox binary
+# once was (see vcsim spec D-97-20). Never fails the build: TestVMCI_SystemdInit_GuestInfoRoundTrip
+# and TestVMCI_NestedContainers_GuestInfoRoundTrip skip themselves (t.Skipf) when the image is
+# absent, so a system without docker/podman, or any build failure (no network, etc.), must not
+# break `make test`.
+.PHONY: vmci-systemd-init-image
+vmci-systemd-init-image: ## Build the vmci-systemd-init image for simulator VMCI/nestedContainers tests
+	-@command -v docker >/dev/null 2>&1 && \
+		docker build -t $(VMCI_SYSTEMD_INIT_IMAGE) ./simulator/testdata/vmci-systemd-init/ || \
+		echo "vmci-systemd-init-image: skipping (docker/podman unavailable, or build failed); dependent simulator tests will skip themselves"
+
 .PHONY: go-test
-go-test: ## Runs go unit tests with race detector enabled
+go-test: vmci-systemd-init-image ## Runs go unit tests with race detector enabled
 	GORACE=$(GORACE) CGO_ENABLED=1 $(GO) test \
   -count $(TEST_COUNT) \
   -race \

--- a/simulator/container.go
+++ b/simulator/container.go
@@ -29,6 +29,28 @@ var (
 	eventWatch eventWatcher
 )
 
+// shellQuote wraps s in POSIX single quotes, escaping any embedded single
+// quotes with the '\” sequence.  Use this before appending container image
+// names or command args to the bash -c string in create().
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// filterSeccompUnconfined removes the "--security-opt seccomp=unconfined" pair
+// from run (in-place, preserving order).  Used when a custom seccomp profile
+// replaces the unconfined setting added by nestedContainers mode.
+func filterSeccompUnconfined(run []string) []string {
+	out := run[:0]
+	for i := 0; i < len(run); i++ {
+		if run[i] == "--security-opt" && i+1 < len(run) && run[i+1] == "seccomp=unconfined" {
+			i++ // skip both tokens
+			continue
+		}
+		out = append(out, run[i])
+	}
+	return out
+}
+
 const (
 	deleteWithContainer = "lifecycle=container"
 	createdByVcsim      = "createdBy=vcsim"
@@ -40,12 +62,22 @@ func init() {
 	}
 }
 
+// exitErrStderr returns the trimmed stderr captured by an *exec.ExitError, or
+// "" if err is not an *exec.ExitError (or captured no stderr). Shared by
+// every call site in this file that needs to inspect a failed command's
+// stderr, whether to format an error (commandError) or to decide on a
+// specific failure reason (e.g. "already exists", "already in use").
+func exitErrStderr(err error) string {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return ""
+	}
+	return strings.TrimSpace(string(exitErr.Stderr))
+}
+
 // commandError logs and returns an error from a command execution failure, including stderr if available.
 func commandError(operation string, args []string, err error) error {
-	stderr := ""
-	if xerr, ok := err.(*exec.ExitError); ok {
-		stderr = strings.TrimSpace(string(xerr.Stderr))
-	}
+	stderr := exitErrStderr(err)
 	var cmdErr error
 	if stderr != "" {
 		cmdErr = fmt.Errorf("%s %v failed: %s: %s", operation, args, err, stderr)
@@ -220,9 +252,17 @@ func createVolume(volumeName string, labels []string, files []tarEntry) (uid str
 		cmd := exec.Command("docker", run...)
 		out, err := cmd.Output()
 		if err != nil {
-			return "", commandError("volume create", cmd.Args, err)
+			// Podman (unlike Docker) rejects volume create when the volume already
+			// exists; Docker is idempotent here.  Named volumes can be implicitly
+			// created by "docker create -v name:/path" before we reach this explicit
+			// create, so treat "already exists" as success and continue to populate.
+			if !strings.Contains(exitErrStderr(err), "already exists") {
+				return "", commandError("volume create", cmd.Args, err)
+			}
+			uid = name // volume already exists; provided name is the uid
+		} else {
+			uid = strings.TrimSpace(string(out))
 		}
-		uid = strings.TrimSpace(string(out))
 
 		if name == "" {
 			name = uid
@@ -360,15 +400,54 @@ func createBridge(bridgeName string, labels ...string) (string, error) {
 	return id, nil
 }
 
-// create
+// createOptions groups the docker/podman "run" configuration for create().
+// Grouped into a struct so call sites are self-documenting instead of relying
+// on argument order.
+type createOptions struct {
+	Networks []string // set of bridges to connect the container to
+	// Volumes are colon-separated tuples of volume name to mount path,
+	// passed directly to docker via -v so mount options can be postfixed.
+	Volumes []string
+	Ports   []string
+	Env     []string // environment variables in name=value form
+
+	// Privileged adds --privileged.
+	// Has no additional effect when NestedContainers is true since that already
+	// implies --privileged.
+	Privileged bool
+	// NestedContainers adds the flags required for running containers
+	// inside the container (e.g. Kubernetes): --cgroupns=private,
+	// --security-opt seccomp=unconfined, --security-opt apparmor=unconfined,
+	// --tmpfs /tmp, --tmpfs /run, --volume /var,
+	// --volume /lib/modules:/lib/modules:ro, --device /dev/fuse.
+	// NestedContainers=true forces privileged to true regardless of the
+	// Privileged field's value.
+	NestedContainers bool
+	SeccompProfile   string // when non-empty, "--security-opt seccomp=<profile>"
+
+	// QuoteImageAndArgs controls shell quoting of image and args before they
+	// are joined into the bash -c command string:
+	//   - true  → JSON-array format: image is a bare name, args are separate
+	//     tokens that may contain shell metacharacters (&&, ;, spaces) — each
+	//     is wrapped in POSIX single quotes so bash does not re-interpret them.
+	//   - false → legacy string format: the image field holds the entire raw
+	//     docker-run flag string (e.g. "-v '/path' nginx"), which must be
+	//     passed verbatim to bash for word-splitting to work correctly.
+	QuoteImageAndArgs bool
+
+	// Controls whether to remove an existing container of the same name. Test failures
+	// due to timeout tend to leave container residue behind as that doesn't trigger
+	// defers
+	RecreateIfExists bool
+}
+
+// create allocates a container for the simulated VM.
 //   - name - pretty name, eg. vm name
 //   - id - uuid or similar - this is merged into container name rather than dictating containerID
-//   - networks - set of bridges to connect the container to
-//   - volumes - colon separated tuple of volume name to mount path. Passed directly to docker via -v so mount options can be postfixed.
-//   - env - array of environment vairables in name=value form
-//   - optsAndImage - pass-though options and must include at least the container image to use, including tag if necessary
+//   - image - the container image to use, including tag if necessary
 //   - args - the command+args to pass to the container
-func create(ctx *Context, name string, id string, networks []string, volumes []string, ports []string, env []string, image string, args []string) (*container, error) {
+//   - opts - see createOptions
+func create(ctx *Context, name string, id string, image string, args []string, opts createOptions) (*container, error) {
 	if len(image) == 0 {
 		return nil, errors.New("cannot create container backing without an image")
 	}
@@ -377,10 +456,21 @@ func create(ctx *Context, name string, id string, networks []string, volumes []s
 	c.name = constructContainerName(name, id)
 	c.changes = make(chan struct{})
 
-	for i := range volumes {
-		// we'll pre-create anonymous volumes, simply for labelling consistency
-		volName := strings.Split(volumes[i], ":")
-		createVolume(volName[0], []string{deleteWithContainer, "container=" + c.name}, nil)
+	if opts.RecreateIfExists {
+		if _, preRmErr := exec.Command("docker", "rm", "-f", c.name).Output(); preRmErr == nil {
+			log.Printf("container create: removed stale container %q before create", c.name)
+		}
+		// preRmErr is deliberately ignored: a non-zero exit means no container with
+		// that name existed, which is the expected case on every clean run.
+	}
+
+	for i := range opts.Volumes {
+		// Pre-create named Docker volumes for labelling consistency.
+		// Skip bind mounts (host paths starting with "/") — those already exist.
+		volName := strings.Split(opts.Volumes[i], ":")
+		if !strings.HasPrefix(volName[0], "/") {
+			createVolume(volName[0], []string{deleteWithContainer, "container=" + c.name}, nil)
+		}
 	}
 
 	// assemble env
@@ -389,33 +479,98 @@ func create(ctx *Context, name string, id string, networks []string, volumes []s
 	var dockerPort []string
 	var dockerEnv []string
 
-	for i := range env {
-		dockerEnv = append(dockerEnv, "--env", env[i])
+	for i := range opts.Env {
+		dockerEnv = append(dockerEnv, "--env", opts.Env[i])
 	}
 
-	for i := range volumes {
-		dockerVol = append(dockerVol, "-v", volumes[i])
+	for i := range opts.Volumes {
+		dockerVol = append(dockerVol, "-v", opts.Volumes[i])
 	}
 
-	for i := range ports {
-		dockerPort = append(dockerPort, "-p", ports[i])
+	for i := range opts.Ports {
+		dockerPort = append(dockerPort, "-p", opts.Ports[i])
 	}
 
-	for i := range networks {
-		dockerNet = append(dockerNet, "--network", networks[i])
+	for i := range opts.Networks {
+		dockerNet = append(dockerNet, "--network", opts.Networks[i])
 	}
 
 	run := []string{"docker", "create", "--name", c.name}
+
+	if opts.Privileged || opts.NestedContainers {
+		// RUN.privileged=true: add --privileged without the full nestedContainers
+		// flag set. Used for systemd-init images that need privilege escalation but
+		// must NOT have --tmpfs /run (which would hide the RUN.vmci GuestRPC socket
+		// at /run/vmware/rpc.sock). cgroupns=host is kept (same as default mode).
+		// For nested, adds privileged mode for systemd compatibility
+		run = append(run, "--privileged")
+	}
+
+	if opts.NestedContainers {
+		// Nested container mode: flags adapted from kind's provision.go for running
+		// Kubernetes inside the container. These enable proper cgroup isolation and
+		// allow containerd/kubelet to create nested containers.
+		// Reference: https://github.com/kubernetes-sigs/kind/blob/main/pkg/cluster/internal/providers/docker/provision.go
+		//
+		// --cgroupns=private: Gives container its own cgroup namespace, required for
+		//   proper cgroup v2 delegation to nested containers
+		// --security-opt seccomp=unconfined: Allows syscalls needed by systemd/containerd
+		// --security-opt apparmor=unconfined: Disables AppArmor restrictions
+		// --tmpfs /tmp,/run: Required for systemd to function properly
+		// --volume /var: Persistent storage for containerd/kubelet data
+		// --volume /lib/modules: Kernel modules for iptables/networking
+		// --device /dev/fuse: Required for fuse-overlayfs snapshotter
+		run = append(run,
+			"--cgroupns=private",
+			"--security-opt", "seccomp=unconfined",
+			"--security-opt", "apparmor=unconfined",
+			"--tmpfs", "/tmp",
+			"--tmpfs", "/run",
+			"--volume", "/var",
+			"--volume", "/lib/modules:/lib/modules:ro",
+			"--device", "/dev/fuse",
+		)
+
+	} else {
+		// Standard mode: use host cgroup namespace for access to all controllers
+		// --cgroupns=host: gives access to all cgroup controllers (cpuset, etc.)
+		run = append(run, "--cgroupns=host")
+	}
+
+	if opts.SeccompProfile != "" {
+		// RUN.vmci=true generates a per-VM seccomp filter with
+		// defaultAction=SCMP_ACT_ALLOW plus AF_VSOCK intercept rules.
+		// Remove any "--security-opt seccomp=unconfined" that nestedContainers mode
+		// already added — two seccomp options confuse podman/runc.
+		run = filterSeccompUnconfined(run)
+		run = append(run, "--security-opt", "seccomp="+opts.SeccompProfile)
+	}
+
 	run = append(run, dockerNet...)
 	run = append(run, dockerVol...)
 	run = append(run, dockerPort...)
 	run = append(run, dockerEnv...)
-	run = append(run, image)
-	run = append(run, args...)
+	if opts.QuoteImageAndArgs {
+		// JSON-array format: image is a plain name and args are separate tokens.
+		// Apply POSIX single-quote escaping so the host bash shell does not
+		// interpret metacharacters (&&, ;, $, etc.) that appear in container
+		// entrypoints or sh -c scripts.
+		run = append(run, shellQuote(image))
+		for _, arg := range args {
+			run = append(run, shellQuote(arg))
+		}
+	} else {
+		// Legacy string format: image holds the entire raw docker-run argument
+		// string (e.g. "-v '/path:/dst:ro' nginx"), passed verbatim so bash
+		// performs word-splitting and tilde/glob expansion as the caller intended.
+		run = append(run, image)
+		run = append(run, args...)
+	}
 
 	// this combines all the run options into a single string that's passed to /bin/bash -c as the single argument to force bash parsing.
 	// TODO: make this configurable behaviour so users also have the option of not escaping everything for bash
-	cmd := exec.Command(shell, "-c", strings.Join(run, " "))
+	createArgs := strings.Join(run, " ")
+	cmd := exec.Command(shell, "-c", createArgs)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, commandError("container create", cmd.Args, err)
@@ -453,10 +608,8 @@ func (c *container) inspect() (out []byte, detail containerDetails, err error) {
 
 	cmd := exec.Command("docker", "inspect", c.id)
 	out, err = cmd.Output()
-	if eErr, ok := err.(*exec.ExitError); ok {
-		if strings.Contains(string(eErr.Stderr), "No such object") {
-			err = uninitializedContainer(errors.New("inspect of uninitialized container"))
-		}
+	if strings.Contains(exitErrStderr(err), "No such object") {
+		err = uninitializedContainer(errors.New("inspect of uninitialized container"))
 	}
 
 	if err != nil {

--- a/simulator/container.go
+++ b/simulator/container.go
@@ -36,21 +36,6 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
-// filterSeccompUnconfined removes the "--security-opt seccomp=unconfined" pair
-// from run (in-place, preserving order).  Used when a custom seccomp profile
-// replaces the unconfined setting added by nestedContainers mode.
-func filterSeccompUnconfined(run []string) []string {
-	out := run[:0]
-	for i := 0; i < len(run); i++ {
-		if run[i] == "--security-opt" && i+1 < len(run) && run[i+1] == "seccomp=unconfined" {
-			i++ // skip both tokens
-			continue
-		}
-		out = append(out, run[i])
-	}
-	return out
-}
-
 const (
 	deleteWithContainer = "lifecycle=container"
 	createdByVcsim      = "createdBy=vcsim"
@@ -423,7 +408,6 @@ type createOptions struct {
 	// NestedContainers=true forces privileged to true regardless of the
 	// Privileged field's value.
 	NestedContainers bool
-	SeccompProfile   string // when non-empty, "--security-opt seccomp=<profile>"
 
 	// QuoteImageAndArgs controls shell quoting of image and args before they
 	// are joined into the bash -c command string:
@@ -535,15 +519,6 @@ func create(ctx *Context, name string, id string, image string, args []string, o
 		// Standard mode: use host cgroup namespace for access to all controllers
 		// --cgroupns=host: gives access to all cgroup controllers (cpuset, etc.)
 		run = append(run, "--cgroupns=host")
-	}
-
-	if opts.SeccompProfile != "" {
-		// RUN.vmci=true generates a per-VM seccomp filter with
-		// defaultAction=SCMP_ACT_ALLOW plus AF_VSOCK intercept rules.
-		// Remove any "--security-opt seccomp=unconfined" that nestedContainers mode
-		// already added — two seccomp options confuse podman/runc.
-		run = filterSeccompUnconfined(run)
-		run = append(run, "--security-opt", "seccomp="+opts.SeccompProfile)
 	}
 
 	run = append(run, dockerNet...)

--- a/simulator/container_guestrpc_test.go
+++ b/simulator/container_guestrpc_test.go
@@ -1,0 +1,191 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+// Phase 3 integration tests: real container writes guestinfo via the GuestRPC
+// unix socket; PropertyCollector sees the change.
+//
+// Requires Docker (or podman aliased as docker) on Linux.
+// Skip gate: test.HasDocker().
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/test"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// buildStaticBinary cross-compiles pkg as a static linux/amd64 binary written
+// to a temp dir.  Returns the output path.
+//
+// Skips the test if the host OS is not Linux.  Fails (not skips) for build
+// errors on Linux, since those indicate a genuine regression rather than a
+// missing cross-compilation toolchain.
+func buildStaticBinary(t *testing.T, pkg, name string) string {
+	t.Helper()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("container integration test requires Linux")
+	}
+
+	outDir := t.TempDir()
+	outPath := filepath.Join(outDir, name)
+
+	cmd := exec.Command("go", "build",
+		"-o", outPath,
+		"-ldflags", "-w -s",
+		pkg)
+	cmd.Env = append(os.Environ(),
+		"CGO_ENABLED=0",
+		"GOOS=linux",
+		"GOARCH=amd64",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build %s: %v\n%s", name, err, out)
+	}
+
+	require.NoError(t, os.Chmod(outPath, fs.FileMode(0755)))
+	return outPath
+}
+
+// buildVsockTestBinary builds the Component A (unix socket) test binary.
+func buildVsockTestBinary(t *testing.T) string {
+	return buildStaticBinary(t, "github.com/vmware/govmomi/simulator/testdata/vsock-test", "vsock-test")
+}
+
+// TestContainerGuestRPC_RoundTrip is the Phase 3 integration gate:
+// a real container process writes guestinfo via the GuestRPC unix socket, and
+// the test verifies the value appears in ExtraConfig via PropertyCollector.
+//
+// Container setup:
+//   - image:   alpine (small, available, shell included)
+//   - command: sh -c "/vsock-test --roundtrip guestinfo.from.container hello && sleep 9999"
+//   - volumes: <vsock-test binary>:/vsock-test:ro  (injected)
+//   - RUN.vmci=true  → GuestRPC server started; socket bind-mounted at /run/vmware/rpc.sock
+func TestContainerGuestRPC_RoundTrip(t *testing.T) {
+	if !test.HasDocker() {
+		t.Skip("requires docker or podman (aliased as docker) on linux")
+	}
+
+	vsockTestBin := buildVsockTestBinary(t)
+
+	env := newVCSIMEnv(t)
+
+	const key = "guestinfo.from.container"
+	const val = "hello-from-container"
+	cmd := fmt.Sprintf(
+		`/vsock-test --socket %s --roundtrip %s %s && sleep 9999`,
+		GuestRPCSocketName, key, val,
+	)
+
+	spec := types.VirtualMachineConfigSpec{
+		Name: "guestrpc-integration-test",
+		Files: &types.VirtualMachineFileInfo{
+			VmPathName: "[LocalDS_0] guestrpc-integration-test",
+		},
+		ExtraConfig: []types.BaseOptionValue{
+			&types.OptionValue{Key: ContainerBackingOptionKey, Value: fmt.Sprintf(`["alpine","sh","-c",%q]`, cmd)},
+			&types.OptionValue{Key: "RUN.vmci", Value: "true"},
+			&types.OptionValue{Key: "RUN.volume.vsock-test", Value: vsockTestBin + ":/vsock-test:ro"},
+		},
+	}
+
+	require.NoError(t, test.ApplyContainerRuntimeDefaults(&spec))
+
+	task, err := env.folder.VmFolder.CreateVM(env.goCtx, spec, env.pool, nil)
+	require.NoError(t, err)
+
+	info, err := task.WaitForResult(env.goCtx, nil)
+	require.NoError(t, err)
+
+	vmRef := info.Result.(types.ManagedObjectReference)
+	vm := object.NewVirtualMachine(env.client.Client, vmRef)
+
+	powerTask, err := vm.PowerOn(env.goCtx)
+	require.NoError(t, err)
+	require.NoError(t, powerTask.Wait(env.goCtx))
+
+	pollExtraConfig(t, env, vmRef, key, val, 30*time.Second)
+
+	offTask, err := vm.PowerOff(env.goCtx)
+	require.NoError(t, err)
+	require.NoError(t, offTask.Wait(env.goCtx))
+}
+
+// TestContainerGuestRPC_MultiVM verifies that N concurrent container-backed VMs
+// each write independent guestinfo values and neither VM can read the other's data.
+func TestContainerGuestRPC_MultiVM(t *testing.T) {
+	if !test.HasDocker() {
+		t.Skip("requires docker or podman (aliased as docker) on linux")
+	}
+
+	vsockTestBin := buildVsockTestBinary(t)
+
+	env := newVCSIMEnv(t)
+
+	const n = 2
+	type vmEntry struct {
+		ref types.ManagedObjectReference
+		vm  *object.VirtualMachine
+		key string
+		val string
+	}
+
+	var vms []vmEntry
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("guestinfo.multivm.vm%d", i)
+		val := fmt.Sprintf("vm%d-hello", i)
+		cmd := fmt.Sprintf(
+			`/vsock-test --socket %s --roundtrip %s %s && sleep 9999`,
+			GuestRPCSocketName, key, val,
+		)
+		spec := types.VirtualMachineConfigSpec{
+			Name: fmt.Sprintf("guestrpc-multivm-%d", i),
+			Files: &types.VirtualMachineFileInfo{
+				VmPathName: fmt.Sprintf("[LocalDS_0] guestrpc-multivm-%d", i),
+			},
+			ExtraConfig: []types.BaseOptionValue{
+				&types.OptionValue{Key: ContainerBackingOptionKey, Value: fmt.Sprintf(`["alpine","sh","-c",%q]`, cmd)},
+				&types.OptionValue{Key: "RUN.vmci", Value: "true"},
+				&types.OptionValue{Key: "RUN.volume.vsock-test", Value: vsockTestBin + ":/vsock-test:ro"},
+			},
+		}
+		require.NoError(t, test.ApplyContainerRuntimeDefaults(&spec))
+
+		task, err := env.folder.VmFolder.CreateVM(env.goCtx, spec, env.pool, nil)
+		require.NoError(t, err)
+		info, err := task.WaitForResult(env.goCtx, nil)
+		require.NoError(t, err)
+
+		ref := info.Result.(types.ManagedObjectReference)
+		vm := object.NewVirtualMachine(env.client.Client, ref)
+		powerTask, err := vm.PowerOn(env.goCtx)
+		require.NoError(t, err)
+		require.NoError(t, powerTask.Wait(env.goCtx))
+
+		vms = append(vms, vmEntry{ref: ref, vm: vm, key: key, val: val})
+	}
+
+	for _, entry := range vms {
+		pollExtraConfig(t, env, entry.ref, entry.key, entry.val, 30*time.Second)
+	}
+
+	for _, entry := range vms {
+		offTask, err := entry.vm.PowerOff(env.goCtx)
+		require.NoError(t, err)
+		require.NoError(t, offTask.Wait(env.goCtx))
+	}
+}

--- a/simulator/container_host_system.go
+++ b/simulator/container_host_system.go
@@ -209,6 +209,7 @@ func createSimulationHost(ctx *Context, host *HostSystem) (*simHost, error) {
 		Volumes:           dockerVol,
 		Env:               dockerEnv,
 		QuoteImageAndArgs: true,
+		RecreateIfExists:  true,
 	})
 	if err != nil {
 		return nil, err

--- a/simulator/container_host_system.go
+++ b/simulator/container_host_system.go
@@ -203,8 +203,13 @@ func createSimulationHost(ctx *Context, host *HostSystem) (*simHost, error) {
 	}
 	execCmds = append(execCmds, netCmds...)
 
-	// create the container
-	sh.c, err = create(ctx, hName, hUuid, dockerNet, dockerVol, nil, dockerEnv, "alpine:3.20.3", []string{"sleep", "infinity"})
+	// create the container (host simulation: no privileged required, no nested containers)
+	sh.c, err = create(ctx, hName, hUuid, "alpine:3.20.3", []string{"sleep", "infinity"}, createOptions{
+		Networks:          dockerNet,
+		Volumes:           dockerVol,
+		Env:               dockerEnv,
+		QuoteImageAndArgs: true,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/simulator/container_virtual_machine.go
+++ b/simulator/container_virtual_machine.go
@@ -514,13 +514,17 @@ func (svm *simVM) start(ctx *Context) error {
 
 	var err error
 	svm.c, err = create(ctx, svm.vm.Name, svm.vm.uid.String(), args[0], args[1:], createOptions{
-		Networks:          networks,
-		Volumes:           volumes,
-		Ports:             ports,
-		Env:               env,
-		Privileged:        privileged,
-		NestedContainers:  nestedContainers,
-		SeccompProfile:    "",
+		Networks:         networks,
+		Volumes:          volumes,
+		Ports:            ports,
+		Env:              env,
+		Privileged:       privileged,
+		NestedContainers: nestedContainers,
+		// A crashed prior test run leaves this VM's container name in use;
+		// vcsim is exclusively a test/simulation harness, so recovering from
+		// that residue is always correct here (a real VM's backing has no
+		// equivalent stale-name problem to guard against).
+		RecreateIfExists:  true,
 		QuoteImageAndArgs: jsonArgs,
 	})
 	if err != nil {

--- a/simulator/container_virtual_machine.go
+++ b/simulator/container_virtual_machine.go
@@ -38,11 +38,25 @@
 //     --volume /var, --volume /lib/modules:/lib/modules:ro, --device /dev/fuse.
 //     Reference: https://github.com/kubernetes-sigs/kind/blob/main/pkg/cluster/internal/providers/docker/provision.go
 //
+//   - RUN.vmci: Boolean. Activate the VMCI simulation layer:
+//     a per-VM GuestRPC unix socket server — injects the socket at
+//     /run/vmware/rpc.sock and sets VMX_RPC_SOCK so vmware-rpctool (toolbox
+//     binary) uses it. Clients must tolerate AF_VSOCK being unavailable and
+//     fall back to the VMX_RPC_SOCK unix socket path. A seccomp-based AF_VSOCK
+//     interception layer is tracked as future work.
+//
 //   - RUN.port.<containerPort>: Map container port to host port.
 //     Example: RUN.port.80 = "8080" maps container port 80 to host port 8080.
 //
 //   - RUN.env.<name>: Set environment variable in the container.
 //     Example: RUN.env.DEBUG = "true" sets DEBUG=true in the container.
+//
+//   - guestinfo.*: Each key is exposed as a VMX_GUESTINFO_* environment
+//     variable and VMX_GUESTINFO=true is set so cloud-init's DataSourceVMware
+//     uses the envvar seed (cloud-init's container detection always skips the
+//     guestinfo transport).  With RUN.vmci=true the GuestRPC server also
+//     serves these keys via info-get for in-container write-back (e.g. an
+//     init process writing back a status key such as guestinfo.myapp.ready).
 //
 // # Example: Basic Container
 //
@@ -102,8 +116,9 @@ var (
 )
 
 type simVM struct {
-	vm *VirtualMachine
-	c  *container
+	vm       *VirtualMachine
+	c        *container
+	guestRPC *GuestRPCServer // non-nil when RUN.vmci=true; per-VM unix socket RPCI server
 }
 
 // createSimulationVM inspects the provided VirtualMachine and creates a simVM binding for it if
@@ -442,8 +457,53 @@ func (svm *simVM) start(ctx *Context) error {
 	}
 
 	if len(env) != 0 {
-		// Configure env as the data access method for cloud-init-vmware-guestinfo
+		// VMX_GUESTINFO=true activates DataSourceVMware's envvar seed so that
+		// cloud-init reads guestinfo from VMX_GUESTINFO_* environment variables.
+		//
+		// The guestinfo transport (cloud-init calling vmware-rpctool as a
+		// subprocess) is always skipped in containers: cloud-init's
+		// read_dmi_data() returns nil for containers (it calls is_container(),
+		// which detects the podman environment via /run/systemd/container and
+		// container= in PID 1's environ), so is_vmware_platform() always returns
+		// false, and the guestinfo transport's require_vmware_platform guard
+		// skips it.  The envvar seed (require_vmware_platform=false) is therefore
+		// the only transport cloud-init will use in a container.
+		//
+		// In-container WRITE operations (e.g. an init process writing back a
+		// status key such as guestinfo.myapp.ready) use GuestRPC via the
+		// toolbox binary auto-injected at /usr/bin/vmware-rpctool if VMCI sim
+		// is enabled.
 		env = append(env, "VMX_GUESTINFO=true")
+	}
+
+	// VMCI simulation: start the per-VM GuestRPC server before creating the container
+	// so the socket exists when the container process first connects to it.
+	// Activated by RUN.vmci=true.
+	// GuestRPC server over unix socket (no kernel requirements).
+	// AF_VSOCK seccomp interception is disabled; see RUN.vmci doc.
+	if vmciEnabled(svm.vm.Config.ExtraConfig) {
+		socketPath := GuestRPCSocketPath(svm.vm.uid.String())
+		socketDirPath := GuestRPCSocketDirPath(svm.vm.uid.String())
+		srv := newGuestRPCServer(svm.vm, socketPath)
+		if err := srv.Start(ctx); err != nil {
+			return fmt.Errorf("guestrpc server: %w", err)
+		}
+		svm.guestRPC = srv
+
+		// Bind-mount the socket DIRECTORY (not the file) so the mount is visible
+		// even when RUN.nestedContainers=true adds --tmpfs /run. See guestRPCVolumeMount.
+		extraVolumes = append(extraVolumes, guestRPCVolumeMount(socketDirPath))
+		env = append(env, "VMX_RPC_SOCK="+GuestRPCSocketName)
+
+		// Build the toolbox binary (once per process).
+		toolboxBin, shimBuildErr := buildToolboxArtifact()
+		if shimBuildErr != nil {
+			log.Printf("%s: toolbox artifact build failed (%v); vmware-rpctool auto-injection skipped", svm.vm.Name, shimBuildErr)
+		} else if toolboxBin != "" && !hasVolumeDest(svm.vm.Config.ExtraConfig, "/usr/bin/vmware-rpctool") {
+			// Inject the govmomi/toolbox binary at /usr/bin/vmware-rpctool.
+			// Skip if the caller already bound this destination explicitly.
+			extraVolumes = append(extraVolumes, toolboxBin+":/usr/bin/vmware-rpctool:ro")
+		}
 	}
 
 	volumes := []string{}
@@ -548,8 +608,11 @@ func (svm *simVM) stop(ctx *Context) error {
 	err := svm.c.stop(ctx)
 	if err != nil {
 		log.Printf("%s %s: %s", svm.vm.Name, "stop", err)
-
 		return err
+	}
+
+	if svm.guestRPC != nil {
+		svm.guestRPC.Stop()
 	}
 
 	ctx.Update(svm.vm, toolsNotRunning)
@@ -599,10 +662,13 @@ func (svm *simVM) remove(ctx *Context) error {
 		return nil
 	}
 
+	if svm.guestRPC != nil {
+		svm.guestRPC.Stop()
+	}
+
 	err := svm.c.remove(ctx)
 	if err != nil {
 		log.Printf("%s %s: %s", svm.vm.Name, "remove", err)
-
 		return err
 	}
 

--- a/simulator/container_virtual_machine.go
+++ b/simulator/container_virtual_machine.go
@@ -2,6 +2,71 @@
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
+// Container Backing for Virtual Machines
+//
+// This file implements container-backed VMs for vcsim. When a VM is created with
+// the ExtraConfig key "RUN.container" set to a container image, vcsim will create
+// a real container to back the simulated VM.
+//
+// # ExtraConfig Options
+//
+// The following ExtraConfig keys control container backing behavior:
+//
+//   - RUN.container: Container image to use (e.g., "nginx:latest", "alpine:3.20")
+//     Can be a simple image name or JSON array with command args.
+//
+//   - RUN.mountdmi: Boolean (default: true). Mount /sys/class/dmi/id for DMI info.
+//     Set to "false" for rootless containers that can't mount system paths.
+//
+//   - RUN.network: Container network to use (e.g., "podman", "bridge").
+//     Important for rootless podman which needs explicit network for IP assignment.
+//
+//   - RUN.privileged: Boolean (default: false). Add --privileged to the container.
+//     Use this for images that run systemd as PID 1 but do NOT need the full
+//     kind-style nested-containers setup (which adds --tmpfs /run and conflicts
+//     with the RUN.vmci GuestRPC socket bind-mount at /run/vmware/rpc.sock).
+//     For full Kubernetes-in-container workloads, use RUN.nestedContainers=true
+//     instead. Note: RUN.nestedContainers=true forces privileged to true
+//     regardless of this key's value, since the full nested-containers flag
+//     set already implies --privileged.
+//
+//   - RUN.nestedContainers: Boolean (default: false). Enable nested container mode
+//     for running Kubernetes or other container workloads inside the container.
+//     When true, adds kind-style flags:
+//     --cgroupns=private, --security-opt seccomp=unconfined,
+//     --security-opt apparmor=unconfined, --tmpfs /tmp, --tmpfs /run,
+//     --volume /var, --volume /lib/modules:/lib/modules:ro, --device /dev/fuse.
+//     Reference: https://github.com/kubernetes-sigs/kind/blob/main/pkg/cluster/internal/providers/docker/provision.go
+//
+//   - RUN.port.<containerPort>: Map container port to host port.
+//     Example: RUN.port.80 = "8080" maps container port 80 to host port 8080.
+//
+//   - RUN.env.<name>: Set environment variable in the container.
+//     Example: RUN.env.DEBUG = "true" sets DEBUG=true in the container.
+//
+// # Example: Basic Container
+//
+//	spec := types.VirtualMachineConfigSpec{
+//		Name: "web-server",
+//		ExtraConfig: []types.BaseOptionValue{
+//			&types.OptionValue{Key: "RUN.container", Value: "nginx:latest"},
+//			&types.OptionValue{Key: "RUN.port.80", Value: "8080"},
+//		},
+//	}
+//
+// # Example: Kubernetes Node (Nested Containers)
+//
+//	spec := types.VirtualMachineConfigSpec{
+//		Name: "k8s-node",
+//		ExtraConfig: []types.BaseOptionValue{
+//			&types.OptionValue{Key: "RUN.container", Value: "my-k8s-image:latest"},
+//			&types.OptionValue{Key: "RUN.mountdmi", Value: "false"},
+//			&types.OptionValue{Key: "RUN.nestedContainers", Value: "true"},
+//			&types.OptionValue{Key: "guestinfo.metadata", Value: metadataEncoded},
+//			&types.OptionValue{Key: "guestinfo.userdata", Value: userdataEncoded},
+//		},
+//	}
+
 package simulator
 
 import (
@@ -266,15 +331,26 @@ func (svm *simVM) start(ctx *Context) error {
 	var env []string
 	var ports []string
 	var networks []string
+	var extraVolumes []string
 	mountDMI := true
+	privileged := false
+	nestedContainers := false
 
+	// jsonArgs is true when ContainerBackingOptionKey value was a valid JSON
+	// array (structured format: ["image","arg1","arg2"]).  It is false for the
+	// legacy raw-string format ("-v '/path' image").  create() uses this flag
+	// to decide whether to POSIX-quote image and args before passing them to
+	// the host bash shell, preventing metacharacters (&&, ;) in sh -c scripts
+	// from being interpreted by the host rather than the container shell.
+	jsonArgs := false
 	for _, opt := range svm.vm.Config.ExtraConfig {
 		val := opt.GetOptionValue()
 		if val.Key == ContainerBackingOptionKey {
 			run := val.Value.(string)
-			err := json.Unmarshal([]byte(run), &args)
-			if err != nil {
+			if err := json.Unmarshal([]byte(run), &args); err != nil {
 				args = []string{run}
+			} else {
+				jsonArgs = true
 			}
 
 			continue
@@ -285,6 +361,32 @@ func (svm *simVM) start(ctx *Context) error {
 			err := json.Unmarshal([]byte(val.Value.(string)), &mount)
 			if err == nil {
 				mountDMI = mount
+			}
+
+			continue
+		}
+
+		if val.Key == "RUN.privileged" {
+			// Add --privileged to the container without the full nestedContainers
+			// flag set. Use for systemd-init images that need privilege escalation
+			// but must NOT have --tmpfs /run (which would hide the RUN.vmci GuestRPC
+			// socket bind-mounted at /run/vmware/rpc.sock).
+			var priv bool
+			if err := json.Unmarshal([]byte(val.Value.(string)), &priv); err == nil {
+				privileged = priv
+			}
+			continue
+		}
+
+		if val.Key == "RUN.nestedContainers" {
+			// Enable nested container mode for running Kubernetes or other container
+			// workloads inside the container. This adds flags adapted from kind's
+			// provision.go including --cgroupns=private, security-opt unconfined,
+			// tmpfs mounts, and /dev/fuse device.
+			var nested bool
+			err := json.Unmarshal([]byte(val.Value.(string)), &nested)
+			if err == nil {
+				nestedContainers = nested
 			}
 
 			continue
@@ -303,6 +405,19 @@ func (svm *simVM) start(ctx *Context) error {
 			sKey := strings.Split(val.Key, ".")
 			containerPort := sKey[len(sKey)-1]
 			ports = append(ports, fmt.Sprintf("%s:%s", val.Value.(string), containerPort))
+
+			continue
+		}
+
+		if strings.HasPrefix(val.Key, "RUN.volume.") {
+			// RUN.volume.<label> adds an extra bind mount or named volume.
+			// Value format: "host_path:container_path[:options]" — the same
+			// format accepted by docker/podman -v.  Use this to inject
+			// test-specific files (scripts, configs) into the container without
+			// modifying the container image or container.go.
+			if v := strings.TrimSpace(val.Value.(string)); v != "" {
+				extraVolumes = append(extraVolumes, v)
+			}
 
 			continue
 		}
@@ -335,9 +450,19 @@ func (svm *simVM) start(ctx *Context) error {
 	if mountDMI {
 		volumes = append(volumes, constructVolumeName(svm.vm.Name, svm.vm.uid.String(), "dmi")+":/sys/class/dmi/id")
 	}
+	volumes = append(volumes, extraVolumes...)
 
 	var err error
-	svm.c, err = create(ctx, svm.vm.Name, svm.vm.uid.String(), networks, volumes, ports, env, args[0], args[1:])
+	svm.c, err = create(ctx, svm.vm.Name, svm.vm.uid.String(), args[0], args[1:], createOptions{
+		Networks:          networks,
+		Volumes:           volumes,
+		Ports:             ports,
+		Env:               env,
+		Privileged:        privileged,
+		NestedContainers:  nestedContainers,
+		SeccompProfile:    "",
+		QuoteImageAndArgs: jsonArgs,
+	})
 	if err != nil {
 		return err
 	}

--- a/simulator/container_virtual_machine.go
+++ b/simulator/container_virtual_machine.go
@@ -605,14 +605,18 @@ func (svm *simVM) stop(ctx *Context) error {
 		return nil
 	}
 
+	// Release the GuestRPC server on every path out, including the error path
+	// below: a container-stop failure must not leave the listener, its
+	// goroutines and the socket alive. remove() defers identically, so the two
+	// teardown paths agree rather than differing for no stated reason.
+	if svm.guestRPC != nil {
+		defer svm.guestRPC.Stop()
+	}
+
 	err := svm.c.stop(ctx)
 	if err != nil {
 		log.Printf("%s %s: %s", svm.vm.Name, "stop", err)
 		return err
-	}
-
-	if svm.guestRPC != nil {
-		svm.guestRPC.Stop()
 	}
 
 	ctx.Update(svm.vm, toolsNotRunning)
@@ -662,8 +666,9 @@ func (svm *simVM) remove(ctx *Context) error {
 		return nil
 	}
 
+	// Deferred to match stop(): released on the error path too.
 	if svm.guestRPC != nil {
-		svm.guestRPC.Stop()
+		defer svm.guestRPC.Stop()
 	}
 
 	err := svm.c.remove(ctx)

--- a/simulator/guestrpc_framing_test.go
+++ b/simulator/guestrpc_framing_test.go
@@ -6,11 +6,15 @@ package simulator
 
 import (
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/vmware/govmomi/toolbox"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 // serveOnePipe runs serveConn against one end of a net.Pipe and returns the
@@ -102,4 +106,75 @@ func TestInfoSet_RejectsNonGuestinfoNamespace(t *testing.T) {
 			t.Errorf("info-set %s: got %q, want a rejection", key, got)
 		}
 	}
+}
+
+// TestInfoSet_RejectsSlashInKey pins real VMX's second guest-write
+// restriction: a key containing "/" is read-only from the guest even when it
+// is otherwise under guestinfo.*. This is distinct from the namespace check
+// above — a key can pass the guestinfo. prefix and still be unwritable.
+func TestInfoSet_RejectsSlashInKey(t *testing.T) {
+	srv := newGuestRPCServer(&VirtualMachine{}, "")
+
+	for _, key := range []string{
+		"guestinfo.foo/bar",
+		"guestinfo./tools/state",
+	} {
+		if got := srv.dispatch("info-set " + key + " value"); !strings.HasPrefix(got, "0 ") {
+			t.Errorf("info-set %s: got %q, want a rejection", key, got)
+		}
+	}
+}
+
+// TestInfoGet_RejectsNonGuestinfoNamespace mirrors
+// TestInfoSet_RejectsNonGuestinfoNamespace for the read side. Real VMX
+// restricts info-get to guestinfo.* the same as info-set; before this test
+// existed, info-get had no namespace check at all and would return the value
+// of any ExtraConfig key present on the VM, including RUN.* host-config
+// directives.
+func TestInfoGet_RejectsNonGuestinfoNamespace(t *testing.T) {
+	srv := newGuestRPCServer(&VirtualMachine{}, "")
+
+	for _, key := range []string{
+		"RUN.container",
+		"RUN.vmci",
+		"RUN.volume.evil",
+		"guestinfoNoDot",
+	} {
+		if got := srv.dispatch("info-get " + key); !strings.HasPrefix(got, "0 ") {
+			t.Errorf("info-get %s: got %q, want a rejection", key, got)
+		}
+	}
+}
+
+// TestInfoGet_AllowsSlashInKey pins the asymmetry: unlike info-set, info-get
+// does NOT reject a slash-containing guestinfo.* key. Real VMX makes such
+// keys read-only from the guest, not unreadable — the host (e.g. via
+// ReconfigVM) can still set one, and the guest can still read it back.
+func TestInfoGet_AllowsSlashInKey(t *testing.T) {
+	env := newVCSIMEnv(t)
+
+	vmObj := firstVM(env.simCtx)
+	require.NotNil(t, vmObj, "no VMs in test inventory")
+
+	const key = "guestinfo.foo/bar"
+	const val = "host-value"
+
+	// Host-side write, bypassing GuestRPC entirely (as ReconfigVM would).
+	// Only the guest info-set path enforces the slash restriction.
+	env.simCtx.AutoUpdate(vmObj, func() {
+		vmObj.Config.ExtraConfig = append(vmObj.Config.ExtraConfig,
+			&types.OptionValue{Key: key, Value: val})
+	})
+
+	socketPath := GuestRPCSocketPath(vmObj.Self.Value)
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+	srv := newGuestRPCServer(vmObj, socketPath)
+	require.NoError(t, srv.Start(env.simCtx))
+	t.Cleanup(srv.Stop)
+
+	out := dialGuestRPC(t, socketPath)
+	reply, err := out.Request([]byte("info-get " + key))
+	require.NoError(t, err, "info-get")
+	require.Equal(t, val, strings.TrimSpace(string(reply)))
 }

--- a/simulator/guestrpc_framing_test.go
+++ b/simulator/guestrpc_framing_test.go
@@ -1,0 +1,132 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"bytes"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vmware/govmomi/toolbox"
+)
+
+// serveOnePipe runs serveConn against one end of a net.Pipe and returns the
+// caller's end. "tools.set-state" is used throughout because dispatch answers
+// it without touching the VM object, keeping these tests about framing only.
+func serveOnePipe(t *testing.T) net.Conn {
+	t.Helper()
+
+	srv := newGuestRPCServer(&VirtualMachine{}, "")
+	client, server := net.Pipe()
+
+	srv.wg.Add(1)
+	go srv.serveConn(server)
+
+	t.Cleanup(func() { _ = client.Close() })
+	_ = client.SetDeadline(time.Now().Add(10 * time.Second))
+
+	return client
+}
+
+// TestServeConn_DataMapFramingNotMisrouted pins the framing discrimination
+// against a regression that a magnitude threshold cannot avoid.
+//
+// Both framings open with a 4-byte length, one big-endian and one little-
+// endian, so their readings overlap. The previous threshold routed to DataMap
+// only when the little-endian reading exceeded 1 MiB, which is false whenever
+// the DataMap entries length is a multiple of 256 below 3840 — an ordinary
+// info-set command. Those packets were parsed as LE frames and answered in the
+// wrong framing.
+//
+// The payload sizes below are exactly the ones measured to misroute; each
+// produces an entries section of 256, 512 and 768 bytes respectively.
+func TestServeConn_DataMapFramingNotMisrouted(t *testing.T) {
+	for _, payloadLen := range []int{228, 484, 740} {
+		cmd := "tools.set-state " + strings.Repeat("x", payloadLen-len("tools.set-state "))
+		if len(cmd) != payloadLen {
+			t.Fatalf("test setup: built a %d-byte command, wanted %d", len(cmd), payloadLen)
+		}
+
+		client := serveOnePipe(t)
+
+		if err := toolbox.WriteDataMapPacket(client, []byte(cmd), true); err != nil {
+			t.Fatalf("payload %d: WriteDataMapPacket: %v", payloadLen, err)
+		}
+
+		reply, _, err := toolbox.ReadDataMapPacket(client)
+		if err != nil {
+			t.Fatalf("payload %d: response was not DataMap-framed (misrouted to the LE parser): %v",
+				payloadLen, err)
+		}
+		if got := strings.TrimRight(string(reply), "\x00"); got != "1 " {
+			t.Errorf("payload %d: got reply %q, want %q", payloadLen, got, "1 ")
+		}
+	}
+}
+
+// TestServeConn_LEFramingStillRouted is the negative control: the structural
+// discriminator must not pull ordinary LE frames into the DataMap parser.
+func TestServeConn_LEFramingStillRouted(t *testing.T) {
+	for _, cmd := range []string{
+		"tools.set-state powerOn",
+		"tools.capability.foo",
+		"tools.set-state " + strings.Repeat("y", 4096),
+	} {
+		client := serveOnePipe(t)
+
+		if err := toolbox.WriteUnixFrame(client, []byte(cmd)); err != nil {
+			t.Fatalf("WriteUnixFrame(%d bytes): %v", len(cmd), err)
+		}
+
+		reply, err := toolbox.ReadUnixFrame(client)
+		if err != nil {
+			t.Fatalf("LE frame of %d bytes was not answered in LE framing: %v", len(cmd), err)
+		}
+		if got := strings.TrimRight(string(reply), "\x00"); got != "1 " {
+			t.Errorf("LE frame of %d bytes: got reply %q, want %q", len(cmd), got, "1 ")
+		}
+	}
+}
+
+// TestServeConn_ZeroLengthLEFrame covers the keepalive frame, which carries no
+// payload and so must be settled without reading further bytes.
+func TestServeConn_ZeroLengthLEFrame(t *testing.T) {
+	client := serveOnePipe(t)
+
+	if err := toolbox.WriteUnixFrame(client, nil); err != nil {
+		t.Fatalf("WriteUnixFrame(nil): %v", err)
+	}
+
+	reply, err := toolbox.ReadUnixFrame(client)
+	if err != nil {
+		t.Fatalf("zero-length frame not answered: %v", err)
+	}
+	if !bytes.Equal(reply, []byte("1 ")) {
+		t.Errorf("zero-length frame: got %q, want %q", reply, "1 ")
+	}
+}
+
+// TestInfoSet_RejectsNonGuestinfoNamespace pins the write namespace.
+//
+// The socket directory is bind-mounted read-write into a container that may run
+// an arbitrary image, and vcsim reads RUN.* keys as host-side container
+// directives, so a guest able to write them could reconfigure its own backing.
+func TestInfoSet_RejectsNonGuestinfoNamespace(t *testing.T) {
+	srv := newGuestRPCServer(&VirtualMachine{}, "")
+
+	for _, key := range []string{
+		"RUN.container",
+		"RUN.vmci",
+		"RUN.volume.evil",
+		"RUN.nestedContainers",
+		"guestinfoNoDot",
+	} {
+		if got := srv.dispatch("info-set " + key + " value"); !strings.HasPrefix(got, "0 ") {
+			t.Errorf("info-set %s: got %q, want a rejection", key, got)
+		}
+	}
+}

--- a/simulator/guestrpc_framing_test.go
+++ b/simulator/guestrpc_framing_test.go
@@ -5,7 +5,6 @@
 package simulator
 
 import (
-	"bytes"
 	"net"
 	"strings"
 	"testing"
@@ -32,20 +31,17 @@ func serveOnePipe(t *testing.T) net.Conn {
 	return client
 }
 
-// TestServeConn_DataMapFramingNotMisrouted pins the framing discrimination
-// against a regression that a magnitude threshold cannot avoid.
+// TestServeConn_DataMapAcrossPayloadSizes guards against reintroducing a
+// length-based framing heuristic.
 //
-// Both framings open with a 4-byte length, one big-endian and one little-
-// endian, so their readings overlap. The previous threshold routed to DataMap
-// only when the little-endian reading exceeded 1 MiB, which is false whenever
-// the DataMap entries length is a multiple of 256 below 3840 — an ordinary
-// info-set command. Those packets were parsed as LE frames and answered in the
-// wrong framing.
-//
-// The payload sizes below are exactly the ones measured to misroute; each
-// produces an entries section of 256, 512 and 768 bytes respectively.
-func TestServeConn_DataMapFramingNotMisrouted(t *testing.T) {
-	for _, payloadLen := range []int{228, 484, 740} {
+// This socket previously carried two framings and chose between them by
+// comparing the 4-byte length prefix against a threshold. Because a DataMap
+// length is big-endian and the other framing's was little-endian, their
+// readings overlapped: 255 entries lengths below 1 MiB were routed to the
+// wrong parser, and the guest selects the length by padding its payload. The
+// sizes below are the ones measured to misroute; they must all round-trip.
+func TestServeConn_DataMapAcrossPayloadSizes(t *testing.T) {
+	for _, payloadLen := range []int{16, 32, 228, 484, 740, 996, 4096} {
 		cmd := "tools.set-state " + strings.Repeat("x", payloadLen-len("tools.set-state "))
 		if len(cmd) != payloadLen {
 			t.Fatalf("test setup: built a %d-byte command, wanted %d", len(cmd), payloadLen)
@@ -54,13 +50,11 @@ func TestServeConn_DataMapFramingNotMisrouted(t *testing.T) {
 		client := serveOnePipe(t)
 
 		if err := toolbox.WriteDataMapPacket(client, []byte(cmd), true); err != nil {
-			t.Fatalf("payload %d: WriteDataMapPacket: %v", payloadLen, err)
+			t.Fatalf("payload %d: write: %v", payloadLen, err)
 		}
-
 		reply, _, err := toolbox.ReadDataMapPacket(client)
 		if err != nil {
-			t.Fatalf("payload %d: response was not DataMap-framed (misrouted to the LE parser): %v",
-				payloadLen, err)
+			t.Fatalf("payload %d: response not DataMap-framed: %v", payloadLen, err)
 		}
 		if got := strings.TrimRight(string(reply), "\x00"); got != "1 " {
 			t.Errorf("payload %d: got reply %q, want %q", payloadLen, got, "1 ")
@@ -68,45 +62,24 @@ func TestServeConn_DataMapFramingNotMisrouted(t *testing.T) {
 	}
 }
 
-// TestServeConn_LEFramingStillRouted is the negative control: the structural
-// discriminator must not pull ordinary LE frames into the DataMap parser.
-func TestServeConn_LEFramingStillRouted(t *testing.T) {
-	for _, cmd := range []string{
-		"tools.set-state powerOn",
-		"tools.capability.foo",
-		"tools.set-state " + strings.Repeat("y", 4096),
-	} {
-		client := serveOnePipe(t)
-
-		if err := toolbox.WriteUnixFrame(client, []byte(cmd)); err != nil {
-			t.Fatalf("WriteUnixFrame(%d bytes): %v", len(cmd), err)
-		}
-
-		reply, err := toolbox.ReadUnixFrame(client)
-		if err != nil {
-			t.Fatalf("LE frame of %d bytes was not answered in LE framing: %v", len(cmd), err)
-		}
-		if got := strings.TrimRight(string(reply), "\x00"); got != "1 " {
-			t.Errorf("LE frame of %d bytes: got reply %q, want %q", len(cmd), got, "1 ")
-		}
-	}
-}
-
-// TestServeConn_ZeroLengthLEFrame covers the keepalive frame, which carries no
-// payload and so must be settled without reading further bytes.
-func TestServeConn_ZeroLengthLEFrame(t *testing.T) {
+// TestServeConn_PersistentConnection pins that the server keeps serving a
+// connection across exchanges when the client does not set fastClose.
+// UnixChannel opens once in Start and reuses the connection, so a server that
+// closed per request would break on the second exchange.
+func TestServeConn_PersistentConnection(t *testing.T) {
 	client := serveOnePipe(t)
 
-	if err := toolbox.WriteUnixFrame(client, nil); err != nil {
-		t.Fatalf("WriteUnixFrame(nil): %v", err)
-	}
-
-	reply, err := toolbox.ReadUnixFrame(client)
-	if err != nil {
-		t.Fatalf("zero-length frame not answered: %v", err)
-	}
-	if !bytes.Equal(reply, []byte("1 ")) {
-		t.Errorf("zero-length frame: got %q, want %q", reply, "1 ")
+	for i := 0; i < 3; i++ {
+		if err := toolbox.WriteDataMapPacket(client, []byte("tools.set-state powerOn"), false); err != nil {
+			t.Fatalf("exchange %d: write: %v", i, err)
+		}
+		reply, _, err := toolbox.ReadDataMapPacket(client)
+		if err != nil {
+			t.Fatalf("exchange %d: read: %v", i, err)
+		}
+		if got := strings.TrimRight(string(reply), "\x00"); got != "1 " {
+			t.Errorf("exchange %d: got %q, want %q", i, got, "1 ")
+		}
 	}
 }
 

--- a/simulator/guestrpc_server.go
+++ b/simulator/guestrpc_server.go
@@ -5,8 +5,6 @@
 package simulator
 
 import (
-	"bytes"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"log"
@@ -33,11 +31,6 @@ const (
 	// bind-mount creates a new submount that overrides the tmpfs contents at that path.
 	GuestRPCSocketDir = "/run/vmware"
 
-	// dataMapMinEntries is the smallest possible DataMap entries section: one
-	// field header of fieldType(4B) + fieldID(4B). Used to rule out DataMap
-	// framing without consuming bytes the LE path would need.
-	dataMapMinEntries = 8
-
 	// guestInfoPrefix is the only ExtraConfig namespace a guest may write via
 	// info-set. Real VMX restricts guest writes to guestinfo.*, and vcsim reads
 	// other namespaces (RUN.*) as host-side container directives — so accepting
@@ -48,9 +41,11 @@ const (
 // GuestRPCServer is a per-VM host-side server that implements the toolbox RPCI
 // protocol over a Unix stream socket.
 //
-// Wire format: 4-byte LE uint32 length prefix + payload bytes, matching
-// toolbox.WriteUnixFrame / toolbox.ReadUnixFrame. Response status prefix:
-// "1 " = success, "0 " = error (same as toolbox.rpciOK / rpciERR).
+// Wire format: DataMap packets, the same framing real vmtoolsd uses over
+// AF_VSOCK (toolbox.ReadDataMapPacket / WriteDataMapPacket). Using one framing
+// across every GuestRPC transport means this server never has to guess what it
+// is reading. Response status prefix: "1 " = success, "0 " = error (same as
+// toolbox.rpciOK / rpciERR).
 //
 // Each VM with RUN.vmci=true has its own GuestRPCServer at a unique socket path.
 // Multiple concurrent VMs do not share any state.
@@ -191,86 +186,11 @@ func (s *GuestRPCServer) serveConn(conn net.Conn) {
 		}
 	}()
 
-	// Detect which framing this connection uses.
-	//
-	// Two protocols reach this server and both begin with a 4-byte length, so
-	// the length alone cannot separate them: a DataMap length is big-endian, an
-	// LE-frame length is little-endian, and the two readings overlap. A
-	// magnitude threshold therefore has holes in both directions — measured, a
-	// DataMap entries section of 256 bytes (an ordinary info-set) reads as
-	// 65536 little-endian and would be misrouted.
-	//
-	// Discriminate on STRUCTURE instead. A DataMap entries section opens with a
-	// field header of fieldType(4B) fieldID(4B), both big-endian and both small
-	// (see toolbox.ReadDataMapPacket). An LE frame's payload is an RPCI command
-	// string, so its first bytes are ASCII and can never be the zero bytes a
-	// big-endian small integer starts with.
-	var hdr [4]byte
-	if _, err := io.ReadFull(conn, hdr[:]); err != nil {
-		return
-	}
-	beLen := binary.BigEndian.Uint32(hdr[:])
-	leLen := binary.LittleEndian.Uint32(hdr[:])
-
-	consumed := hdr[:]
-	isDataMap := false
-
-	// A DataMap entries section holds at least one 8-byte field header. When
-	// either reading rules that out, the framing is settled without reading
-	// further — which also avoids blocking on a short or zero-length LE frame.
-	if beLen >= dataMapMinEntries && leLen >= dataMapMinEntries {
-		var probe [8]byte
-		if _, err := io.ReadFull(conn, probe[:]); err != nil {
-			return
-		}
-		consumed = append(hdr[:], probe[:]...)
-
-		fieldType := binary.BigEndian.Uint32(probe[0:4])
-		fieldID := binary.BigEndian.Uint32(probe[4:8])
-		isDataMap = (fieldType == toolbox.DMFieldTypeInt64 || fieldType == toolbox.DMFieldTypeString) &&
-			fieldID >= toolbox.GuestRPCFieldType && fieldID <= toolbox.GuestRPCFieldFastClose
-	}
-
-	// MultiReader replays every byte consumed above so the framing logic can
-	// re-read the header it was given.
-	mr := io.MultiReader(bytes.NewReader(consumed), conn)
-
-	if isDataMap {
-		s.serveConnDataMap(mr, conn)
-	} else {
-		s.serveConnLEWithConn(mr, conn)
-	}
-}
-
-// serveConnLEWithConn handles connections using the 4-byte LE length-prefix
-// framing (toolbox.UnixChannel / vmci-guest test binary protocol).
-func (s *GuestRPCServer) serveConnLEWithConn(r io.Reader, w io.Writer) {
-	for {
-		select {
-		case <-s.done:
-			return
-		default:
-		}
-
-		msg, err := toolbox.ReadUnixFrame(r)
-		if err != nil {
-			return
-		}
-		if msg == nil {
-			if werr := toolbox.WriteUnixFrame(w, []byte("1 ")); werr != nil {
-				return
-			}
-			continue
-		}
-		rpcCmd := strings.TrimRight(string(msg), "\x00")
-		if Trace {
-			log.Printf("GuestRPCServer %s: cmd=%q", s.vm.Name, rpcCmd)
-		}
-		resp := s.dispatch(rpcCmd)
-		if werr := toolbox.WriteUnixFrame(w, []byte(resp)); werr != nil {
-			return
-		}
-	}
+	// One framing on this socket: DataMap, the format real vmtoolsd speaks.
+	// There is nothing to detect, which is deliberate — two self-delimiting
+	// framings sharing one socket cannot be told apart reliably by any length
+	// heuristic, and the guest chooses the lengths by padding its payload.
+	s.serveConnDataMap(conn, conn)
 }
 
 // serveConnDataMap handles connections using the DataMap framing protocol,

--- a/simulator/guestrpc_server.go
+++ b/simulator/guestrpc_server.go
@@ -1,0 +1,405 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+	"sync"
+
+	"github.com/vmware/govmomi/toolbox"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	// GuestRPCSocketName is the well-known path inside every container-backed VM
+	// with RUN.vmci=true. The host-side unix socket is bind-mounted to this path.
+	GuestRPCSocketName = "/run/vmware/rpc.sock"
+
+	// GuestRPCSocketDir is the well-known DIRECTORY path inside every container-backed VM
+	// with RUN.vmci=true. vcsim bind-mounts this directory (not just the socket file) so
+	// the mount remains visible even when RUN.nestedContainers=true adds --tmpfs /run.
+	// A file bind-mount target under a tmpfs must already exist as a file; a directory
+	// bind-mount creates a new submount that overrides the tmpfs contents at that path.
+	GuestRPCSocketDir = "/run/vmware"
+)
+
+// GuestRPCServer is a per-VM host-side server that implements the toolbox RPCI
+// protocol over a Unix stream socket.
+//
+// Wire format: 4-byte LE uint32 length prefix + payload bytes, matching
+// toolbox.WriteUnixFrame / toolbox.ReadUnixFrame. Response status prefix:
+// "1 " = success, "0 " = error (same as toolbox.rpciOK / rpciERR).
+//
+// Each VM with RUN.vmci=true has its own GuestRPCServer at a unique socket path.
+// Multiple concurrent VMs do not share any state.
+//
+// Lifecycle:
+//
+//	srv = newGuestRPCServer(vm, path)
+//	srv.Start(ctx)    — before container create; removes stale socket from prior crash
+//	(container runs; guest code connects and issues RPCI commands)
+//	srv.Stop()        — from simVM.stop() / simVM.remove()
+//
+// Recovery: Start removes any stale socket file before binding, so a crashed test
+// does not block the next run. The socket file is also removed by Stop().
+type GuestRPCServer struct {
+	vm         *VirtualMachine
+	ctx        *Context // captures the PowerOn Context for AutoUpdate
+	socketPath string   // host-side absolute path
+
+	ln   net.Listener
+	done chan struct{}
+	once sync.Once
+	wg   sync.WaitGroup
+
+	// rpcMu serializes concurrent infoGet / infoSet calls from multiple
+	// serveConn goroutines.  Without this, concurrent goroutines sharing the
+	// same s.ctx bypass ObjectLock's mutual exclusion (ObjectLock.Acquire
+	// grants re-entry to the same *Context pointer, so all serveConn goroutines
+	// that share s.ctx can enter WithLock/AutoUpdate simultaneously, causing a
+	// data race on ExtraConfig).
+	//
+	// Lock order: rpcMu → ObjectLock (via WithLock/AutoUpdate).  This order is
+	// consistent because no code holds ObjectLock and then acquires rpcMu.
+	rpcMu sync.RWMutex
+}
+
+// newGuestRPCServer creates (but does not start) a GuestRPCServer.
+func newGuestRPCServer(vm *VirtualMachine, socketPath string) *GuestRPCServer {
+	return &GuestRPCServer{
+		vm:         vm,
+		socketPath: socketPath,
+		done:       make(chan struct{}),
+	}
+}
+
+// GuestRPCSocketDir returns the canonical per-VM host-side socket directory.
+// The directory is bind-mounted at GuestRPCSocketDir inside the container.
+// Using a directory mount (not a file mount) means the submount is visible even
+// when RUN.nestedContainers=true adds --tmpfs /run: the directory mount is applied
+// after the tmpfs in the OCI spec and creates a new submount at /run/vmware/,
+// whereas a file bind-mount requires the target file to already exist in the tmpfs.
+func GuestRPCSocketDirPath(vmUID string) string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("vcsim-rpc-%s", vmUID))
+}
+
+// GuestRPCSocketPath returns the canonical per-VM host-side unix socket path.
+// The socket resides inside GuestRPCSocketDirPath so the directory bind-mount exposes it.
+func GuestRPCSocketPath(vmUID string) string {
+	return filepath.Join(GuestRPCSocketDirPath(vmUID), "rpc.sock")
+}
+
+// Start begins listening on the unix socket and launches the accept loop.
+// ctx is the PowerOn/start Context; it is stored and used for AutoUpdate calls.
+// Creates the socket directory and removes any stale socket from a prior crash.
+func (s *GuestRPCServer) Start(ctx *Context) error {
+	s.ctx = ctx
+
+	// Create the socket directory.  The directory is bind-mounted into the
+	// container (not the socket file), so it must exist before docker create runs.
+	socketDir := filepath.Dir(s.socketPath)
+	if err := os.MkdirAll(socketDir, 0o700); err != nil {
+		return fmt.Errorf("GuestRPCServer %s: mkdir socket dir: %w", s.vm.Name, err)
+	}
+
+	// Remove stale socket from a prior crash.  If a live process still holds
+	// the socket, net.Listen will fail — surfacing the conflict rather than
+	// silently breaking it.
+	_ = os.Remove(s.socketPath)
+
+	ln, err := net.Listen("unix", s.socketPath)
+	if err != nil {
+		return fmt.Errorf("GuestRPCServer %s: %w", s.vm.Name, err)
+	}
+	s.ln = ln
+
+	s.wg.Add(1)
+	go s.acceptLoop()
+
+	return nil
+}
+
+// Stop closes the listener, signals the accept loop to exit, waits for all
+// handler goroutines to finish, and removes the socket file.
+// Safe to call multiple times (idempotent via sync.Once).
+func (s *GuestRPCServer) Stop() {
+	s.once.Do(func() {
+		close(s.done)
+		if s.ln != nil {
+			_ = s.ln.Close()
+		}
+	})
+	s.wg.Wait()
+	_ = os.Remove(s.socketPath)
+	// Best-effort cleanup of the socket directory created in Start.
+	// os.Remove fails silently if the directory is not empty (e.g. left-over
+	// files from a test crash), which is acceptable.
+	_ = os.Remove(filepath.Dir(s.socketPath))
+}
+
+func (s *GuestRPCServer) acceptLoop() {
+	defer s.wg.Done()
+
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			select {
+			case <-s.done:
+				return // normal shutdown; listener was closed by Stop()
+			default:
+				log.Printf("GuestRPCServer %s: accept: %v", s.vm.Name, err)
+				return
+			}
+		}
+		log.Printf("GuestRPCServer %s: new connection from %s", s.vm.Name, conn.RemoteAddr())
+		s.wg.Add(1)
+		go s.serveConn(conn)
+	}
+}
+
+func (s *GuestRPCServer) serveConn(conn net.Conn) {
+	defer s.wg.Done()
+	defer conn.Close()
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("GuestRPCServer %s: panic in serveConn: %v\n%s",
+				s.vm.Name, r, debug.Stack())
+		}
+	}()
+
+	// Peek at the first 4 bytes to detect the framing protocol in use.
+	//
+	// Two protocols reach this server:
+	//
+	//  1. DataMap / vsock protocol — used by real vmtoolsd binaries.
+	//     The first 4 bytes are a big-endian uint32 = length of the DataMap
+	//     entries section.  For realistic payloads this value is 10–500 bytes,
+	//     so the first byte is 0x00.  Interpreted as little-endian the value
+	//     is enormous (> 1 GB), which is the distinguishing property.
+	//
+	//  2. LE-frame protocol — used by the vmci-guest test binary and
+	//     toolbox.UnixChannel.  The first 4 bytes are a little-endian uint32 =
+	//     payload length.  For realistic payloads this value is 10–500 bytes,
+	//     so the last byte is 0x00.  Interpreted as big-endian the value is
+	//     enormous (> 1 GB).
+	var hdr [4]byte
+	if _, err := io.ReadFull(conn, hdr[:]); err != nil {
+		return
+	}
+	beLen := binary.BigEndian.Uint32(hdr[:])
+	leLen := binary.LittleEndian.Uint32(hdr[:])
+
+	// MultiReader replays the header bytes so framing logic can re-read them.
+	mr := io.MultiReader(bytes.NewReader(hdr[:]), conn)
+
+	const maxReasonableLen = 1 << 20 // 1 MiB
+	if beLen < maxReasonableLen && leLen >= maxReasonableLen {
+		// DataMap framing: big-endian length prefix + DataMap-encoded body.
+		s.serveConnDataMap(mr, conn)
+	} else {
+		// LE-frame framing: little-endian length prefix + raw payload.
+		// Reads via mr (replays header), writes directly to conn.
+		s.serveConnLEWithConn(mr, conn)
+	}
+}
+
+// serveConnLEWithConn handles connections using the 4-byte LE length-prefix
+// framing (toolbox.UnixChannel / vmci-guest test binary protocol).
+func (s *GuestRPCServer) serveConnLEWithConn(r io.Reader, w io.Writer) {
+	for {
+		select {
+		case <-s.done:
+			return
+		default:
+		}
+
+		msg, err := toolbox.ReadUnixFrame(r)
+		if err != nil {
+			return
+		}
+		if msg == nil {
+			if werr := toolbox.WriteUnixFrame(w, []byte("1 ")); werr != nil {
+				return
+			}
+			continue
+		}
+		rpcCmd := strings.TrimRight(string(msg), "\x00")
+		log.Printf("GuestRPCServer %s: cmd=%q", s.vm.Name, rpcCmd)
+		resp := s.dispatch(rpcCmd)
+		if werr := toolbox.WriteUnixFrame(w, []byte(resp)); werr != nil {
+			return
+		}
+	}
+}
+
+// serveConnDataMap handles connections using the DataMap framing protocol,
+// which is the wire format used by real vmtoolsd binaries over vsock.
+//
+// DataMap framing is documented in toolbox.ReadDataMapPacket / WriteDataMapPacket.
+// The RPC command is the GUESTRPCPKT_FIELD_PAYLOAD string; the response is a
+// DataMap packet with FIELD_TYPE=TYPE_DATA and FIELD_PAYLOAD="1 result"|"0 err".
+func (s *GuestRPCServer) serveConnDataMap(r io.Reader, w io.Writer) {
+	for {
+		select {
+		case <-s.done:
+			return
+		default:
+		}
+
+		payload, fastClose, err := toolbox.ReadDataMapPacket(r)
+		if err != nil {
+			return // EOF or peer closed
+		}
+
+		rpcCmd := strings.TrimRight(string(payload), "\x00")
+		log.Printf("GuestRPCServer %s: [vsock/DataMap] cmd=%q fastClose=%v",
+			s.vm.Name, rpcCmd, fastClose)
+
+		resp := s.dispatch(rpcCmd)
+		if werr := toolbox.WriteDataMapPacket(w, []byte(resp), false); werr != nil {
+			return
+		}
+
+		if fastClose {
+			// Client set FAST_CLOSE: it will close the connection after reading
+			// our response; no need to loop.
+			return
+		}
+	}
+}
+
+// dispatch parses and executes an RPCI command.
+func (s *GuestRPCServer) dispatch(cmd string) string {
+	switch {
+	case strings.HasPrefix(cmd, "info-get "):
+		return s.infoGet(strings.TrimPrefix(cmd, "info-get "))
+
+	case strings.HasPrefix(cmd, "info-set "):
+		rest := strings.TrimPrefix(cmd, "info-set ")
+		// "info-set guestinfo.key value with spaces"
+		parts := strings.SplitN(rest, " ", 2)
+		if len(parts) == 2 {
+			return s.infoSet(parts[0], parts[1])
+		}
+		return "0 Bad syntax for info-set"
+
+	case strings.HasPrefix(cmd, "tools.capability."),
+		strings.HasPrefix(cmd, "tools.set-state"),
+		strings.HasPrefix(cmd, "tools.set.version"),
+		strings.HasPrefix(cmd, "Capabilities_Register"):
+		// Acknowledge without semantic effect.
+		return "1 "
+
+	default:
+		return "0 Unknown command"
+	}
+}
+
+// infoGet reads key from the VM's ExtraConfig under the object lock.
+func (s *GuestRPCServer) infoGet(key string) string {
+	s.rpcMu.RLock()
+	defer s.rpcMu.RUnlock()
+
+	var result string
+	found := false
+
+	s.ctx.WithLock(s.vm, func() {
+		for _, opt := range s.vm.Config.ExtraConfig {
+			v := opt.GetOptionValue()
+			if v.Key == key {
+				if v.Value != nil {
+					result = fmt.Sprintf("%v", v.Value)
+				}
+				found = true
+				break
+			}
+		}
+	})
+
+	if found {
+		return "1 " + result
+	}
+	return "0 No value found"
+}
+
+// infoSet writes key=value to the VM's ExtraConfig and emits a PropertyChange.
+func (s *GuestRPCServer) infoSet(key, value string) string {
+	s.rpcMu.Lock()
+	defer s.rpcMu.Unlock()
+
+	log.Printf("GuestRPCServer %s: info-set %s=%q", s.vm.Name, key, value)
+	s.ctx.AutoUpdate(s.vm, func() {
+		for _, opt := range s.vm.Config.ExtraConfig {
+			v := opt.GetOptionValue()
+			if v.Key == key {
+				v.Value = value
+				return
+			}
+		}
+		s.vm.Config.ExtraConfig = append(s.vm.Config.ExtraConfig,
+			&types.OptionValue{Key: key, Value: value})
+	})
+	return "1 "
+}
+
+// vmciEnabled reports whether the full VMCI simulation layer (Component A:
+// GuestRPC unix socket server + Component B: seccomp AF_VSOCK intercept) should
+// be activated for this VM.  Returns true when RUN.vmci is set to "true"
+// (case-insensitive, whitespace-trimmed) in extraConfig.
+func vmciEnabled(extraConfig []types.BaseOptionValue) bool {
+	for _, opt := range extraConfig {
+		v := opt.GetOptionValue()
+		if v.Key != "RUN.vmci" {
+			continue
+		}
+		s, ok := v.Value.(string)
+		return ok && strings.EqualFold(strings.TrimSpace(s), "true")
+	}
+	return false
+}
+
+// guestRPCVolumeMount returns the -v argument for bind-mounting the per-VM
+// GuestRPC socket directory into the container.
+//
+// We bind-mount the DIRECTORY (not the socket file) so the mount remains visible
+// when RUN.nestedContainers=true adds --tmpfs /run. A file bind-mount requires the
+// target to already exist as a file inside a fresh tmpfs (it doesn't); a directory
+// bind-mount creates a new submount at /run/vmware/ that overrides the empty tmpfs
+// content at that path, making rpc.sock accessible at its well-known container path.
+func guestRPCVolumeMount(socketDirPath string) string {
+	return fmt.Sprintf("%s:%s", socketDirPath, GuestRPCSocketDir)
+}
+
+// hasVolumeDest returns true if any RUN.volume.* ExtraConfig entry has dest as
+// its container-side mount destination.  The volume value format is
+// "hostPath:containerPath[:options]".  Used to avoid injecting a duplicate
+// auto-managed volume when the caller has already provided one.
+func hasVolumeDest(extraConfig []types.BaseOptionValue, dest string) bool {
+	for _, opt := range extraConfig {
+		v := opt.GetOptionValue()
+		if !strings.HasPrefix(v.Key, "RUN.volume.") {
+			continue
+		}
+		s, ok := v.Value.(string)
+		if !ok {
+			continue
+		}
+		// Value format: "hostPath:containerPath" or "hostPath:containerPath:opts"
+		parts := strings.SplitN(s, ":", 3)
+		if len(parts) >= 2 && parts[1] == dest {
+			return true
+		}
+	}
+	return false
+}

--- a/simulator/guestrpc_server.go
+++ b/simulator/guestrpc_server.go
@@ -32,6 +32,17 @@ const (
 	// A file bind-mount target under a tmpfs must already exist as a file; a directory
 	// bind-mount creates a new submount that overrides the tmpfs contents at that path.
 	GuestRPCSocketDir = "/run/vmware"
+
+	// dataMapMinEntries is the smallest possible DataMap entries section: one
+	// field header of fieldType(4B) + fieldID(4B). Used to rule out DataMap
+	// framing without consuming bytes the LE path would need.
+	dataMapMinEntries = 8
+
+	// guestInfoPrefix is the only ExtraConfig namespace a guest may write via
+	// info-set. Real VMX restricts guest writes to guestinfo.*, and vcsim reads
+	// other namespaces (RUN.*) as host-side container directives — so accepting
+	// them here would let guest code reconfigure its own backing on next start.
+	guestInfoPrefix = "guestinfo."
 )
 
 // GuestRPCServer is a per-VM host-side server that implements the toolbox RPCI
@@ -84,7 +95,7 @@ func newGuestRPCServer(vm *VirtualMachine, socketPath string) *GuestRPCServer {
 	}
 }
 
-// GuestRPCSocketDir returns the canonical per-VM host-side socket directory.
+// GuestRPCSocketDirPath returns the canonical per-VM host-side socket directory.
 // The directory is bind-mounted at GuestRPCSocketDir inside the container.
 // Using a directory mount (not a file mount) means the submount is visible even
 // when RUN.nestedContainers=true adds --tmpfs /run: the directory mount is applied
@@ -162,7 +173,9 @@ func (s *GuestRPCServer) acceptLoop() {
 				return
 			}
 		}
-		log.Printf("GuestRPCServer %s: new connection from %s", s.vm.Name, conn.RemoteAddr())
+		if Trace {
+			log.Printf("GuestRPCServer %s: new connection from %s", s.vm.Name, conn.RemoteAddr())
+		}
 		s.wg.Add(1)
 		go s.serveConn(conn)
 	}
@@ -178,21 +191,20 @@ func (s *GuestRPCServer) serveConn(conn net.Conn) {
 		}
 	}()
 
-	// Peek at the first 4 bytes to detect the framing protocol in use.
+	// Detect which framing this connection uses.
 	//
-	// Two protocols reach this server:
+	// Two protocols reach this server and both begin with a 4-byte length, so
+	// the length alone cannot separate them: a DataMap length is big-endian, an
+	// LE-frame length is little-endian, and the two readings overlap. A
+	// magnitude threshold therefore has holes in both directions — measured, a
+	// DataMap entries section of 256 bytes (an ordinary info-set) reads as
+	// 65536 little-endian and would be misrouted.
 	//
-	//  1. DataMap / vsock protocol — used by real vmtoolsd binaries.
-	//     The first 4 bytes are a big-endian uint32 = length of the DataMap
-	//     entries section.  For realistic payloads this value is 10–500 bytes,
-	//     so the first byte is 0x00.  Interpreted as little-endian the value
-	//     is enormous (> 1 GB), which is the distinguishing property.
-	//
-	//  2. LE-frame protocol — used by the vmci-guest test binary and
-	//     toolbox.UnixChannel.  The first 4 bytes are a little-endian uint32 =
-	//     payload length.  For realistic payloads this value is 10–500 bytes,
-	//     so the last byte is 0x00.  Interpreted as big-endian the value is
-	//     enormous (> 1 GB).
+	// Discriminate on STRUCTURE instead. A DataMap entries section opens with a
+	// field header of fieldType(4B) fieldID(4B), both big-endian and both small
+	// (see toolbox.ReadDataMapPacket). An LE frame's payload is an RPCI command
+	// string, so its first bytes are ASCII and can never be the zero bytes a
+	// big-endian small integer starts with.
 	var hdr [4]byte
 	if _, err := io.ReadFull(conn, hdr[:]); err != nil {
 		return
@@ -200,16 +212,32 @@ func (s *GuestRPCServer) serveConn(conn net.Conn) {
 	beLen := binary.BigEndian.Uint32(hdr[:])
 	leLen := binary.LittleEndian.Uint32(hdr[:])
 
-	// MultiReader replays the header bytes so framing logic can re-read them.
-	mr := io.MultiReader(bytes.NewReader(hdr[:]), conn)
+	consumed := hdr[:]
+	isDataMap := false
 
-	const maxReasonableLen = 1 << 20 // 1 MiB
-	if beLen < maxReasonableLen && leLen >= maxReasonableLen {
-		// DataMap framing: big-endian length prefix + DataMap-encoded body.
+	// A DataMap entries section holds at least one 8-byte field header. When
+	// either reading rules that out, the framing is settled without reading
+	// further — which also avoids blocking on a short or zero-length LE frame.
+	if beLen >= dataMapMinEntries && leLen >= dataMapMinEntries {
+		var probe [8]byte
+		if _, err := io.ReadFull(conn, probe[:]); err != nil {
+			return
+		}
+		consumed = append(hdr[:], probe[:]...)
+
+		fieldType := binary.BigEndian.Uint32(probe[0:4])
+		fieldID := binary.BigEndian.Uint32(probe[4:8])
+		isDataMap = (fieldType == toolbox.DMFieldTypeInt64 || fieldType == toolbox.DMFieldTypeString) &&
+			fieldID >= toolbox.GuestRPCFieldType && fieldID <= toolbox.GuestRPCFieldFastClose
+	}
+
+	// MultiReader replays every byte consumed above so the framing logic can
+	// re-read the header it was given.
+	mr := io.MultiReader(bytes.NewReader(consumed), conn)
+
+	if isDataMap {
 		s.serveConnDataMap(mr, conn)
 	} else {
-		// LE-frame framing: little-endian length prefix + raw payload.
-		// Reads via mr (replays header), writes directly to conn.
 		s.serveConnLEWithConn(mr, conn)
 	}
 }
@@ -235,7 +263,9 @@ func (s *GuestRPCServer) serveConnLEWithConn(r io.Reader, w io.Writer) {
 			continue
 		}
 		rpcCmd := strings.TrimRight(string(msg), "\x00")
-		log.Printf("GuestRPCServer %s: cmd=%q", s.vm.Name, rpcCmd)
+		if Trace {
+			log.Printf("GuestRPCServer %s: cmd=%q", s.vm.Name, rpcCmd)
+		}
 		resp := s.dispatch(rpcCmd)
 		if werr := toolbox.WriteUnixFrame(w, []byte(resp)); werr != nil {
 			return
@@ -263,8 +293,10 @@ func (s *GuestRPCServer) serveConnDataMap(r io.Reader, w io.Writer) {
 		}
 
 		rpcCmd := strings.TrimRight(string(payload), "\x00")
-		log.Printf("GuestRPCServer %s: [vsock/DataMap] cmd=%q fastClose=%v",
-			s.vm.Name, rpcCmd, fastClose)
+		if Trace {
+			log.Printf("GuestRPCServer %s: [vsock/DataMap] cmd=%q fastClose=%v",
+				s.vm.Name, rpcCmd, fastClose)
+		}
 
 		resp := s.dispatch(rpcCmd)
 		if werr := toolbox.WriteDataMapPacket(w, []byte(resp), false); werr != nil {
@@ -335,10 +367,18 @@ func (s *GuestRPCServer) infoGet(key string) string {
 
 // infoSet writes key=value to the VM's ExtraConfig and emits a PropertyChange.
 func (s *GuestRPCServer) infoSet(key, value string) string {
+	if !strings.HasPrefix(key, guestInfoPrefix) {
+		return "0 Permission denied"
+	}
+
 	s.rpcMu.Lock()
 	defer s.rpcMu.Unlock()
 
-	log.Printf("GuestRPCServer %s: info-set %s=%q", s.vm.Name, key, value)
+	// The value is guest-supplied and routinely carries cloud-init userdata,
+	// so it is never logged; the key alone identifies the operation.
+	if Trace {
+		log.Printf("GuestRPCServer %s: info-set %s", s.vm.Name, key)
+	}
 	s.ctx.AutoUpdate(s.vm, func() {
 		for _, opt := range s.vm.Config.ExtraConfig {
 			v := opt.GetOptionValue()
@@ -353,9 +393,13 @@ func (s *GuestRPCServer) infoSet(key, value string) string {
 	return "1 "
 }
 
-// vmciEnabled reports whether the full VMCI simulation layer (Component A:
-// GuestRPC unix socket server + Component B: seccomp AF_VSOCK intercept) should
-// be activated for this VM.  Returns true when RUN.vmci is set to "true"
+// vmciEnabled reports whether the GuestRPC simulation layer should be
+// activated for this VM: a per-VM unix socket server speaking RPCI, plus
+// injection of the toolbox binary as /usr/bin/vmware-rpctool.
+//
+// A seccomp AF_VSOCK interception layer is future work and is NOT part of this
+// implementation; nothing here provides AF_VSOCK inside a container.
+// Returns true when RUN.vmci is set to "true"
 // (case-insensitive, whitespace-trimmed) in extraConfig.
 func vmciEnabled(extraConfig []types.BaseOptionValue) bool {
 	for _, opt := range extraConfig {

--- a/simulator/guestrpc_server.go
+++ b/simulator/guestrpc_server.go
@@ -31,12 +31,27 @@ const (
 	// bind-mount creates a new submount that overrides the tmpfs contents at that path.
 	GuestRPCSocketDir = "/run/vmware"
 
-	// guestInfoPrefix is the only ExtraConfig namespace a guest may write via
-	// info-set. Real VMX restricts guest writes to guestinfo.*, and vcsim reads
-	// other namespaces (RUN.*) as host-side container directives — so accepting
-	// them here would let guest code reconfigure its own backing on next start.
+	// guestInfoPrefix is the only ExtraConfig namespace a guest may read or
+	// write via GuestRPC. Real VMX restricts guest access to guestinfo.*, and
+	// vcsim reads other namespaces (RUN.*) as host-side container directives —
+	// so accepting them here would let guest code inspect or reconfigure its
+	// own backing on next start.
 	guestInfoPrefix = "guestinfo."
 )
+
+// isGuestReadable reports whether key is a namespace a guest may read via
+// info-get. Real VMX restricts guest reads to guestinfo.*.
+func isGuestReadable(key string) bool {
+	return strings.HasPrefix(key, guestInfoPrefix)
+}
+
+// isGuestWritable reports whether key is a namespace a guest may write via
+// info-set. Real VMX additionally makes any key containing "/" read-only
+// from the guest (used for host/tools-managed sub-namespaces under
+// guestinfo.*), so a writable key must be readable AND slash-free.
+func isGuestWritable(key string) bool {
+	return isGuestReadable(key) && !strings.Contains(key, "/")
+}
 
 // GuestRPCServer is a per-VM host-side server that implements the toolbox RPCI
 // protocol over a Unix stream socket.
@@ -260,6 +275,10 @@ func (s *GuestRPCServer) dispatch(cmd string) string {
 
 // infoGet reads key from the VM's ExtraConfig under the object lock.
 func (s *GuestRPCServer) infoGet(key string) string {
+	if !isGuestReadable(key) {
+		return "0 Permission denied"
+	}
+
 	s.rpcMu.RLock()
 	defer s.rpcMu.RUnlock()
 
@@ -287,7 +306,7 @@ func (s *GuestRPCServer) infoGet(key string) string {
 
 // infoSet writes key=value to the VM's ExtraConfig and emits a PropertyChange.
 func (s *GuestRPCServer) infoSet(key, value string) string {
-	if !strings.HasPrefix(key, guestInfoPrefix) {
+	if !isGuestWritable(key) {
 		return "0 Permission denied"
 	}
 

--- a/simulator/guestrpc_test.go
+++ b/simulator/guestrpc_test.go
@@ -1,0 +1,302 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/toolbox"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// vcSimEnv bundles the common vcsim test infrastructure so tests do not
+// need to repeat the 10-line VPX setup block.  Call newVCSIMEnv(t) at the
+// start of any test that needs a running vcsim instance.
+type vcSimEnv struct {
+	goCtx  context.Context
+	m      *Model
+	simCtx *Context
+	client *govmomi.Client
+	finder *find.Finder
+	pool   *object.ResourcePool
+	folder *object.DatacenterFolders
+	pc     *property.Collector
+}
+
+// newVCSIMEnv creates a VPX model and HTTP server, registers cleanup via
+// t.Cleanup, and returns a fully-initialised vcSimEnv.
+func newVCSIMEnv(t *testing.T) *vcSimEnv {
+	t.Helper()
+
+	goCtx := context.Background()
+	m := VPX()
+	t.Cleanup(m.Remove)
+	require.NoError(t, m.Create())
+	s := m.Service.NewServer()
+	t.Cleanup(s.Close)
+
+	c, err := govmomi.NewClient(goCtx, s.URL, true)
+	require.NoError(t, err)
+
+	finder := find.NewFinder(c.Client)
+	pool, err := finder.ResourcePool(goCtx, "DC0_H0/Resources")
+	require.NoError(t, err)
+	dc, err := finder.Datacenter(goCtx, "DC0")
+	require.NoError(t, err)
+	f, err := dc.Folders(goCtx)
+	require.NoError(t, err)
+
+	return &vcSimEnv{
+		goCtx:  goCtx,
+		m:      m,
+		simCtx: m.Service.Context,
+		client: c,
+		finder: finder,
+		pool:   pool,
+		folder: f,
+		pc:     property.DefaultCollector(c.Client),
+	}
+}
+
+// pollExtraConfig blocks until KEY==WANT appears in vmRef's ExtraConfig via
+// PropertyCollector, or the test fails with a timeout error.
+func pollExtraConfig(t *testing.T, env *vcSimEnv, vmRef types.ManagedObjectReference, key, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var mvm mo.VirtualMachine
+		if err := env.pc.RetrieveOne(env.goCtx, vmRef, []string{"config.extraConfig"}, &mvm); err != nil {
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		for _, opt := range mvm.Config.ExtraConfig {
+			v := opt.GetOptionValue()
+			if v.Key == key {
+				require.Equalf(t, want, v.Value,
+					"guestinfo key %q: got %v want %q", key, v.Value, want)
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("timeout after %s: %q not found in ExtraConfig", timeout, key)
+}
+
+// removeStaleGuestRPCSockets removes vcsim-rpc-*.sock stale files left by
+// previously crashed test runs.  TestMain calls the equivalent sweep before
+// the entire test binary runs; this function is available for tests that
+// need an extra clean before a specific sensitive operation.
+func removeStaleGuestRPCSockets() {
+	for _, pattern := range []string{
+		filepath.Join(os.TempDir(), "vcsim-rpc-*.sock"),
+	} {
+		if matches, err := filepath.Glob(pattern); err == nil {
+			for _, f := range matches {
+				_ = os.Remove(f)
+			}
+		}
+	}
+}
+
+// dialGuestRPC connects a ChannelOut to the unix socket at socketPath.
+func dialGuestRPC(t *testing.T, socketPath string) *toolbox.ChannelOut {
+	t.Helper()
+	ch := toolbox.NewUnixChannelOut(socketPath)
+	require.NoError(t, ch.Start(), "dialGuestRPC: connect %s", socketPath)
+	t.Cleanup(func() { _ = ch.Stop() })
+	return &toolbox.ChannelOut{Channel: ch}
+}
+
+// firstVM returns the first VirtualMachine object from the registry.
+func firstVM(simCtx *Context) *VirtualMachine {
+	refs := simCtx.Map.AllReference("VirtualMachine")
+	if len(refs) == 0 {
+		return nil
+	}
+	return simCtx.Map.Get(refs[0].Reference()).(*VirtualMachine)
+}
+
+// TestGuestRPCServer_InfoGetSet exercises basic info-get and info-set.
+func TestGuestRPCServer_InfoGetSet(t *testing.T) {
+	env := newVCSIMEnv(t)
+
+	vmObj := firstVM(env.simCtx)
+	require.NotNil(t, vmObj, "no VMs in test inventory")
+
+	socketPath := GuestRPCSocketPath(vmObj.Self.Value)
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+	srv := newGuestRPCServer(vmObj, socketPath)
+	require.NoError(t, srv.Start(env.simCtx))
+	t.Cleanup(srv.Stop)
+
+	out := dialGuestRPC(t, socketPath)
+
+	_, err := out.Request([]byte("info-set guestinfo.test.key hello"))
+	require.NoError(t, err, "info-set")
+
+	reply, err := out.Request([]byte("info-get guestinfo.test.key"))
+	require.NoError(t, err, "info-get")
+	require.Equal(t, "hello", strings.TrimSpace(string(reply)))
+}
+
+// TestGuestRPCServer_InfoSet_PropertyChange verifies info-set triggers a
+// PropertyCollector notification.
+func TestGuestRPCServer_InfoSet_PropertyChange(t *testing.T) {
+	env := newVCSIMEnv(t)
+
+	vmObj := firstVM(env.simCtx)
+	require.NotNil(t, vmObj)
+
+	socketPath := GuestRPCSocketPath(vmObj.Self.Value)
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+	srv := newGuestRPCServer(vmObj, socketPath)
+	require.NoError(t, srv.Start(env.simCtx))
+	t.Cleanup(srv.Stop)
+
+	out := dialGuestRPC(t, socketPath)
+	_, err := out.Request([]byte("info-set guestinfo.notify.test triggered"))
+	require.NoError(t, err)
+
+	pollExtraConfig(t, env, vmObj.Self, "guestinfo.notify.test", "triggered", 2*time.Second)
+}
+
+// TestGuestRPCServer_RoundTrip tests host-write/guest-read and guest-write/host-read.
+func TestGuestRPCServer_RoundTrip(t *testing.T) {
+	env := newVCSIMEnv(t)
+
+	vmObj := firstVM(env.simCtx)
+	require.NotNil(t, vmObj)
+
+	socketPath := GuestRPCSocketPath(vmObj.Self.Value)
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+	srv := newGuestRPCServer(vmObj, socketPath)
+	require.NoError(t, srv.Start(env.simCtx))
+	t.Cleanup(srv.Stop)
+
+	env.simCtx.AutoUpdate(vmObj, func() {
+		vmObj.Config.ExtraConfig = append(vmObj.Config.ExtraConfig,
+			&types.OptionValue{Key: "guestinfo.from.host", Value: "hostvalue"})
+	})
+
+	out := dialGuestRPC(t, socketPath)
+
+	reply, err := out.Request([]byte("info-get guestinfo.from.host"))
+	require.NoError(t, err)
+	require.Equal(t, "hostvalue", strings.TrimSpace(string(reply)))
+
+	_, err = out.Request([]byte("info-set guestinfo.from.guest guestvalue"))
+	require.NoError(t, err)
+
+	var gotValue string
+	env.simCtx.WithLock(vmObj, func() {
+		for _, opt := range vmObj.Config.ExtraConfig {
+			v := opt.GetOptionValue()
+			if v.Key == "guestinfo.from.guest" {
+				gotValue = fmt.Sprintf("%v", v.Value)
+				break
+			}
+		}
+	})
+	require.Equal(t, "guestvalue", gotValue)
+}
+
+// TestGuestRPCServer_MultiVM verifies that two coexisting VMs each get an
+// independent GuestRPC server, and that one VM's guestinfo keys are not
+// visible to the other. The two VMs' servers are exercised sequentially, not
+// concurrently; this test is about isolation, not concurrency.
+func TestGuestRPCServer_MultiVM(t *testing.T) {
+	env := newVCSIMEnv(t)
+
+	refs := env.simCtx.Map.AllReference("VirtualMachine")
+	if len(refs) < 2 {
+		t.Skip("need at least 2 VMs")
+	}
+
+	type vmHandle struct {
+		obj *VirtualMachine
+		srv *GuestRPCServer
+		out *toolbox.ChannelOut
+	}
+
+	var handles []vmHandle
+	for i := 0; i < 2; i++ {
+		obj := env.simCtx.Map.Get(refs[i].Reference()).(*VirtualMachine)
+		sp := GuestRPCSocketPath(obj.Self.Value)
+		t.Cleanup(func() { _ = os.Remove(sp) })
+
+		srv := newGuestRPCServer(obj, sp)
+		require.NoError(t, srv.Start(env.simCtx), "Start VM %d", i)
+		t.Cleanup(srv.Stop)
+
+		handles = append(handles, vmHandle{obj: obj, srv: srv, out: dialGuestRPC(t, sp)})
+	}
+
+	for i, h := range handles {
+		key := fmt.Sprintf("guestinfo.concurrent.vm%d", i)
+		val := fmt.Sprintf("vm%d-value", i)
+		_, err := h.out.Request([]byte(fmt.Sprintf("info-set %s %s", key, val)))
+		require.NoError(t, err, "VM %d info-set", i)
+	}
+
+	for i, h := range handles {
+		key := fmt.Sprintf("guestinfo.concurrent.vm%d", i)
+		want := fmt.Sprintf("vm%d-value", i)
+		reply, err := h.out.Request([]byte("info-get " + key))
+		require.NoError(t, err, "VM %d info-get own key", i)
+		require.Equal(t, want, strings.TrimSpace(string(reply)))
+
+		otherKey := fmt.Sprintf("guestinfo.concurrent.vm%d", 1-i)
+		_, err2 := h.out.Request([]byte("info-get " + otherKey))
+		require.Error(t, err2, "VM %d should not see VM %d's key %s", i, 1-i, otherKey)
+	}
+}
+
+// TestGuestRPCServer_Cleanup verifies stale socket recovery.
+func TestGuestRPCServer_Cleanup(t *testing.T) {
+	env := newVCSIMEnv(t)
+
+	vmObj := firstVM(env.simCtx)
+
+	socketPath := GuestRPCSocketPath(vmObj.Self.Value + "-cleanup")
+	socketDir := GuestRPCSocketDirPath(vmObj.Self.Value + "-cleanup")
+	t.Cleanup(func() {
+		_ = os.Remove(socketPath)
+		_ = os.Remove(socketDir)
+	})
+
+	// Simulate a stale socket from a prior crash: pre-create the directory
+	// (normally created by Start) then write a non-socket placeholder file.
+	require.NoError(t, os.MkdirAll(socketDir, 0o700))
+	require.NoError(t, os.WriteFile(socketPath, []byte("stale"), 0600))
+
+	srv := newGuestRPCServer(vmObj, socketPath)
+	require.NoError(t, srv.Start(env.simCtx), "Start with stale file")
+	t.Cleanup(srv.Stop) // idempotent (sync.Once); also covers early-return on assertion failure below
+
+	fi, err := os.Stat(socketPath)
+	require.NoError(t, err)
+	require.NotZero(t, fi.Mode()&os.ModeSocket, "expected socket mode, got %v", fi.Mode())
+
+	srv.Stop()
+
+	_, err = os.Stat(socketPath)
+	require.True(t, os.IsNotExist(err), "socket file should be gone after Stop")
+}

--- a/simulator/main_test.go
+++ b/simulator/main_test.go
@@ -1,0 +1,40 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Remove any leftover vcsim GuestRPC sockets from previously crashed test
+	// runs.  A fresh Start() would also remove them, but sweeping here catches
+	// all patterns before any test even begins.
+	for _, pattern := range []string{
+		filepath.Join(os.TempDir(), "vcsim-rpc-*.sock"),
+	} {
+		if matches, err := filepath.Glob(pattern); err == nil {
+			for _, f := range matches {
+				_ = os.Remove(f)
+			}
+		}
+	}
+
+	// Force-remove any stale vcsim containers left by previously crashed tests.
+	// Without this, docker create spends the full grace period (up to 60 s+)
+	// waiting for the old container to stop before it can remove it, which
+	// easily exhausts the per-test timeout.
+	if out, err := exec.Command("docker", "ps", "-aq", "--filter", "name=vcsim").Output(); err == nil {
+		for _, id := range strings.Fields(string(out)) {
+			_ = exec.Command("docker", "rm", "-f", id).Run()
+		}
+	}
+
+	os.Exit(m.Run())
+}

--- a/simulator/main_test.go
+++ b/simulator/main_test.go
@@ -13,15 +13,18 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// Remove any leftover vcsim GuestRPC sockets from previously crashed test
-	// runs.  A fresh Start() would also remove them, but sweeping here catches
-	// all patterns before any test even begins.
+	// Remove leftover vcsim GuestRPC socket directories from crashed test runs.
+	//
+	// The socket lives at <TempDir>/vcsim-rpc-<uid>/rpc.sock, so the pattern
+	// must match the DIRECTORY: filepath.Match does not let * cross a path
+	// separator, so a "vcsim-rpc-*.sock" pattern matched nothing and the
+	// directories accumulated under TempDir.
 	for _, pattern := range []string{
-		filepath.Join(os.TempDir(), "vcsim-rpc-*.sock"),
+		filepath.Join(os.TempDir(), "vcsim-rpc-*"),
 	} {
 		if matches, err := filepath.Glob(pattern); err == nil {
 			for _, f := range matches {
-				_ = os.Remove(f)
+				_ = os.RemoveAll(f)
 			}
 		}
 	}

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -692,8 +692,11 @@ var enableLocker = os.Getenv("VCSIM_LOCKER") != "false"
 // WithLock holds a lock for the given object while then given function is run.
 func (r *Registry) WithLock(onBehalfOf *Context, obj mo.Reference, f func()) {
 	unlock := r.AcquireLock(onBehalfOf, obj)
+	// Deferred so a panic inside f releases the lock. ObjectLock.Release only
+	// clears heldBy once its refcount reaches zero, so an unwound-past unlock
+	// would leave the object permanently locked to every other caller.
+	defer unlock()
 	f()
-	unlock()
 }
 
 // AcquireLock acquires the lock for onBehalfOf then returns. The lock MUST be

--- a/simulator/testdata/vmci-systemd-init/Dockerfile
+++ b/simulator/testdata/vmci-systemd-init/Dockerfile
@@ -1,0 +1,65 @@
+# vmci-systemd-init — minimal debian+systemd image for govmomi VMCI tests.
+#
+# Purpose: TestVMCI_SystemdInit_GuestInfoRoundTrip runs this image with
+# RUN.vmci=true and RUN.privileged=true to verify that a systemd-managed
+# one-shot service can write a guestinfo key via the GuestRPC Unix socket
+# (Component A, $VMX_RPC_SOCK=/run/vmware/rpc.sock).
+#
+# Design choices:
+#   - Debian bookworm (slim) base: systemd packages are well-tested there.
+#   - Only packages required to boot systemd cleanly are installed; no
+#     containerd, kubelet, or other heavy services.
+#   - CMD ["/sbin/init"] runs systemd as PID 1. The STOPSIGNAL matches
+#     systemd's clean shutdown signal.
+#   - /usr/bin/vmware-rpctool is NOT included: vcsim injects it at container
+#     start when RUN.vmci=true is set (govmomi/simulator/container.go
+#     toolbox auto-injection).
+#
+# Build:
+#   docker build -t docker.io/library/vmci-systemd-init:latest \
+#     ./simulator/testdata/vmci-systemd-init/
+#
+# The image is intentionally small (~120 MB); do not add k8s-related packages.
+
+FROM debian:bookworm-slim
+
+# Install systemd and the bare minimum for a clean boot.
+# systemd-sysv provides /sbin/init → /lib/systemd/systemd symlink.
+# dbus is required for systemd's internal IPC.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        systemd \
+        systemd-sysv \
+        dbus \
+        procps \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Mask units that are not meaningful or harmful in a container environment.
+# systemd-networkd-wait-online and similar units would cause boot delays.
+RUN systemctl mask \
+        getty@tty1.service \
+        getty.target \
+        console-getty.service \
+        systemd-networkd-wait-online.service \
+        systemd-resolved.service \
+        apt-daily.service \
+        apt-daily-upgrade.service \
+        apt-daily.timer \
+        apt-daily-upgrade.timer \
+        e2scrub_reap.service \
+    && true
+
+# Bake the test service into the image so it is always available without
+# requiring a bind-mount injection at test time.  The govmomi vmci simulation
+# injects /usr/bin/vmware-rpctool as a bind mount when RUN.vmci=true, so the
+# binary does not need to be present in the image itself.
+COPY vmci-test-writer.service /etc/systemd/system/vmci-test-writer.service
+RUN systemctl enable vmci-test-writer.service
+
+# /run is NOT declared as a tmpfs in the OCI spec; the host bind-mount for
+# /run/vmware/rpc.sock (Component A) must survive container start.
+# Declaring /run as a VOLUME would cause Docker to initialise it as a tmpfs
+# and shadow the bind mount — do NOT add it here.
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/simulator/testdata/vmci-systemd-init/vmci-test-writer.service
+++ b/simulator/testdata/vmci-systemd-init/vmci-test-writer.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=VMCI SystemdInit GuestRPC Test Writer
+After=basic.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+# vmware-rpctool expects its entire RPCI command as exactly one positional
+# argument.  Wrap with /bin/sh -c so systemd's word-splitting does not turn
+# "info-set guestinfo.vmci-systemd-test pass" into three separate argv
+# entries, which would cause the binary to print usage and exit 2.
+ExecStart=/bin/sh -c "/usr/bin/vmware-rpctool 'info-set guestinfo.vmci-systemd-test pass'"
+# Propagate the VMX_RPC_SOCK env var (set by govmomi in the container's
+# initial environment) into this service process so that vmware-rpctool
+# prefers Component A (GuestRPC Unix socket) over AF_VSOCK.
+PassEnvironment=VMX_RPC_SOCK
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/simulator/testdata/vsock-test/main.go
+++ b/simulator/testdata/vsock-test/main.go
@@ -1,0 +1,85 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+// vsock-test is a minimal binary compiled for linux/amd64 and injected into
+// container-backed vcsim VMs via RUN.volume.  It exercises the GuestRPC server
+// over the unix socket that vcsim mounts at /run/vmware/rpc.sock.
+//
+// Usage:
+//
+//	vsock-test --socket /run/vmware/rpc.sock --rpc 'info-get guestinfo.test'
+//	vsock-test --socket /run/vmware/rpc.sock --rpc 'info-set guestinfo.test hello'
+//	vsock-test --socket /run/vmware/rpc.sock --roundtrip guestinfo.test hello
+//
+// Exit code 0 = success; non-zero = failure.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/vmware/govmomi/toolbox"
+)
+
+func main() {
+	sockPath := flag.String("socket", "/run/vmware/rpc.sock", "path to GuestRPC unix socket")
+	rpcCmd := flag.String("rpc", "", "single RPCI command to send (e.g. 'info-get guestinfo.foo')")
+	roundtrip := flag.Bool("roundtrip", false, "if true, next two args are key and value for a set+get roundtrip")
+	flag.Parse()
+
+	ch := toolbox.NewUnixChannelOut(*sockPath)
+	out := &toolbox.ChannelOut{Channel: ch}
+
+	if err := ch.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "connect %s: %v\n", *sockPath, err)
+		os.Exit(1)
+	}
+	defer ch.Stop()
+
+	if *roundtrip {
+		args := flag.Args()
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "--roundtrip requires two arguments: <key> <value>")
+			os.Exit(1)
+		}
+		key, value := args[0], args[1]
+
+		// Set the value.
+		setCmd := fmt.Sprintf("info-set %s %s", key, value)
+		if _, err := out.Request([]byte(setCmd)); err != nil {
+			fmt.Fprintf(os.Stderr, "info-set: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Get it back.
+		getCmd := fmt.Sprintf("info-get %s", key)
+		reply, err := out.Request([]byte(getCmd))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "info-get: %v\n", err)
+			os.Exit(1)
+		}
+		got := string(reply)
+		if strings.TrimSpace(got) != strings.TrimSpace(value) {
+			fmt.Fprintf(os.Stderr, "roundtrip mismatch: want %q got %q\n", value, got)
+			os.Exit(1)
+		}
+		fmt.Printf("roundtrip OK: %s=%s\n", key, got)
+		return
+	}
+
+	if *rpcCmd != "" {
+		reply, err := out.Request([]byte(*rpcCmd))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %v\n", *rpcCmd, err)
+			os.Exit(1)
+		}
+		fmt.Printf("1 %s\n", string(reply))
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "specify --rpc or --roundtrip")
+	os.Exit(1)
+}

--- a/simulator/vmci_artifacts_linux.go
+++ b/simulator/vmci_artifacts_linux.go
@@ -22,18 +22,16 @@ var (
 	vmciArtifactsErr         error
 )
 
-// artifactsBinDir returns the stable host directory used to cache vmci
-// simulation binaries across test invocations.
+// artifactsBinDir returns the stable host directory used to hold the built
+// toolbox binary across test invocations.
 //
-// The directory is simulator/bin/ relative to this source file so that the
-// binaries persist between "go test" runs.  When a binary already exists it is
-// re-used without invoking "go build", benefiting from Go's incremental build:
-// repeated test runs pay the compilation cost only on the first invocation (or
-// after sources change and the caller deletes the stale binary).
-//
-// To force a rebuild, delete the cache directory:
-//
-//	rm -rf <govmomi>/simulator/bin/
+// The directory is simulator/bin/ relative to this source file. "go build -o"
+// is invoked on every call (see buildToolboxArtifact); the directory only
+// exists to give that output a stable, discoverable path, not to skip the
+// build. Go's own content-addressed build cache (~/.cache/go-build) is what
+// makes repeated invocations cheap when toolbox sources are unchanged — this
+// directory deliberately carries no invalidation logic of its own, so a
+// presence check can never serve a binary built from stale sources.
 //
 // Falls back to os.MkdirTemp when the source path is unavailable (e.g. binaries
 // built with -trimpath or deployed outside the source tree).
@@ -70,25 +68,28 @@ func buildToolboxArtifact() (toolboxBinPath string, err error) {
 		}
 
 		toolboxBin := filepath.Join(dir, "toolbox")
-		if _, statErr := os.Stat(toolboxBin); os.IsNotExist(statErr) {
-			toolboxBuild := exec.Command(
-				"go", "build",
-				"-o", toolboxBin,
-				"github.com/vmware/govmomi/toolbox/toolbox",
-			)
-			toolboxBuild.Env = append(os.Environ(),
-				"CGO_ENABLED=0",
-				"GOOS=linux",
-				"GOARCH=amd64",
-			)
-			if out, buildErr := toolboxBuild.CombinedOutput(); buildErr != nil {
-				vmciArtifactsErr = fmt.Errorf("toolbox build: %w\n%s", buildErr, out)
-				return
-			}
-			log.Printf("vmci-artifacts: built toolbox at %s", toolboxBin)
-		} else {
-			log.Printf("vmci-artifacts: toolbox cached at %s", toolboxBin)
+		// Always build: a presence check here previously let an ancient binary
+		// (built before a toolbox wire-protocol change) go on serving requests
+		// indefinitely, since nothing about this directory's content changes
+		// when the sources it was built from do. "go build -o" always
+		// overwrites toolboxBin with a binary matching the current sources;
+		// Go's own build cache (keyed on source content, not a stat) is what
+		// keeps the repeat-invocation cost low.
+		toolboxBuild := exec.Command(
+			"go", "build",
+			"-o", toolboxBin,
+			"github.com/vmware/govmomi/toolbox/toolbox",
+		)
+		toolboxBuild.Env = append(os.Environ(),
+			"CGO_ENABLED=0",
+			"GOOS=linux",
+			"GOARCH=amd64",
+		)
+		if out, buildErr := toolboxBuild.CombinedOutput(); buildErr != nil {
+			vmciArtifactsErr = fmt.Errorf("toolbox build: %w\n%s", buildErr, out)
+			return
 		}
+		log.Printf("vmci-artifacts: built toolbox at %s", toolboxBin)
 		vmciArtifactsToolboxPath = toolboxBin
 	})
 	return vmciArtifactsToolboxPath, vmciArtifactsErr

--- a/simulator/vmci_artifacts_linux.go
+++ b/simulator/vmci_artifacts_linux.go
@@ -1,0 +1,113 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package simulator
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+var (
+	vmciArtifactsOnce        sync.Once
+	vmciArtifactsToolboxPath string
+	vmciArtifactsErr         error
+)
+
+// artifactsBinDir returns the stable host directory used to cache vmci
+// simulation binaries across test invocations.
+//
+// The directory is simulator/bin/ relative to this source file so that the
+// binaries persist between "go test" runs.  When a binary already exists it is
+// re-used without invoking "go build", benefiting from Go's incremental build:
+// repeated test runs pay the compilation cost only on the first invocation (or
+// after sources change and the caller deletes the stale binary).
+//
+// To force a rebuild, delete the cache directory:
+//
+//	rm -rf <govmomi>/simulator/bin/
+//
+// Falls back to os.MkdirTemp when the source path is unavailable (e.g. binaries
+// built with -trimpath or deployed outside the source tree).
+func artifactsBinDir() (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return os.MkdirTemp("", "vcsim-vmci-artifacts-*")
+	}
+	dir := filepath.Join(filepath.Dir(thisFile), "bin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("vmci-artifacts: mkdir %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
+// buildToolboxArtifact returns the path to the govmomi/toolbox binary
+// (injected as /usr/bin/vmware-rpctool in container-backed VMs with
+// RUN.vmci=true), building it only if it is not already present in the
+// cache directory.
+//
+// The function is idempotent and thread-safe (sync.Once per process).  It is
+// called automatically inside simVM.start() when RUN.vmci=true.
+//
+// A build failure here is non-fatal to the caller: it is logged and the
+// returned path is empty, so /usr/bin/vmware-rpctool auto-injection is
+// skipped, but the container still starts. Callers that need to guarantee
+// the binary is present should check VmciToolboxBinaryPath() for emptiness.
+func buildToolboxArtifact() (toolboxBinPath string, err error) {
+	vmciArtifactsOnce.Do(func() {
+		dir, mkErr := artifactsBinDir()
+		if mkErr != nil {
+			vmciArtifactsErr = mkErr
+			return
+		}
+
+		toolboxBin := filepath.Join(dir, "toolbox")
+		if _, statErr := os.Stat(toolboxBin); os.IsNotExist(statErr) {
+			toolboxBuild := exec.Command(
+				"go", "build",
+				"-o", toolboxBin,
+				"github.com/vmware/govmomi/toolbox/toolbox",
+			)
+			toolboxBuild.Env = append(os.Environ(),
+				"CGO_ENABLED=0",
+				"GOOS=linux",
+				"GOARCH=amd64",
+			)
+			if out, buildErr := toolboxBuild.CombinedOutput(); buildErr != nil {
+				vmciArtifactsErr = fmt.Errorf("toolbox build: %w\n%s", buildErr, out)
+				return
+			}
+			log.Printf("vmci-artifacts: built toolbox at %s", toolboxBin)
+		} else {
+			log.Printf("vmci-artifacts: toolbox cached at %s", toolboxBin)
+		}
+		vmciArtifactsToolboxPath = toolboxBin
+	})
+	return vmciArtifactsToolboxPath, vmciArtifactsErr
+}
+
+// VmciToolboxBinaryPath returns the host path of the govmomi/toolbox static
+// binary built by buildToolboxArtifact.  It is auto-injected as
+// /usr/bin/vmware-rpctool in every container-backed VM with RUN.vmci=true.
+//
+// Callers that also want to replace /usr/bin/vmtoolsd (e.g. integration tests
+// whose init process needs to write guestinfo via the toolbox binary) can
+// obtain the path here and add a RUN.volume.<label> ExtraConfig entry:
+//
+//	"RUN.volume.vmtoolsd": simulator.VmciToolboxBinaryPath() + ":/usr/bin/vmtoolsd:ro"
+//
+// Returns "" if the build failed (RUN.vmci containers still work via the
+// auto-injected /usr/bin/vmware-rpctool, but /usr/bin/vmtoolsd callers will
+// fall back to whatever is in the container image).
+func VmciToolboxBinaryPath() string {
+	path, _ := buildToolboxArtifact()
+	return path
+}

--- a/simulator/vmci_artifacts_other.go
+++ b/simulator/vmci_artifacts_other.go
@@ -1,0 +1,20 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package simulator
+
+import "errors"
+
+// buildToolboxArtifact is a no-op stub on non-Linux platforms.
+// The toolbox binary build is only supported on Linux, where container-backed
+// VM simulation runs.
+func buildToolboxArtifact() (toolboxBinPath string, err error) {
+	return "", errors.New("vmci-artifacts: only available on linux")
+}
+
+// VmciToolboxBinaryPath returns "" on non-Linux platforms where VMCI simulation
+// is not supported.
+func VmciToolboxBinaryPath() string { return "" }

--- a/simulator/vsock_container_test.go
+++ b/simulator/vsock_container_test.go
@@ -1,0 +1,456 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package simulator
+
+// Container-backed integration tests for the govmomi/toolbox binary acting as
+// vmtoolsd/vmware-rpctool, exercising GuestRPC over the Component-A Unix
+// socket. A seccomp-based AF_VSOCK intercept ("Component B") was prototyped
+// separately and is not part of this change; it remains a candidate for
+// future re-enablement if a caller needs a real AF_VSOCK socket() call to
+// succeed inside the container rather than falling back to the Unix socket.
+//
+// Requires: Docker (or podman aliased as docker) on Linux.
+// Skip gate: test.HasDocker().
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/test"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// buildToolboxBinary builds the govmomi/toolbox binary as a static linux/amd64
+// binary.  It is the canonical vmtoolsd / vmware-rpctool replacement for
+// container-backed VMs in vcsim tests.
+// buildToolboxBinary returns the path to the cached govmomi/toolbox binary,
+// sharing the build with the simulator's own buildToolboxArtifact (sync.Once).
+// This avoids a second independent "go build" when RUN.vmci=true is set,
+// which would also trigger buildToolboxArtifact during PowerOn.
+func buildToolboxBinary(t *testing.T) string {
+	t.Helper()
+	path, err := buildToolboxArtifact()
+	if err != nil {
+		t.Skipf("toolbox artifact build failed: %v", err)
+	}
+	if path == "" {
+		t.Skip("toolbox binary unavailable (govmomi/toolbox build may have been skipped)")
+	}
+	return path
+}
+
+// dockerExec runs "docker exec containerID args..." and returns trimmed stdout.
+// Stderr from docker exec (including podman compatibility warnings) is isolated
+// and only included in the failure message, not in the return value.
+func dockerExec(t *testing.T, ctx context.Context, containerID string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, "docker",
+		append([]string{"exec", containerID}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		var stderr []byte
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = ee.Stderr
+		}
+		t.Fatalf("docker exec %v: %v\nstderr: %s", args, err, stderr)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// containerIDFor returns the Docker container ID for vmObj's running container.
+func containerIDFor(t *testing.T, simCtx *Context, vmObj *VirtualMachine) string {
+	t.Helper()
+	var id string
+	simCtx.WithLock(vmObj, func() {
+		if vmObj.svm != nil && vmObj.svm.c != nil {
+			id = vmObj.svm.c.id
+		}
+	})
+	require.NotEmpty(t, id, "container ID must be set after PowerOn")
+	return id
+}
+
+// readGuestInfoKey reads KEY directly from vmObj's ExtraConfig without going
+// through the PropertyCollector.  Must be called with no lock held.
+func readGuestInfoKey(simCtx *Context, vmObj *VirtualMachine, key string) string {
+	var val string
+	simCtx.WithLock(vmObj, func() {
+		for _, opt := range vmObj.Config.ExtraConfig {
+			ov := opt.GetOptionValue()
+			if ov.Key == key {
+				val = fmt.Sprintf("%v", ov.Value)
+				return
+			}
+		}
+	})
+	return val
+}
+
+// TestVMCI_ToolboxBinary_GuestInfoRoundTrip validates that the govmomi/toolbox
+// binary, when volume-overlaid as /usr/bin/vmtoolsd and /usr/bin/vmware-rpctool
+// in a container-backed VM, correctly reads and writes guestinfo through the
+// vcsim GuestRPC Unix socket server.
+//
+// Subtests:
+//  1. vmtoolsd-info-set: info-set KEY VAL → value visible in ExtraConfig.
+//  2. vmtoolsd-info-get: info-get KEY → bare value printed to stdout, exit 0.
+//  3. vmware-rpctool-info-get: raw "1 VALUE" response, exit 0 (cloud-init contract).
+//  4. vmtoolsd-info-get-missing: missing key → exit 1, no stdout (cloud-init contract).
+//  5. stop: PowerOff completes cleanly.
+func TestVMCI_ToolboxBinary_GuestInfoRoundTrip(t *testing.T) {
+	if !test.HasDocker() {
+		t.Skip("requires docker or podman (aliased as docker) on linux")
+	}
+
+	// ── Build the toolbox binary ──────────────────────────────────────────
+	toolboxBin := buildToolboxBinary(t)
+
+	// ── Stand up vcsim ────────────────────────────────────────────────────
+	env := newVCSIMEnv(t)
+
+	// ── Create container-backed VM ────────────────────────────────────────
+	// Overlay the toolbox binary as /usr/bin/vmtoolsd (explicit RUN.volume).
+	// /usr/bin/vmware-rpctool is auto-injected by buildToolboxArtifact (RUN.vmci=true).
+	// Both dispatch on filepath.Base(os.Args[0]).
+	const key = "guestinfo.toolbox-roundtrip"
+	const val = "hello-from-toolbox"
+
+	spec := types.VirtualMachineConfigSpec{
+		Name:  "toolbox-roundtrip-test",
+		Files: &types.VirtualMachineFileInfo{VmPathName: "[LocalDS_0] toolbox-roundtrip-test"},
+		ExtraConfig: []types.BaseOptionValue{
+			&types.OptionValue{
+				Key:   ContainerBackingOptionKey,
+				Value: `["alpine","sh","-c","trap exit SIGTERM; sleep infinity & wait"]`,
+			},
+			&types.OptionValue{Key: "RUN.vmci", Value: "true"},
+			// Inject the toolbox binary as /usr/bin/vmtoolsd so vmtoolsd --cmd
+			// dispatches on filepath.Base(os.Args[0]) = "vmtoolsd".
+			// /usr/bin/vmware-rpctool is auto-injected by buildToolboxArtifact when
+			// RUN.vmci=true; no explicit RUN.volume entry needed for it.
+			&types.OptionValue{
+				Key:   "RUN.volume.vmtoolsd",
+				Value: toolboxBin + ":/usr/bin/vmtoolsd:ro",
+			},
+		},
+	}
+	require.NoError(t, test.ApplyContainerRuntimeDefaults(&spec))
+
+	task, err := env.folder.VmFolder.CreateVM(env.goCtx, spec, env.pool, nil)
+	require.NoError(t, err)
+	info, err := task.WaitForResult(env.goCtx, nil)
+	require.NoError(t, err)
+
+	vmRef := info.Result.(types.ManagedObjectReference)
+	vm := object.NewVirtualMachine(env.client.Client, vmRef)
+
+	powerTask, err := vm.PowerOn(env.goCtx)
+	require.NoError(t, err)
+	require.NoError(t, powerTask.Wait(env.goCtx))
+
+	vmObj := env.simCtx.Map.Get(vmRef).(*VirtualMachine)
+	containerID := containerIDFor(t, env.simCtx, vmObj)
+
+	// ── TEST 1: vmtoolsd --cmd info-set ───────────────────────────────────
+	t.Run("vmtoolsd-info-set", func(t *testing.T) {
+		// info-set exits 0 and produces no stdout on success.
+		dockerExec(t, env.goCtx, containerID,
+			"vmtoolsd", "--cmd", "info-set "+key+" "+val)
+
+		got := readGuestInfoKey(env.simCtx, vmObj, key)
+		require.Equal(t, val, got,
+			"ExtraConfig key %q must be set after vmtoolsd --cmd info-set", key)
+	})
+
+	// ── TEST 2: vmtoolsd --cmd info-get ───────────────────────────────────
+	t.Run("vmtoolsd-info-get", func(t *testing.T) {
+		// info-get exits 0 and prints the bare value (no "1 " prefix).
+		out := dockerExec(t, env.goCtx, containerID,
+			"vmtoolsd", "--cmd", "info-get "+key)
+		require.Equal(t, val, out,
+			"vmtoolsd --cmd info-get must print bare value")
+	})
+
+	// ── TEST 3: vmware-rpctool info-get ───────────────────────────────────
+	t.Run("vmware-rpctool-info-get", func(t *testing.T) {
+		// vmware-rpctool prints the raw "1 VALUE" or "0 ..." response and
+		// always exits 0 on a successful channel round-trip.  cloud-init
+		// parses the "1 " prefix itself.
+		out := dockerExec(t, env.goCtx, containerID,
+			"vmware-rpctool", "info-get "+key)
+		require.Equal(t, "1 "+val, out,
+			"vmware-rpctool info-get must print raw '1 VALUE' response")
+	})
+
+	// ── TEST 4: vmtoolsd info-get missing key → exit 1 ───────────────────
+	// Verifies the exit-code contract that cloud-init DataSourceVMware depends on:
+	// exit 0 = key found, exit 1 = key missing or channel error.
+	t.Run("vmtoolsd-info-get-missing", func(t *testing.T) {
+		cmd := exec.CommandContext(env.goCtx, "docker",
+			"exec", containerID,
+			"vmtoolsd", "--cmd", "info-get guestinfo.nonexistent.key")
+		out, err := cmd.Output()
+
+		var exitErr *exec.ExitError
+		require.ErrorAs(t, err, &exitErr,
+			"vmtoolsd info-get for a missing key must exit non-zero")
+		require.Equal(t, 1, exitErr.ExitCode(),
+			"vmtoolsd info-get for a missing key must exit 1")
+		require.Empty(t, strings.TrimSpace(string(out)),
+			"vmtoolsd info-get for a missing key must produce no stdout")
+	})
+
+	// ── TEST 5: Stop path ─────────────────────────────────────────────────
+	t.Run("stop", func(t *testing.T) {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		offTask, err := vm.PowerOff(stopCtx)
+		require.NoError(t, err)
+		require.NoError(t, offTask.Wait(stopCtx),
+			"PowerOff must complete within 60 s")
+
+		t.Logf("PowerOff completed")
+	})
+}
+
+// TestVMCI_SystemdInit_GuestInfoRoundTrip validates that a systemd-managed
+// one-shot service can write a guestinfo key via the govmomi toolbox binary
+// when systemd is the container's PID 1.
+//
+// # Design rationale
+//
+// The fix in toolbox/toolbox/main.go (openRPCChannel) makes vmware-rpctool
+// prefer $VMX_RPC_SOCK (Component A — the GuestRPC Unix socket bind-mounted by
+// vcsim) over AF_VSOCK. Component A is accessible for the full container
+// lifetime; it is not affected by the crun→systemd exec transition.
+//
+// The test uses the dedicated image simulator/testdata/vmci-systemd-init, which
+// is a minimal debian+systemd container with the vmci-test-writer.service unit
+// baked in (via 'systemctl enable' in the Dockerfile). Baking the service into
+// the image avoids the Docker/Podman bind-mount pitfall where mounting a host
+// file to a non-existent container path creates a directory, not a file.
+//
+// This test does NOT use RUN.nestedContainers=true because --tmpfs /run
+// (added by that flag) hides the /run/vmware/rpc.sock bind mount. The
+// dedicated image has no nested container runtime so --tmpfs /run is not
+// needed. RUN.privileged=true provides --privileged for systemd without the
+// tmpfs mounts.
+//
+// # Test layout
+//
+//   - Image: docker.io/library/vmci-systemd-init:latest (minimal debian+systemd).
+//     Build with: docker build -t docker.io/library/vmci-systemd-init:latest
+//     ./simulator/testdata/vmci-systemd-init/
+//   - RUN.vmci=true: Component A (GuestRPC Unix socket at $VMX_RPC_SOCK) +
+//     toolbox binary injection.
+//   - RUN.privileged=true: --privileged for systemd, WITHOUT --tmpfs /run.
+//   - vmci-test-writer.service is baked into the image. It runs after
+//     basic.target and calls vmware-rpctool to set guestinfo.vmci-systemd-test.
+//   - Test polls ExtraConfig for guestinfo.vmci-systemd-test within 90 s.
+//
+// # Expected result: PASS.
+// If this test fails, check:
+//  1. VMX_RPC_SOCK is set in the container env and propagated via PassEnvironment=.
+//  2. /run/vmware/rpc.sock is accessible (not hidden by --tmpfs /run).
+//  3. openRPCChannel() in toolbox/toolbox/main.go checks VMX_RPC_SOCK first.
+func TestVMCI_SystemdInit_GuestInfoRoundTrip(t *testing.T) {
+	if !test.HasDocker() {
+		t.Skip("requires docker or podman (aliased as docker) on linux")
+	}
+
+	const image = "docker.io/library/vmci-systemd-init:latest"
+	if err := exec.Command("docker", "image", "inspect", image).Run(); err != nil {
+		t.Skipf("image %s not available locally; "+
+			"build with: docker build -t %s ./simulator/testdata/vmci-systemd-init/",
+			image, image)
+	}
+
+	// ── Build the toolbox binary ──────────────────────────────────────────
+	// RUN.vmci=true auto-injects the toolbox binary as /usr/bin/vmware-rpctool.
+	// buildToolboxBinary ensures the binary is compiled and cached before the
+	// container starts, so the injection bind-mount is available at PowerOn.
+	buildToolboxBinary(t)
+
+	// ── Stand up vcsim ────────────────────────────────────────────────────
+	env := newVCSIMEnv(t)
+
+	// ── Create container-backed VM ────────────────────────────────────────
+	const guestInfoKey = "guestinfo.vmci-systemd-test"
+
+	spec := types.VirtualMachineConfigSpec{
+		Name:  "systemd-init-test",
+		Files: &types.VirtualMachineFileInfo{VmPathName: "[LocalDS_0] systemd-init-test"},
+		ExtraConfig: []types.BaseOptionValue{
+			// vmci-systemd-init uses CMD ["/sbin/init"], which boots systemd as PID 1.
+			&types.OptionValue{Key: ContainerBackingOptionKey, Value: `["` + image + `"]`},
+			// RUN.vmci activates:
+			//   - Component A: GuestRPC Unix socket (VMX_RPC_SOCK=/run/vmware/rpc.sock)
+			//   - toolbox binary auto-injected as /usr/bin/vmware-rpctool
+			&types.OptionValue{Key: "RUN.vmci", Value: "true"},
+			// RUN.privileged: adds --privileged so systemd can mount cgroups.
+			// Does NOT add --tmpfs /run, keeping /run/vmware/rpc.sock accessible.
+			&types.OptionValue{Key: "RUN.privileged", Value: "true"},
+		},
+	}
+	require.NoError(t, test.ApplyContainerRuntimeDefaults(&spec))
+
+	task, err := env.folder.VmFolder.CreateVM(env.goCtx, spec, env.pool, nil)
+	require.NoError(t, err)
+	info, err := task.WaitForResult(env.goCtx, nil)
+	require.NoError(t, err)
+
+	vmRef := info.Result.(types.ManagedObjectReference)
+	vm := object.NewVirtualMachine(env.client.Client, vmRef)
+
+	powerTask, err := vm.PowerOn(env.goCtx)
+	require.NoError(t, err)
+	require.NoError(t, powerTask.Wait(env.goCtx))
+
+	vmObj := env.simCtx.Map.Get(vmRef).(*VirtualMachine)
+	containerID := containerIDFor(t, env.simCtx, vmObj)
+
+	// ── Poll for guestinfo write ───────────────────────────────────────────
+	// The service runs after network.target; systemd boot in a container
+	// typically takes 10–30 s. Poll every 2 s with a 90 s ceiling.
+	t.Logf("container %s: polling for %q (up to 90 s)…", containerID, guestInfoKey)
+	const pollInterval = 2 * time.Second
+	const pollTimeout = 90 * time.Second
+	deadline := time.Now().Add(pollTimeout)
+
+	var got string
+	for time.Now().Before(deadline) {
+		got = readGuestInfoKey(env.simCtx, vmObj, guestInfoKey)
+		if got != "" {
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+
+	t.Logf("guestinfo value after polling: %q", got)
+	require.Equal(t, "pass", got,
+		"vmci-test-writer.service did not write guestinfo via vmware-rpctool within %s", pollTimeout)
+
+	// ── Stop path ─────────────────────────────────────────────────────────
+	stopCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	offTask, err := vm.PowerOff(stopCtx)
+	require.NoError(t, err)
+	require.NoError(t, offTask.Wait(stopCtx),
+		"PowerOff must complete within 60 s")
+}
+
+// TestVMCI_NestedContainers_GuestInfoRoundTrip is the nestedContainers=true variant
+// of TestVMCI_SystemdInit_GuestInfoRoundTrip. It exercises the full production
+// configuration: systemd PID 1 + RUN.vmci=true + RUN.nestedContainers=true.
+//
+// # Why this test exists
+//
+// The "privileged, no tmpfs" variant (TestVMCI_SystemdInit_GuestInfoRoundTrip)
+// confirms the basic GuestRPC path. This test adds:
+//   - --tmpfs /run (from nestedContainers), which hides /run/vmware/rpc.sock
+//     unless the bind-mount is a directory mount (see guestRPCVolumeMount fix).
+//   - --cgroupns=private and --privileged (needed for containerd/kubelet inside).
+//
+// Its purpose is to characterise exactly where the nestedContainers combination
+// fails or passes. It is expected to PASS once the directory bind-mount fix in
+// guestrpc_server.go (guestRPCVolumeMount) is in place. If it still fails,
+// the failure log will identify the next gap.
+//
+// # Known failure modes before the directory-mount fix
+//
+//   - guestinfo.vmci-systemd-test never set: vmware-rpctool cannot connect to the
+//     GuestRPC socket because /run/vmware/rpc.sock is hidden by --tmpfs /run.
+//     Fixed by bind-mounting the directory /run/vmware/ instead of the file.
+//
+// # Build prerequisite
+//
+// Build the test image first if not already present:
+//
+//	docker build -t docker.io/library/vmci-systemd-init:latest \
+//	  ./simulator/testdata/vmci-systemd-init/
+func TestVMCI_NestedContainers_GuestInfoRoundTrip(t *testing.T) {
+	if !test.HasDocker() {
+		t.Skip("requires docker or podman (aliased as docker) on linux")
+	}
+
+	const image = "docker.io/library/vmci-systemd-init:latest"
+	if err := exec.Command("docker", "image", "inspect", image).Run(); err != nil {
+		t.Skipf("image %s not available locally; "+
+			"build with: docker build -t %s ./simulator/testdata/vmci-systemd-init/",
+			image, image)
+	}
+
+	buildToolboxBinary(t)
+
+	env := newVCSIMEnv(t)
+
+	const guestInfoKey = "guestinfo.vmci-systemd-test"
+
+	spec := types.VirtualMachineConfigSpec{
+		Name:  "nested-containers-test",
+		Files: &types.VirtualMachineFileInfo{VmPathName: "[LocalDS_0] nested-containers-test"},
+		ExtraConfig: []types.BaseOptionValue{
+			&types.OptionValue{Key: ContainerBackingOptionKey, Value: `["` + image + `"]`},
+			&types.OptionValue{Key: "RUN.vmci", Value: "true"},
+			// Use nestedContainers=true (not RUN.privileged). This adds --tmpfs /run,
+			// which is the scenario we need to validate. The directory bind-mount fix
+			// in guestRPCVolumeMount should keep /run/vmware/rpc.sock accessible.
+			&types.OptionValue{Key: "RUN.nestedContainers", Value: "true"},
+		},
+	}
+	require.NoError(t, test.ApplyContainerRuntimeDefaults(&spec))
+
+	task, err := env.folder.VmFolder.CreateVM(env.goCtx, spec, env.pool, nil)
+	require.NoError(t, err)
+	info, err := task.WaitForResult(env.goCtx, nil)
+	require.NoError(t, err)
+
+	vmRef := info.Result.(types.ManagedObjectReference)
+	vm := object.NewVirtualMachine(env.client.Client, vmRef)
+
+	powerTask, err := vm.PowerOn(env.goCtx)
+	require.NoError(t, err)
+	require.NoError(t, powerTask.Wait(env.goCtx))
+
+	vmObj := env.simCtx.Map.Get(vmRef).(*VirtualMachine)
+	containerID := containerIDFor(t, env.simCtx, vmObj)
+
+	t.Logf("container %s: polling for %q (up to 120 s)…", containerID, guestInfoKey)
+	const pollInterval = 2 * time.Second
+	const pollTimeout = 120 * time.Second
+	deadline := time.Now().Add(pollTimeout)
+
+	var got string
+	for time.Now().Before(deadline) {
+		got = readGuestInfoKey(env.simCtx, vmObj, guestInfoKey)
+		if got != "" {
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+
+	t.Logf("guestinfo value after polling: %q", got)
+	require.Equal(t, "pass", got,
+		"vmci-test-writer.service did not write guestinfo within %s "+
+			"(RUN.nestedContainers=true + --tmpfs /run)", pollTimeout)
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	offTask, err := vm.PowerOff(stopCtx)
+	require.NoError(t, err)
+	require.NoError(t, offTask.Wait(stopCtx))
+}

--- a/toolbox/datamap.go
+++ b/toolbox/datamap.go
@@ -1,0 +1,144 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package toolbox
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// DataMap field types (from open-vm-tools lib/dataMap/dataMap.h).
+const (
+	DMFieldTypeInt64  = 1
+	DMFieldTypeString = 2
+)
+
+// GuestRPC DataMap field IDs (from open-vm-tools lib/guestRpc/tclodefs.h).
+const (
+	GuestRPCFieldType      = 1
+	GuestRPCFieldPayload   = 2
+	GuestRPCFieldFastClose = 3
+
+	GuestRPCTypeData = 1
+)
+
+// ReadDataMapPacket reads one DataMap-framed packet from r and returns the
+// GUESTRPCPKT_FIELD_PAYLOAD bytes and whether GUESTRPCPKT_FIELD_FAST_CLOSE was set.
+//
+// Wire format (all integers big-endian):
+//
+//	[4B: entries_length]
+//	[entries: repeated { fieldType(4B) fieldID(4B) value... }]
+//
+//	int64 value:  low32(4B) high32(4B)
+//	string value: strLen(4B) bytes(strLen)
+func ReadDataMapPacket(r io.Reader) (payload []byte, fastClose bool, err error) {
+	var hdr [4]byte
+	if _, err = io.ReadFull(r, hdr[:]); err != nil {
+		return
+	}
+	entriesLen := binary.BigEndian.Uint32(hdr[:])
+	if entriesLen == 0 {
+		return nil, false, nil
+	}
+
+	entries := make([]byte, entriesLen)
+	if _, err = io.ReadFull(r, entries); err != nil {
+		return
+	}
+
+	buf := entries
+	for len(buf) >= 8 {
+		fieldType := binary.BigEndian.Uint32(buf[:4])
+		fieldID := binary.BigEndian.Uint32(buf[4:8])
+		buf = buf[8:]
+
+		switch fieldType {
+		case DMFieldTypeInt64:
+			if len(buf) < 8 {
+				err = fmt.Errorf("DataMap: truncated int64 field %d", fieldID)
+				return
+			}
+			low := binary.BigEndian.Uint32(buf[:4])
+			// high32 (buf[4:8]) is intentionally ignored: all DataMap int64
+			// fields we care about (FIELD_TYPE, FIELD_FAST_CLOSE) fit in uint32.
+			buf = buf[8:]
+			if fieldID == GuestRPCFieldFastClose && low != 0 {
+				fastClose = true
+			}
+
+		case DMFieldTypeString:
+			if len(buf) < 4 {
+				err = fmt.Errorf("DataMap: truncated string length for field %d", fieldID)
+				return
+			}
+			strLen := binary.BigEndian.Uint32(buf[:4])
+			buf = buf[4:]
+			if uint32(len(buf)) < strLen {
+				err = fmt.Errorf("DataMap: truncated string body field %d (want %d have %d)",
+					fieldID, strLen, len(buf))
+				return
+			}
+			if fieldID == GuestRPCFieldPayload {
+				payload = buf[:strLen]
+			}
+			buf = buf[strLen:]
+
+		default:
+			// Unknown field type — stop parsing to avoid spinning on malformed input.
+			return
+		}
+	}
+	return
+}
+
+// WriteDataMapPacket encodes payload as a DataMap packet and writes it to w.
+// When fastClose is true, GUESTRPCPKT_FIELD_FAST_CLOSE=1 is appended (used by
+// one-shot RPCI callers like vmtoolsd --cmd; set false for server responses).
+func WriteDataMapPacket(w io.Writer, payload []byte, fastClose bool) error {
+	// Entry layout sizes:
+	//   FIELD_TYPE  (int64): type(4) + fieldID(4) + low32(4) + high32(4) = 16 bytes
+	//   FIELD_PAYLOAD (str): type(4) + fieldID(4) + strlen(4) + bytes     = 12 + len(payload)
+	//   FIELD_FAST_CLOSE (int64, optional): 16 bytes
+	entriesLen := 16 + 12 + len(payload)
+	if fastClose {
+		entriesLen += 16
+	}
+
+	buf := make([]byte, 4+entriesLen)
+	off := 0
+	put32 := func(v uint32) {
+		binary.BigEndian.PutUint32(buf[off:], v)
+		off += 4
+	}
+
+	put32(uint32(entriesLen)) // header: length of entries section
+
+	// FIELD_TYPE = TYPE_DATA
+	put32(DMFieldTypeInt64)
+	put32(GuestRPCFieldType)
+	put32(GuestRPCTypeData) // low32
+	put32(0)                // high32
+
+	// FIELD_PAYLOAD = payload string
+	put32(DMFieldTypeString)
+	put32(GuestRPCFieldPayload)
+	put32(uint32(len(payload)))
+	// String body is variable-length so it can't use put32; copy + advance manually.
+	copy(buf[off:], payload)
+	off += len(payload)
+
+	if fastClose {
+		// FIELD_FAST_CLOSE = 1
+		put32(DMFieldTypeInt64)
+		put32(GuestRPCFieldFastClose)
+		put32(1) // low32 = 1
+		put32(0) // high32
+	}
+
+	_, err := w.Write(buf)
+	return err
+}

--- a/toolbox/datamap.go
+++ b/toolbox/datamap.go
@@ -16,6 +16,15 @@ const (
 	DMFieldTypeString = 2
 )
 
+// MaxDataMapEntries bounds the entries section ReadDataMapPacket will accept.
+//
+// The length prefix is supplied by the peer. govmomi/simulator bind-mounts the
+// GuestRPC socket directory read-write into a container that may run an
+// arbitrary image, so without a bound four bytes from the guest would size an
+// allocation in the host process (up to 4 GiB). RPCI commands and their
+// responses are small; 1 MiB is well above any legitimate packet.
+const MaxDataMapEntries = 1 << 20
+
 // GuestRPC DataMap field IDs (from open-vm-tools lib/guestRpc/tclodefs.h).
 const (
 	GuestRPCFieldType      = 1
@@ -43,6 +52,10 @@ func ReadDataMapPacket(r io.Reader) (payload []byte, fastClose bool, err error) 
 	entriesLen := binary.BigEndian.Uint32(hdr[:])
 	if entriesLen == 0 {
 		return nil, false, nil
+	}
+	if entriesLen > MaxDataMapEntries {
+		return nil, false, fmt.Errorf(
+			"DataMap packet too large: %d bytes (max %d)", entriesLen, MaxDataMapEntries)
 	}
 
 	entries := make([]byte, entriesLen)

--- a/toolbox/noop_channel.go
+++ b/toolbox/noop_channel.go
@@ -1,0 +1,24 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package toolbox
+
+// noopChannel implements Channel with no-op operations.
+// It is used as the TCLO "in" channel when host-to-guest delivery of TCLO
+// commands is not implemented. The Service's event loop calls in.Send(nil) and
+// in.Receive() on each tick; the no-op implementation causes the service to
+// back off to maxDelay (100 ms) and keep running without doing any work,
+// keeping vmtoolsd alive for systemd while awaiting guest-initiated RPCI calls.
+type noopChannel struct{}
+
+// NewNoopChannelIn returns a Channel whose Send/Receive are permanent no-ops.
+// Use this as the rpcIn argument to NewService when the host will not send
+// TCLO commands (e.g., govmomi/simulator container-backed VMs where
+// host-to-guest DialVM is not yet implemented).
+func NewNoopChannelIn() Channel { return &noopChannel{} }
+
+func (c *noopChannel) Start() error             { return nil }
+func (c *noopChannel) Stop() error              { return nil }
+func (c *noopChannel) Send(_ []byte) error      { return nil }
+func (c *noopChannel) Receive() ([]byte, error) { return nil, nil }

--- a/toolbox/toolbox/main.go
+++ b/toolbox/toolbox/main.go
@@ -121,15 +121,96 @@ func main() {
 }
 
 // selectChannels returns (in, out) channels for daemon mode.
-// VMX_RPC_SOCK is NOT used here: the Unix socket server closes after each
-// request, so a persistent daemon channel would break on the second exchange.
-// Daemon mode relies on AF_VSOCK (which the seccomp intercept keeps alive
-// during initial crun setup) or the x86 backdoor.
+//
+// It selects from rpcTransports, the same ordered list the one-shot modes use,
+// so daemon mode cannot drift apart from them. A transport is chosen by
+// connecting to it and then discarding the probe: Service.Start opens the
+// channel it is handed, so returning an already-started channel would dial
+// twice and leak the first connection.
+//
+// The Unix socket is a valid daemon transport. govmomi/simulator's GuestRPC
+// server serves a connection until read error and does not close after each
+// request, so a persistent daemon channel over it survives repeated exchanges.
 func selectChannels() (toolbox.Channel, toolbox.Channel) {
-	if toolbox.IsVsockAvailable() {
-		return toolbox.NewNoopChannelIn(), toolbox.NewVsockChannelOut()
+	all := rpcTransports()
+
+	for _, t := range all {
+		probe := t.out()
+		if err := probe.Start(); err != nil {
+			continue
+		}
+		_ = probe.Stop()
+		return t.in(), t.out()
 	}
-	return toolbox.NewBackdoorChannelIn(), toolbox.NewBackdoorChannelOut()
+
+	// Nothing answered. Hand back the last transport so Service.Start reports a
+	// real channel error rather than this function failing silently.
+	last := all[len(all)-1]
+	return last.in(), last.out()
+}
+
+// rpcTransport is one GuestRPC transport candidate.
+//
+// out and in are constructors rather than channel instances so that a caller
+// may probe a transport, discard the probe, and still hand an unopened channel
+// to a consumer that opens its own.
+type rpcTransport struct {
+	name string
+	out  func() toolbox.Channel
+	in   func() toolbox.Channel
+}
+
+// rpcTransports returns the GuestRPC transports in preference order.
+//
+// Every invocation mode selects from this one list, which is what keeps the
+// modes consistent; the ordering exists in exactly one place.
+//
+// Selection is by SUCCESSFUL CONNECTION, never by capability probe.
+// IsVsockAvailable reports only that the kernel will create an AF_VSOCK
+// socket, which succeeds on any host with the vsock family compiled in
+// regardless of whether a peer is listening, so choosing a transport on that
+// signal alone selects an endpoint that nothing answers on.
+//
+// Order:
+//  1. $VMX_RPC_SOCK unix socket — set by govmomi/simulator on container-backed
+//     VMs. Accessible for the full container lifetime, and unaffected by the
+//     crun-to-systemd exec transition.
+//  2. Well-known unix path — the same socket reached by path when
+//     VMX_RPC_SOCK is absent from the environment, which is the case for
+//     systemd service units (systemd does not propagate PID 1's environment).
+//  3. AF_VSOCK with DataMap framing — real VMs with the vmci module loaded.
+//  4. x86 backdoor — VMware Workstation/Fusion fallback.
+func rpcTransports() []rpcTransport {
+	noopIn := func() toolbox.Channel { return toolbox.NewNoopChannelIn() }
+
+	var transports []rpcTransport
+	seen := map[string]bool{}
+
+	for _, sockPath := range []string{os.Getenv("VMX_RPC_SOCK"), wellKnownGuestRPCSock} {
+		if sockPath == "" || seen[sockPath] {
+			continue
+		}
+		seen[sockPath] = true
+
+		transports = append(transports, rpcTransport{
+			name: "unix:" + sockPath,
+			out:  func() toolbox.Channel { return toolbox.NewUnixChannelOut(sockPath) },
+			in:   noopIn,
+		})
+	}
+
+	return append(transports,
+		rpcTransport{
+			name: "vsock",
+			out:  func() toolbox.Channel { return toolbox.NewVsockChannelOut() },
+			in:   noopIn,
+		},
+		rpcTransport{
+			name: "backdoor",
+			out:  func() toolbox.Channel { return toolbox.NewBackdoorChannelOut() },
+			in:   func() toolbox.Channel { return toolbox.NewBackdoorChannelIn() },
+		},
+	)
 }
 
 // wellKnownGuestRPCSock is the path at which govmomi/simulator bind-mounts the
@@ -140,44 +221,23 @@ func selectChannels() (toolbox.Channel, toolbox.Channel) {
 // variables from PID 1's environment to child service units).
 const wellKnownGuestRPCSock = "/run/vmware/rpc.sock"
 
-// openRPCChannel returns the best available GuestRPC outbound channel.
+// openRPCChannel returns a started Channel on the first transport in
+// rpcTransports that accepts a connection.
 //
-// Selection order:
-//  1. VMX_RPC_SOCK unix socket — set by govmomi/simulator on container-backed VMs.
-//     The socket is accessible for the full container lifetime and is not affected
-//     by the crun→systemd exec transition that invalidates the AF_VSOCK seccomp fd.
-//  2. Well-known unix socket path (/run/vmware/rpc.sock) — same socket as (1)
-//     but accessed by path when VMX_RPC_SOCK is not present in the process
-//     environment (e.g. systemd service units invoked from the bootstrapper).
-//  3. AF_VSOCK (DataMap framing) — real ESX VMs or RUN.vmci=true during crun phase.
-//  4. x86 backdoor — VMware Workstation/Fusion fallback.
-//
-// Returns a non-nil error only if all four transports are unavailable.
+// Returns a non-nil error only when no transport could be reached.
 func openRPCChannel() (toolbox.Channel, error) {
-	// Unix socket: try VMX_RPC_SOCK env var first, then the well-known path.
-	// If both resolve to the same path (or if VMX_RPC_SOCK is unset), the
-	// extra attempt is two fast dial failures — acceptable cost for simplicity.
-	for _, sockPath := range []string{os.Getenv("VMX_RPC_SOCK"), wellKnownGuestRPCSock} {
-		if sockPath == "" {
-			continue
-		}
-		ch := toolbox.NewUnixChannelOut(sockPath)
+	var names []string
+
+	for _, t := range rpcTransports() {
+		ch := t.out()
 		if err := ch.Start(); err == nil {
 			return ch, nil
 		}
+		names = append(names, t.name)
 	}
-	if toolbox.IsVsockAvailable() {
-		ch := toolbox.NewVsockChannelOut()
-		if err := ch.Start(); err == nil {
-			return ch, nil
-		}
-	}
-	ch := toolbox.NewBackdoorChannelOut()
-	if err := ch.Start(); err != nil {
-		return nil, fmt.Errorf("GuestRPC channel unavailable: unix socket not found at %s or %s, AF_VSOCK not present, and backdoor failed: %w",
-			os.Getenv("VMX_RPC_SOCK"), wellKnownGuestRPCSock, err)
-	}
-	return ch, nil
+
+	return nil, fmt.Errorf("GuestRPC channel unavailable: none of %s could be reached",
+		strings.Join(names, ", "))
 }
 
 // rpcCmd sends a raw GuestRPC command and prints the raw server response

--- a/toolbox/toolbox/main.go
+++ b/toolbox/toolbox/main.go
@@ -2,25 +2,103 @@
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
+// toolbox is a GuestRPC agent binary built on the govmomi/toolbox library.
+//
+// It is intended to be embedded in guest processes (custom init processes,
+// container-backed VMs, test harnesses) that need VMware GuestRPC / guestinfo
+// functionality without linking to the full open-vm-tools stack.
+//
+// # Transport selection
+//
+// All modes (daemon, one-shot, rpctool) share the same selection logic:
+//
+//  1. VMX_RPC_SOCK Unix socket — preferred when $VMX_RPC_SOCK is set.
+//     govmomi/simulator sets this env var on container-backed VMs (RUN.vmci=true)
+//     and bind-mounts the socket into the container. The Unix socket persists for
+//     the full container lifetime, unlike the AF_VSOCK seccomp intercept which is
+//     tied to the initial crun process and cannot be re-established after systemd
+//     (or a nested container runtime) exec-replaces that process. Use this transport
+//     for any service that runs AFTER initial container boot (e.g. systemd services).
+//
+//  2. AF_VSOCK with DataMap framing.  Status:
+//     • works in real VMs with the vmci kernel module loaded.
+//     • govmomi/simulator container-backed VMs - support pending via seccomp intercept.
+//
+//  3. x86 backdoor channel (in eax,dx / port 0x5658) — fallback when neither
+//     VMX_RPC_SOCK nor AF_VSOCK is available. Real VMs only.
+//
+// Errors from channel open are always reported to stderr; the binary never
+// fails silently.
+//
+// # Invocation modes
+//
+// Daemon mode (no --cmd):
+//
+//	toolbox            — register capabilities + poll TCLO (vsock or backdoor)
+//
+// One-shot RPCI mode (vmtoolsd --cmd semantics):
+//
+//	toolbox --cmd "info-get guestinfo.KEY"
+//	toolbox --cmd "info-set guestinfo.KEY VALUE"
+//	toolbox --cmd "RPCI_COMMAND"
+//
+//	  • info-get: print bare value to stdout; exit 0 on found, exit 1 on missing.
+//	  • info-set: exit 0 on success, exit 1 on failure.
+//	  • capability / state RPCs: exit 0 immediately (no server round-trip needed).
+//	  • other RPCs: exit 0 on "1 ..." response, exit 1 on "0 ..." response.
+//
+// vmware-rpctool compatibility (invoked as "vmware-rpctool"):
+//
+//	vmware-rpctool 'RPCI_COMMAND'
+//
+//	Sends the raw command, prints the raw "1 VALUE" or "0 reason" response, and
+//	exits 0 on a successful channel round-trip (including "0 No value found").
+//	Exits 1 only on channel failure.  This matches the real vmware-rpctool
+//	contract that cloud-init DataSourceVMware relies on.
 package main
 
 import (
+	"bytes"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/vmware/govmomi/toolbox"
 )
 
-// This example can be run on a VM hosted by ESX, Fusion or Workstation
 func main() {
+	// vmware-rpctool compatibility: when invoked as "vmware-rpctool", treat
+	// the single positional argument as a raw GuestRPC command string.
+	if strings.Contains(filepath.Base(os.Args[0]), "vmware-rpctool") {
+		if len(os.Args) != 2 {
+			fmt.Fprintln(os.Stderr, "usage: vmware-rpctool 'COMMAND'")
+			os.Exit(2)
+		}
+		if err := rpcCmd(os.Args[1]); err != nil {
+			fmt.Fprintf(os.Stderr, "vmware-rpctool: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	cmdArg := flag.String("cmd", "", "send a one-shot RPCI command and exit (vmtoolsd --cmd semantics)")
 	flag.Parse()
 
-	in := toolbox.NewBackdoorChannelIn()
-	out := toolbox.NewBackdoorChannelOut()
+	if *cmdArg != "" {
+		if err := vmtoolsdCmd(*cmdArg); err != nil {
+			fmt.Fprintf(os.Stderr, "vmtoolsd: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
 
+	// Daemon mode: start the full toolbox service.
+	in, out := selectChannels()
 	service := toolbox.NewService(in, out)
 
 	if os.Getuid() == 0 {
@@ -28,19 +106,148 @@ func main() {
 		service.Power.Reboot.Handler = toolbox.Reboot
 	}
 
-	err := service.Start()
-	if err != nil {
+	if err := service.Start(); err != nil {
 		log.Fatal(err)
 	}
 
-	// handle the signals and gracefully shutdown the service
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-
 	go func() {
 		log.Printf("signal %s received", <-sig)
 		service.Stop()
 	}()
 
 	service.Wait()
+}
+
+// selectChannels returns (in, out) channels for daemon mode.
+// VMX_RPC_SOCK is NOT used here: the Unix socket server closes after each
+// request, so a persistent daemon channel would break on the second exchange.
+// Daemon mode relies on AF_VSOCK (which the seccomp intercept keeps alive
+// during initial crun setup) or the x86 backdoor.
+func selectChannels() (toolbox.Channel, toolbox.Channel) {
+	if toolbox.IsVsockAvailable() {
+		return toolbox.NewNoopChannelIn(), toolbox.NewVsockChannelOut()
+	}
+	return toolbox.NewBackdoorChannelIn(), toolbox.NewBackdoorChannelOut()
+}
+
+// wellKnownGuestRPCSock is the path at which govmomi/simulator bind-mounts the
+// per-VM GuestRPC unix socket when RUN.vmci=true.  It is tried as a fallback
+// when VMX_RPC_SOCK is not set — which happens when the toolbox binary is
+// invoked from a systemd service unit that does not inherit the container's
+// initial environment (systemd does not automatically propagate environment
+// variables from PID 1's environment to child service units).
+const wellKnownGuestRPCSock = "/run/vmware/rpc.sock"
+
+// openRPCChannel returns the best available GuestRPC outbound channel.
+//
+// Selection order:
+//  1. VMX_RPC_SOCK unix socket — set by govmomi/simulator on container-backed VMs.
+//     The socket is accessible for the full container lifetime and is not affected
+//     by the crun→systemd exec transition that invalidates the AF_VSOCK seccomp fd.
+//  2. Well-known unix socket path (/run/vmware/rpc.sock) — same socket as (1)
+//     but accessed by path when VMX_RPC_SOCK is not present in the process
+//     environment (e.g. systemd service units invoked from the bootstrapper).
+//  3. AF_VSOCK (DataMap framing) — real ESX VMs or RUN.vmci=true during crun phase.
+//  4. x86 backdoor — VMware Workstation/Fusion fallback.
+//
+// Returns a non-nil error only if all four transports are unavailable.
+func openRPCChannel() (toolbox.Channel, error) {
+	// Unix socket: try VMX_RPC_SOCK env var first, then the well-known path.
+	// If both resolve to the same path (or if VMX_RPC_SOCK is unset), the
+	// extra attempt is two fast dial failures — acceptable cost for simplicity.
+	for _, sockPath := range []string{os.Getenv("VMX_RPC_SOCK"), wellKnownGuestRPCSock} {
+		if sockPath == "" {
+			continue
+		}
+		ch := toolbox.NewUnixChannelOut(sockPath)
+		if err := ch.Start(); err == nil {
+			return ch, nil
+		}
+	}
+	if toolbox.IsVsockAvailable() {
+		ch := toolbox.NewVsockChannelOut()
+		if err := ch.Start(); err == nil {
+			return ch, nil
+		}
+	}
+	ch := toolbox.NewBackdoorChannelOut()
+	if err := ch.Start(); err != nil {
+		return nil, fmt.Errorf("GuestRPC channel unavailable: unix socket not found at %s or %s, AF_VSOCK not present, and backdoor failed: %w",
+			os.Getenv("VMX_RPC_SOCK"), wellKnownGuestRPCSock, err)
+	}
+	return ch, nil
+}
+
+// rpcCmd sends a raw GuestRPC command and prints the raw server response
+// ("1 VALUE" or "0 reason") to stdout, then exits.
+//
+// Exit semantics match the real vmware-rpctool binary:
+//   - Exit 0 + print response on a successful channel round-trip.
+//   - Exit 1 + message on stderr on channel failure (connect error, I/O error).
+//
+// cloud-init DataSourceVMware calls vmware-rpctool and checks:
+//   - "1 " prefix → VMware environment, datasource active.
+//   - "0 " prefix or exit 1 → not VMware / key missing, datasource deactivates.
+func rpcCmd(command string) error {
+	ch, err := openRPCChannel()
+	if err != nil {
+		return err
+	}
+	defer ch.Stop()
+
+	if err := ch.Send([]byte(command)); err != nil {
+		return err
+	}
+	reply, err := ch.Receive()
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(reply))
+	return nil
+}
+
+// vmtoolsdCmd dispatches a vmtoolsd --cmd "COMMAND" argument.
+//
+// Exit semantics match the real vmtoolsd binary:
+//   - info-get KEY: print bare value, exit 0 (found) or exit 1 (missing/error).
+//   - info-set KEY VAL: exit 0 on success, exit 1 on failure.
+//   - tools.* / Capabilities_Register / Set_Option: acknowledge, exit 0.
+//   - other RPCs: exit 0 on "1 ..." response, exit 1 on "0 ..." response.
+//   - channel failure: exit 1 + message on stderr.
+func vmtoolsdCmd(command string) error {
+	command = strings.TrimSpace(command)
+
+	// Capability and state RPCs are acknowledged without a server round-trip.
+	// The real vmtoolsd also short-circuits these in some configurations.
+	if strings.HasPrefix(command, "tools.") ||
+		strings.HasPrefix(command, "Capabilities_Register") ||
+		strings.HasPrefix(command, "Set_Option ") {
+		return nil
+	}
+
+	ch, err := openRPCChannel()
+	if err != nil {
+		return err
+	}
+	defer ch.Stop()
+	rpci := &toolbox.ChannelOut{Channel: ch}
+
+	if strings.HasPrefix(command, "info-get ") {
+		// info-get: exit 0 + print bare value on success; exit 1 on missing.
+		// ChannelOut.Request strips the "1 " prefix on success and returns
+		// an error (wrapping the "0 ..." response) on failure.
+		val, err := rpci.Request([]byte(command))
+		if err != nil {
+			return err
+		}
+		// Strip the trailing null byte that some callers append.
+		fmt.Println(string(bytes.TrimRight(val, "\x00")))
+		return nil
+	}
+
+	// info-set and everything else: success = "1 ...", failure = "0 ...".
+	_, err = rpci.Request([]byte(command))
+	return err
 }

--- a/toolbox/unix_channel.go
+++ b/toolbox/unix_channel.go
@@ -85,7 +85,17 @@ func WriteUnixFrame(w io.Writer, buf []byte) error {
 	return err
 }
 
+// MaxUnixFrameSize bounds the payload length ReadUnixFrame will accept.
+//
+// The length prefix is supplied by the peer. On a container-backed VM the
+// socket directory is bind-mounted read-write into a container that may run an
+// arbitrary image, so without a bound four bytes from the guest would size an
+// allocation in the host process (up to 4 GiB). RPCI commands and their
+// responses are small; 1 MiB is well above any legitimate frame.
+const MaxUnixFrameSize = 1 << 20
+
 // ReadUnixFrame reads a 4-byte LE length prefix and then that many bytes.
+// Frames declaring more than MaxUnixFrameSize are rejected before allocating.
 // Exported so that govmomi/simulator can share the same framing.
 func ReadUnixFrame(r io.Reader) ([]byte, error) {
 	var hdr [4]byte
@@ -95,6 +105,9 @@ func ReadUnixFrame(r io.Reader) ([]byte, error) {
 	n := binary.LittleEndian.Uint32(hdr[:])
 	if n == 0 {
 		return nil, nil
+	}
+	if n > MaxUnixFrameSize {
+		return nil, fmt.Errorf("unix frame too large: %d bytes (max %d)", n, MaxUnixFrameSize)
 	}
 	buf := make([]byte, n)
 	_, err := io.ReadFull(r, buf)

--- a/toolbox/unix_channel.go
+++ b/toolbox/unix_channel.go
@@ -5,20 +5,23 @@
 package toolbox
 
 import (
-	"encoding/binary"
 	"fmt"
-	"io"
 	"net"
 )
 
 // UnixChannel implements the Channel interface over a Unix stream socket.
 //
-// Wire format: each message is framed as a 4-byte little-endian uint32 length
-// prefix followed by that many payload bytes. The same framing is used in both
-// directions (Send and Receive). Zero-length messages are valid (empty payload).
+// Wire format: DataMap packets — the same framing real vmtoolsd uses over
+// AF_VSOCK, and the same framing VsockChannel speaks. One framing across every
+// GuestRPC transport means the server never has to guess which it is reading,
+// and it keeps the simulator exercising the parse path a real guest exercises.
 //
-// This framing is compatible with the ChannelOut.Request pattern used throughout
-// the toolbox package: Send("info-set guestinfo.xxx value") then Receive() returns
+// fastClose is NOT set: the connection is opened once by Start and reused for
+// the lifetime of the channel, so the server must keep serving it. (VsockChannel
+// sets fastClose because it opens a fresh connection per exchange.)
+//
+// This is compatible with the ChannelOut.Request pattern used throughout the
+// toolbox package: Send("info-set guestinfo.xxx value") then Receive() returns
 // "1 " on success or "0 <error>" on failure.
 //
 // Usage (guest side – inside a container or test binary):
@@ -60,56 +63,13 @@ func (c *UnixChannel) Stop() error {
 	return err
 }
 
-// Send transmits buf as a length-prefixed frame to the server.
+// Send transmits buf as a DataMap packet to the server.
 func (c *UnixChannel) Send(buf []byte) error {
-	return WriteUnixFrame(c.conn, buf)
+	return WriteDataMapPacket(c.conn, buf, false)
 }
 
-// Receive reads one length-prefixed frame from the server.
+// Receive reads one DataMap packet from the server.
 func (c *UnixChannel) Receive() ([]byte, error) {
-	return ReadUnixFrame(c.conn)
-}
-
-// WriteUnixFrame writes a 4-byte LE length prefix followed by buf.
-// Exported so that govmomi/simulator can share the same framing.
-func WriteUnixFrame(w io.Writer, buf []byte) error {
-	var hdr [4]byte
-	binary.LittleEndian.PutUint32(hdr[:], uint32(len(buf)))
-	if _, err := w.Write(hdr[:]); err != nil {
-		return err
-	}
-	if len(buf) == 0 {
-		return nil
-	}
-	_, err := w.Write(buf)
-	return err
-}
-
-// MaxUnixFrameSize bounds the payload length ReadUnixFrame will accept.
-//
-// The length prefix is supplied by the peer. On a container-backed VM the
-// socket directory is bind-mounted read-write into a container that may run an
-// arbitrary image, so without a bound four bytes from the guest would size an
-// allocation in the host process (up to 4 GiB). RPCI commands and their
-// responses are small; 1 MiB is well above any legitimate frame.
-const MaxUnixFrameSize = 1 << 20
-
-// ReadUnixFrame reads a 4-byte LE length prefix and then that many bytes.
-// Frames declaring more than MaxUnixFrameSize are rejected before allocating.
-// Exported so that govmomi/simulator can share the same framing.
-func ReadUnixFrame(r io.Reader) ([]byte, error) {
-	var hdr [4]byte
-	if _, err := io.ReadFull(r, hdr[:]); err != nil {
-		return nil, err
-	}
-	n := binary.LittleEndian.Uint32(hdr[:])
-	if n == 0 {
-		return nil, nil
-	}
-	if n > MaxUnixFrameSize {
-		return nil, fmt.Errorf("unix frame too large: %d bytes (max %d)", n, MaxUnixFrameSize)
-	}
-	buf := make([]byte, n)
-	_, err := io.ReadFull(r, buf)
-	return buf, err
+	payload, _, err := ReadDataMapPacket(c.conn)
+	return payload, err
 }

--- a/toolbox/unix_channel.go
+++ b/toolbox/unix_channel.go
@@ -1,0 +1,102 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package toolbox
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+)
+
+// UnixChannel implements the Channel interface over a Unix stream socket.
+//
+// Wire format: each message is framed as a 4-byte little-endian uint32 length
+// prefix followed by that many payload bytes. The same framing is used in both
+// directions (Send and Receive). Zero-length messages are valid (empty payload).
+//
+// This framing is compatible with the ChannelOut.Request pattern used throughout
+// the toolbox package: Send("info-set guestinfo.xxx value") then Receive() returns
+// "1 " on success or "0 <error>" on failure.
+//
+// Usage (guest side – inside a container or test binary):
+//
+//	ch := toolbox.NewUnixChannelOut("/run/vmware/rpc.sock")
+//	out := &toolbox.ChannelOut{Channel: ch}
+//	if err := ch.Start(); err != nil { ... }
+//	reply, err := out.Request([]byte("info-set guestinfo.foo bar"))
+//
+// The host side (govmomi/simulator.GuestRPCServer) speaks the same framing.
+type UnixChannel struct {
+	path string
+	conn net.Conn
+}
+
+// NewUnixChannelOut returns a Channel that connects to the unix socket at path.
+// Call Start() before use.
+func NewUnixChannelOut(path string) Channel {
+	return &UnixChannel{path: path}
+}
+
+// Start connects to the unix socket.
+func (c *UnixChannel) Start() error {
+	conn, err := net.Dial("unix", c.path)
+	if err != nil {
+		return fmt.Errorf("UnixChannel.Start %s: %w", c.path, err)
+	}
+	c.conn = conn
+	return nil
+}
+
+// Stop closes the connection.
+func (c *UnixChannel) Stop() error {
+	if c.conn == nil {
+		return nil
+	}
+	err := c.conn.Close()
+	c.conn = nil
+	return err
+}
+
+// Send transmits buf as a length-prefixed frame to the server.
+func (c *UnixChannel) Send(buf []byte) error {
+	return WriteUnixFrame(c.conn, buf)
+}
+
+// Receive reads one length-prefixed frame from the server.
+func (c *UnixChannel) Receive() ([]byte, error) {
+	return ReadUnixFrame(c.conn)
+}
+
+// WriteUnixFrame writes a 4-byte LE length prefix followed by buf.
+// Exported so that govmomi/simulator can share the same framing.
+func WriteUnixFrame(w io.Writer, buf []byte) error {
+	var hdr [4]byte
+	binary.LittleEndian.PutUint32(hdr[:], uint32(len(buf)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	if len(buf) == 0 {
+		return nil
+	}
+	_, err := w.Write(buf)
+	return err
+}
+
+// ReadUnixFrame reads a 4-byte LE length prefix and then that many bytes.
+// Exported so that govmomi/simulator can share the same framing.
+func ReadUnixFrame(r io.Reader) ([]byte, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	n := binary.LittleEndian.Uint32(hdr[:])
+	if n == 0 {
+		return nil, nil
+	}
+	buf := make([]byte, n)
+	_, err := io.ReadFull(r, buf)
+	return buf, err
+}

--- a/toolbox/unix_channel_test.go
+++ b/toolbox/unix_channel_test.go
@@ -1,0 +1,63 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package toolbox
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// TestUnixFrameRoundTrip covers the ordinary path and the zero-length frame,
+// which is used as a keepalive by the simulator's GuestRPC server.
+func TestUnixFrameRoundTrip(t *testing.T) {
+	for _, payload := range [][]byte{
+		[]byte("info-get guestinfo.metadata"),
+		[]byte("1 "),
+		bytes.Repeat([]byte("x"), MaxUnixFrameSize),
+	} {
+		var buf bytes.Buffer
+		if err := WriteUnixFrame(&buf, payload); err != nil {
+			t.Fatalf("WriteUnixFrame(%d bytes): %v", len(payload), err)
+		}
+		got, err := ReadUnixFrame(&buf)
+		if err != nil {
+			t.Fatalf("ReadUnixFrame(%d bytes): %v", len(payload), err)
+		}
+		if !bytes.Equal(got, payload) {
+			t.Errorf("round-trip of %d bytes did not match", len(payload))
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := WriteUnixFrame(&buf, nil); err != nil {
+		t.Fatalf("WriteUnixFrame(nil): %v", err)
+	}
+	got, err := ReadUnixFrame(&buf)
+	if err != nil || got != nil {
+		t.Errorf("zero-length frame: got %v, %v; want nil, nil", got, err)
+	}
+}
+
+// TestReadUnixFrameRejectsOversizeLength pins the bound on the length prefix.
+//
+// The prefix is peer-supplied: vcsim bind-mounts the GuestRPC socket directory
+// read-write into a container that may run an arbitrary image, so an unbounded
+// length would let four bytes from the guest size an allocation in the host
+// process. Without the bound, the header below requests 4 GiB.
+func TestReadUnixFrameRejectsOversizeLength(t *testing.T) {
+	for _, n := range []uint32{MaxUnixFrameSize + 1, 1 << 30, ^uint32(0)} {
+		hdr := make([]byte, 4)
+		binary.LittleEndian.PutUint32(hdr, n)
+
+		buf, err := ReadUnixFrame(bytes.NewReader(hdr))
+		if err == nil {
+			t.Errorf("length %d: expected an error, got %d bytes", n, len(buf))
+		}
+		if buf != nil {
+			t.Errorf("length %d: expected no allocation, got %d bytes", n, len(buf))
+		}
+	}
+}

--- a/toolbox/unix_channel_test.go
+++ b/toolbox/unix_channel_test.go
@@ -7,57 +7,68 @@ package toolbox
 import (
 	"bytes"
 	"encoding/binary"
+	"strings"
 	"testing"
 )
 
-// TestUnixFrameRoundTrip covers the ordinary path and the zero-length frame,
-// which is used as a keepalive by the simulator's GuestRPC server.
-func TestUnixFrameRoundTrip(t *testing.T) {
-	for _, payload := range [][]byte{
-		[]byte("info-get guestinfo.metadata"),
-		[]byte("1 "),
-		bytes.Repeat([]byte("x"), MaxUnixFrameSize),
-	} {
-		var buf bytes.Buffer
-		if err := WriteUnixFrame(&buf, payload); err != nil {
-			t.Fatalf("WriteUnixFrame(%d bytes): %v", len(payload), err)
-		}
-		got, err := ReadUnixFrame(&buf)
-		if err != nil {
-			t.Fatalf("ReadUnixFrame(%d bytes): %v", len(payload), err)
-		}
-		if !bytes.Equal(got, payload) {
-			t.Errorf("round-trip of %d bytes did not match", len(payload))
-		}
-	}
+// TestDataMapRoundTrip covers the payload sizes a GuestRPC exchange actually
+// uses, including the small regime where a length-based framing heuristic used
+// to misroute packets.
+func TestDataMapRoundTrip(t *testing.T) {
+	for _, n := range []int{0, 1, 2, 8, 16, 228, 484, 740, 4096} {
+		payload := []byte(strings.Repeat("x", n))
 
-	var buf bytes.Buffer
-	if err := WriteUnixFrame(&buf, nil); err != nil {
-		t.Fatalf("WriteUnixFrame(nil): %v", err)
-	}
-	got, err := ReadUnixFrame(&buf)
-	if err != nil || got != nil {
-		t.Errorf("zero-length frame: got %v, %v; want nil, nil", got, err)
+		var buf bytes.Buffer
+		if err := WriteDataMapPacket(&buf, payload, false); err != nil {
+			t.Fatalf("WriteDataMapPacket(%d bytes): %v", n, err)
+		}
+		got, fastClose, err := ReadDataMapPacket(&buf)
+		if err != nil {
+			t.Fatalf("ReadDataMapPacket(%d bytes): %v", n, err)
+		}
+		if fastClose {
+			t.Errorf("payload %d: fastClose set on a packet written with false", n)
+		}
+		if n > 0 && !bytes.Equal(got, payload) {
+			t.Errorf("payload %d: round-trip mismatch", n)
+		}
 	}
 }
 
-// TestReadUnixFrameRejectsOversizeLength pins the bound on the length prefix.
+// TestDataMapFastCloseRoundTrips pins the flag, since UnixChannel relies on
+// NOT setting it (its connection is reused) while VsockChannel relies on it.
+func TestDataMapFastCloseRoundTrips(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteDataMapPacket(&buf, []byte("info-get guestinfo.x"), true); err != nil {
+		t.Fatalf("WriteDataMapPacket: %v", err)
+	}
+	_, fastClose, err := ReadDataMapPacket(&buf)
+	if err != nil {
+		t.Fatalf("ReadDataMapPacket: %v", err)
+	}
+	if !fastClose {
+		t.Error("fastClose was set on write but not reported on read")
+	}
+}
+
+// TestReadDataMapPacketRejectsOversizeLength pins the bound on the entries
+// length prefix.
 //
 // The prefix is peer-supplied: vcsim bind-mounts the GuestRPC socket directory
 // read-write into a container that may run an arbitrary image, so an unbounded
 // length would let four bytes from the guest size an allocation in the host
-// process. Without the bound, the header below requests 4 GiB.
-func TestReadUnixFrameRejectsOversizeLength(t *testing.T) {
-	for _, n := range []uint32{MaxUnixFrameSize + 1, 1 << 30, ^uint32(0)} {
+// process. Without the bound the header below requests 4 GiB.
+func TestReadDataMapPacketRejectsOversizeLength(t *testing.T) {
+	for _, n := range []uint32{MaxDataMapEntries + 1, 1 << 30, ^uint32(0)} {
 		hdr := make([]byte, 4)
-		binary.LittleEndian.PutUint32(hdr, n)
+		binary.BigEndian.PutUint32(hdr, n)
 
-		buf, err := ReadUnixFrame(bytes.NewReader(hdr))
+		payload, _, err := ReadDataMapPacket(bytes.NewReader(hdr))
 		if err == nil {
-			t.Errorf("length %d: expected an error, got %d bytes", n, len(buf))
+			t.Errorf("entries length %d: expected an error, got %d bytes", n, len(payload))
 		}
-		if buf != nil {
-			t.Errorf("length %d: expected no allocation, got %d bytes", n, len(buf))
+		if payload != nil {
+			t.Errorf("entries length %d: expected no allocation, got %d bytes", n, len(payload))
 		}
 	}
 }

--- a/toolbox/vsock_channel_linux.go
+++ b/toolbox/vsock_channel_linux.go
@@ -106,11 +106,15 @@ func (c *VsockChannel) Receive() ([]byte, error) {
 	return payload, err
 }
 
-// IsVsockAvailable returns true if the kernel supports creating AF_VSOCK
-// sockets on this system. On govmomi/simulator container-backed VMs the seccomp
-// intercept handles the socket() call, so this returns true inside containers
-// with RUN.vmci=true. On bare containers or non-VM hosts without the vmci kernel
-// module it returns false, enabling the backdoor fallback.
+// IsVsockAvailable reports whether the kernel will CREATE an AF_VSOCK socket
+// on this system. It does not report that any peer is reachable: socket(2)
+// succeeds on any host with the vsock address family compiled in, including
+// hosts with no vmci module loaded and containers under govmomi/simulator,
+// where nothing answers on the vsock CID.
+//
+// It is therefore a capability probe, not a reachability test, and must not be
+// used to select a transport on its own — see rpcTransports in
+// toolbox/toolbox, which selects by successful connection instead.
 func IsVsockAvailable() bool {
 	fd, err := syscall.Socket(afVsock, syscall.SOCK_STREAM, 0)
 	if err != nil {

--- a/toolbox/vsock_channel_linux.go
+++ b/toolbox/vsock_channel_linux.go
@@ -1,0 +1,150 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package toolbox
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	afVsock       = 40  // AF_VSOCK
+	vmaddrCIDHost = 2   // VMADDR_CID_HOST — the ESX hypervisor CID
+	vsockRPCIPort = 976 // VMware RPCI / GuestRPC vsock port
+)
+
+// sockaddrVM mirrors struct sockaddr_vm from <linux/vm_sockets.h> (amd64 layout).
+type sockaddrVM struct {
+	family    uint16
+	reserved1 uint16
+	port      uint32
+	cid       uint32
+	flags     uint8
+	pad       [3]uint8
+}
+
+// VsockChannel implements the Channel interface over AF_VSOCK using DataMap
+// framing. This is the same wire protocol used by the real vmtoolsd binary over
+// its vsock connection to ESX.
+//
+// The channel is lazy: Start() succeeds immediately without opening a socket.
+// Each Send call opens a fresh AF_VSOCK connection, writes a DataMap packet
+// with FAST_CLOSE=true (one-shot model matching real vmtoolsd --cmd behavior),
+// and keeps the connection open for the paired Receive call. Receive reads the
+// response and closes the connection.
+//
+// Thread safety: a single VsockChannel must not be used concurrently from
+// multiple goroutines. The Service (service.go) calls Send+Receive only from
+// its single event goroutine.
+type VsockChannel struct {
+	cid  uint32
+	port uint32
+	conn net.Conn // open connection after Send, closed after Receive
+}
+
+// NewVsockChannelOut returns a Channel that speaks RPCI via AF_VSOCK to the
+// hypervisor CID (2) on the GuestRPC port (976) using DataMap framing.
+func NewVsockChannelOut() Channel {
+	return &VsockChannel{cid: vmaddrCIDHost, port: vsockRPCIPort}
+}
+
+// Start is a no-op; the connection is opened lazily on the first Send call.
+// This allows Service.Start() to succeed even when running outside a VM.
+func (c *VsockChannel) Start() error { return nil }
+
+// Stop closes any open connection.
+func (c *VsockChannel) Stop() error {
+	if c.conn != nil {
+		err := c.conn.Close()
+		c.conn = nil
+		return err
+	}
+	return nil
+}
+
+// Send opens a new AF_VSOCK connection to the hypervisor and writes a DataMap
+// packet containing payload. The connection is left open for the paired
+// Receive call. If a previous connection was not closed, it is closed first.
+//
+// socket() is called via syscall.Socket and connect() via syscall.Syscall;
+// both result in the kernel socket(2)/connect(2) system calls, making them
+// visible to the vcsim seccomp filter which replaces the AF_VSOCK FD with a
+// Unix socketpair.
+func (c *VsockChannel) Send(buf []byte) error {
+	if c.conn != nil {
+		_ = c.conn.Close()
+		c.conn = nil
+	}
+
+	conn, err := dialVsockLinux(c.cid, c.port)
+	if err != nil {
+		return err
+	}
+	c.conn = conn
+
+	return WriteDataMapPacket(c.conn, buf, true /* fastClose */)
+}
+
+// Receive reads a DataMap response from the open connection and closes it.
+func (c *VsockChannel) Receive() ([]byte, error) {
+	if c.conn == nil {
+		return nil, fmt.Errorf("VsockChannel: Receive called without a prior Send")
+	}
+	defer func() {
+		_ = c.conn.Close()
+		c.conn = nil
+	}()
+
+	payload, _, err := ReadDataMapPacket(c.conn)
+	return payload, err
+}
+
+// IsVsockAvailable returns true if the kernel supports creating AF_VSOCK
+// sockets on this system. On govmomi/simulator container-backed VMs the seccomp
+// intercept handles the socket() call, so this returns true inside containers
+// with RUN.vmci=true. On bare containers or non-VM hosts without the vmci kernel
+// module it returns false, enabling the backdoor fallback.
+func IsVsockAvailable() bool {
+	fd, err := syscall.Socket(afVsock, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		return false
+	}
+	_ = syscall.Close(fd)
+	return true
+}
+
+// dialVsockLinux opens an AF_VSOCK SOCK_STREAM socket and connects it to
+// cid:port using raw syscalls (required for seccomp intercept compatibility).
+func dialVsockLinux(cid, port uint32) (net.Conn, error) {
+	fd, err := syscall.Socket(afVsock, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, fmt.Errorf("VsockChannel: socket(AF_VSOCK): %w", err)
+	}
+
+	addr := sockaddrVM{family: afVsock, port: port, cid: cid}
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_CONNECT,
+		uintptr(fd),
+		uintptr(unsafe.Pointer(&addr)),
+		unsafe.Sizeof(addr),
+	)
+	if errno != 0 {
+		_ = syscall.Close(fd)
+		return nil, fmt.Errorf("VsockChannel: connect(cid=%d, port=%d): %w", cid, port, errno)
+	}
+
+	f := os.NewFile(uintptr(fd), fmt.Sprintf("vsock-cid%d-port%d", cid, port))
+	conn, err := net.FileConn(f)
+	_ = f.Close() // net.FileConn duplicates the fd; the original can be closed
+	if err != nil {
+		return nil, fmt.Errorf("VsockChannel: FileConn: %w", err)
+	}
+	return conn, nil
+}

--- a/toolbox/vsock_channel_other.go
+++ b/toolbox/vsock_channel_other.go
@@ -1,0 +1,30 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package toolbox
+
+import "errors"
+
+// VsockChannel is the stub for non-Linux platforms. AF_VSOCK is a Linux kernel
+// socket family; this stub satisfies the Channel interface so that callers can
+// use NewVsockChannelOut() in cross-platform code and handle the Start() error
+// gracefully (e.g., by falling back to the backdoor channel).
+type VsockChannel struct{}
+
+// NewVsockChannelOut returns a VsockChannel stub that always errors on Start.
+func NewVsockChannelOut() Channel { return &VsockChannel{} }
+
+// IsVsockAvailable returns false on non-Linux platforms.
+func IsVsockAvailable() bool { return false }
+
+func (c *VsockChannel) Start() error {
+	return errors.New("VsockChannel: AF_VSOCK is only supported on Linux")
+}
+func (c *VsockChannel) Stop() error         { return nil }
+func (c *VsockChannel) Send(_ []byte) error { return errors.New("VsockChannel: not started") }
+func (c *VsockChannel) Receive() ([]byte, error) {
+	return nil, errors.New("VsockChannel: not started")
+}


### PR DESCRIPTION
## Summary

Extends vcsim's container-backed VMs (`RUN.container`) so guest-side tooling that expects a real VMware guest environment — cloud-init's `DataSourceVMware`, `vmware-rpctool`, custom init processes reading/writing `guestinfo` — works **unmodified** against a container instead of needing to be VM-agnostic or mocked out.

Three pieces:

1. **`RUN.vmci`**: a per-VM GuestRPC server (Unix socket, bind-mounted into the container) that implements the same RPCI surface as real `vmtoolsd`: `info-get`/`info-set` against the VM's `ExtraConfig`, reflected as `PropertyChange`s. This makes `guestinfo` genuinely **bidirectional** — today, container-backed VMs can only push guestinfo in at creation time; this lets the guest write back status (readiness, config, whatever a workload needs) and have it show up as a normal `ExtraConfig`/property change on the VM object.
2. **`govmomi/toolbox`**: two new `Channel` implementations (Unix socket, AF_VSOCK with DataMap framing — the real `vmtoolsd` wire format) plus a small CLI mode so the `toolbox` binary itself can act as a drop-in `vmware-rpctool` or answer `vmtoolsd --cmd` one-shot invocations. This is generic GuestRPC tooling with no vcsim dependency; the simulator wires it in as a convenience (auto-injected at `/usr/bin/vmware-rpctool` when `RUN.vmci=true`).
3. **Nested-container improvements**: refinements to `RUN.nestedContainers` (the kind-style flag set for running Kubernetes/other container workloads inside the container-backed VM) so it composes cleanly with the GuestRPC socket bind-mount — in particular, the socket *directory* is mounted rather than the socket file, since a file bind-mount requires the target to already exist inside a fresh `--tmpfs /run`, which it doesn't.

This is aimed at anyone using vcsim to simulate a fleet of guests that need to look enough like real VMs for their own tooling to work without a real hypervisor — Kubernetes-node simulation, cloud-init-driven provisioning tests, or anything else that currently has to special-case "running under vcsim."

## What's included

- `simulator/guestrpc_server.go` — the per-VM GuestRPC server, its wire-format auto-detection (a lightweight LE-framed protocol vs. the DataMap framing real `vmtoolsd` uses), and concurrency handling.
- `simulator/vmci_artifacts_linux.go` (+ `_other.go` stub) — builds and caches the `toolbox` binary for auto-injection.
- `toolbox/unix_channel.go`, `toolbox/vsock_channel_linux.go` (+`_other.go`), `toolbox/datamap.go`, `toolbox/noop_channel.go` — the new channels and framing.
- `toolbox/toolbox/main.go` — `vmware-rpctool` and `vmtoolsd --cmd` compatible CLI modes, transport selection.
- Tests: in-process server tests (`guestrpc_test.go`), container-integration tests gated on Docker/Podman (`container_guestrpc_test.go`, `vsock_container_test.go`), and two test fixtures under `simulator/testdata/` (a systemd-init image, a small vsock test binary).

## Known limitations / follow-up

- `info-set` currently accepts any `ExtraConfig` key, not just `guestinfo.*` — real VMX restricts guest writes to that namespace. Worth tightening before this is relied on with untrusted guest images.
- The GuestRPC artifact build (`vmci_artifacts_linux.go`) writes into `simulator/bin/` relative to the source file, which won't resolve when `govmomi` is consumed as a module dependency from the read-only module cache; it also hardcodes `GOARCH=amd64`. A test-fixture build (Makefile target, `go:embed`, or a `TestMain` step) instead of a power-on-time `go build` would sidestep both.
- An AF_VSOCK seccomp-intercept transport was prototyped separately and is not part of this change; the Unix-socket transport (`RUN.vmci=true`) covers the common cases, but a caller that specifically needs a real `socket(AF_VSOCK)` call to succeed inside the container would still need it.

I've posted a more detailed review (findings + what already works) as a review comment on this PR, since some of it is more useful there than in the PR body.

## Testing done

- `go build ./...`, `go vet ./simulator/... ./toolbox/...` — clean.
- `go test ./toolbox/...` — pass.
- `go test ./simulator/...` (full package, unfiltered) — pass.
- Docker-gated container tests pass where a runtime is available (`TestVMCI_ToolboxBinary_GuestInfoRoundTrip`) and skip cleanly otherwise (the two tests needing a locally-built test image skip with a message rather than failing).