### PR TITLE
refactor: use `WaitGroup.Go`

### DIFF
--- a/cli/flags/debug.go
+++ b/cli/flags/debug.go
@@ -138,11 +138,9 @@ func (flag *DebugFlag) newFormatReader(rc io.ReadCloser, w io.Writer, ext string
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		_, _ = io.Copy(w, stdout)
-		wg.Done()
-	}()
+	})
 
 	return debug.ReadCloser{
 		Reader: io.TeeReader(rc, stdin),

--- a/object/vm_guest_test.go
+++ b/object/vm_guest_test.go
@@ -53,15 +53,13 @@ func TestVirtualMachineWaitForIP(t *testing.T) {
 		delay := time.Second / 2
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			t.Logf("delaying map update for %v", delay)
 			time.Sleep(delay)
 			if err := reconfig("10.0.0.1"); err != nil {
 				t.Logf("reconfig error: %s", err)
 			}
-		}()
+		})
 
 		ip, err = vm.WaitForIP(ctx, true)
 		if err != nil {

--- a/simulator/internal/server.go
+++ b/simulator/internal/server.go
@@ -260,11 +260,9 @@ func (s *Server) Client() *http.Client {
 }
 
 func (s *Server) goServe() {
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
+	s.wg.Go(func() {
 		s.Config.Serve(s.Listener)
-	}()
+	})
 }
 
 // wrap installs the connection state-tracking hook to know which

--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -278,11 +278,9 @@ func TestWaitForUpdates(t *testing.T) {
 
 	wctx, cancel := context.WithCancel(ctx)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		_ = property.Wait(wctx, pc, folder.Reference(), props, cb(false))
-	}()
+	})
 	<-updates
 	cancel()
 	wg.Wait()
@@ -410,9 +408,7 @@ func TestIncrementalWaitForUpdates(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 
 		filter := new(property.WaitFilter).Add(v.Reference(), ref.Type, tests[0].props, v.TraversalSpec())
 		perr := property.WaitForUpdates(ctx, pc, filter, func(updates []types.ObjectUpdate) bool {
@@ -431,7 +427,7 @@ func TestIncrementalWaitForUpdates(t *testing.T) {
 		if perr != nil {
 			t.Error(perr)
 		}
-	}()
+	})
 
 	wg.Wait() // wait for 1st enter
 	wg.Add(1)

--- a/simulator/property_diff_test.go
+++ b/simulator/property_diff_test.go
@@ -886,9 +886,7 @@ func TestPropertyDiff_ConcurrentAccess(t *testing.T) {
 
 	// Goroutine A: simulates a background watcher (e.g. watchContainer callback).
 	// ctx.AutoUpdate holds a single lock for checkpoint + modify + diff + update.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx := newCtx()
 		for i := range iters {
 			ctx.AutoUpdate(obj, func() {
@@ -898,13 +896,11 @@ func TestPropertyDiff_ConcurrentAccess(t *testing.T) {
 				obj.Guest.IpAddress = fmt.Sprintf("10.0.0.%d", i)
 			})
 		}
-	}()
+	})
 
 	// Goroutine B: simulates a concurrent SOAP handler that modifies VM fields
 	// under the object lock, as all SOAP task handlers do via Task.Run → AcquireLock.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx := newCtx()
 		for i := range iters {
 			ctx.WithLock(obj, func() {
@@ -914,7 +910,7 @@ func TestPropertyDiff_ConcurrentAccess(t *testing.T) {
 				obj.Guest.HostName = fmt.Sprintf("host-%d", i)
 			})
 		}
-	}()
+	})
 
 	wg.Wait()
 }

