### PR TITLE
refactor: use 'strings.Split' variant inspection

### DIFF
--- a/cli/cluster/stretch.go
+++ b/cli/cluster/stretch.go
@@ -174,7 +174,7 @@ func (cmd *stretch) getManagedObjectRefs(domainHosts string, ctx context.Context
 	}
 
 	var refs []vim.ManagedObjectReference
-	for _, host := range strings.Split(domainHosts, ",") {
+	for host := range strings.SplitSeq(domainHosts, ",") {
 		h, err := finder.HostSystem(ctx, host)
 		if err != nil {
 			return nil, err

--- a/cli/dvs/add.go
+++ b/cli/dvs/add.go
@@ -83,7 +83,7 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	backing := new(types.DistributedVirtualSwitchHostMemberPnicBacking)
 
-	for _, vmnic := range strings.Split(cmd.pnic, ",") {
+	for vmnic := range strings.SplitSeq(cmd.pnic, ",") {
 		backing.PnicSpec = append(backing.PnicSpec, types.DistributedVirtualSwitchHostMemberPnicSpec{
 			PnicDevice: strings.TrimSpace(vmnic),
 		})

--- a/cli/dvs/portgroup/spec.go
+++ b/cli/dvs/portgroup/spec.go
@@ -52,8 +52,8 @@ func (spec *DVPortgroupConfigSpec) Register(ctx context.Context, f *flag.FlagSet
 
 func getRange(vlanRange string) []types.NumericRange {
 	nRanges := make([]types.NumericRange, 0)
-	strRanges := strings.Split(vlanRange, ",")
-	for _, v := range strRanges {
+	strRanges := strings.SplitSeq(vlanRange, ",")
+	for v := range strRanges {
 		vlans := strings.Split(v, "-")
 		if len(vlans) != 2 {
 			panic(fmt.Sprintf("range %s does not follow format with vlanId-vlanId", v))

--- a/cli/flags/version.go
+++ b/cli/flags/version.go
@@ -23,8 +23,8 @@ func ParseVersion(s string) (version, error) {
 	v := make(version, 0)
 
 	ds := strings.Split(s, "-")
-	ps := strings.Split(ds[0], ".")
-	for _, p := range ps {
+	ps := strings.SplitSeq(ds[0], ".")
+	for p := range ps {
 		i, err := strconv.Atoi(p)
 		if err != nil {
 			return nil, err

--- a/cli/vm/customize.go
+++ b/cli/vm/customize.go
@@ -117,7 +117,7 @@ Examples:
 
 // Parse a string of multiple IPv6 addresses with optional netmask; separated by comma
 func parseIPv6Argument(argv string) (ipconf []types.BaseCustomizationIpV6Generator, err error) {
-	for _, substring := range strings.Split(argv, ",") {
+	for substring := range strings.SplitSeq(argv, ",") {
 		// remove leading and trailing white space
 		substring = strings.TrimSpace(substring)
 		// handle "dhcp6" and lists of static IPv6 addresses

--- a/cli/vm/keystrokes.go
+++ b/cli/vm/keystrokes.go
@@ -628,7 +628,7 @@ func (cmd *keystrokes) processUsbCode() ([]hidKey, error) {
 
 	if cmd.hexCodeProvided() {
 		var retKeyArray []hidKey
-		for _, c := range strings.Split(cmd.UsbHidCodes, ",") {
+		for c := range strings.SplitSeq(cmd.UsbHidCodes, ",") {
 			var s int32
 			lookupvalue, ok := hidKeyMap[c]
 			if ok {

--- a/object/host_certificate_info.go
+++ b/object/host_certificate_info.go
@@ -145,7 +145,7 @@ func (info *HostCertificateInfo) fromName(name *pkix.Name) string {
 func (info *HostCertificateInfo) toName(s string) *pkix.Name {
 	var name pkix.Name
 
-	for _, pair := range strings.Split(s, ",") {
+	for pair := range strings.SplitSeq(s, ",") {
 		attr := strings.SplitN(pair, "=", 2)
 		if len(attr) != 2 {
 			continue

--- a/ovf/configspec.go
+++ b/ovf/configspec.go
@@ -779,8 +779,8 @@ var validSCSIControllerTypes = map[string]struct{}{
 func resolveSCSIControllerType(resourceSubType string) string {
 	trimmed := strings.TrimSpace(resourceSubType)
 	// Split on comma or space (one or more of either)
-	tokens := strings.Fields(strings.ReplaceAll(trimmed, ",", " "))
-	for _, tok := range tokens {
+	tokens := strings.FieldsSeq(strings.ReplaceAll(trimmed, ",", " "))
+	for tok := range tokens {
 		t := strings.TrimSpace(tok)
 		lower := strings.ToLower(t)
 		if _, ok := validSCSIControllerTypes[lower]; ok {

--- a/ovf/parser.go
+++ b/ovf/parser.go
@@ -48,10 +48,10 @@ func ParseCapacityAllocationUnits(s string) int64 {
 	// Split s on multiplication operator (*) so that we can just calculate integer multipliers. Each token will
 	// then be either an integer, an exponential term to be converted to an integer, or a unit term to be converted
 	// to an integer
-	tokens := strings.Split(s, "*")
+	tokens := strings.SplitSeq(s, "*")
 
 	// Loop through all tokens and convert any to integers if necessary and use to compute a running product
-	for _, token := range tokens {
+	for token := range tokens {
 		switch {
 		// "" should be treated identically to "byte". capacityBytes is already set to 1 so there is nothing to do
 		case len(token) == 0:

--- a/pbm/pbm_util.go
+++ b/pbm/pbm_util.go
@@ -102,7 +102,7 @@ func createCapabilityInstances(rules []Capability) ([]types.PbmCapabilityInstanc
 				property.Value = propertyRule.Value
 			case "set":
 				set := types.PbmCapabilityDiscreteSet{}
-				for _, val := range strings.Split(propertyRule.Value, ",") {
+				for val := range strings.SplitSeq(propertyRule.Value, ",") {
 					set.Values = append(set.Values, val)
 				}
 				property.Value = set

--- a/simulator/ip_pool_manager.go
+++ b/simulator/ip_pool_manager.go
@@ -252,8 +252,8 @@ func NewIpPool(config *types.IpPool) (*IpPool, error) {
 func (p *IpPool) init() error {
 	// IPv4 range
 	if p.config.Ipv4Config != nil {
-		ranges := strings.Split(p.config.Ipv4Config.Range, ",")
-		for _, r := range ranges {
+		ranges := strings.SplitSeq(p.config.Ipv4Config.Range, ",")
+		for r := range ranges {
 			sp := strings.Split(r, "#")
 			if len(sp) != 2 {
 				return fmt.Errorf("format of range should be ip#number; got %q", r)
@@ -277,8 +277,8 @@ func (p *IpPool) init() error {
 
 	// IPv6 range
 	if p.config.Ipv6Config != nil {
-		ranges := strings.Split(p.config.Ipv6Config.Range, ",")
-		for _, r := range ranges {
+		ranges := strings.SplitSeq(p.config.Ipv6Config.Range, ",")
+		for r := range ranges {
 			sp := strings.Split(r, "#")
 			if len(sp) != 2 {
 				return fmt.Errorf("format of range should be ip#number; got %q", r)

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -121,7 +121,7 @@ func main() {
 
 	if methodDelay != "" {
 		m := make(map[string]int)
-		for _, s := range strings.Split(methodDelay, ",") {
+		for s := range strings.SplitSeq(methodDelay, ",") {
 			s = strings.TrimSpace(s)
 			tuples := strings.Split(s, ":")
 			if len(tuples) == 2 {


### PR DESCRIPTION
## Description

In Go 1.24 and later, `strings.SplitSeq` (and `strings. FieldsSeq`) returns iterators that yield each piece without allocating an intermediate.