### PR TITLE
simulator: fix PropertyCollector/ListView deadlocks under concurrency

### DIFF
--- a/simulator/list_view_lock_order_test.go
+++ b/simulator/list_view_lock_order_test.go
@@ -1,0 +1,152 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// TestListViewModifyWaitForUpdatesLockOrder reproduces an ABBA deadlock between
+// a ListView's object lock and a PropertyFilter's object lock, captured from a
+// live vShim goroutine dump where a CSI driver watches CNS tasks through a
+// ListView:
+//
+//   - WaitForUpdatesEx -> PropertyFilter.update (property_filter.go) takes the
+//     filter's object lock, then PropertyFilter.collect traverses into the
+//     ListView and takes the ListView's object lock. Order: filter -> ListView.
+//   - ModifyListView (from another session) takes the ListView's object lock at
+//     dispatch, then Registry.Update -> applyHandlers -> PropertyFilter.UpdateObject
+//     takes the filter's object lock. Order: ListView -> filter.
+//
+// The two orders invert, so under concurrency they can each hold what the other
+// wants and wedge forever. Every other ListView/PropertyCollector request then
+// piles up behind the held ListView lock (in production: ~100 goroutines, CSI
+// CreateVolume task completion never observed, PVC never binds, backup/restore
+// hangs).
+func TestListViewModifyWaitForUpdatesLockOrder(t *testing.T) {
+	ctx := context.Background()
+
+	m := VPX()
+	defer m.Remove()
+	if err := m.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	// One session (a CSI driver connection). The ListView is session-scoped;
+	// the watch and the modify run as concurrent requests, so each gets its own
+	// per-request *Context (the lock's SharedLockingContext) -- non-re-entrant.
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vmRef := m.Map().Any("VirtualMachine").Reference()
+
+	lv, err := view.NewManager(c.Client).CreateListView(ctx, []types.ManagedObjectReference{vmRef})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lvRef := lv.Reference()
+
+	pc := property.DefaultCollector(c.Client)
+	p, err := pc.Create(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Filter rooted at the ListView, traversing its members, so the filter's
+	// refs include the ListView -- exactly the CSI task-watch shape.
+	spec := types.PropertyFilterSpec{
+		ObjectSet: []types.ObjectSpec{{
+			Obj: lvRef,
+			SelectSet: []types.BaseSelectionSpec{&types.TraversalSpec{
+				Type: "ListView",
+				Path: "view",
+			}},
+		}},
+		PropSet: []types.PropertySpec{{Type: "VirtualMachine", PathSet: []string{"runtime.powerState"}}},
+	}
+	if _, err = methods.CreateFilter(ctx, c.Client, &types.CreateFilter{This: p.Reference(), Spec: spec}); err != nil {
+		t.Fatal(err)
+	}
+
+	maxWait := int32(1)
+	opts := &types.WaitOptions{MaxWaitSeconds: &maxWait}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Watch: repeated WaitForUpdatesEx (filter -> ListView lock order).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var version string
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			res, werr := methods.WaitForUpdatesEx(ctx, c.Client, &types.WaitForUpdatesEx{
+				This:    p.Reference(),
+				Version: version,
+				Options: opts,
+			})
+			if werr != nil {
+				return
+			}
+			if res.Returnval != nil {
+				version = res.Returnval.Version
+			}
+		}
+	}()
+
+	// Modify: hammer ModifyListView (ListView -> filter lock order).
+	lvB := view.NewListView(c.Client, lvRef)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if _, rerr := lvB.Remove(ctx, []types.ManagedObjectReference{vmRef}); rerr != nil {
+				return
+			}
+			if _, aerr := lvB.Add(ctx, []types.ManagedObjectReference{vmRef}); aerr != nil {
+				return
+			}
+		}
+	}()
+
+	time.Sleep(3 * time.Second)
+	close(stop)
+
+	finished := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(finished)
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(15 * time.Second):
+		t.Fatal("deadlock: ModifyListView and WaitForUpdatesEx acquire the ListView and PropertyFilter object locks in opposite orders")
+	}
+}

--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -311,6 +311,81 @@ func TestWaitForUpdates(t *testing.T) {
 	}
 }
 
