### PR TITLE
refactor: replace `sort.Slice` with `slices.Sort`

### DIFF
--- a/vim25/types/esxi_version_test.go
+++ b/vim25/types/esxi_version_test.go
@@ -6,7 +6,7 @@ package types
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"testing"
 )
@@ -194,8 +194,8 @@ func TestESXiVersion(t *testing.T) {
 
 	t.Run("GetESXiVersions", func(t *testing.T) {
 		a, e := uniqueExpectedVersions, GetESXiVersions()
-		sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
-		sort.Slice(e, func(i, j int) bool { return e[i] < e[j] })
+		slices.Sort(a)
+		slices.Sort(e)
 		if a, e := len(a), len(e); a != e {
 			t.Errorf("unexpected number of versions: a=%d, e=%d", a, e)
 		}

--- a/vim25/types/hardware_version_test.go
+++ b/vim25/types/hardware_version_test.go
@@ -6,7 +6,7 @@ package types
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"testing"
 )
@@ -218,8 +218,8 @@ func TestHardwareVersion(t *testing.T) {
 
 	t.Run("GetHardwareVersions", func(t *testing.T) {
 		a, e := uniqueExpectedVersions, GetHardwareVersions()
-		sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
-		sort.Slice(e, func(i, j int) bool { return e[i] < e[j] })
+		slices.Sort(a)
+		slices.Sort(e)
 		if a, e := len(a), len(e); a != e {
 			t.Errorf("unexpected number of versions: a=%d, e=%d", a, e)
 		}


### PR DESCRIPTION
## Description

Replaces `sort.Slice` with `slices.Sort`, which sorts the slice directly and removes the index-based comparison function.

