### PR TITLE
refactor: use `strings.CutPrefix` for inspection

### DIFF
--- a/ovf/configspec.go
+++ b/ovf/configspec.go
@@ -584,9 +584,9 @@ func (e Envelope) setPCISlotNumber(
 
 func (e Envelope) ovfDisk(diskID string) *VirtualDiskDesc {
 
-	if strings.HasPrefix(diskID, "ovf:/disk/") {
+	if after, ok := strings.CutPrefix(diskID, "ovf:/disk/"); ok {
 		// Find an exact match.
-		diskID = strings.TrimPrefix(diskID, "ovf:/disk/")
+		diskID = after
 		for _, disk := range e.Disk.Disks {
 			if diskID == disk.DiskID {
 				return &disk

--- a/vmdk/descriptor.go
+++ b/vmdk/descriptor.go
@@ -85,7 +85,7 @@ func ParseDescriptor(r io.Reader) (*Descriptor, error) {
 
 		key, val := strings.TrimSpace(s[0]), strings.TrimSpace(s[1])
 		val = strings.Trim(val, `"`)
-		if k := strings.TrimPrefix(key, "ddb."); k != key {
+		if k, ok := strings.CutPrefix(key, "ddb."); ok {
 			d.DDB[k] = val
 			continue
 		}


### PR DESCRIPTION
## Description

The `HasPrefix` and `TrimPrefix` patterns scan the prefix twice. `strings.CutPrefix` removes the prefix in one step and returns the updated string and a boolean that reports whether the prefix was present.