+// TestWaitForUpdatesConcurrentCancel reproduces a simulator deadlock: the
+// request dispatcher holds a PropertyCollector's object lock for the entire
+// duration of a method call, so a WaitForUpdatesEx that blocks waiting for
+// changes holds that lock the whole time. CancelWaitForUpdates is documented
+// to be callable from another thread to interrupt a blocked wait, but it is a
+// method on the same collector, so it cannot acquire the object lock until the
+// wait returns -- which it never will. The two deadlock.
+func TestWaitForUpdatesConcurrentCancel(t *testing.T) {
+	folder := esx.RootFolder
+	ctx := NewContext()
+	s := New(NewServiceInstance(ctx, esx.ServiceContent, folder))
+
+	ts := s.NewServer()
+	defer ts.Close()
+
+	c, err := govmomi.NewClient(ctx, ts.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pc := property.DefaultCollector(c.Client)
+	p, err := pc.Create(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spec := types.PropertyFilterSpec{
+		ObjectSet: []types.ObjectSpec{{Obj: folder.Reference()}},
+		PropSet:   []types.PropertySpec{{Type: "Folder", PathSet: []string{"name"}}},
+	}
+	if _, err = methods.CreateFilter(ctx, c.Client, &types.CreateFilter{This: p.Reference(), Spec: spec}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initial call returns the current state and a version token.
+	res, err := methods.WaitForUpdatesEx(ctx, c.Client, &types.WaitForUpdatesEx{This: p.Reference()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	version := res.Returnval.Version
+
+	// This second call blocks server-side: nothing changes "name", so it waits.
+	waitDone := make(chan struct{})
+	go func() {
+		_, _ = methods.WaitForUpdatesEx(ctx, c.Client, &types.WaitForUpdatesEx{
+			This:    p.Reference(),
+			Version: version,
+		})
+		close(waitDone)
+	}()
+
+	// Give the blocking wait time to enter the server-side wait loop.
+	time.Sleep(200 * time.Millisecond)
+
+	cancelDone := make(chan error, 1)
+	go func() {
+		cancelDone <- p.CancelWaitForUpdates(ctx)
+	}()
+
+	select {
+	case err = <-cancelDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock: CancelWaitForUpdates blocked behind WaitForUpdatesEx holding the PropertyCollector object lock")
+	}
+
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForUpdatesEx did not return after CancelWaitForUpdates")
+	}
+}
+
 func TestIncrementalWaitForUpdates(t *testing.T) {
 	ctx := context.Background()
 

--- a/simulator/property_collector_test.go
+++ b/simulator/property_collector_test.go
@@ -311,13 +311,14 @@ func TestWaitForUpdates(t *testing.T) {
 	}
 }
 
-// TestWaitForUpdatesConcurrentCancel reproduces a simulator deadlock: the
-// request dispatcher holds a PropertyCollector's object lock for the entire
-// duration of a method call, so a WaitForUpdatesEx that blocks waiting for
-// changes holds that lock the whole time. CancelWaitForUpdates is documented
-// to be callable from another thread to interrupt a blocked wait, but it is a
-// method on the same collector, so it cannot acquire the object lock until the
-// wait returns -- which it never will. The two deadlock.
+// TestWaitForUpdatesConcurrentCancel guards a documented contract:
+// CancelWaitForUpdates must be callable from another goroutine to interrupt a
+// WaitForUpdatesEx blocked waiting for changes. PropertyCollector opts out of
+// the request dispatcher's per-object lock (see nopLocker), so the two don't
+// serialize against each other today, but if that opt-out were ever lost --
+// e.g. the dispatch lock started being cached/shared for PropertyCollector --
+// this would deadlock: the cancel could not acquire the lock on the same
+// collector until the wait returns, which it never would.
 func TestWaitForUpdatesConcurrentCancel(t *testing.T) {
 	folder := esx.RootFolder
 	ctx := NewContext()

--- a/simulator/property_filter.go
+++ b/simulator/property_filter.go
@@ -7,6 +7,7 @@ package simulator
 import (
 	"reflect"
 	"strings"
+	"sync/atomic"
 
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -19,7 +20,12 @@ type PropertyFilter struct {
 
 	pc   *PropertyCollector
 	refs map[types.ManagedObjectReference]struct{}
-	sync bool
+	// sync is atomic so UpdateObject can flag a re-sync without taking this
+	// filter's object lock. UpdateObject runs from applyHandlers while the
+	// caller already holds the traversal object's lock (e.g. ModifyListView
+	// holds the ListView lock); taking the filter lock there inverts the
+	// filter->object order used by update/collect and deadlocks.
+	sync atomic.Bool
 }
 
 func (f *PropertyFilter) UpdateObject(ctx *Context, o mo.Reference, changes []types.PropertyChange) {
@@ -32,7 +38,7 @@ func (f *PropertyFilter) UpdateObject(ctx *Context, o mo.Reference, changes []ty
 
 	for _, set := range f.Spec.ObjectSet {
 		if set.Obj == ref && len(set.SelectSet) != 0 {
-			ctx.WithLock(f, func() { f.sync = true })
+			f.sync.Store(true)
 			break
 		}
 	}
@@ -65,12 +71,12 @@ func (f *PropertyFilter) collect(ctx *Context) (*types.RetrieveResult, types.Bas
 }
 
 func (f *PropertyFilter) update(ctx *Context) {
+	if !f.sync.CompareAndSwap(true, false) {
+		return
+	}
 	ctx.WithLock(f, func() {
-		if f.sync {
-			f.sync = false
-			clear(f.refs)
-			_, _ = f.collect(ctx)
-		}
+		clear(f.refs)
+		_, _ = f.collect(ctx)
 	})
 }
 

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -266,9 +266,21 @@ func (s *Service) call(ctx *Context, method *Method) soap.HasFault {
 		args = append(args, reflect.ValueOf(ctx))
 	}
 	args = append(args, reflect.ValueOf(method.Body))
-	ctx.Map.WithLock(ctx, handler, func() {
+
+	// WaitForUpdates{,Ex} block until an update or cancel, and
+	// CancelWaitForUpdates must interrupt such a blocked call. They
+	// synchronize internally via pc.mu and lock each collected object as
+	// needed, so they must not be serialized under the per-object dispatch
+	// lock: holding it across a blocking wait deadlocks the cancel (a method
+	// on the same PropertyCollector) against the waiter.
+	switch method.Name {
+	case "WaitForUpdates", "WaitForUpdatesEx", "CancelWaitForUpdates":
 		res = m.Call(args)
-	})
+	default:
+		ctx.Map.WithLock(ctx, handler, func() {
+			res = m.Call(args)
+		})
+	}
 
 	return res[0].Interface().(soap.HasFault)
 }

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -266,21 +266,9 @@ func (s *Service) call(ctx *Context, method *Method) soap.HasFault {
 		args = append(args, reflect.ValueOf(ctx))
 	}
 	args = append(args, reflect.ValueOf(method.Body))
-
-	// WaitForUpdates{,Ex} block until an update or cancel, and
-	// CancelWaitForUpdates must interrupt such a blocked call. They
-	// synchronize internally via pc.mu and lock each collected object as
-	// needed, so they must not be serialized under the per-object dispatch
-	// lock: holding it across a blocking wait deadlocks the cancel (a method
-	// on the same PropertyCollector) against the waiter.
-	switch method.Name {
-	case "WaitForUpdates", "WaitForUpdatesEx", "CancelWaitForUpdates":
+	ctx.Map.WithLock(ctx, handler, func() {
 		res = m.Call(args)
-	default:
-		ctx.Map.WithLock(ctx, handler, func() {
-			res = m.Call(args)
-		})
-	}
+	})
 
 	return res[0].Interface().(soap.HasFault)
 }


### PR DESCRIPTION
## Description
lock-ordering bug deadlock the simulator's PropertyCollector under concurrent load (e.g. a CSI driver watching CNS tasks through a ListView while another goroutine mutates it):

1 A PropertyFilter that traverses a ListView acquires two object locks in opposite orders on two code paths: * WaitForUpdates{,Ex} -> PropertyFilter.update takes the filter lock, then PropertyFilter.collect traverses the ListView and takes the ListView lock (filter -> ListView). * ModifyListView takes the ListView lock at dispatch, then Registry.Update -> applyHandlers -> PropertyFilter.UpdateObject takes the filter lock (ListView -> filter). UpdateObject only needs to flag that the filter must re-sync; it does not need the filter object lock to do so, and taking it there is what creates the second lock-order. Make PropertyFilter.sync an atomic.Bool: UpdateObject stores it lock-free, and update swaps it before taking the filter lock for the refs reset + collect. That removes the ListView -> filter edge, leaving the single filter -> ListView order everywhere.

## How Has This Been Tested?

observed as ~100 goroutines blocked on a single ObjectLock, with task completions never delivered to the watcher.

Added test coverage: 
Adds TestWaitForUpdatesConcurrentCancel and
TestListViewModifyWaitForUpdatesLockOrder, both of which deadlock without these fixes.

tested in fork branch for several weeks with hundreds of iterations.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
