### PR TITLE
refactor: prefer `reflect.Pointer` over deprecated `Ptr` alias

### DIFF
--- a/cli/flags/debug.go
+++ b/cli/flags/debug.go
@@ -266,7 +266,7 @@ func (*verbose) str(val reflect.Value) string {
 	}
 
 	switch val.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		if val.IsNil() {
 			return "nil"
 		}
@@ -299,7 +299,7 @@ func (*verbose) str(val reflect.Value) string {
 
 func (v *verbose) value(val types.AnyType) string {
 	rval := reflect.ValueOf(val)
-	if rval.Kind() == reflect.Ptr && !rval.IsNil() {
+	if rval.Kind() == reflect.Pointer && !rval.IsNil() {
 		rval = rval.Elem()
 	}
 	if rval.Kind() == reflect.Struct {
@@ -411,7 +411,7 @@ func (v *verbose) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
 		p := v.str(val)
 		if p == "" {
 			switch val.Kind() {
-			case reflect.Ptr, reflect.Slice, reflect.Struct:
+			case reflect.Pointer, reflect.Slice, reflect.Struct:
 				p = val.Type().String()
 			default:
 				p = fmt.Sprintf("%v", val.Interface())

--- a/cli/flags/output.go
+++ b/cli/flags/output.go
@@ -127,7 +127,7 @@ func dumpValue(val any) any {
 	}
 
 	rval := reflect.ValueOf(val)
-	if rval.Type().Kind() != reflect.Ptr {
+	if rval.Type().Kind() != reflect.Pointer {
 		return val
 	}
 

--- a/cli/object/collect.go
+++ b/cli/object/collect.go
@@ -128,7 +128,7 @@ func (pc *change) output(name string, rval reflect.Value, rtype reflect.Type) {
 
 	kind := rval.Kind()
 
-	if kind == reflect.Ptr || kind == reflect.Interface {
+	if kind == reflect.Pointer || kind == reflect.Interface {
 		if rval.IsNil() {
 			s = ""
 		} else {
@@ -138,7 +138,7 @@ func (pc *change) output(name string, rval reflect.Value, rtype reflect.Type) {
 	}
 
 	switch kind {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 	case reflect.Slice:
 		if rval.Len() == 0 {
 			s = ""

--- a/fault/fault.go
+++ b/fault/fault.go
@@ -42,7 +42,7 @@ func As(err, target any) (localizedMessage string, okay bool) {
 	}
 	val := reflect.ValueOf(target)
 	typ := val.Type()
-	if typ.Kind() != reflect.Ptr || val.IsNil() {
+	if typ.Kind() != reflect.Pointer || val.IsNil() {
 		panic("fault: target must be a non-nil pointer")
 	}
 	targetType := typ.Elem()

--- a/simulator/property_collector.go
+++ b/simulator/property_collector.go
@@ -151,7 +151,7 @@ func wrapValue(rval reflect.Value, rtype reflect.Type) any {
 }
 
 func fieldValueInterface(f reflect.StructField, rval reflect.Value, keyed ...bool) any {
-	if rval.Kind() == reflect.Ptr {
+	if rval.Kind() == reflect.Pointer {
 		rval = rval.Elem()
 	}
 
@@ -177,7 +177,7 @@ func fieldValue(rval reflect.Value, p string, keyed ...bool) (any, error) {
 			kind = rval.Type().Kind()
 		}
 
-		if kind == reflect.Ptr {
+		if kind == reflect.Pointer {
 			if rval.IsNil() {
 				continue
 			}
@@ -223,7 +223,7 @@ func fieldValueKey(rval reflect.Value, p mo.Field) (any, error) {
 		if item.Kind() == reflect.Interface {
 			item = item.Elem()
 		}
-		if item.Kind() == reflect.Ptr {
+		if item.Kind() == reflect.Pointer {
 			item = item.Elem()
 		}
 		if item.Kind() != reflect.Struct {
@@ -284,7 +284,7 @@ func fieldRefs(f any) []types.ManagedObjectReference {
 
 func isEmpty(rval reflect.Value) bool {
 	switch rval.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return rval.IsNil()
 	case reflect.String:
 		return rval.Len() == 0

--- a/vim25/json/decode.go
+++ b/vim25/json/decode.go
@@ -85,14 +85,13 @@ import (
 //
 // The JSON null value unmarshals into an interface, map, pointer, or slice
 // by setting that Go value to nil. Because null is often used in JSON to mean
-// ``not present,'' unmarshaling a JSON null into any other Go type has no effect
+// “not present,” unmarshaling a JSON null into any other Go type has no effect
 // on the value and produces no error.
 //
 // When unmarshaling quoted strings, invalid UTF-8 or
 // invalid UTF-16 surrogate pairs are not treated as an error.
 // Instead, they are replaced by the Unicode replacement
 // character U+FFFD.
-//
 func Unmarshal(data []byte, v interface{}) error {
 	// Check for well-formedness.
 	// Avoids filling out half a data structure
@@ -161,7 +160,7 @@ func (e *InvalidUnmarshalError) Error() string {
 		return "json: Unmarshal(nil)"
 	}
 
-	if e.Type.Kind() != reflect.Ptr {
+	if e.Type.Kind() != reflect.Pointer {
 		return "json: Unmarshal(non-pointer " + e.Type.String() + ")"
 	}
 	return "json: Unmarshal(nil " + e.Type.String() + ")"
@@ -169,7 +168,7 @@ func (e *InvalidUnmarshalError) Error() string {
 
 func (d *decodeState) unmarshal(v interface{}) error {
 	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
 		return &InvalidUnmarshalError{reflect.TypeOf(v)}
 	}
 
@@ -217,9 +216,9 @@ type decodeState struct {
 	useNumber             bool
 	disallowUnknownFields bool
 
-	discriminatorTypeFieldName   string
-	discriminatorValueFieldName  string
-	discriminatorToTypeFn        DiscriminatorToTypeFunc
+	discriminatorTypeFieldName  string
+	discriminatorValueFieldName string
+	discriminatorToTypeFn       DiscriminatorToTypeFunc
 }
 
 // readIndex returns the position of the last byte read.
@@ -444,7 +443,7 @@ func indirect(v reflect.Value, decodingNull bool) (Unmarshaler, encoding.TextUnm
 	// If v is a named type and is addressable,
 	// start with its address, so that if the type has pointer methods,
 	// we find them.
-	if v.Kind() != reflect.Ptr && v.Type().Name() != "" && v.CanAddr() {
+	if v.Kind() != reflect.Pointer && v.Type().Name() != "" && v.CanAddr() {
 		haveAddr = true
 		v = v.Addr()
 	}
@@ -453,14 +452,14 @@ func indirect(v reflect.Value, decodingNull bool) (Unmarshaler, encoding.TextUnm
 		// usefully addressable.
 		if v.Kind() == reflect.Interface && !v.IsNil() {
 			e := v.Elem()
-			if e.Kind() == reflect.Ptr && !e.IsNil() && (!decodingNull || e.Elem().Kind() == reflect.Ptr) {
+			if e.Kind() == reflect.Pointer && !e.IsNil() && (!decodingNull || e.Elem().Kind() == reflect.Pointer) {
 				haveAddr = false
 				v = e
 				continue
 			}
 		}
 
-		if v.Kind() != reflect.Ptr {
+		if v.Kind() != reflect.Pointer {
 			break
 		}
 
@@ -724,7 +723,7 @@ func (d *decodeState) object(v reflect.Value) error {
 				subv = v
 				destring = f.quoted
 				for _, i := range f.index {
-					if subv.Kind() == reflect.Ptr {
+					if subv.Kind() == reflect.Pointer {
 						if subv.IsNil() {
 							// If a struct embeds a pointer to an unexported type,
 							// it is not possible to set a newly allocated value
@@ -916,7 +915,7 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool
 			break
 		}
 		switch v.Kind() {
-		case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice:
+		case reflect.Interface, reflect.Pointer, reflect.Map, reflect.Slice:
 			v.Set(reflect.Zero(v.Type()))
 			// otherwise, ignore null for primitives/string
 		}

--- a/vim25/json/decode_test.go
+++ b/vim25/json/decode_test.go
@@ -1103,7 +1103,7 @@ func TestUnmarshal(t *testing.T) {
 		}
 
 		typ := reflect.TypeOf(tt.ptr)
-		if typ.Kind() != reflect.Ptr {
+		if typ.Kind() != reflect.Pointer {
 			t.Errorf("#%d: unmarshalTest.ptr %T is not a pointer type", i, tt.ptr)
 			continue
 		}

--- a/vim25/json/discriminator.go
+++ b/vim25/json/discriminator.go
@@ -272,7 +272,7 @@ func (d *decodeState) discriminatorGetValue() (reflect.Value, error) {
 	// likely the decoder was unable to decode the value.
 	if err := dd.savedError; err != nil {
 		switch v.Kind() {
-		case reflect.Ptr, reflect.Interface:
+		case reflect.Pointer, reflect.Interface:
 			v = v.Elem()
 		}
 		if v.IsZero() {
@@ -305,7 +305,7 @@ func (d *decodeState) discriminatorInterfaceDecode(t reflect.Type, v reflect.Val
 			v.Set(pdv)
 			return nil
 		}
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if dve := dv.Elem(); dve.Type().AssignableTo(t) {
 			v.Set(dve)
 			return nil
@@ -353,7 +353,7 @@ func discriminatorInterfaceEncode(e *encodeState, v reflect.Value, opts encOpts)
 	case reflect.Struct:
 		e.discriminatorEncodeTypeName = true
 		newStructEncoder(v.Type())(e, v, opts)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if v.IsZero() {
 			newPtrEncoder(v.Type())(e, v, opts)
 		} else {

--- a/vim25/json/encode.go
+++ b/vim25/json/encode.go
@@ -364,7 +364,7 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Pointer:
 		return v.IsNil()
 	}
 	return false
@@ -441,13 +441,13 @@ func newTypeEncoder(t reflect.Type, allowAddr bool) encoderFunc {
 	// Marshaler with a value receiver, then we're better off taking
 	// the address of the value - otherwise we end up with an
 	// allocation as we cast the value to an interface.
-	if t.Kind() != reflect.Ptr && allowAddr && reflect.PtrTo(t).Implements(marshalerType) {
+	if t.Kind() != reflect.Pointer && allowAddr && reflect.PtrTo(t).Implements(marshalerType) {
 		return newCondAddrEncoder(addrMarshalerEncoder, newTypeEncoder(t, false))
 	}
 	if t.Implements(marshalerType) {
 		return marshalerEncoder
 	}
-	if t.Kind() != reflect.Ptr && allowAddr && reflect.PtrTo(t).Implements(textMarshalerType) {
+	if t.Kind() != reflect.Pointer && allowAddr && reflect.PtrTo(t).Implements(textMarshalerType) {
 		return newCondAddrEncoder(addrTextMarshalerEncoder, newTypeEncoder(t, false))
 	}
 	if t.Implements(textMarshalerType) {
@@ -477,7 +477,7 @@ func newTypeEncoder(t reflect.Type, allowAddr bool) encoderFunc {
 		return newSliceEncoder(t)
 	case reflect.Array:
 		return newArrayEncoder(t)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return newPtrEncoder(t)
 	default:
 		return unsupportedTypeEncoder
@@ -489,7 +489,7 @@ func invalidValueEncoder(e *encodeState, v reflect.Value, _ encOpts) {
 }
 
 func marshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
-	if v.Kind() == reflect.Ptr && v.IsNil() {
+	if v.Kind() == reflect.Pointer && v.IsNil() {
 		e.WriteString("null")
 		return
 	}
@@ -526,7 +526,7 @@ func addrMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 }
 
 func textMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
-	if v.Kind() == reflect.Ptr && v.IsNil() {
+	if v.Kind() == reflect.Pointer && v.IsNil() {
 		e.WriteString("null")
 		return
 	}
@@ -767,7 +767,7 @@ FieldLoop:
 		// Find the nested struct field by following f.index.
 		fv := v
 		for _, i := range f.index {
-			if fv.Kind() == reflect.Ptr {
+			if fv.Kind() == reflect.Pointer {
 				if fv.IsNil() {
 					continue FieldLoop
 				}
@@ -1023,7 +1023,7 @@ func isValidTag(s string) bool {
 
 func typeByIndex(t reflect.Type, index []int) reflect.Type {
 	for _, i := range index {
-		if t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Pointer {
 			t = t.Elem()
 		}
 		t = t.Field(i).Type
@@ -1043,7 +1043,7 @@ func (w *reflectWithString) resolve() error {
 		return nil
 	}
 	if tm, ok := w.k.Interface().(encoding.TextMarshaler); ok {
-		if w.k.Kind() == reflect.Ptr && w.k.IsNil() {
+		if w.k.Kind() == reflect.Pointer && w.k.IsNil() {
 			return nil
 		}
 		buf, err := tm.MarshalText()
@@ -1277,7 +1277,7 @@ func typeFields(t reflect.Type) structFields {
 				sf := f.typ.Field(i)
 				if sf.Anonymous {
 					t := sf.Type
-					if t.Kind() == reflect.Ptr {
+					if t.Kind() == reflect.Pointer {
 						t = t.Elem()
 					}
 					if !sf.IsExported() && t.Kind() != reflect.Struct {
@@ -1303,7 +1303,7 @@ func typeFields(t reflect.Type) structFields {
 				index[len(f.index)] = i
 
 				ft := sf.Type
-				if ft.Name() == "" && ft.Kind() == reflect.Ptr {
+				if ft.Name() == "" && ft.Kind() == reflect.Pointer {
 					// Follow pointer.
 					ft = ft.Elem()
 				}

--- a/vim25/mo/retrieve.go
+++ b/vim25/mo/retrieve.go
@@ -88,7 +88,7 @@ func ApplyPropertyChange(obj Reference, changes []types.PropertyChange) {
 // RetrieveProperties{Ex} to one or more managed objects.
 func LoadObjectContent(content []types.ObjectContent, dst any) error {
 	rt := reflect.TypeOf(dst)
-	if rt == nil || rt.Kind() != reflect.Ptr {
+	if rt == nil || rt.Kind() != reflect.Pointer {
 		panic("need pointer")
 	}
 
@@ -235,7 +235,7 @@ func References(s any, follow ...bool) []types.ManagedObjectReference {
 	rval := reflect.ValueOf(s)
 	rtype := rval.Type()
 
-	if rval.Kind() == reflect.Ptr {
+	if rval.Kind() == reflect.Pointer {
 		rval = rval.Elem()
 		rtype = rval.Type()
 	}
@@ -264,7 +264,7 @@ func References(s any, follow ...bool) []types.ManagedObjectReference {
 			continue
 		}
 
-		if ftype.Kind() == reflect.Ptr {
+		if ftype.Kind() == reflect.Pointer {
 			if val.IsNil() {
 				continue
 			}

--- a/vim25/mo/type_info.go
+++ b/vim25/mo/type_info.go
@@ -101,7 +101,7 @@ func buildName(fn string, f reflect.StructField) string {
 }
 
 func (t *typeInfo) build(typ reflect.Type, fn string, fi []int) {
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 
@@ -138,7 +138,7 @@ func (t *typeInfo) build(typ reflect.Type, fn string, fi []int) {
 		t.props[fnc] = fic
 
 		// Dereference pointer.
-		if ftyp.Kind() == reflect.Ptr {
+		if ftyp.Kind() == reflect.Pointer {
 			ftyp = ftyp.Elem()
 		}
 
@@ -188,7 +188,7 @@ func assignValue(val reflect.Value, fi []int, pv reflect.Value, field ...string)
 	}
 
 	// Create new value if necessary.
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			val.Set(reflect.New(val.Type().Elem()))
 		}
@@ -208,7 +208,7 @@ func assignValue(val reflect.Value, fi []int, pv reflect.Value, field ...string)
 		pt := pv.Type()
 
 		// If type is a pointer, create new instance of type.
-		if rt.Kind() == reflect.Ptr {
+		if rt.Kind() == reflect.Pointer {
 			rv.Set(reflect.New(rt.Elem()))
 			rv = rv.Elem()
 			rt = rv.Type()
@@ -216,7 +216,7 @@ func assignValue(val reflect.Value, fi []int, pv reflect.Value, field ...string)
 
 		// If the target type is a slice, but the source is not, deference any ArrayOfXYZ type
 		if rt.Kind() == reflect.Slice && pt.Kind() != reflect.Slice {
-			if pt.Kind() == reflect.Ptr {
+			if pt.Kind() == reflect.Pointer {
 				pv = pv.Elem()
 				pt = pt.Elem()
 			}
@@ -243,7 +243,7 @@ func assignValue(val reflect.Value, fi []int, pv reflect.Value, field ...string)
 			} else {
 				panic(fmt.Sprintf("type %s doesn't implement %s", pt.Name(), rt.Name()))
 			}
-		} else if rt.Kind() == reflect.Struct && pt.Kind() == reflect.Ptr {
+		} else if rt.Kind() == reflect.Struct && pt.Kind() == reflect.Pointer {
 			pv = pv.Elem()
 			pt = pv.Type()
 		}

--- a/vim25/soap/error.go
+++ b/vim25/soap/error.go
@@ -68,7 +68,7 @@ type vimFaultError struct {
 
 func (v vimFaultError) Error() string {
 	typ := reflect.TypeOf(v.fault)
-	for typ.Kind() == reflect.Ptr {
+	for typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 

--- a/vim25/soap/json_client.go
+++ b/vim25/soap/json_client.go
@@ -182,7 +182,7 @@ func (c *Client) getPathForName(this types.ManagedObjectReference, name string) 
 // struct "This" member is the this MoRef value.
 func unpackSOAPRequest(req HasFault) (this types.ManagedObjectReference, method string, params any, err error) {
 	reqBodyPtr := reflect.ValueOf(req)
-	if reqBodyPtr.Kind() != reflect.Ptr {
+	if reqBodyPtr.Kind() != reflect.Pointer {
 		err = fmt.Errorf("Expected pointer to request body as input. %w", errInputError)
 		return
 	}
@@ -192,7 +192,7 @@ func unpackSOAPRequest(req HasFault) (this types.ManagedObjectReference, method 
 		return
 	}
 	methodRequestPtr := reqBody.FieldByName("Req")
-	if methodRequestPtr.Kind() != reflect.Ptr {
+	if methodRequestPtr.Kind() != reflect.Pointer {
 		err = fmt.Errorf("Expected method request body field to be pointer to struct. %w", errInputError)
 		return
 	}
@@ -222,7 +222,7 @@ func unpackSOAPRequest(req HasFault) (this types.ManagedObjectReference, method 
 // reflection from a SOAP data structure used for marshalling.
 func getSOAPResultPtr(result HasFault) (res any, err error) {
 	resBodyPtr := reflect.ValueOf(result)
-	if resBodyPtr.Kind() != reflect.Ptr {
+	if resBodyPtr.Kind() != reflect.Pointer {
 		err = fmt.Errorf("Expected pointer to result body as input. %w", errInputError)
 		return
 	}
@@ -232,7 +232,7 @@ func getSOAPResultPtr(result HasFault) (res any, err error) {
 		return
 	}
 	methodResponsePtr := resBody.FieldByName("Res")
-	if methodResponsePtr.Kind() != reflect.Ptr {
+	if methodResponsePtr.Kind() != reflect.Pointer {
 		err = fmt.Errorf("Expected method response body field to be pointer to struct. %w", errInputError)
 		return
 	}


### PR DESCRIPTION
## Description

`reflect.Ptr` is marked `//go:fix inline` to `Pointer`; use the canonical Kind name in the test helper switch.