### PR TITLE
vcsim: fix Datastore.path() fallback when only Info.Url is set and in load path

### DIFF
--- a/govc/test/import.bats
+++ b/govc/test/import.bats
@@ -15,9 +15,10 @@ load test_helper
   run govc vm.destroy "$TTYLINUX_NAME"
   assert_success
 
-  # link ovf/ova to datastore so we can test with an http source
-  dir=$(govc datastore.info -json | jq -r .datastores[].info.url)
-  ln -s "$GOVC_IMAGES/$TTYLINUX_NAME"* "$dir"
+  # upload ovf/ova to datastore so we can test with an http source
+  for f in "$GOVC_IMAGES/$TTYLINUX_NAME"*; do
+    govc datastore.upload "$f" "$(basename "$f")"
+  done
 
   run govc import.spec "https://$(govc env GOVC_URL)/folder/$TTYLINUX_NAME.ovf"
   assert_success

--- a/govc/test/library.bats
+++ b/govc/test/library.bats
@@ -213,14 +213,16 @@ load test_helper
 
 @test "library.deploy" {
   vcsim_env
+  unset GOVC_HOST # else datastore.download tries via ESX
 
   run govc library.create my-content
   assert_success
   library_id="$output"
 
-  # link ovf/ova to datastore so we can test library.import with an http source
-  dir=$(govc datastore.info -json | jq -r .datastores[].info.url)
-  ln -s "$GOVC_IMAGES/$TTYLINUX_NAME."* "$dir"
+  # upload ovf/ova to datastore so we can test library.import with an http source
+  for f in "$GOVC_IMAGES/$TTYLINUX_NAME."*; do
+    govc datastore.upload "$f" "$(basename "$f")"
+  done
 
   run govc library.import -c fake -pull my-content -n invalid-sha1 "https://$(govc env GOVC_URL)/folder/$TTYLINUX_NAME.ovf"
   assert_failure # invalid checksum
@@ -252,7 +254,7 @@ load test_helper
   assert_success
 
   item_id=$(govc library.info -json /my-content/ttylinux-unpacked | jq -r .[].id)
-  assert_equal "$(cat "$GOVC_IMAGES/$TTYLINUX_NAME.ovf")" "$(cat "$dir/contentlib-$library_id/$item_id/$TTYLINUX_NAME.ovf")"
+  assert_equal "$(cat "$GOVC_IMAGES/$TTYLINUX_NAME.ovf")" "$(govc datastore.download "contentlib-$library_id/$item_id/$TTYLINUX_NAME.ovf" -)"
 
   cat > "$BATS_TMPDIR/ttylinux.json" <<EOF
 {

--- a/govc/test/snapshot.bats
+++ b/govc/test/snapshot.bats
@@ -31,7 +31,7 @@ load test_helper
   run govc snapshot.export -lease -vm "$vm" "$id"
   assert_success
 
-  dir=$(govc datastore.info -json | jq -r .datastores[].info.url)
+  dir=$($mktemp --tmpdir -d govc-test-XXXXX 2>/dev/null || $mktemp -d -t govc-test-XXXXX)
   mkdir "$dir/$id"
 
   run govc snapshot.export -d "$dir/$id" -vm "$vm" "$id"

--- a/simulator/datastore.go
+++ b/simulator/datastore.go
@@ -26,6 +26,24 @@ type Datastore struct {
 	mo.Datastore
 
 	namespace map[string]string // TODO: make thread safe
+
+	// localPath is the real on-disk directory backing this datastore. It is only
+	// set for datastores created via CreateLocalDatastore, where Info.Url/Summary.Url
+	// are overwritten with a synthesized ds:///vmfs/volumes/<uuid>/ style value to
+	// match what a real vCenter local/VMFS datastore reports (some SOAP clients parse
+	// this URL and reject vcsim's raw temp-dir path). All other datastore types leave
+	// this empty and continue to use Summary.Url directly, which is already a real path.
+	localPath string
+}
+
+// path returns the real on-disk directory backing this datastore, for vcsim's own
+// internal file resolution -- as opposed to Summary.Url/Info.Url, which for local
+// datastores is a synthesized value meant only for external API consumers.
+func (ds *Datastore) path() string {
+	if ds.localPath != "" {
+		return ds.localPath
+	}
+	return ds.Summary.Url
 }
 
 func (ds *Datastore) eventArgument() *types.DatastoreEventArgument {
@@ -72,7 +90,7 @@ func (ds *Datastore) model(m *Model) error {
 // Note that VirtualDevice file backing paths must use the vSAN uuid.
 func (ds *Datastore) resolve(ctx *Context, p string, remove ...bool) string {
 	if p == "" || !internal.IsDatastoreVSAN(ds.Datastore) {
-		return path.Join(ds.Summary.Url, p)
+		return path.Join(ds.path(), p)
 	}
 
 	rm := len(remove) != 0 && remove[0]
@@ -110,7 +128,7 @@ func (ds *Datastore) resolve(ctx *Context, p string, remove ...bool) string {
 		}
 	}
 
-	return path.Join(ds.Summary.Url, p)
+	return path.Join(ds.path(), p)
 }
 
 func parseDatastorePath(dsPath string) (*object.DatastorePath, types.BaseMethodFault) {
@@ -126,7 +144,7 @@ func parseDatastorePath(dsPath string) (*object.DatastorePath, types.BaseMethodF
 func (ds *Datastore) RefreshDatastore(*Context, *types.RefreshDatastore) soap.HasFault {
 	r := &methods.RefreshDatastoreBody{}
 
-	_, err := os.Stat(ds.Info.GetDatastoreInfo().Url)
+	_, err := os.Stat(ds.path())
 	if err != nil {
 		r.Fault_ = Fault(err.Error(), &types.HostConfigFault{})
 		return r

--- a/simulator/datastore.go
+++ b/simulator/datastore.go
@@ -27,12 +27,13 @@ type Datastore struct {
 
 	namespace map[string]string // TODO: make thread safe
 
-	// localPath is the real on-disk directory backing this datastore. It is only
-	// set for datastores created via CreateLocalDatastore, where Info.Url/Summary.Url
-	// are overwritten with a synthesized ds:///vmfs/volumes/<uuid>/ style value to
-	// match what a real vCenter local/VMFS datastore reports (some SOAP clients parse
-	// this URL and reject vcsim's raw temp-dir path). All other datastore types leave
-	// this empty and continue to use Summary.Url directly, which is already a real path.
+	// localPath is the real on-disk directory backing this datastore. It is set by
+	// CreateLocalDatastore and by model() (the -load path), both of which need
+	// Info.Url/Summary.Url to look like a real vCenter URL (ds:///vmfs/volumes/<uuid>/)
+	// for external API consumers -- some SOAP clients parse it and reject vcsim's raw
+	// temp-dir path -- while vcsim itself still needs a real, on-disk directory for its
+	// own file resolution. Datastores loaded/created any other way leave this empty and
+	// continue to use Summary.Url directly, which is already a real path.
 	localPath string
 }
 
@@ -57,7 +58,12 @@ func (ds *Datastore) model(m *Model) error {
 	info := ds.Info.GetDatastoreInfo()
 	u, _ := url.Parse(info.Url)
 	if u.Scheme == "ds" {
-		// rewrite saved vmfs path to a local temp dir
+		// This is a real vCenter datastore's ds:///vmfs/volumes/<uuid>/ URL,
+		// captured via `govc object.save` -- back it locally with a fresh temp
+		// dir for vcsim's own file resolution (the real backing storage doesn't
+		// exist here), but keep reporting the original, already-real-vCenter-shaped
+		// Url to API clients instead of overwriting it with the local temp dir
+		// (some SOAP clients parse this URL and reject anything else).
 		u.Path = path.Clean(u.Path)
 		parent := strings.ReplaceAll(path.Dir(u.Path), "/", "_")
 		name := strings.ReplaceAll(path.Base(u.Path), ":", "_")
@@ -67,15 +73,18 @@ func (ds *Datastore) model(m *Model) error {
 			return err
 		}
 
-		info.Url = dir
+		ds.localPath = dir
 	} else {
-		// rewrite local path from a saved vcsim instance
+		// This was itself a raw local path (e.g. re-loading a previously-saved
+		// vcsim instance's local datastore) -- there's no real-vCenter-shaped Url
+		// to preserve, so synthesize one, same as CreateLocalDatastore.
 		dir, err := m.createTempDir(path.Base(u.Path))
 		if err != nil {
 			return err
 		}
 
-		info.Url = dir
+		ds.localPath = dir
+		info.Url = "ds:///vmfs/volumes/" + uuid.NewString() + "/"
 	}
 
 	ds.Summary.Url = info.Url

--- a/simulator/datastore.go
+++ b/simulator/datastore.go
@@ -37,15 +37,17 @@ type Datastore struct {
 	localPath string
 }
 
-// path returns the real on-disk directory backing this datastore, for vcsim's own
+// Path returns the real on-disk directory backing this datastore, for vcsim's own
 // internal file resolution -- as opposed to Summary.Url/Info.Url, which for local
-// datastores is a synthesized value meant only for external API consumers.
+// datastores is a synthesized value meant only for external API consumers. Exported
+// so other vcsim-internal simulator packages (e.g. vapi/simulator's content library)
+// can resolve the real path too, rather than reading Info.Url/Summary.Url directly.
 //
 // localPath is only set for datastores that went through CreateLocalDatastore or
 // model() (the -load path); for every other datastore Summary.Url/Info.Url still
 // hold a real path, so fall back to those. Info is checked last because some
 // callers construct a Datastore with only Info.Url populated.
-func (ds *Datastore) path() string {
+func (ds *Datastore) Path() string {
 	if ds.localPath != "" {
 		return ds.localPath
 	}
@@ -110,7 +112,7 @@ func (ds *Datastore) model(m *Model) error {
 // Note that VirtualDevice file backing paths must use the vSAN uuid.
 func (ds *Datastore) resolve(ctx *Context, p string, remove ...bool) string {
 	if p == "" || !internal.IsDatastoreVSAN(ds.Datastore) {
-		return path.Join(ds.path(), p)
+		return path.Join(ds.Path(), p)
 	}
 
 	rm := len(remove) != 0 && remove[0]
@@ -148,7 +150,7 @@ func (ds *Datastore) resolve(ctx *Context, p string, remove ...bool) string {
 		}
 	}
 
-	return path.Join(ds.path(), p)
+	return path.Join(ds.Path(), p)
 }
 
 func parseDatastorePath(dsPath string) (*object.DatastorePath, types.BaseMethodFault) {
@@ -164,7 +166,7 @@ func parseDatastorePath(dsPath string) (*object.DatastorePath, types.BaseMethodF
 func (ds *Datastore) RefreshDatastore(*Context, *types.RefreshDatastore) soap.HasFault {
 	r := &methods.RefreshDatastoreBody{}
 
-	_, err := os.Stat(ds.path())
+	_, err := os.Stat(ds.Path())
 	if err != nil {
 		r.Fault_ = Fault(err.Error(), &types.HostConfigFault{})
 		return r

--- a/simulator/datastore.go
+++ b/simulator/datastore.go
@@ -40,11 +40,22 @@ type Datastore struct {
 // path returns the real on-disk directory backing this datastore, for vcsim's own
 // internal file resolution -- as opposed to Summary.Url/Info.Url, which for local
 // datastores is a synthesized value meant only for external API consumers.
+//
+// localPath is only set for datastores that went through CreateLocalDatastore or
+// model() (the -load path); for every other datastore Summary.Url/Info.Url still
+// hold a real path, so fall back to those. Info is checked last because some
+// callers construct a Datastore with only Info.Url populated.
 func (ds *Datastore) path() string {
 	if ds.localPath != "" {
 		return ds.localPath
 	}
-	return ds.Summary.Url
+	if ds.Summary.Url != "" {
+		return ds.Summary.Url
+	}
+	if ds.Info != nil {
+		return ds.Info.GetDatastoreInfo().Url
+	}
+	return ""
 }
 
 func (ds *Datastore) eventArgument() *types.DatastoreEventArgument {

--- a/simulator/datastore_namespace_manager.go
+++ b/simulator/datastore_namespace_manager.go
@@ -39,7 +39,7 @@ func (m *DatastoreNamespaceManager) ConvertNamespacePathToUuidPath(ctx *Context,
 
 	for _, ref := range dc.Datastore {
 		ds = ctx.Map.Get(ref).(*Datastore)
-		ns = strings.TrimPrefix(req.NamespaceUrl, ds.Summary.Url)
+		ns = strings.TrimPrefix(req.NamespaceUrl, ds.path())
 		if ns != req.NamespaceUrl {
 			break
 		}
@@ -129,7 +129,7 @@ func (m *DatastoreNamespaceManager) DeleteDirectory(ctx *Context, req *types.Del
 	var ds *Datastore
 	for _, ref := range dc.Datastore {
 		ds = ctx.Map.Get(ref).(*Datastore)
-		if strings.HasPrefix(req.DatastorePath, ds.Summary.Url) {
+		if strings.HasPrefix(req.DatastorePath, ds.path()) {
 			break
 		}
 		ds = nil

--- a/simulator/datastore_namespace_manager.go
+++ b/simulator/datastore_namespace_manager.go
@@ -39,7 +39,7 @@ func (m *DatastoreNamespaceManager) ConvertNamespacePathToUuidPath(ctx *Context,
 
 	for _, ref := range dc.Datastore {
 		ds = ctx.Map.Get(ref).(*Datastore)
-		ns = strings.TrimPrefix(req.NamespaceUrl, ds.path())
+		ns = strings.TrimPrefix(req.NamespaceUrl, ds.Path())
 		if ns != req.NamespaceUrl {
 			break
 		}
@@ -129,7 +129,7 @@ func (m *DatastoreNamespaceManager) DeleteDirectory(ctx *Context, req *types.Del
 	var ds *Datastore
 	for _, ref := range dc.Datastore {
 		ds = ctx.Map.Get(ref).(*Datastore)
-		if strings.HasPrefix(req.DatastorePath, ds.path()) {
+		if strings.HasPrefix(req.DatastorePath, ds.Path()) {
 			break
 		}
 		ds = nil

--- a/simulator/datastore_test.go
+++ b/simulator/datastore_test.go
@@ -534,9 +534,9 @@ func TestLocalDatastoreURLFormat(t *testing.T) {
 
 	// ...but internally, the backing directory must still be a real one, so vcsim's own
 	// file operations keep working.
-	backing := ds.path()
+	backing := ds.Path()
 	if backing == ds.Summary.Url {
-		t.Fatalf("internal path() returned the synthesized URL %q", backing)
+		t.Fatalf("internal Path() returned the synthesized URL %q", backing)
 	}
 	fi, err := os.Stat(backing)
 	if err != nil {
@@ -588,7 +588,7 @@ func TestDatastoreModelURLHandling(t *testing.T) {
 		if ds.Summary.Url != saved {
 			t.Errorf("Summary.Url = %q, want %q", ds.Summary.Url, saved)
 		}
-		if _, err := os.Stat(ds.path()); err != nil {
+		if _, err := os.Stat(ds.Path()); err != nil {
 			t.Errorf("no real backing dir was created: %s", err)
 		}
 	})
@@ -613,7 +613,7 @@ func TestDatastoreModelURLHandling(t *testing.T) {
 		if ds.Summary.Url != ds.Info.GetDatastoreInfo().Url {
 			t.Errorf("Summary.Url (%q) != Info.Url (%q)", ds.Summary.Url, ds.Info.GetDatastoreInfo().Url)
 		}
-		if _, err := os.Stat(ds.path()); err != nil {
+		if _, err := os.Stat(ds.Path()); err != nil {
 			t.Errorf("no real backing dir was created: %s", err)
 		}
 	})

--- a/simulator/datastore_test.go
+++ b/simulator/datastore_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -490,4 +491,130 @@ func TestDatastoreHTTP(t *testing.T) {
 			}
 		}
 	}
+}
+
+// dsURLPattern matches the ds:///vmfs/volumes/<uuid>/ form a real vCenter reports for a
+// local/VMFS datastore.
+var dsURLPattern = regexp.MustCompile(`^ds:///vmfs/volumes/[0-9a-fA-F-]+/$`)
+
+// TestLocalDatastoreURLFormat asserts that a datastore created via CreateLocalDatastore
+// reports a real-vCenter-shaped Url to API clients, while vcsim keeps using the actual
+// on-disk directory for its own file resolution.
+//
+// Reporting the raw temp-dir path (the previous behaviour) breaks clients that parse the
+// datastore URL: a real collector rejected it with "Datastore url format is not correct
+// /tmp/govcsim-.../DC0-LocalDS_0", which killed Datastore config collection entirely.
+func TestLocalDatastoreURLFormat(t *testing.T) {
+	m := VPX()
+	m.Datastore = 1
+	m.Machine = 1
+
+	if err := m.Create(); err != nil {
+		t.Fatal(err)
+	}
+	defer m.Remove()
+
+	ctx := m.Service.Context
+	ds := ctx.Map.Any("Datastore").(*Datastore)
+
+	info := ds.Info.GetDatastoreInfo()
+
+	// Externally visible URL must look like a real vCenter's, not a filesystem path.
+	for name, u := range map[string]string{"Info.Url": info.Url, "Summary.Url": ds.Summary.Url} {
+		if !dsURLPattern.MatchString(u) {
+			t.Errorf("%s = %q, want ds:///vmfs/volumes/<uuid>/", name, u)
+		}
+		if strings.HasPrefix(u, "/") {
+			t.Errorf("%s = %q, still a raw filesystem path", name, u)
+		}
+	}
+	if info.Url != ds.Summary.Url {
+		t.Errorf("Info.Url (%q) and Summary.Url (%q) disagree", info.Url, ds.Summary.Url)
+	}
+
+	// ...but internally, the backing directory must still be a real one, so vcsim's own
+	// file operations keep working.
+	backing := ds.path()
+	if backing == ds.Summary.Url {
+		t.Fatalf("internal path() returned the synthesized URL %q", backing)
+	}
+	fi, err := os.Stat(backing)
+	if err != nil {
+		t.Fatalf("internal backing dir %q: %s", backing, err)
+	}
+	if !fi.IsDir() {
+		t.Fatalf("internal backing dir %q is not a directory", backing)
+	}
+
+	// End-to-end: a VM created by the model must have its files on that real directory.
+	vm := ctx.Map.Any("VirtualMachine").(*VirtualMachine)
+	vmx := vm.Config.Files.VmPathName
+	p, fault := parseDatastorePath(vmx)
+	if fault != nil {
+		t.Fatalf("parse %q: %v", vmx, fault)
+	}
+	if _, err := os.Stat(path.Join(backing, p.Path)); err != nil {
+		t.Errorf("VM file %q not found under the datastore's real backing dir: %s", vmx, err)
+	}
+}
+
+// TestDatastoreModelURLHandling covers Datastore.model(), which runs on the vcsim -load
+// path (an inventory captured from a real vCenter via `govc object.save`).
+func TestDatastoreModelURLHandling(t *testing.T) {
+	m := VPX()
+
+	if err := m.Create(); err != nil {
+		t.Fatal(err)
+	}
+	defer m.Remove()
+
+	t.Run("preserves a real vCenter ds:// URL", func(t *testing.T) {
+		const saved = "ds:///vmfs/volumes/5e7a2b1c-deadbeef/"
+
+		ds := &Datastore{}
+		ds.Name = "preserve"
+		ds.Info = &types.LocalDatastoreInfo{
+			DatastoreInfo: types.DatastoreInfo{Name: ds.Name, Url: saved},
+		}
+
+		if err := ds.model(m); err != nil {
+			t.Fatal(err)
+		}
+
+		// The captured URL was already correct, so it must not be rewritten.
+		if got := ds.Info.GetDatastoreInfo().Url; got != saved {
+			t.Errorf("Info.Url = %q, want it left as %q", got, saved)
+		}
+		if ds.Summary.Url != saved {
+			t.Errorf("Summary.Url = %q, want %q", ds.Summary.Url, saved)
+		}
+		if _, err := os.Stat(ds.path()); err != nil {
+			t.Errorf("no real backing dir was created: %s", err)
+		}
+	})
+
+	t.Run("synthesizes a URL for a raw local path", func(t *testing.T) {
+		dir := t.TempDir()
+
+		ds := &Datastore{}
+		ds.Name = "synth"
+		ds.Info = &types.LocalDatastoreInfo{
+			DatastoreInfo: types.DatastoreInfo{Name: ds.Name, Url: dir},
+		}
+
+		if err := ds.model(m); err != nil {
+			t.Fatal(err)
+		}
+
+		// Nothing real to preserve here, so a ds:// URL is synthesized.
+		if got := ds.Info.GetDatastoreInfo().Url; !dsURLPattern.MatchString(got) {
+			t.Errorf("Info.Url = %q, want ds:///vmfs/volumes/<uuid>/", got)
+		}
+		if ds.Summary.Url != ds.Info.GetDatastoreInfo().Url {
+			t.Errorf("Summary.Url (%q) != Info.Url (%q)", ds.Summary.Url, ds.Info.GetDatastoreInfo().Url)
+		}
+		if _, err := os.Stat(ds.path()); err != nil {
+			t.Errorf("no real backing dir was created: %s", err)
+		}
+	})
 }

--- a/simulator/host_datastore_system.go
+++ b/simulator/host_datastore_system.go
@@ -134,7 +134,7 @@ func (dss *HostDatastoreSystem) CreateLocalDatastore(ctx *Context, c *types.Crea
 
 	// add() (and the RefreshDatastore it triggers) needs Info.Url to be the real,
 	// existing directory above, since it os.Stat()s it. Only now, after that's done,
-	// save the real path for vcsim's own internal use (ds.path()) and overwrite the
+	// save the real path for vcsim's own internal use (ds.Path()) and overwrite the
 	// externally-visible Url/Summary.Url with a value shaped like what a real
 	// vCenter local/VMFS datastore reports (ds:///vmfs/volumes/<uuid>/) instead of
 	// vcsim's raw local temp-dir path -- at least one real collector's SOAP client

--- a/simulator/host_datastore_system.go
+++ b/simulator/host_datastore_system.go
@@ -132,6 +132,19 @@ func (dss *HostDatastoreSystem) CreateLocalDatastore(ctx *Context, c *types.Crea
 		return r
 	}
 
+	// add() (and the RefreshDatastore it triggers) needs Info.Url to be the real,
+	// existing directory above, since it os.Stat()s it. Only now, after that's done,
+	// save the real path for vcsim's own internal use (ds.path()) and overwrite the
+	// externally-visible Url/Summary.Url with a value shaped like what a real
+	// vCenter local/VMFS datastore reports (ds:///vmfs/volumes/<uuid>/) instead of
+	// vcsim's raw local temp-dir path -- at least one real collector's SOAP client
+	// parses this URL and throws on anything else (e.g.
+	// "IllegalArgumentException: Datastore url format is not correct /tmp/govcsim-.../DC0-LocalDS_0").
+	ds.localPath = c.Path
+	fakeURL := "ds:///vmfs/volumes/" + uuid.NewString() + "/"
+	ds.Info.GetDatastoreInfo().Url = fakeURL
+	ds.Summary.Url = fakeURL
+
 	r.Res = &types.CreateLocalDatastoreResponse{
 		Returnval: ds.Self,
 	}

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -685,9 +685,9 @@ func (s *Service) ServeDatastore(w http.ResponseWriter, r *http.Request) {
 	default:
 		// ds.resolve() may have translated vsan friendly name to uuid,
 		// apply the same to the Request.URL.Path
-		r.URL.Path = strings.TrimPrefix(p, ds.Summary.Url)
+		r.URL.Path = strings.TrimPrefix(p, ds.path())
 
-		fs := http.FileServer(http.Dir(ds.Summary.Url))
+		fs := http.FileServer(http.Dir(ds.path()))
 
 		fs.ServeHTTP(w, r)
 	}

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -685,9 +685,9 @@ func (s *Service) ServeDatastore(w http.ResponseWriter, r *http.Request) {
 	default:
 		// ds.resolve() may have translated vsan friendly name to uuid,
 		// apply the same to the Request.URL.Path
-		r.URL.Path = strings.TrimPrefix(p, ds.path())
+		r.URL.Path = strings.TrimPrefix(p, ds.Path())
 
-		fs := http.FileServer(http.Dir(ds.path()))
+		fs := http.FileServer(http.Dir(ds.Path()))
 
 		fs.ServeHTTP(w, r)
 	}

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -2683,7 +2683,7 @@ func (s *handler) libraryPath(l *library.Library, id string) string {
 		panic("invalid file name")
 	}
 
-	return path.Join(append([]string{ds.Info.GetDatastoreInfo().Url, "contentlib-" + l.ID}, id)...)
+	return path.Join(append([]string{ds.Path(), "contentlib-" + l.ID}, id)...)
 }
 
 func (s *handler) libraryItemFileCreate(

--- a/vmdk/disk_info_test.go
+++ b/vmdk/disk_info_test.go
@@ -7,8 +7,6 @@ package vmdk_test
 import (
 	"bytes"
 	"context"
-	"os"
-	"path"
 	"strings"
 	"testing"
 
@@ -590,17 +588,6 @@ func TestGetVirtualDiskInfoByUUID(t *testing.T) {
 			}
 
 			datastore := object.NewDatastore(c, datastoreRef)
-			var moDatastore mo.Datastore
-			if err := datastore.Properties(
-				ctx,
-				datastore.Reference(),
-				[]string{"info"},
-				&moDatastore); err != nil {
-
-				t.Fatal(err)
-			}
-
-			datastorePath := moDatastore.Info.GetDatastoreInfo().Url
 			var diskPath object.DatastorePath
 			if !diskPath.FromString(diskInfo.FileName) {
 				t.Fatalf("invalid disk file name: %q", diskInfo.FileName)
@@ -608,10 +595,13 @@ func TestGetVirtualDiskInfoByUUID(t *testing.T) {
 
 			const vmdkSize = 500
 
-			assert.NoError(t, os.WriteFile(
-				path.Join(datastorePath, diskPath.Path),
-				bytes.Repeat([]byte{1}, vmdkSize),
-				os.ModeAppend))
+			// Write via the datastore file service (as a real client must), rather than
+			// assuming the datastore's reported Url is a locally-writable path -- a real
+			// vCenter's Url is an opaque ds:///vmfs/volumes/<uuid>/ handle, not one.
+			upload := soap.DefaultUpload
+			data := bytes.Repeat([]byte{1}, vmdkSize)
+			upload.ContentLength = int64(len(data))
+			assert.NoError(t, datastore.Upload(ctx, bytes.NewReader(data), diskPath.Path, &upload))
 			assert.NoError(t, vm.RefreshStorageInfo(ctx))
 
 			diskInfo.Size = vmdkSize


### PR DESCRIPTION
## Description

**Recorded inventory**
    vcsim: preserve a saved datastore Url on the -load path

    Same bug class as e56e8606, different trigger: Datastore.model() runs
    when loading a saved inventory (vcsim -load, typically produced by
    `govc object.save` against a real vCenter) and unconditionally rewrote
    Info.Url/Summary.Url to vcsim's own local temp dir, discarding whatever
    URL the datastore actually had -- including a real vCenter's genuine
    ds:///vmfs/volumes/<uuid>/ URL, which record/replay testing against a
    real vCenter's captured inventory would hit immediately.

    Fix: reuse the localPath/path() mechanism from e56e8606. For a loaded
    datastore whose saved Url already has the real-vCenter ds:// shape,
    back it locally with a fresh temp dir (ds.localPath) but leave the
    original, already-correct Url untouched instead of overwriting it. For
    a loaded datastore that was itself a raw local path (e.g. re-loading a
    previously-saved vcsim instance), synthesize a ds:///vmfs/volumes/<uuid>/
    value same as CreateLocalDatastore, since there's no real URL to
    preserve in that case.

    Verified: saved a running vcsim instance's own inventory (govc
    object.save), loaded it into a fresh instance -- datastore Url reports
    ds:///vmfs/volumes/<uuid>/ (not a raw temp path), and datastore.ls/
    datastore.info resolve without error against the freshly-created real
    backing directory. Full simulator test suite passes, including
    TestModelLoadAlignCounter.

    Signed-off-by: Dinesh Bhat <dinesh.bhat@broadcom.com>

**New Inventory**

    vcsim: report a real vCenter-shaped Url for local datastores

    CreateLocalDatastore set Info.Url/Summary.Url to vcsim's own raw backing
    directory (e.g. /tmp/govcsim-<pid>/DC0-LocalDS_0), instead of the
    ds:///vmfs/volumes/<uuid>/ style URL a real vCenter local/VMFS datastore
    reports. At least one real collector's SOAP client parses this URL and
    throws (IllegalArgumentException: Datastore url format is not correct)
    when it doesn't contain /vmfs/volumes, which silently kills that
    datastore's entire config payload every poll cycle -- and cascades
    downstream into the platform never resolving VM-to-datastore link
    objects for any datastore-attributed metric.

    Fix: keep the real directory for vcsim's own internal file resolution
    (new Datastore.localPath field, used via a new path() helper in place of
    Summary.Url in resolve()/RefreshDatastore()/ServeDatastore()), and only
    overwrite the externally-visible Info.Url/Summary.Url with a synthesized
    ds:///vmfs/volumes/<uuid>/ value after CreateLocalDatastore's add() (which
    needs the real path to os.Stat) succeeds. No other datastore type
    (NAS/vSAN/loaded) is affected -- they leave localPath unset and continue
    using Summary.Url directly, unchanged.

    Verified: local vcsim instance now reports Info.Url/Summary.Url as
    ds:///vmfs/volumes/<uuid>/; VM creation/vmx placement and datastore.ls
    still correctly resolve against the real backing directory; full
    simulator test suite passes.

    Signed-off-by: Dinesh Bhat <dinesh.bhat@broadcom.com>
