### PR TITLE
vcsim: fix nil dereference when removing a vApp property or product

### DIFF
--- a/simulator/virtual_machine.go
+++ b/simulator/virtual_machine.go
@@ -451,6 +451,20 @@ func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 	vm.Config.Modified = time.Now()
 }
 
+// vAppUpdateKey resolves the key of the vApp property or product an update spec
+// targets. An add or edit carries it in Info; a remove leaves Info nil and names
+// the element in RemoveKey instead.
+func vAppUpdateKey(spec types.ArrayUpdateSpec, infoKey *int32) (int32, bool) {
+	if infoKey != nil {
+		return *infoKey, true
+	}
+	if spec.Operation != types.ArrayUpdateOperationRemove {
+		return 0, false
+	}
+	key, ok := spec.RemoveKey.(int32)
+	return key, ok
+}
+
 // updateVAppProperty updates the simulator VM with the specified VApp properties.
 func (vm *VirtualMachine) updateVAppProperty(spec *types.VmConfigSpec) types.BaseMethodFault {
 	if vm.Config.VAppConfig == nil {
@@ -462,12 +476,21 @@ func (vm *VirtualMachine) updateVAppProperty(spec *types.VmConfigSpec) types.Bas
 	productInfo := info.Product
 
 	for _, prop := range spec.Property {
+		var infoKey *int32
+		if prop.Info != nil {
+			infoKey = &prop.Info.Key
+		}
+		matchKey, ok := vAppUpdateKey(prop.ArrayUpdateSpec, infoKey)
+		if !ok {
+			return new(types.InvalidArgument)
+		}
+
 		var foundIndex int
 		exists := false
 		// Check if the specified property exists or not. This helps rejecting invalid
 		// operations (e.g., Adding a VApp property that already exists)
 		for i, p := range propertyInfo {
-			if p.Key == prop.Info.Key {
+			if p.Key == matchKey {
 				exists = true
 				foundIndex = i
 				break
@@ -494,12 +517,21 @@ func (vm *VirtualMachine) updateVAppProperty(spec *types.VmConfigSpec) types.Bas
 	}
 
 	for _, prod := range spec.Product {
+		var infoKey *int32
+		if prod.Info != nil {
+			infoKey = &prod.Info.Key
+		}
+		matchKey, ok := vAppUpdateKey(prod.ArrayUpdateSpec, infoKey)
+		if !ok {
+			return new(types.InvalidArgument)
+		}
+
 		var foundIndex int
 		exists := false
 		// Check if the specified product exists or not. This helps rejecting invalid
 		// operations (e.g., Adding a VApp product that already exists)
 		for i, p := range productInfo {
-			if p.Key == prod.Info.Key {
+			if p.Key == matchKey {
 				exists = true
 				foundIndex = i
 				break

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -1805,6 +1805,83 @@ func TestVAppConfigRemove(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "returns success when a property is removed by RemoveKey",
+			existingVMConfig: &types.VirtualMachineConfigSpec{
+				VAppConfig: &types.VmConfigSpec{
+					Property: []types.VAppPropertySpec{
+						{
+							ArrayUpdateSpec: types.ArrayUpdateSpec{
+								Operation: types.ArrayUpdateOperationAdd,
+							},
+							Info: &types.VAppPropertyInfo{
+								Key: int32(3),
+							},
+						},
+					},
+				},
+			},
+			spec: types.VirtualMachineConfigSpec{
+				VAppConfig: &types.VmConfigSpec{
+					Property: []types.VAppPropertySpec{
+						{
+							ArrayUpdateSpec: types.ArrayUpdateSpec{
+								Operation: types.ArrayUpdateOperationRemove,
+								RemoveKey: int32(3),
+							},
+						},
+					},
+				},
+			},
+			expectedProps: []types.VAppPropertyInfo{},
+		},
+		{
+			description: "return error when a property removed by RemoveKey does not exist",
+			expectedErr: new(types.InvalidArgument),
+			spec: types.VirtualMachineConfigSpec{
+				VAppConfig: &types.VmConfigSpec{
+					Property: []types.VAppPropertySpec{
+						{
+							ArrayUpdateSpec: types.ArrayUpdateSpec{
+								Operation: types.ArrayUpdateOperationRemove,
+								RemoveKey: int32(4),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "return error when an add carries no Info",
+			expectedErr: new(types.InvalidArgument),
+			spec: types.VirtualMachineConfigSpec{
+				VAppConfig: &types.VmConfigSpec{
+					Property: []types.VAppPropertySpec{
+						{
+							ArrayUpdateSpec: types.ArrayUpdateSpec{
+								Operation: types.ArrayUpdateOperationAdd,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "return error when RemoveKey is not an int32",
+			expectedErr: new(types.InvalidArgument),
+			spec: types.VirtualMachineConfigSpec{
+				VAppConfig: &types.VmConfigSpec{
+					Property: []types.VAppPropertySpec{
+						{
+							ArrayUpdateSpec: types.ArrayUpdateSpec{
+								Operation: types.ArrayUpdateOperationRemove,
+								RemoveKey: "1",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range tests {
@@ -1829,6 +1906,67 @@ func TestVAppConfigRemove(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestVAppConfigProductRemove(t *testing.T) {
+	ctx := context.Background()
+
+	m := ESX()
+	defer m.Remove()
+	if err := m.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vmm := m.Map().Any("VirtualMachine").(*VirtualMachine)
+	vm := object.NewVirtualMachine(c.Client, vmm.Reference())
+
+	add := types.VirtualMachineConfigSpec{
+		VAppConfig: &types.VmConfigSpec{
+			Product: []types.VAppProductSpec{
+				{
+					ArrayUpdateSpec: types.ArrayUpdateSpec{
+						Operation: types.ArrayUpdateOperationAdd,
+					},
+					Info: &types.VAppProductInfo{
+						Key:  int32(1),
+						Name: "product",
+					},
+				},
+			},
+		},
+	}
+
+	rtask, _ := vm.Reconfigure(ctx, add)
+	if err := rtask.Wait(ctx); err != nil {
+		t.Fatalf("Reconfigure failed during test setup. err: %v", err)
+	}
+
+	remove := types.VmConfigSpec{
+		Product: []types.VAppProductSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: types.ArrayUpdateOperationRemove,
+					RemoveKey: int32(1),
+				},
+			},
+		},
+	}
+
+	if fault := vmm.updateVAppProperty(&remove); fault != nil {
+		t.Fatalf("unexpected fault removing VApp product by RemoveKey: %v", fault)
+	}
+
+	if prods := vmm.Config.VAppConfig.GetVmConfigInfo().Product; len(prods) != 0 {
+		t.Errorf("expected no VApp products, got: %v", prods)
 	}
 }
 


### PR DESCRIPTION
### Describe the bug

`(*VirtualMachine).updateVAppProperty` takes the key it matches on from `prop.Info.Key` for every operation:

https://github.com/vmware/govmomi/blob/main/simulator/virtual_machine.go#L470

But a remove operation identifies the element by `RemoveKey` and leaves `Info` nil — `vim.vApp.PropertySpec` documents `info` as "not set" for a remove, and `RemoveKey` as the identifier. So an API-correct removal panics the simulator instead of removing the property:

```
panic: runtime error: invalid memory address or nil pointer dereference
	simulator/virtual_machine.go:470
```

The `spec.Product` loop has the same defect (`prod.Info.Key`, L502).

`TestVAppConfigRemove` does not catch this because its removal specs carry `Info` rather than `RemoveKey`, which is not the shape a client sends.

### Reproduction steps

Found via the vSphere BOSH CPI. Its `detach_disk` removes the vApp property recording a persistent disk's device key, building the spec as `remove_key = <key>` + `operation = REMOVE` with `info` unset; real vCenter accepts it. Against vcsim it kills the process, which is why the CPI had no attach-then-detach test at all.

Minimal spec:

```go
vmm.updateVAppProperty(&types.VmConfigSpec{
	Property: []types.VAppPropertySpec{{
		ArrayUpdateSpec: types.ArrayUpdateSpec{
			Operation: types.ArrayUpdateOperationRemove,
			RemoveKey: existingKey,
		},
	}},
})
```

Present in v0.30.0 (where `updateVAppProperty` was introduced, #2642) through v0.56.0 and `main`.

### Fix

Derive the match key from `RemoveKey` when `Info` is nil, in both loops. An add or edit with no `Info` previously panicked at the `*prop.Info` deref and is now `InvalidArgument`, since there is nothing to add.

Tests added for the documented removal shape, for a product removal (the `Product` loop had no coverage at all), and for the nil-`Info` add. Each fails without the fix — the removal cases with the original panic.