--- a/simulator/race_test.go
+++ b/simulator/race_test.go
@@ -51,9 +51,7 @@ func TestRace(t *testing.T) {
 	em := event.NewManager(c.Client)
 
 	wg.Add(1)
-	collectors.Add(1)
-	go func() {
-		defer collectors.Done()
+	collectors.Go(func() {
 
 		werr := em.Events(wctx, []types.ManagedObjectReference{content.RootFolder}, 50, true, false,
 			func(_ types.ManagedObjectReference, e []types.BaseEvent) error {
@@ -68,11 +66,9 @@ func TestRace(t *testing.T) {
 		if werr != nil {
 			t.Error(werr)
 		}
-	}()
+	})
 
-	collectors.Add(1)
-	go func() {
-		defer collectors.Done()
+	collectors.Go(func() {
 
 		ec, werr := em.CreateCollectorForEvents(ctx, types.EventFilterSpec{})
 		if werr != nil {
@@ -102,7 +98,7 @@ func TestRace(t *testing.T) {
 			case <-time.After(time.Millisecond * 100):
 			}
 		}
-	}()
+	})
 
 	ntasks := -1
 	tv, err := view.NewManager(c.Client).CreateTaskView(ctx, content.TaskManager)
@@ -116,9 +112,7 @@ func TestRace(t *testing.T) {
 	}
 
 	wg.Add(1)
-	collectors.Add(1)
-	go func() {
-		defer collectors.Done()
+	collectors.Go(func() {
 
 		werr := tv.Collect(ctx, func(tasks []types.TaskInfo) {
 			if ntasks == -1 {
@@ -130,7 +124,7 @@ func TestRace(t *testing.T) {
 		if werr != nil {
 			t.Error(werr)
 		}
-	}()
+	})
 
 	for i := range 2 {
 		spec := types.VirtualMachineConfigSpec{
@@ -141,9 +135,7 @@ func TestRace(t *testing.T) {
 			},
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			finder := find.NewFinder(c.Client, false)
 			pc := property.DefaultCollector(c.Client)
@@ -168,9 +160,7 @@ func TestRace(t *testing.T) {
 				cspec := spec // copy spec and give it a unique name
 				cspec.Name += fmt.Sprintf("-%d", j)
 
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 
 					task, _ := f.VmFolder.CreateVM(ctx, cspec, pool, nil)
 					r, terr := task.WaitForResult(ctx, nil)
@@ -181,7 +171,7 @@ func TestRace(t *testing.T) {
 					if terr != nil {
 						t.Error(terr)
 					}
-				}()
+				})
 			}
 
 			vms, err := finder.VirtualMachineList(ctx, "*")
@@ -193,9 +183,7 @@ func TestRace(t *testing.T) {
 				props := []string{"runtime.powerState"}
 				vm := vms[i]
 
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 
 					werr := property.Wait(ctx, pc, vm.Reference(), props, func(changes []types.PropertyChange) bool {
 						for _, change := range changes {
@@ -224,9 +212,9 @@ func TestRace(t *testing.T) {
 							t.Error(werr)
 						}
 					}
-				}()
+				})
 			}
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -280,9 +268,7 @@ func TestRaceDestroy(t *testing.T) {
 	notFound := false
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for _, vm := range vms {
 			task, err := vm.Destroy(ctx)
 			if err != nil {
@@ -297,11 +283,9 @@ func TestRaceDestroy(t *testing.T) {
 				}
 			}
 		}
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		task, err := folder.Destroy(ctx)
 		if err != nil {
 			t.Error(err)
@@ -310,7 +294,7 @@ func TestRaceDestroy(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-	}()
+	})
 
 	wg.Wait()
 
@@ -350,9 +334,7 @@ func TestRaceVmRelocate(t *testing.T) {
 				Folder: types.NewReference(vmFolder.Reference()),
 			}
 
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				task, err := vm.Relocate(ctx, spec, types.VirtualMachineMovePriorityDefaultPriority)
 				if err != nil {
 					panic(err)
@@ -360,7 +342,7 @@ func TestRaceVmRelocate(t *testing.T) {
 				if err = task.Wait(ctx); err != nil {
 					failed.Add(1)
 				}
-			}()
+			})
 
 			vmFolder, err = vmFolder.CreateFolder(ctx, "child")
 			if err != nil {

--- a/toolbox/hgfs/archive.go
+++ b/toolbox/hgfs/archive.go
@@ -174,9 +174,7 @@ func (h *ArchiveHandler) newArchiveToGuest(u *url.URL) (File, error) {
 		return cerr
 	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 
 		c := func() error {
 			// Drain the pipe of tar trailer data (two null blocks)
@@ -206,7 +204,7 @@ func (h *ArchiveHandler) newArchiveToGuest(u *url.URL) (File, error) {
 
 		_ = c()
 		_ = r.CloseWithError(cerr)
-	}()
+	})
 
 	return a, nil
 }

--- a/view/example_test.go
+++ b/view/example_test.go
@@ -192,9 +192,7 @@ func ExampleListView_tasks() {
 
 		var werr error
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() { // WaitForUpdates blocks until func returns true
-			defer wg.Done()
+		wg.Go(func() { // WaitForUpdates blocks until func returns true
 			werr = property.WaitForUpdates(ctx, p, filter, func(updates []types.ObjectUpdate) bool {
 				for _, update := range updates {
 					for _, change := range update.ChangeSet {
@@ -214,7 +212,7 @@ func ExampleListView_tasks() {
 
 				return false
 			})
-		}()
+		})
 
 		for _, vm := range vms {
 			task, err := vm.PowerOff(ctx)

--- a/vim25/debug/debug_test.go
+++ b/vim25/debug/debug_test.go
@@ -31,16 +31,14 @@ func TestSetProvider(t *testing.T) {
 
 		// hit the debug package with some concurrency (see PR #2469)
 		for range 5 {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				finder := find.NewFinder(c)
 
 				_, err := finder.VirtualMachineList(ctx, "*")
 				if err != nil {
 					t.Error(err)
 				}
-			}()
+			})
 		}
 
 		wg.Wait()

--- a/vim25/xml/marshal_test.go
+++ b/vim25/xml/marshal_test.go
@@ -2394,11 +2394,9 @@ func TestRace9796(t *testing.T) {
 	}
 	var wg sync.WaitGroup
 	for range 2 {
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			Marshal(B{[]A{{}}})
-			wg.Done()
-		}()
+		})
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
## Description

In Go 1.25 and later, `WaitGroup` goroutine pattern can use `WaitGroup.Go`. The `(*sync.WaitGroup).Go(func())` combines these steps in one call. This keeps the goroutine launch and the `WaitGroup `accounting together and reduces boilerplate code.

