### PR TITLE
fix: VirtualMachineConfigSpec ExtCompat field order

### DIFF
--- a/vim25/types/types.go
+++ b/vim25/types/types.go
@@ -90150,6 +90150,19 @@ type VirtualMachineConfigSpec struct {
 	//
 	// Reconfigure privilege: VirtualMachine.Config.ManagedBy
 	ManagedBy *ManagedByInfo `xml:"managedBy,omitempty" json:"managedBy,omitempty"`
+	// The full set of extension compatibility constraints for this virtual
+	// machine, declared by its managing extension (see ManagedBy) so that
+	// vCenter can protect the VM's properties during operations that would
+	// change them. At create time the constraints are persisted atomically with
+	// the VM; at reconfigure time the set fully replaces the existing set
+	// (an empty constraint array clears it).
+	ExtensionCompatibilityConstraint *VirtualMachineExtensionCompatibilityConstraintSet `xml:"extensionCompatibilityConstraint,omitempty" json:"extensionCompatibilityConstraint,omitempty" vim:"9.1.0.0"`
+	// Whether to skip enforcement of the extensionCompatibilityConstraint set.
+	// Honored only when the caller holds the
+	// VirtualMachine.ExtensionCompatibility.Bypass privilege on the virtual
+	// machine; otherwise the operation is rejected. When unset, the value is
+	// treated as false and the registered constraints are enforced.
+	SkipExtensionCompatibilityChecks *bool `xml:"skipExtensionCompatibilityChecks" json:"skipExtensionCompatibilityChecks,omitempty" vim:"9.1.0.0"`
 	// If set true, memory resource reservation for this virtual machine will always be
 	// equal to the virtual machine's memory size; increases in memory size will be
 	// rejected when a corresponding reservation increase is not possible.
@@ -90360,19 +90373,6 @@ type VirtualMachineConfigSpec struct {
 	// existing vSphere compute-policies or affinity rules, then they will still
 	// be considered during this VM's placement.
 	VmPlacementPolicies []BaseVmPlacementPolicy `xml:"vmPlacementPolicies,omitempty,typeattr" json:"vmPlacementPolicies,omitempty" vim:"9.1.0.0"`
-	// The full set of extension compatibility constraints for this virtual
-	// machine, declared by its managing extension (see ManagedBy) so that
-	// vCenter can protect the VM's properties during operations that would
-	// change them. At create time the constraints are persisted atomically with
-	// the VM; at reconfigure time the set fully replaces the existing set
-	// (an empty constraint array clears it).
-	ExtensionCompatibilityConstraint *VirtualMachineExtensionCompatibilityConstraintSet `xml:"extensionCompatibilityConstraint,omitempty" json:"extensionCompatibilityConstraint,omitempty" vim:"9.1.0.0"`
-	// Whether to skip enforcement of the extensionCompatibilityConstraint set.
-	// Honored only when the caller holds the
-	// VirtualMachine.ExtensionCompatibility.Bypass privilege on the virtual
-	// machine; otherwise the operation is rejected. When unset, the value is
-	// treated as false and the registered constraints are enforced.
-	SkipExtensionCompatibilityChecks *bool `xml:"skipExtensionCompatibilityChecks" json:"skipExtensionCompatibilityChecks,omitempty" vim:"9.1.0.0"`
 }
 
 func init() {

--- a/vim25/types/unreleased_test.go
+++ b/vim25/types/unreleased_test.go
@@ -74,22 +74,39 @@ func TestExtensionCompatibilityConstraint(t *testing.T) {
 	})
 
 	// Request-side write + bypass fields (vcsim does not persist these); assert
-	// they serialize.
+	// they serialize, and in VMODL sequence order: vpxd parses a DataObject
+	// with a forward cursor over the property list, so an element emitted
+	// after a later-declared property (e.g. vmProfile) is rejected with
+	// "Unexpected element tag".
 	skip := true
 	b, err := xml.Marshal(types.VirtualMachineConfigSpec{
+		ManagedBy:                        &types.ManagedByInfo{ExtensionKey: "ext", Type: "t"},
 		ExtensionCompatibilityConstraint: set,
 		SkipExtensionCompatibilityChecks: &skip,
+		MemoryReservationLockedToMax:     &skip,
+		VmProfile:                        []types.BaseVirtualMachineProfileSpec{&types.VirtualMachineDefaultProfileSpec{}},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{
-		"extensionCompatibilityConstraint", "skipExtensionCompatibilityChecks",
-		"pool-invariant", "POOL", "INVARIANT",
-	} {
+	for _, want := range []string{"pool-invariant", "POOL", "INVARIANT"} {
 		if !strings.Contains(string(b), want) {
 			t.Errorf("expected %q in marshaled ConfigSpec:\n%s", want, b)
 		}
+	}
+	prev := -1
+	for _, name := range []string{
+		"managedBy", "extensionCompatibilityConstraint", "skipExtensionCompatibilityChecks",
+		"memoryReservationLockedToMax", "vmProfile",
+	} {
+		i := strings.Index(string(b), "<"+name)
+		if i < 0 {
+			t.Fatalf("expected %q in marshaled ConfigSpec:\n%s", name, b)
+		}
+		if i <= prev {
+			t.Errorf("%q emitted out of VMODL order in marshaled ConfigSpec:\n%s", name, b)
+		}
+		prev = i
 	}
 
 	if b, err = xml.Marshal(types.VirtualMachineRelocateSpec{SkipExtensionCompatibilityChecks: &skip}); err != nil {


### PR DESCRIPTION
## Description

5a7b322 appended ExtensionCompatibilityConstraint and SkipExtensionCompatibilityChecks as the last two fields of VirtualMachineConfigSpec. In vim.vm.ConfigSpec they follow managedBy and precede memoryReservationLockedToMax. govmomi's XML encoder emits elements in struct field order and vpxd parses a DataObject with a forward cursor over the VMODL property list, so a ReconfigVM_Task (or placeVmsXCluster) that sets these fields together with a later-declared property such as vmProfile failed with:

    Unexpected element tag "skipExtensionCompatibilityChecks" seen while
    parsing serialized DataObject of type vim.vm.ConfigSpec

Move the two fields after ManagedBy. Field names, types and tags are unchanged. RelocateSpec and ConfigInfo are already in VMODL order.

Extend TestExtensionCompatibilityConstraint to assert the emitted element order, which fails without the struct change.

## How Has This Been Tested?

- go test ./vim25/types/... ./vim25/xml/...; the new order assertion fails on main and passes with this change.
- Against a vCenter 9.2 build with the ExtensionCompatConstraint feature enabled: a ConfigSpec that carries skipExtensionCompatibilityChecks together with vmProfile is rejected with the fault above when built from main and accepted when built from this branch.
- Deployed a build of a govmomi consumer (mobility-operator) with this change to a Supervisor cluster on that vCenter: a VM import that failed at ReconfigVM_Task before now completes, and every reconfigure task carrying the bypass flag succeeds with no parse errors in vpxd.log.

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md
