### PR TITLE
refactor: remove redundant else branches

### DIFF
--- a/cli/cluster/draft/commit.go
+++ b/cli/cluster/draft/commit.go
@@ -63,7 +63,7 @@ func (cmd *commit) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	} else if _, err = tasks.NewManager(rc).WaitForCompletion(ctx, taskId); err != nil {
 		return err
-	} else {
-		return nil
 	}
+
+	return nil
 }

--- a/cli/cluster/draft/create.go
+++ b/cli/cluster/draft/create.go
@@ -73,7 +73,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	} else if err := cmd.WriteResult(createResult(draftId)); err != nil {
 		return err
-	} else {
-		return nil
 	}
+
+	return nil
 }

--- a/cli/cluster/vlcm/enable.go
+++ b/cli/cluster/vlcm/enable.go
@@ -64,7 +64,7 @@ func (cmd *enable) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	} else if _, err := tasks.NewManager(rc).WaitForCompletion(ctx, taskId); err != nil {
 		return err
-	} else {
-		return nil
 	}
+
+	return nil
 }

--- a/cli/metric/performance.go
+++ b/cli/metric/performance.go
@@ -80,9 +80,9 @@ func (f *PerformanceFlag) Interval(val int32) int32 {
 
 			if n > math.MaxInt32 {
 				panic(fmt.Errorf("value out of range for int32: %d", n))
-			} else {
-				interval = int32(n)
 			}
+
+			interval = int32(n)
 		}
 	}
 

--- a/cli/vlcm/depot/offline/create.go
+++ b/cli/vlcm/depot/offline/create.go
@@ -68,7 +68,7 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	} else if _, err = tasks.NewManager(rc).WaitForCompletion(ctx, taskId); err != nil {
 		return err
-	} else {
-		return nil
 	}
+
+	return nil
 }

--- a/cli/vlcm/depot/offline/rm.go
+++ b/cli/vlcm/depot/offline/rm.go
@@ -61,7 +61,7 @@ func (cmd *rm) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	} else if _, err = tasks.NewManager(rc).WaitForCompletion(ctx, taskId); err != nil {
 		return err
-	} else {
-		return nil
 	}
+
+	return nil
 }

--- a/cli/vm/disk/attach.go
+++ b/cli/vm/disk/attach.go
@@ -111,12 +111,12 @@ func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
 
 		disk = devices.ChildDisk(disk)
 		return vm.AddDevice(ctx, disk)
