### PR TITLE
refactor: use `strings.Cut` for slicing

### DIFF
--- a/object/datastore_path.go
+++ b/object/datastore_path.go
@@ -31,13 +31,13 @@ func (p *DatastorePath) FromString(s string) bool {
 
 	s = s[1:]
 
-	ix := strings.Index(s, "]")
-	if ix < 0 {
+	before, after, ok := strings.Cut(s, "]")
+	if !ok {
 		return false
 	}
 
-	p.Datastore = s[:ix]
-	p.Path = strings.TrimSpace(s[ix+1:])
+	p.Datastore = before
+	p.Path = strings.TrimSpace(after)
 
 	return true
 }


### PR DESCRIPTION
## Description

Use `strings.Cut` for slicing. `strings.Cut` splits a string around the first instance of a separator and returns the prefix, suffix, and a boolean that reports whether the separator was found.
