### PR TITLE
refactor: use nil slice declaration

### DIFF
--- a/cli/datastore/create.go
+++ b/cli/datastore/create.go
@@ -68,7 +68,7 @@ var localTypes = []string{
 	"local",
 }
 
-var allTypes = []string{}
+var allTypes []string
 
 func init() {
 	allTypes = append(allTypes, nasTypes...)

--- a/cli/device/model/tree.go
+++ b/cli/device/model/tree.go
@@ -110,7 +110,7 @@ func getTree[T, K any]() treeprint.Tree {
 	var (
 		rootObj       K
 		rootType      = reflect.TypeOf(rootObj)
-		allTypes      = []reflect.Type{}
+		allTypes      []reflect.Type
 		embedsTypeMap = map[reflect.Type][]reflect.Type{}
 		rootIfaceType = reflect.TypeOf((*T)(nil)).Elem()
 	)
@@ -141,7 +141,7 @@ func getTree[T, K any]() treeprint.Tree {
 
 	// Each child should have a single parent.
 	for child, parents := range embedsTypeMap {
-		notAncestors := []reflect.Type{}
+		var notAncestors []reflect.Type
 		for i := range parents {
 			p := parents[i]
 			if !typeEmbeddedBy(p, parents...) {

--- a/cli/device/pci/add.go
+++ b/cli/device/pci/add.go
@@ -110,7 +110,7 @@ func (cmd *add) Run(ctx context.Context, f *flag.FlagSet) error {
 		reqDevices[info.PciDevice.Id] = info
 	}
 
-	newDevices := []types.BaseVirtualDevice{}
+	var newDevices []types.BaseVirtualDevice
 	for id, d := range reqDevices {
 		if d == nil {
 			return fmt.Errorf("%s is not found in allowed PCI passthrough device list", id)

--- a/cli/device/pci/remove.go
+++ b/cli/device/pci/remove.go
@@ -91,7 +91,7 @@ func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	rmDevices := []types.BaseVirtualDevice{}
+	var rmDevices []types.BaseVirtualDevice
 	for _, d := range vmDevices.SelectByType(&types.VirtualPCIPassthrough{}) {
 		name := vmDevices.Name(d)
 		_, ok := reqDevices[name]

--- a/cli/dvs/portgroup/info.go
+++ b/cli/dvs/portgroup/info.go
@@ -130,7 +130,7 @@ func printTable(trafficRuleSet map[int]map[int]trafficRule, portID int) {
 		return
 	}
 
-	keys := []int{}
+	var keys []int
 	for k := range trafficRuleSet[portID] {
 		keys = append(keys, k)
 	}

--- a/cli/esx/command.go
+++ b/cli/esx/command.go
@@ -108,7 +108,7 @@ func (c *Command) Parse(params []CommandInfoParam) ([]internal.ReflectManagedMet
 		return nil, err
 	}
 
-	args := []internal.ReflectManagedMethodExecuterSoapArgument{}
+	var args []internal.ReflectManagedMethodExecuterSoapArgument
 
 	for i, p := range params {
 		if len(vals[i]) != 0 {

--- a/cli/esx/command_test.go
+++ b/cli/esx/command_test.go
@@ -105,7 +105,7 @@ func TestNetworkVmListCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expect := []internal.ReflectManagedMethodExecuterSoapArgument{}
+	var expect []internal.ReflectManagedMethodExecuterSoapArgument
 
 	if !reflect.DeepEqual(args, expect) {
 		t.Errorf("%s != %s", args, expect)

--- a/cli/folder/place.go
+++ b/cli/folder/place.go
@@ -21,7 +21,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-var allTypes = []string{}
+var allTypes []string
 
 var createAndPowerOnTypes = []string{
 	string(types.PlaceVmsXClusterSpecPlacementTypeCreateAndPowerOn),

--- a/cli/vm/clone.go
+++ b/cli/vm/clone.go
@@ -287,7 +287,7 @@ func (cmd *clone) cloneVM(ctx context.Context) (*object.VirtualMachine, error) {
 	}
 
 	// prepare virtual device config spec for network card
-	configSpecs := []types.BaseVirtualDeviceConfigSpec{}
+	var configSpecs []types.BaseVirtualDeviceConfigSpec
 
 	if cmd.NetworkFlag.IsSet() {
 		op := types.VirtualDeviceConfigSpecOperationAdd

--- a/cli/vm/instantclone.go
+++ b/cli/vm/instantclone.go
@@ -171,7 +171,7 @@ func (cmd *instantclone) instantcloneVM(ctx context.Context) (*object.VirtualMac
 		}
 
 		// prepare virtual device config spec for network card
-		configSpecs := []types.BaseVirtualDeviceConfigSpec{}
+		var configSpecs []types.BaseVirtualDeviceConfigSpec
 
 		op := types.VirtualDeviceConfigSpecOperationAdd
 		card, derr := cmd.NetworkFlag.Device()

--- a/cns/simulator/simulator.go
+++ b/cns/simulator/simulator.go
@@ -385,7 +385,7 @@ func (m *CnsVolumeManager) CnsUpdateVolumeMetadata(ctx *simulator.Context, req *
 		if len(req.UpdateSpecs) == 0 {
 			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsUpdateVolumeMetadataSpec"}
 		}
-		operationResult := []cnstypes.BaseCnsVolumeOperationResult{}
+		var operationResult []cnstypes.BaseCnsVolumeOperationResult
 		for _, updateSpecs := range req.UpdateSpecs {
 			for _, dsVolumes := range m.volumes {
 				for id, volume := range dsVolumes {
@@ -418,7 +418,7 @@ func (m *CnsVolumeManager) CnsAttachVolume(ctx *simulator.Context, req *cnstypes
 		if len(req.AttachSpecs) == 0 {
 			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsAttachVolumeSpec"}
 		}
-		operationResult := []cnstypes.BaseCnsVolumeOperationResult{}
+		var operationResult []cnstypes.BaseCnsVolumeOperationResult
 		for _, attachSpec := range req.AttachSpecs {
 			node := vctx.Map.Get(attachSpec.Vm).(*simulator.VirtualMachine)
 			if _, ok := m.attachments[attachSpec.VolumeId]; !ok {
@@ -454,7 +454,7 @@ func (m *CnsVolumeManager) CnsDetachVolume(ctx *simulator.Context, req *cnstypes
 		if len(req.DetachSpecs) == 0 {
 			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsDetachVolumeSpec"}
 		}
-		operationResult := []cnstypes.BaseCnsVolumeOperationResult{}
+		var operationResult []cnstypes.BaseCnsVolumeOperationResult
 		for _, detachSpec := range req.DetachSpecs {
 			if _, ok := m.attachments[detachSpec.VolumeId]; ok {
 				delete(m.attachments, detachSpec.VolumeId)
@@ -554,7 +554,7 @@ func (m *CnsVolumeManager) CnsQueryVolumeInfo(ctx *simulator.Context, req *cnsty
 
 func (m *CnsVolumeManager) CnsQueryAsync(ctx *simulator.Context, req *cnstypes.CnsQueryAsync) soap.HasFault {
 	task := simulator.CreateTask(m, "QueryVolumeAsync", func(*simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
-		retVolumes := []cnstypes.CnsVolume{}
+		var retVolumes []cnstypes.CnsVolume
 		reqVolumeIds := make(map[string]bool)
 		isQueryFilter := false
 
@@ -577,7 +577,7 @@ func (m *CnsVolumeManager) CnsQueryAsync(ctx *simulator.Context, req *cnstypes.C
 				}
 			}
 		}
-		operationResult := []cnstypes.BaseCnsVolumeOperationResult{}
+		var operationResult []cnstypes.BaseCnsVolumeOperationResult
 		operationResult = append(operationResult, &cnstypes.CnsAsyncQueryResult{
 			QueryResult: cnstypes.CnsQueryResult{
 				Volumes: retVolumes,
@@ -603,7 +603,7 @@ func (m *CnsVolumeManager) CnsCreateSnapshots(ctx *simulator.Context, req *cnsty
 			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsSnapshotCreateSpec"}
 		}
 
-		snapshotOperationResult := []cnstypes.BaseCnsVolumeOperationResult{}
+		var snapshotOperationResult []cnstypes.BaseCnsVolumeOperationResult
 		for _, snapshotCreateSpec := range req.SnapshotSpecs {
 			for _, dsVolumes := range m.volumes {
 				for id := range dsVolumes {
@@ -651,7 +651,7 @@ func (m *CnsVolumeManager) CnsCreateSnapshots(ctx *simulator.Context, req *cnsty
 
 func (m *CnsVolumeManager) CnsDeleteSnapshots(ctx *simulator.Context, req *cnstypes.CnsDeleteSnapshots) soap.HasFault {
 	task := simulator.CreateTask(m, "DeleteSnapshots", func(*simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
-		snapshotOperationResult := []cnstypes.BaseCnsVolumeOperationResult{}
+		var snapshotOperationResult []cnstypes.BaseCnsVolumeOperationResult
 		for _, snapshotDeleteSpec := range req.SnapshotDeleteSpecs {
 			for _, dsVolumes := range m.volumes {
 				for id := range dsVolumes {
@@ -693,7 +693,7 @@ func (m *CnsVolumeManager) CnsQuerySnapshots(ctx *simulator.Context, req *cnstyp
 			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsSnapshotQuerySpec"}
 		}
 
-		snapshotQueryResultEntries := []cnstypes.CnsSnapshotQueryResultEntry{}
+		var snapshotQueryResultEntries []cnstypes.CnsSnapshotQueryResultEntry
 		checkVolumeExists := func(volumeId cnstypes.CnsVolumeId) bool {
 			for _, dsVolumes := range m.volumes {
 				for id := range dsVolumes {

--- a/eam/simulator/agent.go
+++ b/eam/simulator/agent.go
@@ -79,7 +79,7 @@ func NewAgent(
 		var vmRef vim.ManagedObjectReference
 
 		// vmExtraConfig is used when creating the VM for this agent.
-		vmExtraConfig := []vim.BaseOptionValue{}
+		var vmExtraConfig []vim.BaseOptionValue
 
 		// If config.OvfPackageUrl is non-empty and does not appear to point to
 		// a local file or an HTTP URI, then assume it is a container.

--- a/eam/simulator/eam_object.go
+++ b/eam/simulator/eam_object.go
@@ -79,7 +79,7 @@ func (m *EamObject) Resolve(
 
 	// notFoundKeys is a list of issue keys that were sent but
 	// not found for the given object.
-	notFoundKeys := []int32{}
+	var notFoundKeys []int32
 
 	// issueExists is a helper function that returns true
 	issueExists := func(issueKey int32) bool {

--- a/hack/header/main.go
+++ b/hack/header/main.go
@@ -142,7 +142,7 @@ func checkHeader(path string, headerLines []string) (bool, error) {
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
-	lines := []string{}
+	var lines []string
 	skipShebang := filepath.Ext(path) == ".sh" // Handle shebang for shell scripts.
 
 	// Only scan the first `MaxScanLines` lines.

--- a/list/lister.go
+++ b/list/lister.go
@@ -222,7 +222,7 @@ func (l Lister) ListFolder(ctx context.Context) ([]Element, error) {
 		return nil, err
 	}
 
-	es := []Element{}
+	var es []Element
 	for _, v := range dst {
 		es = append(es, ToElement(v.(mo.Reference), l.Prefix))
 	}
@@ -280,7 +280,7 @@ func (l Lister) ListDatacenter(ctx context.Context) ([]Element, error) {
 		return nil, err
 	}
 
-	es := []Element{}
+	var es []Element
 	for _, v := range dst {
 		es = append(es, ToElement(v.(mo.Reference), l.Prefix))
 	}
@@ -347,7 +347,7 @@ func (l Lister) ListComputeResource(ctx context.Context) ([]Element, error) {
 		return nil, err
 	}
 
-	es := []Element{}
+	var es []Element
 	for _, v := range dst {
 		es = append(es, ToElement(v.(mo.Reference), l.Prefix))
 	}
@@ -410,7 +410,7 @@ func (l Lister) ListResourcePool(ctx context.Context) ([]Element, error) {
 		return nil, err
 	}
 
-	es := []Element{}
+	var es []Element
 	for _, v := range dst {
 		es = append(es, ToElement(v.(mo.Reference), l.Prefix))
 	}
@@ -477,7 +477,7 @@ func (l Lister) ListHostSystem(ctx context.Context) ([]Element, error) {
 		return nil, err
 	}
 
-	es := []Element{}
+	var es []Element
 	for _, v := range dst {
 		es = append(es, ToElement(v.(mo.Reference), l.Prefix))
 	}
@@ -540,7 +540,7 @@ func (l Lister) ListDistributedVirtualSwitch(ctx context.Context) ([]Element, er
 		return nil, err
 	}
 
-	es := []Element{}
+	var es []Element
 	for _, v := range dst {
 		es = append(es, ToElement(v.(mo.Reference), l.Prefix))
 	}
@@ -605,7 +605,7 @@ func (l Lister) ListVirtualApp(ctx context.Context) ([]Element, error) {
 		return nil, err
 	}
 
-	es := []Element{}
+	var es []Element
 	for _, v := range dst {
 		es = append(es, ToElement(v.(mo.Reference), l.Prefix))
 	}

--- a/pbm/client_test.go
+++ b/pbm/client_test.go
@@ -541,7 +541,7 @@ func TestStoragePolicyK8sCompliantNames(t *testing.T) {
 			assert.EqualError(t, err, "ServerFaultCode: Duplicate Name")
 
 			// Resolve K8sCompliantName and otherK8sCompliantNames for the policy
-			otherK8sCompliantNamesResolved := []string{}
+			var otherK8sCompliantNamesResolved []string
 			otherK8sCompliantNamesResolved = append(otherK8sCompliantNamesResolved, otherK8sCompliantNamesSuccess...)
 			otherK8sCompliantNamesResolved = append(otherK8sCompliantNamesResolved, validK8sCompliantName+"-latebinding")
 			err = pc.ResolveK8sCompliantNames(ctx)

--- a/simulator/container_virtual_machine.go
+++ b/simulator/container_virtual_machine.go
@@ -331,7 +331,7 @@ func (svm *simVM) start(ctx *Context) error {
 		env = append(env, "VMX_GUESTINFO=true")
 	}
 
-	volumes := []string{}
+	var volumes []string
 	if mountDMI {
 		volumes = append(volumes, constructVolumeName(svm.vm.Name, svm.vm.uid.String(), "dmi")+":/sys/class/dmi/id")
 	}

--- a/simulator/datacenter_test.go
+++ b/simulator/datacenter_test.go
@@ -113,7 +113,7 @@ func TestDatacenterPowerOnMultiVMs(t *testing.T) {
 	if len(vms) < numTestVMs {
 		t.Fatalf("Need at least %v VMs in a datacenter for this test", numTestVMs)
 	}
-	testVMs := []types.ManagedObjectReference{}
+	var testVMs []types.ManagedObjectReference
 	for _, vm := range vms[:numTestVMs] {
 		testVMs = append(testVMs, vm.Reference())
 	}

--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -349,7 +349,7 @@ func (s *DistributedVirtualSwitch) filterDVPortsByPortgroupKey(
 
 	// inside portgroup keys
 	if *criteria.Inside {
-		filtered := []types.DistributedVirtualPort{}
+		var filtered []types.DistributedVirtualPort
 
 		for _, p := range ports {
 			if slices.Contains(criteria.PortgroupKey, p.PortgroupKey) {
@@ -360,7 +360,7 @@ func (s *DistributedVirtualSwitch) filterDVPortsByPortgroupKey(
 	}
 
 	// outside portgroup keys
-	filtered := []types.DistributedVirtualPort{}
+	var filtered []types.DistributedVirtualPort
 
 	for _, p := range ports {
 		found := slices.Contains(criteria.PortgroupKey, p.PortgroupKey)
@@ -380,7 +380,7 @@ func (s *DistributedVirtualSwitch) filterDVPortsByPortKey(
 		return ports
 	}
 
-	filtered := []types.DistributedVirtualPort{}
+	var filtered []types.DistributedVirtualPort
 
 	for _, p := range ports {
 		if slices.Contains(criteria.PortKey, p.Key) {
@@ -399,7 +399,7 @@ func (s *DistributedVirtualSwitch) filterDVPortsByConnected(
 		return ports
 	}
 
-	filtered := []types.DistributedVirtualPort{}
+	var filtered []types.DistributedVirtualPort
 
 	for _, p := range ports {
 		connected := p.Connectee != nil

--- a/simulator/esx/setting.go
+++ b/simulator/esx/setting.go
@@ -25,4 +25,4 @@ var AdvancedOptions = []types.BaseOptionValue{
 // Capture method:
 //
 //	govc object.collect -s -dump OptionManager:HostAgentSettings setting
-var Setting = []types.BaseOptionValue{}
+var Setting []types.BaseOptionValue

--- a/simulator/host_system_test.go
+++ b/simulator/host_system_test.go
@@ -155,7 +155,7 @@ func TestDestroyHostSystem(t *testing.T) {
 	hs := m.Map().Get(*vm.Runtime.Host).(*HostSystem)
 	host := object.NewHostSystem(c, hs.Self)
 
-	vms := []*VirtualMachine{}
+	var vms []*VirtualMachine
 	for _, vmref := range hs.Vm {
 		vms = append(vms, m.Map().Get(vmref).(*VirtualMachine))
 	}

--- a/simulator/http_nfc_lease.go
+++ b/simulator/http_nfc_lease.go
@@ -189,7 +189,7 @@ func (l *HttpNfcLease) getDeviceKey(name string) string {
 }
 
 func (l *HttpNfcLease) HttpNfcLeaseGetManifest(ctx *Context, req *types.HttpNfcLeaseGetManifest) soap.HasFault {
-	entries := []types.HttpNfcLeaseManifestEntry{}
+	var entries []types.HttpNfcLeaseManifestEntry
 	for name, md := range l.metadata {
 		entries = append(entries, types.HttpNfcLeaseManifestEntry{
 			Key:  l.getDeviceKey(name),

--- a/simulator/ip_pool_manager.go
+++ b/simulator/ip_pool_manager.go
@@ -83,7 +83,7 @@ func (m *IpPoolManager) DestroyIpPool(req *types.DestroyIpPool) soap.HasFault {
 }
 
 func (m *IpPoolManager) QueryIpPools(req *types.QueryIpPools) soap.HasFault {
-	pools := []types.IpPool{}
+	var pools []types.IpPool
 
 	for i := int32(1); i < m.nextPoolId; i++ {
 		if p, ok := m.pools[i]; ok {

--- a/simulator/tenant_manager.go
+++ b/simulator/tenant_manager.go
@@ -37,7 +37,7 @@ func (t *TenantManager) unmarkEntities(entities []types.ManagedObjectReference) 
 }
 
 func (t *TenantManager) getEntities() []types.ManagedObjectReference {
-	entities := []types.ManagedObjectReference{}
+	var entities []types.ManagedObjectReference
 	for e := range t.spEntities {
 		entities = append(entities, e)
 	}

--- a/vim25/json/encode.go
+++ b/vim25/json/encode.go
@@ -1247,7 +1247,7 @@ func (x byIndex) Less(i, j int) bool {
 // and then any reachable anonymous structs.
 func typeFields(t reflect.Type) structFields {
 	// Anonymous fields to explore at the current level and the next.
-	current := []field{}
+	var current []field
 	next := []field{{typ: t}}
 
 	// Count of queued names for current level and the next.

--- a/vim25/xml/read_test.go
+++ b/vim25/xml/read_test.go
@@ -830,7 +830,8 @@ func TestUnmarshalEmptyValues(t *testing.T) {
 		t.Fatalf("zero: Unmarshal failed: got %v", err)
 	}
 
-	zBytes, zInt, zStr, zFloat, zBool := []byte{}, 0, "", float32(0), false
+	var zBytes []byte
+	zInt, zStr, zFloat, zBool := 0, "", float32(0), false
 	want := &Parent{
 		IPtr:         &zInt,
 		Is:           []int{zInt},


### PR DESCRIPTION
## Description

Replaces empty slice declaration with nil slice declaration.

An empty slice can be represented by nil or an empty slice literal. They are functionally equivalent (their `len` and `cap` are both zero) but the nil slice is the preferred style.