### PR TITLE
Fix: retry vCenter's "Too many outstanding operations" fault

### DIFF
--- a/cli/flags/client.go
+++ b/cli/flags/client.go
@@ -291,6 +291,11 @@ func (flag *ClientFlag) RoundTripper(c *soap.Client) soap.RoundTripper {
 	// This means a maximum of 3 attempts.
 	rt := vim25.Retry(c, vim25.RetryTemporaryNetworkError, 3)
 
+	// Retry when vCenter's operation queue is briefly saturated, e.g. when
+	// traversing large inventories. Backs off 5s between attempts, up to 5
+	// attempts (20s max additional wait).
+	rt = vim25.Retry(rt, vim25.RetryTooManyOutstandingOperations(5*time.Second), 5)
+
 	switch {
 	case flag.dump:
 		rt = &dump{roundTripper: rt}

--- a/vim25/retry.go
+++ b/vim25/retry.go
@@ -6,9 +6,12 @@ package vim25
 
 import (
 	"context"
+	"strings"
 	"time"
 
+	"github.com/vmware/govmomi/fault"
 	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 type RetryFunc func(err error) (retry bool, delay time.Duration)
@@ -47,6 +50,22 @@ func IsTemporaryNetworkError(err error) bool {
 	}
 
 	return t.Temporary()
+}
+
+// RetryTooManyOutstandingOperations returns a RetryFunc that retries when the
+// server responds with vCenter's "Too many outstanding operations" SystemError
+// fault, waiting delay between attempts. vCenter returns this fault when its
+// internal operation queue is briefly saturated -- common when traversing
+// inventories with thousands of objects -- and it typically clears within a
+// few seconds.
+func RetryTooManyOutstandingOperations(delay time.Duration) RetryFunc {
+	return func(err error) (bool, time.Duration) {
+		var f *types.SystemError
+		if _, ok := fault.As(err, &f); ok && strings.Contains(f.Reason, "Too many outstanding operations") {
+			return true, delay
+		}
+		return false, 0
+	}
 }
 
 type retry struct {

--- a/vim25/retry_test.go
+++ b/vim25/retry_test.go
@@ -17,6 +17,16 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+func systemErrorFault(reason string) error {
+	return soap.WrapSoapFault(&soap.Fault{
+		Detail: struct {
+			Fault types.AnyType `xml:",any,typeattr"`
+		}{
+			Fault: types.SystemError{Reason: reason},
+		},
+	})
+}
+
 type tempError struct{}
 
 func (tempError) Error() string   { return "tempError" }
@@ -74,6 +84,47 @@ func TestRetry(t *testing.T) {
 		if err != tc.expected {
 			t.Errorf("Expected: %s, got: %s", tc.expected, err)
 		}
+	}
+}
+
+func TestRetryTooManyOutstandingOperations(t *testing.T) {
+	var tcs = []struct {
+		name     string
+		errs     []error
+		expected error
+	}{
+		{
+			name:     "recovers after transient throttling",
+			errs:     []error{systemErrorFault("A general system error occurred: Too many outstanding operations"), nil},
+			expected: nil,
+		},
+		{
+			name: "gives up after exhausting attempts",
+			errs: []error{
+				systemErrorFault("Too many outstanding operations"),
+				systemErrorFault("Too many outstanding operations"),
+			},
+			expected: systemErrorFault("Too many outstanding operations"),
+		},
+		{
+			name:     "does not retry unrelated faults",
+			errs:     []error{systemErrorFault("some other system error")},
+			expected: systemErrorFault("some other system error"),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var rt soap.RoundTripper = &fakeRoundTripper{errs: tc.errs}
+			rt = vim25.Retry(rt, vim25.RetryTooManyOutstandingOperations(0), 2)
+
+			err := rt.RoundTrip(context.TODO(), nil, nil)
+			if (err == nil) != (tc.expected == nil) {
+				t.Errorf("expected: %v, got: %v", tc.expected, err)
+			} else if err != nil && err.Error() != tc.expected.Error() {
+				t.Errorf("expected: %v, got: %v", tc.expected, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

`govc object.save` (and other long-running govc commands) can abort partway
through when working against large vCenter inventories:

Saving HostCertificateManager:ha-certificate-manager-29...ok
Saving HostVirtualNicManager:virtualNicManager-29...ok
Saving HostNetworkSystem:networkSystem-29...ok
govc: ServerFaultCode: A general system error occurred: Too many outstanding operations

This is vCenter's own `SystemError` fault, returned when its internal
operation queue is briefly saturated — common when traversing inventories
with thousands of objects (e.g. ~5K VMs). It's transient and normally
clears within a few seconds, but govc had no retry for it, so a single
blip anywhere in a multi-hour dump fails the entire run with no resume.

## Fix

- Add `vim25.RetryTooManyOutstandingOperations(delay)`, a `RetryFunc` that
  detects this specific fault (via the existing `fault.As` helper, matching
  on the `SystemError.Reason` text) and retries after `delay`.
- Wire it into govc's default `RoundTripper` (`cli/flags/client.go`)
  alongside the existing temporary-network-error retry: up to 5 attempts,
  5s apart (max ~20s additional wait), applied to every govc command.

## Test plan

- Added `TestRetryTooManyOutstandingOperations` in `vim25/retry_test.go`
  covering: recovery after a transient fault, giving up after exhausting
  attempts, and not retrying unrelated `SystemError` faults.
- `go build ./...`
- `go test ./vim25/... ./cli/flags/... ./fault/...`
