### PR TITLE
Fix/dvs concrete type

### DIFF
--- a/cli/object/find.go
+++ b/cli/object/find.go
@@ -54,7 +54,7 @@ var alias = []struct {
 	{"p", "ResourcePool"},
 	{"r", "ComputeResource"},
 	{"s", "Datastore"},
-	{"w", "DistributedVirtualSwitch"},
+	{"w", "VmwareDistributedVirtualSwitch"},
 }
 
 func aliasHelp() string {

--- a/cli/object/find_test.go
+++ b/cli/object/find_test.go
@@ -1,0 +1,25 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package object
+
+import "testing"
+
+// TestKindsAliasVmwareDVS guards against "-type w" mapping back to the
+// abstract DistributedVirtualSwitch. That name resolves fine against a
+// generic hierarchy-aware type filter, but "govc find" applies it as an
+// exact string match against each traversed object's own reported type
+// (kinds.wanted), which is always the concrete VmwareDistributedVirtualSwitch
+// on a real vCenter -- so the abstract name here silently matched nothing.
+// It went unnoticed because vcsim used to (incorrectly) register its own
+// switch under the abstract type too, until that was fixed to match real
+// vCenter.
+func TestKindsAliasVmwareDVS(t *testing.T) {
+	var k kinds
+	got := k.alias("w")
+	want := "VmwareDistributedVirtualSwitch"
+	if got != want {
+		t.Errorf(`alias("w") = %q, want %q`, got, want)
+	}
+}

--- a/object/common.go
+++ b/object/common.go
@@ -130,7 +130,7 @@ var refTypeMap = map[string]string{
 	"datastore":   "Datastore",
 	"domain":      "ComputeResource",
 	"dvportgroup": "DistributedVirtualPortgroup",
-	"dvs":         "DistributedVirtualSwitch",
+	"dvs":         "VmwareDistributedVirtualSwitch",
 	"group":       "Folder",
 	"host":        "HostSystem",
 	"network":     "Network",

--- a/object/common_test.go
+++ b/object/common_test.go
@@ -70,6 +70,10 @@ func TestReferenceFromString(t *testing.T) {
 		{"group-p2", &types.ManagedObjectReference{Type: "StoragePod", Value: "group-p2"}},
 		{"resgroup-42", &types.ManagedObjectReference{Type: "ResourcePool", Value: "resgroup-42"}},
 		{"resgroup-v32", &types.ManagedObjectReference{Type: "VirtualApp", Value: "resgroup-v32"}},
+		// A real vCenter's DVS is always the concrete VmwareDistributedVirtualSwitch,
+		// never the abstract DistributedVirtualSwitch -- this must resolve to the
+		// same type real "govc collect dvs-N" needs to find the object with.
+		{"dvs-8", &types.ManagedObjectReference{Type: "VmwareDistributedVirtualSwitch", Value: "dvs-8"}},
 	}
 
 	for _, test := range tests {

--- a/object/distributed_virtual_switch_test.go
+++ b/object/distributed_virtual_switch_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestDistributedVirtualSwitchEthernetCardBackingInfo(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
-		obj := simulator.Map(ctx).Any("DistributedVirtualSwitch").(*simulator.DistributedVirtualSwitch)
+		obj := simulator.Map(ctx).Any("VmwareDistributedVirtualSwitch").(*simulator.VmwareDistributedVirtualSwitch)
 
 		dvs := object.NewDistributedVirtualSwitch(c, obj.Self)
 

--- a/simulator/datacenter.go
+++ b/simulator/datacenter.go
@@ -55,7 +55,7 @@ func (dc *Datacenter) createFolders(ctx *Context) {
 		{&dc.VmFolder, "vm", []string{"VirtualMachine", "VirtualApp", "Folder"}},
 		{&dc.HostFolder, "host", []string{"ComputeResource", "Folder"}},
 		{&dc.DatastoreFolder, "datastore", []string{"Datastore", "StoragePod", "Folder"}},
-		{&dc.NetworkFolder, "network", []string{"Network", "DistributedVirtualSwitch", "Folder"}},
+		{&dc.NetworkFolder, "network", []string{"Network", "DistributedVirtualSwitch", "VmwareDistributedVirtualSwitch", "Folder"}},
 	}
 
 	for _, f := range folders {

--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -18,13 +18,13 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-type DistributedVirtualSwitch struct {
-	mo.DistributedVirtualSwitch
+type VmwareDistributedVirtualSwitch struct {
+	mo.VmwareDistributedVirtualSwitch
 
 	types.FetchDVPortsResponse
 }
 
-func (s *DistributedVirtualSwitch) eventArgument() *types.DvsEventArgument {
+func (s *VmwareDistributedVirtualSwitch) eventArgument() *types.DvsEventArgument {
 	return &types.DvsEventArgument{
 		EntityEventArgument: types.EntityEventArgument{
 			Name: s.Name,
@@ -33,7 +33,7 @@ func (s *DistributedVirtualSwitch) eventArgument() *types.DvsEventArgument {
 	}
 }
 
-func (s *DistributedVirtualSwitch) event(ctx *Context) types.DvsEvent {
+func (s *VmwareDistributedVirtualSwitch) event(ctx *Context) types.DvsEvent {
 	return types.DvsEvent{
 		Event: types.Event{
 			Datacenter: datacenterEventArgument(ctx, s),
@@ -42,7 +42,7 @@ func (s *DistributedVirtualSwitch) event(ctx *Context) types.DvsEvent {
 	}
 }
 
-func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.AddDVPortgroup_Task) soap.HasFault {
+func (s *VmwareDistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.AddDVPortgroup_Task) soap.HasFault {
 	task := CreateTask(s, "addDVPortgroup", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		f := ctx.Map.getEntityParent(s, "Folder").(*Folder)
 
@@ -181,7 +181,7 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.Add
 	}
 }
 
-func (s *DistributedVirtualSwitch) ReconfigureDvsTask(ctx *Context, req *types.ReconfigureDvs_Task) soap.HasFault {
+func (s *VmwareDistributedVirtualSwitch) ReconfigureDvsTask(ctx *Context, req *types.ReconfigureDvs_Task) soap.HasFault {
 	task := CreateTask(s, "reconfigureDvs", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		spec := req.Spec.GetDVSConfigSpec()
 
@@ -272,7 +272,7 @@ func (s *DistributedVirtualSwitch) ReconfigureDvsTask(ctx *Context, req *types.R
 	}
 }
 
-func (s *DistributedVirtualSwitch) FetchDVPorts(ctx *Context, req *types.FetchDVPorts) soap.HasFault {
+func (s *VmwareDistributedVirtualSwitch) FetchDVPorts(ctx *Context, req *types.FetchDVPorts) soap.HasFault {
 	body := &methods.FetchDVPortsBody{}
 	body.Res = &types.FetchDVPortsResponse{
 		Returnval: s.dvPortgroups(ctx, req.Criteria),
@@ -280,7 +280,7 @@ func (s *DistributedVirtualSwitch) FetchDVPorts(ctx *Context, req *types.FetchDV
 	return body
 }
 
-func (s *DistributedVirtualSwitch) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.HasFault {
+func (s *VmwareDistributedVirtualSwitch) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.HasFault {
 	task := CreateTask(s, "destroy", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		// TODO: should return ResourceInUse fault if any VM is using a port on this switch
 		// and past that, remove refs from each host.Network, etc
@@ -297,7 +297,7 @@ func (s *DistributedVirtualSwitch) DestroyTask(ctx *Context, req *types.Destroy_
 	}
 }
 
-func (s *DistributedVirtualSwitch) dvPortgroups(ctx *Context, criteria *types.DistributedVirtualSwitchPortCriteria) []types.DistributedVirtualPort {
+func (s *VmwareDistributedVirtualSwitch) dvPortgroups(ctx *Context, criteria *types.DistributedVirtualSwitchPortCriteria) []types.DistributedVirtualPort {
 	res := s.FetchDVPortsResponse.Returnval
 	if len(res) != 0 {
 		return res
@@ -324,7 +324,7 @@ func (s *DistributedVirtualSwitch) dvPortgroups(ctx *Context, criteria *types.Di
 	return res
 }
 
-func (s *DistributedVirtualSwitch) filterDVPorts(
+func (s *VmwareDistributedVirtualSwitch) filterDVPorts(
 	ports []types.DistributedVirtualPort,
 	criteria *types.DistributedVirtualSwitchPortCriteria,
 ) []types.DistributedVirtualPort {
@@ -339,7 +339,7 @@ func (s *DistributedVirtualSwitch) filterDVPorts(
 	return ports
 }
 
-func (s *DistributedVirtualSwitch) filterDVPortsByPortgroupKey(
+func (s *VmwareDistributedVirtualSwitch) filterDVPortsByPortgroupKey(
 	ports []types.DistributedVirtualPort,
 	criteria *types.DistributedVirtualSwitchPortCriteria,
 ) []types.DistributedVirtualPort {
@@ -372,7 +372,7 @@ func (s *DistributedVirtualSwitch) filterDVPortsByPortgroupKey(
 	return filtered
 }
 
-func (s *DistributedVirtualSwitch) filterDVPortsByPortKey(
+func (s *VmwareDistributedVirtualSwitch) filterDVPortsByPortKey(
 	ports []types.DistributedVirtualPort,
 	criteria *types.DistributedVirtualSwitchPortCriteria,
 ) []types.DistributedVirtualPort {
@@ -391,7 +391,7 @@ func (s *DistributedVirtualSwitch) filterDVPortsByPortKey(
 	return filtered
 }
 
-func (s *DistributedVirtualSwitch) filterDVPortsByConnected(
+func (s *VmwareDistributedVirtualSwitch) filterDVPortsByConnected(
 	ports []types.DistributedVirtualPort,
 	criteria *types.DistributedVirtualSwitchPortCriteria,
 ) []types.DistributedVirtualPort {

--- a/simulator/dvs_manager.go
+++ b/simulator/dvs_manager.go
@@ -18,8 +18,8 @@ type DistributedVirtualSwitchManager struct {
 func (m *DistributedVirtualSwitchManager) DVSManagerLookupDvPortGroup(ctx *Context, req *types.DVSManagerLookupDvPortGroup) soap.HasFault {
 	body := &methods.DVSManagerLookupDvPortGroupBody{}
 
-	for _, obj := range ctx.Map.All("DistributedVirtualSwitch") {
-		dvs := obj.(*DistributedVirtualSwitch)
+	for _, obj := range ctx.Map.All("VmwareDistributedVirtualSwitch") {
+		dvs := obj.(*VmwareDistributedVirtualSwitch)
 		if dvs.Uuid == req.SwitchUuid {
 			for _, ref := range dvs.Portgroup {
 				pg := ctx.Map.Get(ref).(*DistributedVirtualPortgroup)

--- a/simulator/dvs_test.go
+++ b/simulator/dvs_test.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/task"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -33,7 +35,7 @@ func TestDVS(t *testing.T) {
 	finder.SetDatacenter(dc[0])
 	folders, _ := dc[0].Folders(ctx)
 	hosts, _ := finder.HostSystemList(ctx, "*/*")
-	vswitch := m.Map().Any("DistributedVirtualSwitch").(*DistributedVirtualSwitch)
+	vswitch := m.Map().Any("VmwareDistributedVirtualSwitch").(*VmwareDistributedVirtualSwitch)
 	dvs0 := object.NewDistributedVirtualSwitch(c, vswitch.Reference())
 
 	if len(vswitch.Summary.HostMember) == 0 {
@@ -175,7 +177,7 @@ func TestFetchDVPortsCriteria(t *testing.T) {
 	finder := find.NewFinder(c, false)
 	dc, _ := finder.DatacenterList(ctx, "*")
 	finder.SetDatacenter(dc[0])
-	vswitch := m.Map().Any("DistributedVirtualSwitch").(*DistributedVirtualSwitch)
+	vswitch := m.Map().Any("VmwareDistributedVirtualSwitch").(*VmwareDistributedVirtualSwitch)
 	dvs0 := object.NewDistributedVirtualSwitch(c, vswitch.Reference())
 	pgs := vswitch.Portgroup
 	if len(pgs) != 2 {
@@ -266,4 +268,43 @@ func TestFetchDVPortsCriteria(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDVSConcreteType guards against vcsim regressing to reporting its DVS as
+// the abstract DistributedVirtualSwitch type. A real vCenter always reports
+// the concrete VmwareDistributedVirtualSwitch -- vRNI's collector (and any
+// client that keys off the managed object type, e.g. to pick the SDM/config
+// type to publish) derives its behavior from that MOR type, not from
+// config content, so an abstractly-typed switch is invisible to it even
+// though its portgroups are discovered fine.
+func TestDVSConcreteType(t *testing.T) {
+	Test(func(ctx context.Context, c *vim25.Client) {
+		ref := Map(ctx).Any("VmwareDistributedVirtualSwitch").Reference()
+		if ref.Type != "VmwareDistributedVirtualSwitch" {
+			t.Fatalf("MOR type = %q, want VmwareDistributedVirtualSwitch", ref.Type)
+		}
+
+		// A client may still query generically by the abstract type (as real
+		// vCenter clients have always been able to do, since VmwareDVS is a
+		// vmodl subtype of it) -- the property collector's type-hierarchy
+		// matching (simulator/property_collector.go's use of reflect on the
+		// anonymously-embedded mo field) must still resolve it against the
+		// concrete object after this rename.
+		pc := property.DefaultCollector(c)
+		for _, queryType := range []string{"VmwareDistributedVirtualSwitch", "DistributedVirtualSwitch"} {
+			res, err := pc.RetrieveProperties(ctx, types.RetrieveProperties{
+				SpecSet: []types.PropertyFilterSpec{{
+					ObjectSet: []types.ObjectSpec{{Obj: ref}},
+					PropSet:   []types.PropertySpec{{Type: queryType, PathSet: []string{"name"}}},
+				}},
+			})
+			if err != nil {
+				t.Fatalf("retrieve via type %s: %s", queryType, err)
+			}
+			if len(res.Returnval) != 1 {
+				t.Errorf("query by type %q: got %d objects, want 1 (hierarchy match against the concrete type failed)",
+					queryType, len(res.Returnval))
+			}
+		}
+	})
 }

--- a/simulator/dvs_test.go
+++ b/simulator/dvs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/task"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -305,6 +306,123 @@ func TestDVSConcreteType(t *testing.T) {
 				t.Errorf("query by type %q: got %d objects, want 1 (hierarchy match against the concrete type failed)",
 					queryType, len(res.Returnval))
 			}
+		}
+	})
+}
+
+// TestDVSDefaultProductInfo guards against a DVS ending up with an empty
+// Config.ProductInfo.Vendor. DVSCreateSpec.ProductInfo's own doc comment
+// states a real vCenter defaults it when the client doesn't supply one
+// ("the Server will use the latest version") -- at least one real collector
+// (vRNI) reads config.productInfo.vendor and crashes on a null value.
+// DVSConfigInfo.ProductInfo is a required, always-serialized (non-pointer)
+// field whose own sub-fields are all `omitempty`, so leaving it zero-valued
+// serializes as an empty <productInfo/> with no vendor element at all,
+// which deserializes as a null Vendor on the Java side. Neither
+// `govc dvs.create` (no -product-version) nor this simulator's own default
+// model-driven DVS creation ever supplied one, so this was always empty
+// before the fix. Summary.ProductInfo is checked too since it's the same
+// concept and real vCenter keeps both consistent.
+func TestDVSDefaultProductInfo(t *testing.T) {
+	Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c, false)
+		dc, err := finder.DatacenterList(ctx, "*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		finder.SetDatacenter(dc[0])
+		folders, err := dc[0].Folders(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// No ProductInfo supplied -- must default rather than stay nil.
+		var spec types.DVSCreateSpec
+		spec.ConfigSpec = &types.VMwareDVSConfigSpec{}
+		spec.ConfigSpec.GetDVSConfigSpec().Name = "DVS-default-product-info"
+
+		task, err := folders.NetworkFolder.CreateDVS(ctx, spec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err := task.WaitForResult(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dvs := object.NewDistributedVirtualSwitch(c, info.Result.(types.ManagedObjectReference))
+
+		var moDVS mo.DistributedVirtualSwitch
+		if err := dvs.Properties(ctx, dvs.Reference(), []string{"summary", "config"}, &moDVS); err != nil {
+			t.Fatal(err)
+		}
+		if moDVS.Summary.ProductInfo == nil {
+			t.Fatal("summary.productInfo is nil, want a default value")
+		}
+		if moDVS.Summary.ProductInfo.Vendor == "" {
+			t.Error("summary.productInfo.vendor is empty, want a non-empty default")
+		}
+		if moDVS.Config.GetDVSConfigInfo().ProductInfo.Vendor == "" {
+			t.Error("config.productInfo.vendor is empty, want a non-empty default")
+		}
+
+		// An explicitly-supplied ProductInfo must still be honored, not
+		// overridden by the default.
+		var spec2 types.DVSCreateSpec
+		spec2.ConfigSpec = &types.VMwareDVSConfigSpec{}
+		spec2.ConfigSpec.GetDVSConfigSpec().Name = "DVS-explicit-product-info"
+		spec2.ProductInfo = &types.DistributedVirtualSwitchProductSpec{Vendor: "Acme Corp", Version: "1.2.3"}
+
+		task2, err := folders.NetworkFolder.CreateDVS(ctx, spec2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info2, err := task2.WaitForResult(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dvs2 := object.NewDistributedVirtualSwitch(c, info2.Result.(types.ManagedObjectReference))
+
+		var moDVS2 mo.DistributedVirtualSwitch
+		if err := dvs2.Properties(ctx, dvs2.Reference(), []string{"summary", "config"}, &moDVS2); err != nil {
+			t.Fatal(err)
+		}
+		if moDVS2.Summary.ProductInfo == nil || moDVS2.Summary.ProductInfo.Vendor != "Acme Corp" {
+			t.Errorf("explicit ProductInfo was not preserved: %+v", moDVS2.Summary.ProductInfo)
+		}
+		if moDVS2.Config.GetDVSConfigInfo().ProductInfo.Vendor != "Acme Corp" {
+			t.Errorf("explicit ProductInfo was not preserved in config: %+v", moDVS2.Config.GetDVSConfigInfo().ProductInfo)
+		}
+
+		// `govc dvs.create` (without -product-version) sends a non-nil
+		// ProductInfo with an empty Vendor, not a nil ProductInfo -- this
+		// must also default rather than leave Vendor empty.
+		var spec3 types.DVSCreateSpec
+		spec3.ConfigSpec = &types.VMwareDVSConfigSpec{}
+		spec3.ConfigSpec.GetDVSConfigSpec().Name = "DVS-empty-product-info"
+		spec3.ProductInfo = new(types.DistributedVirtualSwitchProductSpec)
+
+		task3, err := folders.NetworkFolder.CreateDVS(ctx, spec3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info3, err := task3.WaitForResult(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dvs3 := object.NewDistributedVirtualSwitch(c, info3.Result.(types.ManagedObjectReference))
+
+		var moDVS3 mo.DistributedVirtualSwitch
+		if err := dvs3.Properties(ctx, dvs3.Reference(), []string{"summary", "config"}, &moDVS3); err != nil {
+			t.Fatal(err)
+		}
+		if moDVS3.Summary.ProductInfo == nil {
+			t.Fatal("summary.productInfo is nil, want a default value")
+		}
+		if moDVS3.Summary.ProductInfo.Vendor == "" {
+			t.Error("summary.productInfo.vendor is empty, want a non-empty default")
+		}
+		if moDVS3.Config.GetDVSConfigInfo().ProductInfo.Vendor == "" {
+			t.Error("config.productInfo.vendor is empty, want a non-empty default")
 		}
 	})
 }

--- a/simulator/environment_browser.go
+++ b/simulator/environment_browser.go
@@ -285,7 +285,7 @@ func (b *EnvironmentBrowser) QueryConfigTarget(ctx *Context, req *types.QueryCon
 					Network: n.Summary.GetNetworkSummary(),
 				})
 			case *DistributedVirtualPortgroup:
-				dvs := ctx.Map.Get(*n.Config.DistributedVirtualSwitch).(*DistributedVirtualSwitch)
+				dvs := ctx.Map.Get(*n.Config.DistributedVirtualSwitch).(*VmwareDistributedVirtualSwitch)
 				target.DistributedVirtualPortgroup = append(target.DistributedVirtualPortgroup, types.DistributedVirtualPortgroupInfo{
 					SwitchName:                  dvs.Name,
 					SwitchUuid:                  dvs.Uuid,
@@ -313,7 +313,7 @@ func (b *EnvironmentBrowser) QueryConfigTarget(ctx *Context, req *types.QueryCon
 						},
 					})
 				}
-			case *DistributedVirtualSwitch:
+			case *VmwareDistributedVirtualSwitch:
 				target.DistributedVirtualSwitch = append(target.DistributedVirtualSwitch, types.DistributedVirtualSwitchInfo{
 					SwitchName:                  n.Name,
 					SwitchUuid:                  n.Uuid,

--- a/simulator/example_test.go
+++ b/simulator/example_test.go
@@ -166,7 +166,7 @@ func ExampleFolder_AddOpaqueNetwork() {
 }
 
 // AddDVPortgroup against vcsim can create both standard and nsx backed DistributedVirtualPortgroup networks
-func ExampleDistributedVirtualSwitch_AddDVPortgroupTask() {
+func ExampleVmwareDistributedVirtualSwitch_AddDVPortgroupTask() {
 	simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 		finder := find.NewFinder(c)
 

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -612,11 +612,41 @@ func (f *Folder) CreateDVSTask(ctx *Context, req *types.CreateDVS_Task) soap.Has
 
 		folderPutChild(ctx, &f.Folder, dvs)
 
+		// DVSCreateSpec.ProductInfo's own doc comment: "If you do not specify
+		// this property, the Server will use the latest version to create
+		// the DistributedVirtualSwitch" -- a real vCenter always reports a
+		// non-empty Vendor in both DVSSummary.ProductInfo and
+		// DVSConfigInfo.ProductInfo. `govc dvs.create` (without
+		// -product-version) sends a non-nil ProductInfo with an empty
+		// Vendor rather than omitting it, so this must default on empty
+		// Vendor, not just nil. DVSConfigInfo.ProductInfo is a required,
+		// always-serialized (non-pointer) field whose own sub-fields are
+		// all `omitempty`, so leaving it zero-valued serializes as an
+		// empty <productInfo/> with no vendor element at all -- which at
+		// least one real collector (vRNI) deserializes as a null Vendor
+		// and crashes on unconditionally.
+		productInfo := req.Spec.ProductInfo
+		if productInfo == nil {
+			productInfo = new(types.DistributedVirtualSwitchProductSpec)
+		}
+		if productInfo.Vendor == "" {
+			product := ctx.Map.content().About
+			productInfo.Name = "DVS"
+			productInfo.Vendor = product.Vendor
+			productInfo.ForwardingClass = "etherswitch"
+			if productInfo.Version == "" {
+				productInfo.Version = product.Version
+			}
+			if productInfo.Build == "" {
+				productInfo.Build = product.Build
+			}
+		}
+
 		dvs.Summary = types.DVSSummary{
 			Name:        dvs.Name,
 			Uuid:        dvs.Uuid,
 			NumPorts:    spec.NumStandalonePorts,
-			ProductInfo: req.Spec.ProductInfo,
+			ProductInfo: productInfo,
 			Description: spec.Description,
 		}
 
@@ -638,6 +668,7 @@ func (f *Folder) CreateDVSTask(ctx *Context, req *types.CreateDVS_Task) soap.Has
 				DefaultProxySwitchMaxNumPorts:       spec.DefaultProxySwitchMaxNumPorts,
 				InfrastructureTrafficResourceConfig: spec.InfrastructureTrafficResourceConfig,
 				NetworkResourceControlVersion:       spec.NetworkResourceControlVersion,
+				ProductInfo:                         *productInfo,
 			},
 		}
 
@@ -655,17 +686,6 @@ func (f *Folder) CreateDVSTask(ctx *Context, req *types.CreateDVS_Task) soap.Has
 		}
 
 		dvs.Config = configInfo
-
-		if dvs.Summary.ProductInfo == nil {
-			product := ctx.Map.content().About
-			dvs.Summary.ProductInfo = &types.DistributedVirtualSwitchProductSpec{
-				Name:            "DVS",
-				Vendor:          product.Vendor,
-				Version:         product.Version,
-				Build:           product.Build,
-				ForwardingClass: "etherswitch",
-			}
-		}
 
 		ctx.postEvent(&types.DvsCreatedEvent{
 			DvsEvent: dvs.event(ctx),

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -58,7 +58,7 @@ func folderUpdate(ctx *Context, f *mo.Folder, o mo.Reference, u func(*Context, m
 	dc := ctx.Map.getEntityDatacenter(f)
 
 	switch ref.Type {
-	case "Network", "DistributedVirtualSwitch", "DistributedVirtualPortgroup":
+	case "Network", "DistributedVirtualSwitch", "VmwareDistributedVirtualSwitch", "DistributedVirtualPortgroup":
 		u(ctx, dc, &dc.Network, ref)
 	case "Datastore":
 		u(ctx, dc, &dc.Datastore, ref)
@@ -600,7 +600,7 @@ func (f *Folder) MoveIntoFolderTask(ctx *Context, c *types.MoveIntoFolder_Task) 
 func (f *Folder) CreateDVSTask(ctx *Context, req *types.CreateDVS_Task) soap.HasFault {
 	task := CreateTask(f, "createDVS", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		spec := req.Spec.ConfigSpec.GetDVSConfigSpec()
-		dvs := &DistributedVirtualSwitch{}
+		dvs := &VmwareDistributedVirtualSwitch{}
 		dvs.Name = spec.Name
 		dvs.Entity().Name = dvs.Name
 

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -249,7 +249,7 @@ var kinds = map[string]reflect.Type{
 	"Datastore":                          reflect.TypeOf((*Datastore)(nil)).Elem(),
 	"DatastoreNamespaceManager":          reflect.TypeOf((*DatastoreNamespaceManager)(nil)).Elem(),
 	"DistributedVirtualPortgroup":        reflect.TypeOf((*DistributedVirtualPortgroup)(nil)).Elem(),
-	"DistributedVirtualSwitch":           reflect.TypeOf((*DistributedVirtualSwitch)(nil)).Elem(),
+	"DistributedVirtualSwitch":           reflect.TypeOf((*VmwareDistributedVirtualSwitch)(nil)).Elem(),
 	"DistributedVirtualSwitchManager":    reflect.TypeOf((*DistributedVirtualSwitchManager)(nil)).Elem(),
 	"EnvironmentBrowser":                 reflect.TypeOf((*EnvironmentBrowser)(nil)).Elem(),
 	"EventManager":                       reflect.TypeOf((*EventManager)(nil)).Elem(),
@@ -284,7 +284,7 @@ var kinds = map[string]reflect.Type{
 	"VirtualMachine":                     reflect.TypeOf((*VirtualMachine)(nil)).Elem(),
 	"VirtualMachineCompatibilityChecker": reflect.TypeOf((*VmCompatibilityChecker)(nil)).Elem(),
 	"VirtualMachineProvisioningChecker":  reflect.TypeOf((*VmProvisioningChecker)(nil)).Elem(),
-	"VmwareDistributedVirtualSwitch":     reflect.TypeOf((*DistributedVirtualSwitch)(nil)).Elem(),
+	"VmwareDistributedVirtualSwitch":     reflect.TypeOf((*VmwareDistributedVirtualSwitch)(nil)).Elem(),
 }
 
 func loadObject(ctx *Context, content types.ObjectContent) (mo.Reference, error) {

--- a/simulator/ovf_manager.go
+++ b/simulator/ovf_manager.go
@@ -58,7 +58,7 @@ func ovfNetwork(ctx *Context, req *types.CreateImportSpec, item ovf.ResourceAllo
 			},
 		}
 	case *DistributedVirtualPortgroup:
-		dvs := ctx.Map.Get(*obj.Config.DistributedVirtualSwitch).(*DistributedVirtualSwitch)
+		dvs := ctx.Map.Get(*obj.Config.DistributedVirtualSwitch).(*VmwareDistributedVirtualSwitch)
 		return &types.VirtualEthernetCardDistributedVirtualPortBackingInfo{
 			Port: types.DistributedVirtualSwitchPortConnection{
 				PortgroupKey: obj.Key,

--- a/simulator/portgroup.go
+++ b/simulator/portgroup.go
@@ -16,7 +16,7 @@ type DistributedVirtualPortgroup struct {
 }
 
 func (p *DistributedVirtualPortgroup) event(ctx *Context) types.DVPortgroupEvent {
-	dvs := ctx.Map.Get(*p.Config.DistributedVirtualSwitch).(*DistributedVirtualSwitch)
+	dvs := ctx.Map.Get(*p.Config.DistributedVirtualSwitch).(*VmwareDistributedVirtualSwitch)
 
 	return types.DVPortgroupEvent{
 		Event: types.Event{
@@ -66,7 +66,7 @@ func (s *DistributedVirtualPortgroup) ReconfigureDVPortgroupTask(ctx *Context, r
 
 func (s *DistributedVirtualPortgroup) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.HasFault {
 	task := CreateTask(s, "destroy", func(t *Task) (types.AnyType, types.BaseMethodFault) {
-		vswitch := ctx.Map.Get(*s.Config.DistributedVirtualSwitch).(*DistributedVirtualSwitch)
+		vswitch := ctx.Map.Get(*s.Config.DistributedVirtualSwitch).(*VmwareDistributedVirtualSwitch)
 		ctx.Map.RemoveReference(ctx, vswitch, &vswitch.Portgroup, s.Reference())
 		ctx.Map.removeString(ctx, vswitch, &vswitch.Summary.PortgroupName, s.Name)
 

--- a/simulator/portgroup_test.go
+++ b/simulator/portgroup_test.go
@@ -30,7 +30,7 @@ func TestReconfigurePortgroup(t *testing.T) {
 	ctx := m.Service.Context
 
 	dvs := object.NewDistributedVirtualSwitch(c,
-		ctx.Map.Any("DistributedVirtualSwitch").Reference())
+		ctx.Map.Any("VmwareDistributedVirtualSwitch").Reference())
 
 	spec := []types.DVPortgroupConfigSpec{
 		{
@@ -160,7 +160,7 @@ func TestPortgroupSubnetId(t *testing.T) {
 	ctx := m.Service.Context
 
 	dvs := object.NewDistributedVirtualSwitch(c,
-		ctx.Map.Any("DistributedVirtualSwitch").Reference())
+		ctx.Map.Any("VmwareDistributedVirtualSwitch").Reference())
 
 	spec := []types.DVPortgroupConfigSpec{
 		{

--- a/simulator/registry.go
+++ b/simulator/registry.go
@@ -441,6 +441,8 @@ func entityName(e mo.Entity) string {
 		return x.Name
 	case *mo.DistributedVirtualSwitch:
 		return x.Name
+	case *mo.VmwareDistributedVirtualSwitch:
+		return x.Name
 	case *mo.DistributedVirtualPortgroup:
 		return x.Name
 	case *mo.OpaqueNetwork:

--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -1384,11 +1384,11 @@ func changedDiskSize(oldDisk *types.VirtualDisk, newDiskSpec *types.VirtualDisk)
 }
 
 func (vm *VirtualMachine) validateSwitchMembers(ctx *Context, id string) types.BaseMethodFault {
-	var dswitch *DistributedVirtualSwitch
+	var dswitch *VmwareDistributedVirtualSwitch
 
 	var find func(types.ManagedObjectReference)
 	find = func(child types.ManagedObjectReference) {
-		s, ok := ctx.Map.Get(child).(*DistributedVirtualSwitch)
+		s, ok := ctx.Map.Get(child).(*VmwareDistributedVirtualSwitch)
 		if ok && s.Uuid == id {
 			dswitch = s
 			return
@@ -1488,7 +1488,7 @@ func (vm *VirtualMachine) configureDevice(
 			walk(ctx.Map.Get(f), find) // search in NetworkFolder and any sub folders
 
 			if dvpg != nil {
-				dvs := ctx.Map.Get(*dvpg.Config.DistributedVirtualSwitch).(*DistributedVirtualSwitch)
+				dvs := ctx.Map.Get(*dvpg.Config.DistributedVirtualSwitch).(*VmwareDistributedVirtualSwitch)
 				d.Backing = &types.VirtualEthernetCardDistributedVirtualPortBackingInfo{
 					Port: types.DistributedVirtualSwitchPortConnection{
 						PortgroupKey: dvpg.Key,
@@ -1529,7 +1529,7 @@ func (vm *VirtualMachine) configureDevice(
 				return fault
 			}
 
-			dvs := ctx.Map.Get(*dvpg.Config.DistributedVirtualSwitch).(*DistributedVirtualSwitch)
+			dvs := ctx.Map.Get(*dvpg.Config.DistributedVirtualSwitch).(*VmwareDistributedVirtualSwitch)
 
 			d.Backing = &types.VirtualEthernetCardDistributedVirtualPortBackingInfo{
 				Port: types.DistributedVirtualSwitchPortConnection{

--- a/simulator/virtual_machine_fault_test.go
+++ b/simulator/virtual_machine_fault_test.go
@@ -28,7 +28,7 @@ func TestSwitchMembers(t *testing.T) {
 		// The proper way to remove a host from is with dvs.Reconfigure + types.ConfigSpecOperationRemove,
 		// but that would fail here with ResourceInUse. And creating a new DVS + PG is cumbersome,
 		// so just force the removal of host from the DVS + PG, which has the same effect on vm.AddDevice().
-		dswitch := simulator.Map(ctx).Get(dvs.Reference()).(*simulator.DistributedVirtualSwitch)
+		dswitch := simulator.Map(ctx).Get(dvs.Reference()).(*simulator.VmwareDistributedVirtualSwitch)
 		portgrp := simulator.Map(ctx).Get(pg.Reference()).(*simulator.DistributedVirtualPortgroup)
 		simulator.RemoveReference(&dswitch.Summary.HostMember, host.Reference())
 		simulator.RemoveReference(&portgrp.Host, host.Reference())


### PR DESCRIPTION
## Description

vcsim always registers its DVS as the abstract `DistributedVirtualSwitch` type. A real vCenter never does this — it always reports the concrete `VmwareDistributedVirtualSwitch` subtype. Any client that keys off an object's own reported type (rather than querying generically by the abstract type) never sees vcsim's DVS at all. That includes real collectors like vRNI, and it also happened to mask two existing bugs in govmomi's own client code — `object.ReferenceFromString`'s `dvs-NNN` shorthand and `govc find -type w` — which referenced the wrong (abstract) type name and so looked like they worked against vcsim while actually being broken against any real vCenter.

Fixing the type rename surfaced a second, related bug: vcsim never populated `DVSConfigInfo.ProductInfo`. That field is required and always sent by a real vCenter — its own API docs say the server fills it in if the client doesn't — but vcsim left it as an empty value whose `Vendor` sub-field gets dropped from the wire format entirely when unset. At least one real collector (vRNI) reads `config.productInfo.getVendor()` unconditionally and throws a `NullPointerException` on the resulting null, which silently dropped that DVS's config from every single poll cycle.

**This change:**
- Renames vcsim's DVS type to `VmwareDistributedVirtualSwitch`, matching real vCenter, while keeping property queries by the abstract type name working (real clients can still query either way).
- Fixes the two govmomi client bugs the rename uncovered, so both now resolve to the concrete type as they should against a real vCenter too.
- Defaults `DVSConfigInfo.ProductInfo.Vendor` (and the equivalent `DVSSummary.ProductInfo`) whenever the client leaves it empty — which is what `govc dvs.create` does by default — so a vcsim-created DVS always reports a valid vendor.


## How Has This Been Tested?

Added `TestDVSConcreteType` (checks the MOR type, and that queries by both the concrete and abstract type name still resolve it), `TestDVSDefaultProductInfo` (checks the default, an explicitly-supplied `ProductInfo` is preserved, and the empty-but-non-nil case `govc dvs.create` sends also defaults), `TestKindsAliasVmwareDVS`, and a new case in `TestReferenceFromString`. Full `simulator`, `object`, `cli/object`, and `govc` test suites pass.

Also validated end-to-end: built a small multi-cluster, multi-DVS vcsim topology, connected it to a real vRNI collector, and confirmed the DVS and its portgroups now show up correctly in vRNI's UI with no more `NullPointerException` in the collector logs — previously the DVS was invisible to vRNI entirely and its portgroups showed no DVS association.

