### PR TITLE
vcsim: support structured guest IP config, gateway and DNS

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -542,6 +542,19 @@ func extraConfigKey(key string) string {
 	return key
 }
 
+// parseGuestIPAndPrefix accepts either a plain IP ("10.0.0.42") or CIDR
+// notation ("10.0.0.42/24") for the SET.guest.ipAddress backdoor. A plain IP
+// keeps its prior meaning (prefix length 0) for backwards compatibility;
+// CIDR notation additionally provides the prefix length needed to compute a
+// subnet, which the legacy plain-IP form cannot express.
+func parseGuestIPAndPrefix(addr string) (ip string, prefixLen int32) {
+	if i, ipNet, err := net.ParseCIDR(addr); err == nil {
+		ones, _ := ipNet.Mask.Size()
+		return i.String(), int32(ones)
+	}
+	return addr, 0
+}
+
 func (vm *VirtualMachine) applyExtraConfig(ctx *Context, spec *types.VirtualMachineConfigSpec) types.BaseMethodFault {
 	if len(spec.ExtraConfig) == 0 {
 		return nil
@@ -594,22 +607,96 @@ func (vm *VirtualMachine) applyExtraConfig(ctx *Context, spec *types.VirtualMach
 			changes = append(changes, types.PropertyChange{Name: field.String(), Val: val, Op: op})
 			continue
 		}
-		changes = append(changes, types.PropertyChange{Name: key, Val: val.Value})
-
 		switch key {
 		case "guest.ipAddress":
+			addr := val.Value.(string)
+			ip, prefixLen := parseGuestIPAndPrefix(addr)
+			// Guest.IpAddress takes the parsed address, never the raw CIDR string --
+			// same as the generic path below would do for any other real property,
+			// except the value needs parsing first.
+			changes = append(changes, types.PropertyChange{Name: key, Val: ip})
 			if len(vm.Guest.Net) > 0 {
-				ip := val.Value.(string)
 				vm.Guest.Net[0].IpAddress = []string{ip}
+				// GuestNicInfo.IpAddress is a legacy field real Tools-equipped VMs
+				// still populate for backwards compatibility, but real API consumers
+				// (e.g. vRNI's collector) read the structured IpConfig instead -- it
+				// carries the prefix length needed to resolve the VM's subnet, which
+				// the legacy field cannot express.
+				vm.Guest.Net[0].IpConfig = &types.NetIpConfigInfo{
+					IpAddress: []types.NetIpConfigInfoIpAddress{{
+						IpAddress:    ip,
+						PrefixLength: prefixLen,
+						Origin:       string(types.NetIpConfigInfoIpAddressOriginManual),
+						State:        string(types.NetIpConfigInfoIpAddressStatusPreferred),
+					}},
+				}
 				changes = append(changes,
 					types.PropertyChange{Name: "summary." + key, Val: ip},
 					types.PropertyChange{Name: "guest.net", Val: vm.Guest.Net},
 				)
 			}
+		case "guest.defaultGateway":
+			// vcsim-only convenience key -- "guest.defaultGateway" is not a real
+			// property, so unlike every other case here this must NOT also fall
+			// through to the generic property-change path below (there is no such
+			// field for it to apply to). Real vCenter never accepts a gateway this
+			// way either (a real guest reports its route table via VMware Tools
+			// instead); this populates GuestInfo.IpStack, which is where API
+			// consumers actually read a VM's default gateway from -- GuestInfo has
+			// no standalone "gateway" field.
+			//
+			// Only IpRouteConfig is touched here (DnsConfig on the same element,
+			// if already set by SET.guest.dnsServer, is preserved) since real
+			// vCenter reports both the route table and DNS config on the same
+			// GuestStackInfo entry, and a client may set gateway and DNS in the
+			// same ReconfigVM_Task.
+			gw := val.Value.(string)
+			network := "0.0.0.0"
+			if strings.Contains(gw, ":") {
+				network = "::"
+			}
+			if len(vm.Guest.IpStack) == 0 {
+				vm.Guest.IpStack = []types.GuestStackInfo{{}}
+			}
+			vm.Guest.IpStack[0].IpRouteConfig = &types.NetIpRouteConfigInfo{
+				IpRoute: []types.NetIpRouteConfigInfoIpRoute{{
+					Network:      network,
+					PrefixLength: 0,
+					Gateway:      types.NetIpRouteConfigInfoGateway{IpAddress: gw},
+				}},
+			}
+			changes = append(changes,
+				types.PropertyChange{Name: "guest.ipStack", Val: vm.Guest.IpStack},
+			)
+		case "guest.dnsServer":
+			// vcsim-only convenience key, same rationale as guest.defaultGateway
+			// above: not a real property, must not fall through to the generic
+			// path, and shares (rather than replaces) the same GuestStackInfo
+			// element so a gateway set in the same task isn't clobbered. vRNI's
+			// collector reads DNS from GuestStackInfo.dnsConfig -- the same
+			// ipStack entry as the gateway route -- not from the per-NIC
+			// GuestNicInfo.dnsConfig. Accepts a comma-separated list for
+			// multiple DNS servers.
+			servers := strings.Split(val.Value.(string), ",")
+			for i := range servers {
+				servers[i] = strings.TrimSpace(servers[i])
+			}
+			if len(vm.Guest.IpStack) == 0 {
+				vm.Guest.IpStack = []types.GuestStackInfo{{}}
+			}
+			vm.Guest.IpStack[0].DnsConfig = &types.NetDnsConfigInfo{
+				IpAddress: servers,
+			}
+			changes = append(changes,
+				types.PropertyChange{Name: "guest.ipStack", Val: vm.Guest.IpStack},
+			)
 		case "guest.hostName":
 			changes = append(changes,
+				types.PropertyChange{Name: key, Val: val.Value},
 				types.PropertyChange{Name: "summary." + key, Val: val.Value},
 			)
+		default:
+			changes = append(changes, types.PropertyChange{Name: key, Val: val.Value})
 		}
 	}
 

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -3240,6 +3240,97 @@ func TestApplyExtraConfig(t *testing.T) {
 	})
 }
 
