### PR TITLE
vcsim: return PerfSampleInfo in ascending chronological order

### DIFF
--- a/simulator/performance_manager.go
+++ b/simulator/performance_manager.go
@@ -206,8 +206,21 @@ func (p *PerformanceManager) QueryPerf(ctx *Context, req *types.QueryPerf) soap.
 		// Loop through each interval "tick"
 		metrics.SampleInfo = make([]types.PerfSampleInfo, n)
 		metrics.Value = make([]types.BasePerfMetricSeries, len(qs.MetricId))
+		// Emit samples in ascending (oldest first) chronological order, which is what a real
+		// vCenter returns. Indexing tick 0 at `end` produced descending order, so tick 0 was the
+		// newest sample. Clients that assume the vSphere convention -- e.g. taking
+		// SampleInfo[len-1] as the most recent sample to compute a rollup boundary, then walking
+		// forward expecting increasing timestamps -- discard the whole series: the first element
+		// already looks newer than the boundary. Observed with a real collector, which fetched
+		// the series successfully and then silently rolled up zero points.
+		// This also lines the values up with their timestamps: Value[tick] is taken from the
+		// canned data at `offset+tick` where offset is derived from `start`, so tick 0 should be
+		// the sample nearest `start`, i.e. the oldest.
 		for tick := int32(0); tick < n; tick++ {
-			metrics.SampleInfo[tick] = types.PerfSampleInfo{Timestamp: end.Add(time.Duration(-interval*tick) * time.Second), Interval: interval}
+			metrics.SampleInfo[tick] = types.PerfSampleInfo{
+				Timestamp: end.Add(time.Duration(-interval*(n-1-tick)) * time.Second),
+				Interval:  interval,
+			}
 		}
 
 		series := make([]*types.PerfMetricIntSeries, len(qs.MetricId))

--- a/simulator/performance_manager_test.go
+++ b/simulator/performance_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vmware/govmomi/performance"
 	"github.com/vmware/govmomi/simulator/esx"
@@ -400,6 +401,81 @@ func TestQueryPerf(t *testing.T) {
 		}
 		if err := testPerfQueryCSV(ctx, m, ctx.Map.Any("ResourcePool"), 300, maxSample); err != nil {
 			t.Fatal(err)
+		}
+	}
+}
+
+// TestQueryPerfSampleInfoOrder asserts that QueryPerf returns PerfSampleInfo in
+// ascending (oldest first) chronological order, which is what a real vCenter does.
+// Returning them newest-first breaks clients that follow the vSphere convention of
+// treating SampleInfo[len-1] as the most recent sample.
+func TestQueryPerfSampleInfoOrder(t *testing.T) {
+	m := VPX()
+
+	if err := m.Create(); err != nil {
+		t.Fatal(err)
+	}
+	defer m.Remove()
+
+	ctx := m.Service.Context
+	p := performance.NewManager(m.Service.client())
+
+	for _, test := range []struct {
+		kind     string
+		interval int32
+	}{
+		{"VirtualMachine", 20},
+		{"VirtualMachine", 300},
+		{"HostSystem", 20},
+		{"ClusterComputeResource", 300},
+	} {
+		entity := ctx.Map.Any(test.kind)
+
+		result, err := p.Query(ctx, []types.PerfQuerySpec{{
+			IntervalId: test.interval,
+			MetricId:   []types.PerfMetricId{{CounterId: 1}},
+			Entity:     entity.Reference(),
+		}})
+		if err != nil {
+			t.Fatalf("%s interval=%d: %s", test.kind, test.interval, err)
+		}
+
+		series, err := p.ToMetricSeries(ctx, result)
+		if err != nil {
+			t.Fatalf("%s interval=%d: %s", test.kind, test.interval, err)
+		}
+		if len(series) == 0 {
+			t.Fatalf("%s interval=%d: empty metric series", test.kind, test.interval)
+		}
+
+		for _, em := range series {
+			if len(em.SampleInfo) < 2 {
+				t.Fatalf("%s interval=%d: need >1 sample to check ordering, got %d",
+					test.kind, test.interval, len(em.SampleInfo))
+			}
+
+			for i := 1; i < len(em.SampleInfo); i++ {
+				prev, cur := em.SampleInfo[i-1].Timestamp, em.SampleInfo[i].Timestamp
+				if !cur.After(prev) {
+					t.Errorf("%s interval=%d: SampleInfo not ascending at index %d: %s then %s",
+						test.kind, test.interval, i, prev, cur)
+				}
+			}
+
+			// The interval spacing should match what was requested.
+			gap := em.SampleInfo[1].Timestamp.Sub(em.SampleInfo[0].Timestamp)
+			if want := time.Duration(test.interval) * time.Second; gap != want {
+				t.Errorf("%s interval=%d: sample spacing = %s, want %s",
+					test.kind, test.interval, gap, want)
+			}
+
+			// Values must line up 1:1 with the sample timestamps.
+			for _, v := range em.Value {
+				if len(v.Value) != len(em.SampleInfo) {
+					t.Errorf("%s interval=%d: %d values for %d samples",
+						test.kind, test.interval, len(v.Value), len(em.SampleInfo))
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Description

QueryPerf indexed tick 0 at `end`, so the series was returned newest-first.
    The vSphere convention is oldest-first, which this contradicted.

    Three independent confirmations that ascending is correct:

    1. A real vCenter returns ascending. Same query, same counter, interval 300:

         vCenter 8.0.3   2026-08-19T10:05:00Z, 10:10:00Z, 10:15:00Z   (ascending)
         vcsim           2026-08-19T10:43:24,  10:38:24,  10:33:24    (descending)

    2. govmomi's own client library already assumes it. performance.Manager's
       SampleByName over-fetches and then truncates to MaxSample by dropping
       from the *front*:

         n := len(s.SampleInfo)
         diff := n - int(spec.MaxSample)
         if diff > 0 {
             s.SampleInfo = s.SampleInfo[diff:]
         }

       Keeping the tail only yields the most recent samples if the newest are
       last, so the simulator was contradicting its own client.

    3. Values were already indexed as if ascending. Value[tick] reads the canned
       data at `offset+tick`, where offset derives from `start` -- so tick 0 is
       meant to be the sample nearest `start`, i.e. the oldest.

    Clients that follow the convention discard the entire series. Observed with
    a real collector (vRNI): it takes SampleInfo[len-1] as the most recent
    sample to compute a rollup alignment boundary, then walks the array forward
    expecting increasing timestamps, breaking at the first sample past that
    boundary. With descending order [len-1] is the *oldest* sample, so element 0
    already exceeds the boundary and the loop breaks immediately -- zero points
    survive rollup. The failure was silent: the collector logged 1400 metrics
    fetched and 40 per-VM builders created, then pushed nothing, for every VM on
    every cycle, with no error logged.

    Fix: index tick 0 at `end - interval*(n-1)`, so tick 0 is the oldest sample
    and tick n-1 the newest. This also brings the timestamps into line with the
    value indexing described in (3).


**Verification**

Please describe any manual tests done to verify your changes.
I have validated the vcsim by hooking it with vRNI collector (for data collection).

Verified: the same query now returns ascending timestamps; full simulator and
    vim25 suites pass (TestFileInfo fails on macOS only, pre-existing:
    listFiles() hardcodes GNU "stat -c").

Signed-off-by: Dinesh Bhat <dinesh.bhat@broadcom.com>

