### PR TITLE
refactor: replace conditional assignment with `max` or `min`

### DIFF
--- a/simulator/model.go
+++ b/simulator/model.go
@@ -978,10 +978,7 @@ func RunContainer(ctx context.Context, c *vim25.Client, vm mo.Reference, args st
 
 // delay sleeps according to DelayConfig. If no delay specified, returns immediately.
 func (dc *DelayConfig) delay(method string) {
-	d := 0
-	if dc.Delay > 0 {
-		d = dc.Delay
-	}
+	d := max(dc.Delay, 0)
 	if md, ok := dc.MethodDelay[method]; ok {
 		d += md
 	}


### PR DESCRIPTION
## Description

Using `max` or `min` makes the intent explicit and reduces branching code.

