### PR TITLE
vcsim: add -version flag to set the product version

### DIFF
--- a/simulator/service_content_test.go
+++ b/simulator/service_content_test.go
@@ -1,0 +1,51 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi"
+)
+
+// TestServiceContentAboutVersion asserts that ServiceContent.About's Version and
+// ApiVersion are independently settable on the Model and are what a connected client
+// observes. These are the fields the vcsim -version and -api-version flags bind to.
+// Version defaults to a hardcoded 6.5.0 in vpx.ServiceContent, so before -version existed
+// a client saw that while apiVersion reported whatever -api-version was set to.
+func TestServiceContentAboutVersion(t *testing.T) {
+	const (
+		version    = "9.0.0.0"
+		apiVersion = "9.0.0.0"
+	)
+
+	m := VPX()
+	m.ServiceContent.About.Version = version
+	m.ServiceContent.About.ApiVersion = apiVersion
+
+	if err := m.Create(); err != nil {
+		t.Fatal(err)
+	}
+	defer m.Remove()
+
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	ctx := context.Background()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	about := c.Client.ServiceContent.About
+	if about.Version != version {
+		t.Errorf("About.Version = %q, want %q", about.Version, version)
+	}
+	if about.ApiVersion != apiVersion {
+		t.Errorf("About.ApiVersion = %q, want %q", about.ApiVersion, apiVersion)
+	}
+}

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -72,6 +72,8 @@ func main() {
 	flag.BoolVar(&model.Autostart, "autostart", model.Autostart, "Autostart model created VMs")
 	v := &model.ServiceContent.About.ApiVersion
 	flag.StringVar(v, "api-version", *v, "API version")
+	pv := &model.ServiceContent.About.Version
+	flag.StringVar(pv, "version", *pv, "Product version (e.g. vCenter version shown in About)")
 
 	isESX := flag.Bool("esx", false, "Simulate standalone ESX")
 	isTLS := flag.Bool("tls", true, "Enable TLS")


### PR DESCRIPTION
## Description

    ServiceContent.About.Version was hardcoded to 6.5.0 in vpx.ServiceContent
    with no way to override it, while -api-version already allowed setting
    About.ApiVersion. A client could therefore observe version 6.5.0 alongside
    an apiVersion of 9.0.0.0 -- not a combination any real vCenter reports,
    and confusing for clients that inspect both.

    Bind -version to About.Version, mirroring how -api-version binds to
    About.ApiVersion.

    Signed-off-by: Dinesh Bhat <dinesh.bhat@broadcom.com>