### PR TITLE
refactor: use `maps.Copy` for map merge operations

### DIFF
--- a/simulator/dataset.go
+++ b/simulator/dataset.go
@@ -5,6 +5,8 @@
 package simulator
 
 import (
+	"maps"
+
 	"github.com/vmware/govmomi/vapi/vm/dataset"
 )
 
@@ -46,8 +48,6 @@ func copyDataSet(src *DataSet) *DataSet {
 
 func copyEntries(src map[string]string) map[string]string {
 	copy := make(map[string]string, len(src))
-	for k, v := range src {
-		copy[k] = v
-	}
+	maps.Copy(copy, src)
 	return copy
 }

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -499,9 +500,7 @@ func (s *Service) HandleFunc(pattern string, handler func(http.ResponseWriter, *
 // multiple paths.
 func (s *Service) RegisterSDK(r *Registry, alias ...string) {
 	if existing, ok := s.sdk[r.Path]; ok {
-		for id, obj := range r.objects {
-			existing.objects[id] = obj
-		}
+		maps.Copy(existing.objects, r.objects)
 		return
 	}
 

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
@@ -243,9 +244,7 @@ func (c *Client) newServiceClientWithTransport(path string, namespace string, t 
 
 	// Copy the trusted thumbprints
 	c.hostsMu.Lock()
-	for k, v := range c.hosts {
-		client.hosts[k] = v
-	}
+	maps.Copy(client.hosts, c.hosts)
 	c.hostsMu.Unlock()
 
 	// Copy the cookies


### PR DESCRIPTION
## Description

Replace manual key/value copy loops with `maps.Copy` in the clone builder and acceptance test helpers. This simplifies map merging, keeps behavior unchanged, and makes the code more idiomatic and easier to read.

