### PR TITLE
refactor: use `slices.Contains` for membership checks

### DIFF
--- a/cli/datastore/info.go
+++ b/cli/datastore/info.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"text/tabwriter"
 
 	"github.com/vmware/govmomi/cli"
@@ -77,11 +78,8 @@ Examples:
 func intersect(common []types.ManagedObjectReference, refs []types.ManagedObjectReference) []types.ManagedObjectReference {
 	var shared []types.ManagedObjectReference
 	for i := range common {
-		for j := range refs {
-			if common[i] == refs[j] {
-				shared = append(shared, common[i])
-				break
-			}
+		if slices.Contains(refs, common[i]) {
+			shared = append(shared, common[i])
 		}
 	}
 	return shared

--- a/cli/host/storage/info.go
+++ b/cli/host/storage/info.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"text/tabwriter"
 
@@ -26,11 +27,9 @@ type infoType string
 func (t *infoType) Set(s string) error {
 	s = strings.ToLower(s)
 
-	for _, e := range infoTypes {
-		if s == e {
-			*t = infoType(s)
-			return nil
-		}
+	if slices.Contains(infoTypes, s) {
+		*t = infoType(s)
+		return nil
 	}
 
 	return fmt.Errorf("invalid type")

--- a/cli/object/find.go
+++ b/cli/object/find.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"text/tabwriter"
 
@@ -96,13 +97,7 @@ func (e *kinds) wanted(kind string) bool {
 		return true
 	}
 
-	for _, k := range *e {
-		if kind == k {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(*e, kind)
 }
 
 func init() {

--- a/cli/vm/change.go
+++ b/cli/vm/change.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/vmware/govmomi/cli"
@@ -80,13 +81,11 @@ func (cmd *change) setLatency() error {
 	if cmd.Latency == "" {
 		return nil
 	}
-	for _, l := range latencyLevels {
-		if l == cmd.Latency {
-			cmd.LatencySensitivity = &types.LatencySensitivity{
-				Level: types.LatencySensitivitySensitivityLevel(cmd.Latency),
-			}
-			return nil
+	if slices.Contains(latencyLevels, cmd.Latency) {
+		cmd.LatencySensitivity = &types.LatencySensitivity{
+			Level: types.LatencySensitivitySensitivityLevel(cmd.Latency),
 		}
+		return nil
 	}
 	return fmt.Errorf("latency must be one of: %s", strings.Join(latencyLevels, "|"))
 }
@@ -102,13 +101,11 @@ func (cmd *change) setHwUpgradePolicy() error {
 	if cmd.hwUpgradePolicy == "" {
 		return nil
 	}
-	for _, l := range hwUpgradePolicies {
-		if l == cmd.hwUpgradePolicy {
-			cmd.ScheduledHardwareUpgradeInfo = &types.ScheduledHardwareUpgradeInfo{
-				UpgradePolicy: string(types.ScheduledHardwareUpgradeInfoHardwareUpgradePolicy(cmd.hwUpgradePolicy)),
-			}
-			return nil
+	if slices.Contains(hwUpgradePolicies, cmd.hwUpgradePolicy) {
+		cmd.ScheduledHardwareUpgradeInfo = &types.ScheduledHardwareUpgradeInfo{
+			UpgradePolicy: string(types.ScheduledHardwareUpgradeInfoHardwareUpgradePolicy(cmd.hwUpgradePolicy)),
 		}
+		return nil
 	}
 	return fmt.Errorf("Hardware upgrade policy must be one of: %s", strings.Join(hwUpgradePolicies, "|"))
 }

--- a/cli/vm/dataset/create.go
+++ b/cli/vm/dataset/create.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/vmware/govmomi/cli"
@@ -31,12 +32,7 @@ func guestAccessUsage() string {
 }
 
 func validateDataSetAccess(access dataset.Access) bool {
-	for _, validAccess := range accessModes {
-		if string(access) == validAccess {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(accessModes, string(access))
 }
 
 type create struct {

--- a/eam/simulator/eam_object.go
+++ b/eam/simulator/eam_object.go
@@ -5,6 +5,7 @@
 package simulator
 
 import (
+	"slices"
 	"time"
 
 	"github.com/vmware/govmomi/eam/methods"
@@ -82,12 +83,7 @@ func (m *EamObject) Resolve(
 
 	// issueExists is a helper function that returns true
 	issueExists := func(issueKey int32) bool {
-		for _, k := range req.IssueKey {
-			if k == issueKey {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(req.IssueKey, issueKey)
 	}
 
 	// Iterate over the object's issues, and if a key matches, then remove

--- a/find/recurser.go
+++ b/find/recurser.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/vmware/govmomi/list"
@@ -68,13 +69,7 @@ func (s *spec) traversable(o mo.Reference) bool {
 		return true
 	}
 
-	for _, kind := range s.Parents {
-		if kind == ref.Type {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(s.Parents, ref.Type)
 }
 
 func (s *spec) traversableChildType(ctypes []string) bool {
@@ -83,10 +78,8 @@ func (s *spec) traversableChildType(ctypes []string) bool {
 	}
 
 	for _, t := range ctypes {
-		for _, c := range s.ChildType {
-			if t == c {
-				return true
-			}
+		if slices.Contains(s.ChildType, t) {
+			return true
 		}
 	}
 
@@ -100,13 +93,7 @@ func (s *spec) wanted(e list.Element) bool {
 
 	w := e.Object.Reference().Type
 
-	for _, kind := range s.Include {
-		if w == kind {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(s.Include, w)
 }
 
 // listMode is a global option to revert to the original Finder behavior,

--- a/property/match.go
+++ b/property/match.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -140,13 +141,7 @@ func (m Match) ObjectContent(objects []types.ObjectContent) []types.ManagedObjec
 
 // AnyList returns true if any given props match.
 func (m Match) AnyList(props []types.DynamicProperty) bool {
-	for _, p := range props {
-		if m.Property(p) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(props, m.Property)
 }
 
 // AnyObjectContent returns a list of ObjectContent.Obj where the

--- a/simulator/crypto_manager_kmip.go
+++ b/simulator/crypto_manager_kmip.go
@@ -206,13 +206,7 @@ func (m *CryptoManagerKmip) SetDefaultKmsCluster(
 				if req.Entity == nil {
 					c.UseAsDefault = true
 				} else {
-					found := false
-					for j := range c.UseAsEntityDefault {
-						if *req.Entity == c.UseAsEntityDefault[j] {
-							found = true
-							break
-						}
-					}
+					found := slices.Contains(c.UseAsEntityDefault, *req.Entity)
 					if !found {
 						c.UseAsEntityDefault = append(
 							c.UseAsEntityDefault,

--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -6,6 +6,7 @@ package simulator
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -351,11 +352,8 @@ func (s *DistributedVirtualSwitch) filterDVPortsByPortgroupKey(
 		filtered := []types.DistributedVirtualPort{}
 
 		for _, p := range ports {
-			for _, pgk := range criteria.PortgroupKey {
-				if p.PortgroupKey == pgk {
-					filtered = append(filtered, p)
-					break
-				}
+			if slices.Contains(criteria.PortgroupKey, p.PortgroupKey) {
+				filtered = append(filtered, p)
 			}
 		}
 		return filtered
@@ -365,13 +363,7 @@ func (s *DistributedVirtualSwitch) filterDVPortsByPortgroupKey(
 	filtered := []types.DistributedVirtualPort{}
 
 	for _, p := range ports {
-		found := false
-		for _, pgk := range criteria.PortgroupKey {
-			if p.PortgroupKey == pgk {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(criteria.PortgroupKey, p.PortgroupKey)
 
 		if !found {
 			filtered = append(filtered, p)
@@ -391,11 +383,8 @@ func (s *DistributedVirtualSwitch) filterDVPortsByPortKey(
 	filtered := []types.DistributedVirtualPort{}
 
 	for _, p := range ports {
-		for _, pk := range criteria.PortKey {
-			if p.Key == pk {
-				filtered = append(filtered, p)
-				break
-			}
+		if slices.Contains(criteria.PortKey, p.Key) {
+			filtered = append(filtered, p)
 		}
 	}
 

--- a/simulator/event_manager.go
+++ b/simulator/event_manager.go
@@ -9,6 +9,7 @@ import (
 	"container/list"
 	"log"
 	"reflect"
+	"slices"
 	"text/template"
 	"time"
 
@@ -295,12 +296,7 @@ func (c *EventHistoryCollector) typeMatches(_ *Context, event types.BaseEvent, s
 	}
 
 	matches := func(name string) bool {
-		for _, id := range spec.EventTypeId {
-			if id == name {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(spec.EventTypeId, name)
 	}
 
 	if x, ok := event.(*types.EventEx); ok {

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"net/url"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -110,12 +111,7 @@ func folderRemoveReference(ctx *Context, f *mo.Folder, o mo.Reference) {
 }
 
 func folderHasChildType(f *mo.Folder, kind string) bool {
-	for _, t := range f.ChildType {
-		if t == kind {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(f.ChildType, kind)
 }
 
 func (f *Folder) typeNotSupported() *soap.Fault {

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -469,10 +470,8 @@ func (r *Registry) FindByName(name string, refs []types.ManagedObjectReference) 
 // FindReference returns the 1st match found in refs, or nil if not found.
 func FindReference(refs []types.ManagedObjectReference, match ...types.ManagedObjectReference) *types.ManagedObjectReference {
 	for _, ref := range refs {
-		for _, m := range match {
-			if ref == m {
-				return &ref
-			}
+		if slices.Contains(match, ref) {
+			return &ref
 		}
 	}
 

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -240,12 +241,10 @@ func (s *Service) call(ctx *Context, method *Method) soap.HasFault {
 	}
 
 	if e, ok := handler.(mo.Entity); ok {
-		for _, dm := range e.Entity().DisabledMethod {
-			if name == dm {
-				msg := fmt.Sprintf("%s method is disabled: %s", method.This, method.Name)
-				fault := &types.MethodDisabled{}
-				return &serverFaultBody{Reason: Fault(msg, fault)}
-			}
+		if slices.Contains(e.Entity().DisabledMethod, name) {
+			msg := fmt.Sprintf("%s method is disabled: %s", method.This, method.Name)
+			fault := &types.MethodDisabled{}
+			return &serverFaultBody{Reason: Fault(msg, fault)}
 		}
 	}
 

--- a/simulator/task_manager.go
+++ b/simulator/task_manager.go
@@ -6,6 +6,7 @@ package simulator
 
 import (
 	"container/list"
+	"slices"
 	"sync"
 	"time"
 
@@ -231,14 +232,7 @@ func (c *TaskHistoryCollector) stateMatches(_ *Context, task *types.TaskInfo, sp
 		return true
 	}
 
-	for _, state := range spec.State {
-		if task.State == state {
-			return true
-
-		}
-	}
-
-	return false
+	return slices.Contains(spec.State, task.State)
 }
 
 func (c *TaskHistoryCollector) timeMatches(_ *Context, task *types.TaskInfo, spec types.TaskFilterSpec) bool {

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1397,10 +1397,8 @@ func (vm *VirtualMachine) validateSwitchMembers(ctx *Context, id string) types.B
 	h := ctx.Map.Get(*vm.Runtime.Host).(*HostSystem)
 	c := hostParent(ctx, &h.HostSystem)
 	isMember := func(val types.ManagedObjectReference) bool {
-		for _, mem := range dswitch.Summary.HostMember {
-			if mem == val {
-				return true
-			}
+		if slices.Contains(dswitch.Summary.HostMember, val) {
+			return true
 		}
 		log.Printf("%s is not a member of VDS %s", h.Name, dswitch.Name)
 		return false

--- a/simulator/vstorage_object_manager.go
+++ b/simulator/vstorage_object_manager.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -482,12 +483,7 @@ func (m *VcenterVStorageObjectManager) VCenterUpdateVStorageObjectMetadataExTask
 		var metadata []types.KeyValue
 
 		remove := func(key string) bool {
-			for _, dk := range req.DeleteKeys {
-				if key == dk {
-					return true
-				}
-			}
-			return false
+			return slices.Contains(req.DeleteKeys, key)
 		}
 
 		for _, kv := range obj.Metadata {

--- a/vapi/tags/categories.go
+++ b/vapi/tags/categories.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/vmware/govmomi/vapi/internal"
@@ -26,12 +27,7 @@ type Category struct {
 }
 
 func (c *Category) hasType(kind string) bool {
-	for _, k := range c.AssociableTypes {
-		if kind == k {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.AssociableTypes, kind)
 }
 
 // Patch merges Category changes from the given src.


### PR DESCRIPTION
## Description

Replace manual loops that searched string slices with `slices.Contains`. This simplifies the code, improves readability, and standardizes slice membership checks across these components.
