### PR TITLE
chore: remove obsolete `// +build`

### DIFF
--- a/toolbox/hgfs/hgfs_other.go
+++ b/toolbox/hgfs/hgfs_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.


### PR DESCRIPTION
## Description

Starting with Go 1.18, `//go:build` is the primary build constraint syntax. A legacy `// +build` line that follows a `//go:build` line is redundant and can be removed.

