### PR TITLE
vcsim: add -host-ip-base flag for deterministic host IPs

### DIFF
--- a/simulator/model.go
+++ b/simulator/model.go
@@ -7,9 +7,11 @@ package simulator
 import (
 	"context"
 	"crypto/tls"
+	"encoding/binary"
 	"fmt"
 	"log"
 	"math/rand"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -88,6 +90,17 @@ type Model struct {
 	// ClusterHost specifies the number of HostSystems entities to create within a Cluster
 	// Name prefix: H, vcsim flag: -host
 	ClusterHost int `json:"clusterHost,omitempty"`
+
+	// HostIPBase, if set, assigns each created HostSystem's management vnic (vmk0)
+	// a deterministic IPv4 address starting at this value, incrementing by one per
+	// host across both standalone and cluster host creation, in creation order.
+	// This overrides the default template IP (127.0.0.1) that every HostSystem
+	// otherwise shares. Since HostConnectSpec.HostName doubles as both the
+	// connect address and the host's initial display name, the host's name
+	// becomes its IP rather than the usual "<prefix>_H<n>" pattern.
+	// Not applied in -esx (standalone ESX) mode, which does not go through this
+	// host-creation path. vcsim flag: -host-ip-base
+	HostIPBase net.IP `json:"-"`
 
 	// Pool specifies the number of ResourcePool entities to create per Cluster
 	// Note that every cluster has a root ResourcePool named "Resources", as real vCenter does.
@@ -498,6 +511,25 @@ func (m *Model) CreateInfrastructure(ctx *Context) error {
 	// 1 NIC per VM, backed by a DVPG if Model.Portgroup > 0
 	vmnet := esx.EthernetCard.Backing
 
+	// nextHostIP returns the next deterministic host IP when Model.HostIPBase
+	// is set, incrementing across all hosts created by this Model (standalone
+	// and cluster hosts share the same counter, in creation order). Returns ""
+	// if HostIPBase is unset or not a valid IPv4 address.
+	hostIPOffset := uint32(0)
+	nextHostIP := func() string {
+		base := m.HostIPBase.To4()
+		if base == nil {
+			return ""
+		}
+
+		next := binary.BigEndian.Uint32(base) + hostIPOffset
+		hostIPOffset++
+
+		var b [4]byte
+		binary.BigEndian.PutUint32(b[:], next)
+		return net.IP(b[:]).String()
+	}
+
 	// addHost adds a cluster host or a standalone host.
 	addHost := func(name string, f func(types.HostConnectSpec) (*object.Task, error)) (*object.HostSystem, error) {
 		spec := types.HostConnectSpec{
@@ -725,8 +757,12 @@ func (m *Model) CreateInfrastructure(ctx *Context) error {
 
 		for nhost := 0; nhost < m.Host; nhost++ {
 			name := m.fmtName(dcName+"_H", nhost)
+			hostName := name
+			if m.HostIPBase != nil {
+				hostName = nextHostIP()
+			}
 
-			host, err := addHost(name, func(spec types.HostConnectSpec) (*object.Task, error) {
+			host, err := addHost(hostName, func(spec types.HostConnectSpec) (*object.Task, error) {
 				return folders.HostFolder.AddStandaloneHost(ctx, spec, true, nil, nil)
 			})
 			if err != nil {
@@ -746,8 +782,12 @@ func (m *Model) CreateInfrastructure(ctx *Context) error {
 
 			for nhost := 0; nhost < m.ClusterHost; nhost++ {
 				name := m.fmtName(clusterName+"_H", nhost)
+				hostName := name
+				if m.HostIPBase != nil {
+					hostName = nextHostIP()
+				}
 
-				_, err = addHost(name, func(spec types.HostConnectSpec) (*object.Task, error) {
+				_, err = addHost(hostName, func(spec types.HostConnectSpec) (*object.Task, error) {
 					return cluster.AddHost(ctx, spec, true, nil, nil)
 				})
 				if err != nil {

--- a/simulator/model_test.go
+++ b/simulator/model_test.go
@@ -6,6 +6,8 @@ package simulator
 
 import (
 	"encoding/xml"
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -201,5 +203,92 @@ func TestModelLoadAlignCounter(t *testing.T) {
 			t.Logf("Registry object: %s:%s", k.Type, k.Value)
 		}
 		t.Errorf("expected registry counter to be 500, got %d", reg.counter)
+	}
+}
+
+// TestModelHostIPBase asserts that Model.HostIPBase gives every created HostSystem a
+// deterministic management IP on vmk0, sequentially across the whole model rather than
+// resetting per cluster. Without it, esx.HostConfigInfo's shared template leaves every
+// host reporting 127.0.0.1, so clients cannot tell hosts apart by address.
+func TestModelHostIPBase(t *testing.T) {
+	m := VPX()
+	m.Datacenter = 1
+	m.Cluster = 2
+	m.ClusterHost = 2
+	m.Host = 1 // standalone; IPs are assigned across both loops from one counter
+	m.HostIPBase = net.ParseIP("10.20.8.0")
+
+	if err := m.Create(); err != nil {
+		t.Fatal(err)
+	}
+	defer m.Remove()
+
+	ctx := m.Service.Context
+
+	got := make(map[string]string) // ip -> host reference
+	for ref, obj := range ctx.Map.objects {
+		if ref.Type != "HostSystem" {
+			continue
+		}
+		host, ok := obj.(*HostSystem)
+		if !ok {
+			t.Fatalf("%s is not a *HostSystem", ref)
+		}
+
+		vnic := host.Config.Network.Vnic
+		if len(vnic) == 0 {
+			t.Fatalf("%s has no vnic", ref)
+		}
+		ip := vnic[0].Spec.Ip.IpAddress
+
+		if ip == "127.0.0.1" {
+			t.Errorf("%s still has the default shared IP %s", ref, ip)
+		}
+		if net.ParseIP(ip) == nil {
+			t.Errorf("%s vmk0 IP %q is not a valid address", ref, ip)
+		}
+		if prev, dup := got[ip]; dup {
+			t.Errorf("%s and %s share IP %s", prev, ref, ip)
+		}
+		got[ip] = ref.String()
+
+		// HostName doubles as the display name, so the host is named for its IP.
+		if host.Name != ip {
+			t.Errorf("%s name = %q, want the assigned IP %q", ref, host.Name, ip)
+		}
+	}
+
+	// 2 clusters x 2 hosts + 1 standalone
+	if want := 5; len(got) != want {
+		t.Fatalf("got %d distinct host IPs, want %d", len(got), want)
+	}
+
+	// Sequential from the base, with no gap or reset at the standalone->cluster boundary.
+	for i := 0; i < 5; i++ {
+		ip := fmt.Sprintf("10.20.8.%d", i)
+		if _, ok := got[ip]; !ok {
+			t.Errorf("expected a host at %s; assigned IPs were %v", ip, got)
+		}
+	}
+}
+
+// TestModelHostIPBaseUnset asserts the default is untouched when HostIPBase is not set.
+func TestModelHostIPBaseUnset(t *testing.T) {
+	m := VPX()
+	m.Datacenter = 1
+	m.Cluster = 1
+	m.ClusterHost = 1
+	m.Host = 0
+
+	if err := m.Create(); err != nil {
+		t.Fatal(err)
+	}
+	defer m.Remove()
+
+	ctx := m.Service.Context
+	host := ctx.Map.Any("HostSystem").(*HostSystem)
+
+	if ip := host.Config.Network.Vnic[0].Spec.Ip.IpAddress; ip != "127.0.0.1" {
+		t.Errorf("vmk0 IP = %q, want the untouched default 127.0.0.1", ip)
 	}
 }

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -69,6 +69,7 @@ func main() {
 	flag.IntVar(&model.PortgroupNSX, "pg-nsx", model.PortgroupNSX, "Number of NSX backed port groups")
 	flag.IntVar(&model.OpaqueNetwork, "nsx", model.OpaqueNetwork, "Number of NSX backed opaque networks")
 	flag.IntVar(&model.Folder, "folder", model.Folder, "Number of folders")
+	hostIPBase := flag.String("host-ip-base", "", "Base IPv4 address to assign HostSystems from, incrementing by one per host (e.g. 10.20.8.0)")
 	flag.BoolVar(&model.Autostart, "autostart", model.Autostart, "Autostart model created VMs")
 	v := &model.ServiceContent.About.ApiVersion
 	flag.StringVar(v, "api-version", *v, "API version")
@@ -143,6 +144,14 @@ func main() {
 
 	if err = updateHostTemplate(u.Host); err != nil {
 		log.Fatal(err)
+	}
+
+	if *hostIPBase != "" {
+		ip := net.ParseIP(*hostIPBase).To4()
+		if ip == nil {
+			log.Fatalf("-host-ip-base: invalid IPv4 address: %s", *hostIPBase)
+		}
+		model.HostIPBase = ip
 	}
 
 	if *isESX {


### PR DESCRIPTION
## Description

Implemented a flag / argument / switch while will enable the new inventory creation will have the IPs assigned to hosts .


    Model.HostIPBase (vcsim flag -host-ip-base) assigns each created
    HostSystem a deterministic management vnic IP, incrementing across both
    standalone and cluster host creation, instead of the template default
    (127.0.0.1) every host otherwise shares. Since these hosts go through
    the model's own addHost path, they also get real DVS membership and
    datastore mounting automatically - no separate post-startup scripting
    needed for any of that.

Example usage:
vcsim -host 4 -host-ip-base 10.20.8.0
this command will bring up 4 hosts and the hosts will have IPs 10.20.8.0 to 10.20.8.3 (sequential assignment). 

    Signed-off-by: Dinesh Bhat <dinesh.bhat@broadcom.com>