+func TestApplyExtraConfigGuestIPAndGateway(t *testing.T) {
+	Test(func(ctx context.Context, c *vim25.Client) {
+		vm := object.NewVirtualMachine(c, Map(ctx).Any("VirtualMachine").Reference())
+
+		task, err := vm.Reconfigure(ctx, types.VirtualMachineConfigSpec{
+			ExtraConfig: []types.BaseOptionValue{
+				&types.OptionValue{Key: "SET.guest.ipAddress", Value: "10.0.0.42/24"},
+				&types.OptionValue{Key: "SET.guest.defaultGateway", Value: "10.0.0.1"},
+				&types.OptionValue{Key: "SET.guest.dnsServer", Value: "10.0.0.1, 10.0.0.2"},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := task.Wait(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		var moVM mo.VirtualMachine
+		if err := vm.Properties(ctx, vm.Reference(), []string{"guest.ipAddress", "guest.net", "guest.ipStack"}, &moVM); err != nil {
+			t.Fatal(err)
+		}
+
+		if moVM.Guest.IpAddress != "10.0.0.42" {
+			t.Errorf("guest.ipAddress=%q, want 10.0.0.42 (CIDR mask must not leak into the legacy field)", moVM.Guest.IpAddress)
+		}
+
+		if len(moVM.Guest.Net) == 0 || moVM.Guest.Net[0].IpConfig == nil || len(moVM.Guest.Net[0].IpConfig.IpAddress) == 0 {
+			t.Fatal("guest.net[0].ipConfig.ipAddress not populated")
+		}
+		addr := moVM.Guest.Net[0].IpConfig.IpAddress[0]
+		if addr.IpAddress != "10.0.0.42" {
+			t.Errorf("ipConfig.ipAddress=%q, want 10.0.0.42", addr.IpAddress)
+		}
+		if addr.PrefixLength != 24 {
+			t.Errorf("ipConfig.prefixLength=%d, want 24", addr.PrefixLength)
+		}
+		if addr.Origin != string(types.NetIpConfigInfoIpAddressOriginManual) {
+			t.Errorf("ipConfig.origin=%q, want %q", addr.Origin, types.NetIpConfigInfoIpAddressOriginManual)
+		}
+
+		if len(moVM.Guest.IpStack) == 0 || moVM.Guest.IpStack[0].IpRouteConfig == nil || len(moVM.Guest.IpStack[0].IpRouteConfig.IpRoute) == 0 {
+			t.Fatal("guest.ipStack default route not populated")
+		}
+		route := moVM.Guest.IpStack[0].IpRouteConfig.IpRoute[0]
+		if route.Network != "0.0.0.0" || route.PrefixLength != 0 {
+			t.Errorf("default route = %s/%d, want 0.0.0.0/0", route.Network, route.PrefixLength)
+		}
+		if route.Gateway.IpAddress != "10.0.0.1" {
+			t.Errorf("gateway=%q, want 10.0.0.1", route.Gateway.IpAddress)
+		}
+
+		// DNS and gateway share the same GuestStackInfo element and were both
+		// set in the same Reconfigure call above -- neither must clobber the
+		// other.
+		if moVM.Guest.IpStack[0].DnsConfig == nil {
+			t.Fatal("guest.ipStack[0].dnsConfig not populated")
+		}
+		wantDNS := []string{"10.0.0.1", "10.0.0.2"}
+		if !reflect.DeepEqual(moVM.Guest.IpStack[0].DnsConfig.IpAddress, wantDNS) {
+			t.Errorf("dnsConfig.ipAddress=%v, want %v", moVM.Guest.IpStack[0].DnsConfig.IpAddress, wantDNS)
+		}
+		if moVM.Guest.IpStack[0].IpRouteConfig == nil || len(moVM.Guest.IpStack[0].IpRouteConfig.IpRoute) == 0 {
+			t.Fatal("guest.ipStack[0].ipRouteConfig was clobbered by setting DNS in the same call")
+		}
+
+		// A plain (non-CIDR) IP must keep its prior meaning: prefix length 0,
+		// exactly as it behaved before this backdoor understood CIDR notation.
+		task, err = vm.Reconfigure(ctx, types.VirtualMachineConfigSpec{
+			ExtraConfig: []types.BaseOptionValue{
+				&types.OptionValue{Key: "SET.guest.ipAddress", Value: "10.0.0.99"},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := task.Wait(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := vm.Properties(ctx, vm.Reference(), []string{"guest.ipAddress", "guest.net"}, &moVM); err != nil {
+			t.Fatal(err)
+		}
+		if moVM.Guest.IpAddress != "10.0.0.99" {
+			t.Errorf("guest.ipAddress=%q, want 10.0.0.99", moVM.Guest.IpAddress)
+		}
+		if moVM.Guest.Net[0].IpConfig.IpAddress[0].PrefixLength != 0 {
+			t.Errorf("plain IP prefixLength=%d, want 0", moVM.Guest.Net[0].IpConfig.IpAddress[0].PrefixLength)
+		}
+	})
+}
+
 func TestLastModifiedAndChangeVersionAreUpdated(t *testing.T) {
 	Test(func(ctx context.Context, c *vim25.Client) {
 		vm := object.NewVirtualMachine(c, Map(ctx).Any("VirtualMachine").Reference())


### PR DESCRIPTION

## Description

vcsim's `SET.guest.ipAddress` backdoor only ever wrote to the legacy `GuestNicInfo.IpAddress` field, as a bare IP with no subnet info. Real API consumers — vRNI's collector, for one — don't read that legacy field for "IP Address" / "Network Address"; they read the structured `GuestNicInfo.IpConfig` field instead, which needs a prefix length that a bare IP can't carry. There was also no way at all to give a simulated VM a default gateway or DNS server. Net effect: anyone using vcsim to scale-test IP/network discovery had no way to make simulated VMs show up correctly in a real vCenter API consumer.

This change:
- Lets `SET.guest.ipAddress` accept CIDR notation (`10.0.0.42/24`), and populates `GuestNicInfo.IpConfig` (address, prefix length, origin, state) alongside the legacy field. A bare IP with no `/` still behaves exactly as before, so this isn't a breaking change.
- Adds two new backdoor keys, `SET.guest.defaultGateway` and `SET.guest.dnsServer`, which populate `GuestInfo.IpStack`'s route table and DNS config — the only place a real vCenter's API reports this data.
- Makes sure setting gateway and DNS in the same reconfigure call doesn't clobber each other, since they share one `GuestStackInfo` entry.


**Why this change?**
The application  where the vcsim was added as datasource, wasn't getting the IPs of the VM inventories in the vcsim.

## How Has This Been Tested?

Added a unit test covering CIDR parsing, `IpConfig` population, the default route, comma-separated DNS servers, and the gateway/DNS non-clobbering case, alongside the existing `TestApplyExtraConfig` test.

Also validated end-to-end against a live vcsim instance wired up to a real vRNI (VMware Aria Operations for Networks) collector: assigned IPs, gateways, and DNS servers to simulated VMs and confirmed vRNI's UI correctly showed IP Address, Network Address, and Default Gateway — fields that were previously blank.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md