+	}
+
+	if cmd.persist {
+		backing.DiskMode = string(types.VirtualDiskModePersistent)
 	} else {
-		if cmd.persist {
-			backing.DiskMode = string(types.VirtualDiskModePersistent)
-		} else {
-			backing.DiskMode = string(types.VirtualDiskModeNonpersistent)
-		}
+		backing.DiskMode = string(types.VirtualDiskModeNonpersistent)
 	}
 
 	if len(cmd.mode) != 0 {

--- a/cns/client_test.go
+++ b/cns/client_test.go
@@ -1078,9 +1078,9 @@ func TestClient(t *testing.T) {
 	updateVolumeOperationRes := updateTaskResult.GetCnsVolumeOperationResult()
 	if updateVolumeOperationRes.Fault != nil {
 		t.Fatalf("Failed to update volume metadata: fault=%+v", updateVolumeOperationRes.Fault)
-	} else {
-		t.Logf("Successfully updated volume metadata")
 	}
+
+	t.Logf("Successfully updated volume metadata")
 
 	t.Logf("Calling QueryVolume using queryFilter: %+v", pretty.Sprint(queryFilter))
 	queryResult, err = cnsClient.QueryVolume(ctx, &queryFilter)
@@ -1642,10 +1642,10 @@ func TestClient(t *testing.T) {
 			fault, ok := createVolumeOperationRes.Fault.Fault.(*cnstypes.CnsAlreadyRegisteredFault)
 			if !ok {
 				t.Fatalf("Fault is not CnsAlreadyRegisteredFault")
-			} else {
-				t.Logf("Fault is CnsAlreadyRegisteredFault. backingDiskURLPath: %s is already registered", backingDiskURLPath)
-				volumeID = fault.VolumeId.Id
 			}
+
+			t.Logf("Fault is CnsAlreadyRegisteredFault. backingDiskURLPath: %s is already registered", backingDiskURLPath)
+			volumeID = fault.VolumeId.Id
 		} else {
 			volumeID = createVolumeOperationRes.VolumeId.Id
 			t.Logf("Volume created successfully with backingDiskURLPath: %s. volumeId: %s", backingDiskURLPath, volumeID)
@@ -1691,9 +1691,9 @@ func TestClient(t *testing.T) {
 				_, ok := reCreateVolumeOperationRes.Fault.Fault.(*cnstypes.CnsAlreadyRegisteredFault)
 				if !ok {
 					t.Fatalf("Fault is not CnsAlreadyRegisteredFault")
-				} else {
-					t.Logf("Fault is CnsAlreadyRegisteredFault. backingDiskURLPath: %q is already registered", backingDiskURLPath)
 				}
+
+				t.Logf("Fault is CnsAlreadyRegisteredFault. backingDiskURLPath: %q is already registered", backingDiskURLPath)
 			}
 		}
 
@@ -2413,9 +2413,9 @@ func TestHandleCnsNotRegisteredFault(t *testing.T) {
 		_, ok := extendVolumeOperationRes.Fault.Fault.(*cnstypes.CnsNotRegisteredFault)
 		if !ok {
 			t.Fatalf("Fault is not CnsNotRegisteredFault")
-		} else {
-			t.Logf("Fault is CnsNotRegisteredFault")
 		}
+
+		t.Logf("Fault is CnsNotRegisteredFault")
 	}
 	var staticCnsVolumeCreateSpecList []cnstypes.CnsVolumeCreateSpec
 	staticCnsVolumeCreateSpec := cnstypes.CnsVolumeCreateSpec{

--- a/eam/simulator/simulator_test.go
+++ b/eam/simulator/simulator_test.go
@@ -185,9 +185,9 @@ func TestSimulator(t *testing.T) {
 			if soap.IsSoapFault(err) {
 				fault := soap.ToSoapFault(err).VimFault()
 				t.Fatalf("%[1]T %[1]v", fault)
-			} else {
-				t.Fatalf("%[1]T %[1]v", err)
 			}
+
+			t.Fatalf("%[1]T %[1]v", err)
 		}
 		t.Logf("created agency: %v", agency.Reference())
 

--- a/guest/file_manager.go
+++ b/guest/file_manager.go
@@ -140,9 +140,9 @@ func (m FileManager) TransferURL(ctx context.Context, u string) (*url.URL, error
 	if ok {
 		turl.Host = mname
 		return turl, nil
-	} else {
-		mname = turl.Host
 	}
+
+	mname = turl.Host
 
 	c := property.DefaultCollector(m.c)
 

--- a/vapi/esx/settings/simulator/simulator.go
+++ b/vapi/esx/settings/simulator/simulator.go
@@ -140,10 +140,10 @@ func (h *Handler) clusters(w http.ResponseWriter, r *http.Request) {
 		} else if len(segments) > 2 && segments[1] == "software" && segments[2] == "base-image" {
 			h.clustersSoftwareDraftsBaseImage(w, r)
 			return
-		} else {
-			h.clustersSoftwareDrafts(w, r, segments)
-			return
 		}
+
+		h.clustersSoftwareDrafts(w, r, segments)
+		return
 	} else if len(segments) > 3 && segments[2] == "enablement" && segments[3] == "software" {
 		h.clustersSoftwareEnablement(w, r)
 		return
@@ -175,10 +175,10 @@ func (h *Handler) clustersSoftwareDrafts(w http.ResponseWriter, r *http.Request,
 			if _, contains := h.SoftwareDrafts[*draftId]; !contains {
 				vapi.ApiErrorNotFound(w)
 				return
-			} else {
-				delete(h.SoftwareDrafts, *draftId)
-				vapi.StatusOK(w)
 			}
+
+			delete(h.SoftwareDrafts, *draftId)
+			vapi.StatusOK(w)
 		}
 	case http.MethodPost:
 		if strings.Contains(r.URL.RawQuery, "action=commit") {
@@ -186,10 +186,10 @@ func (h *Handler) clustersSoftwareDrafts(w http.ResponseWriter, r *http.Request,
 				if _, contains := h.SoftwareDrafts[*draftId]; !contains {
 					vapi.ApiErrorNotFound(w)
 					return
-				} else {
-					delete(h.SoftwareDrafts, *draftId)
-					vapi.StatusOK(w)
 				}
+
+				delete(h.SoftwareDrafts, *draftId)
+				vapi.StatusOK(w)
 			}
 		}
 		// Only one active draft is permitted

--- a/vslm/global_object_manager.go
+++ b/vslm/global_object_manager.go
@@ -83,9 +83,9 @@ func (this *Task) WaitNonDefault(ctx context.Context, timeoutNS time.Duration, s
 			}
 		} else if info.State == types.VslmTaskInfoStateError {
 			return nil, soap.WrapVimFault(info.Error.Fault)
-		} else {
-			break
 		}
+
+		break
 		// Check context here to see if we should exit
 	}
 	return this.QueryResult(ctx)


### PR DESCRIPTION
## Description

Simplified control flow by removing `else` blocks that followed early `return`/halt paths. This aligns with idiomatic Go style, reduces nesting, and keeps behavior unchanged.

