### PR TITLE
fix: vslm/TestList

### DIFF
--- a/vslm/global_object_manager.go
+++ b/vslm/global_object_manager.go
@@ -83,9 +83,9 @@ func (this *Task) WaitNonDefault(ctx context.Context, timeoutNS time.Duration, s
 			}
 		} else if info.State == types.VslmTaskInfoStateError {
 			return nil, soap.WrapVimFault(info.Error.Fault)
+		} else {
+			break
 		}
-
-		break
 		// Check context here to see if we should exit
 	}
 	return this.QueryResult(ctx)


### PR DESCRIPTION
PR #4099, "remove redundant else branches" incorrectly hoisted an else { break } into an unconditional break in vslm/global_object_manager.go, so WaitNonDefault's polling loop always exited after one check instead of continuing while the task might still be queued Queued/Running. CreateDisk's task result was then queried before completion, returning a nil AnyType and panicking on the disk.(types.VStorageObject) assertion.
