### PR TITLE
refactor: use `strings.Builder` for string concatenation

### DIFF
--- a/cli/host/autostart/info.go
+++ b/cli/host/autostart/info.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/vmware/govmomi/cli"
@@ -80,16 +81,16 @@ func (r *infoResult) vmPaths() (map[string]string, error) {
 			return nil, err
 		}
 
-		path := ""
+		var path strings.Builder
 		for _, me := range mes {
 			// Skip root entity in building inventory path.
 			if me.Parent == nil {
 				continue
 			}
-			path += "/" + me.Name
+			path.WriteString("/" + me.Name)
 		}
 
-		paths[info.Key.Value] = path
+		paths[info.Key.Value] = path.String()
 	}
 
 	return paths, nil

--- a/cli/vm/keystrokes.go
+++ b/cli/vm/keystrokes.go
@@ -527,7 +527,8 @@ func (cmd *keystrokes) Usage() string {
 }
 
 func (cmd *keystrokes) Description() string {
-	description := `Send Keystrokes to VM.
+	var description strings.Builder
+	description.WriteString(`Send Keystrokes to VM.
 
 Examples:
  Default Scenario
@@ -539,7 +540,7 @@ Examples:
   govc vm.keystrokes -vm $vm -c 0x15,KEY_ENTER # writes an 'r' to the console and press ENTER
 
 List of available aliases:
-`
+`)
 	keys := make([]string, 0)
 	for key, _ := range hidKeyMap {
 		keys = append(keys, key)
@@ -547,11 +548,11 @@ List of available aliases:
 	sort.Strings(keys)
 	for i, key := range keys {
 		if i > 0 {
-			description += ", "
+			description.WriteString(", ")
 		}
-		description += key
+		description.WriteString(key)
 	}
-	return description + "\n"
+	return description.String() + "\n"
 }
 
 func (cmd *keystrokes) Process(ctx context.Context) error {

--- a/vapi/tags/errors.go
+++ b/vapi/tags/errors.go
@@ -6,6 +6,7 @@ package tags
 
 import (
 	"fmt"
+	"strings"
 )
 
 const (
@@ -28,16 +29,16 @@ func (b BatchErrors) Error() string {
 		return ""
 	}
 
-	var errString string
+	var errString strings.Builder
 	for i := range b {
 		errType := b[i].Type
 		reason := b[i].Message
-		errString += fmt.Sprintf(errFormat, i, errType, reason)
+		errString.WriteString(fmt.Sprintf(errFormat, i, errType, reason))
 
 		// no separator after last item
 		if i+1 < len(b) {
-			errString += separator
+			errString.WriteString(separator)
 		}
 	}
-	return errString
+	return errString.String()
 }


### PR DESCRIPTION
## Description

Use `strings.Builder` for string concatenation.

