### PR TITLE
vcsim: fix content library storage_uris to match datastore url

### DIFF
--- a/vapi/library/finder/path_test.go
+++ b/vapi/library/finder/path_test.go
@@ -7,6 +7,10 @@ package finder_test
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +24,7 @@ import (
 	_ "github.com/vmware/govmomi/vapi/simulator"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -182,6 +187,144 @@ func TestResolveLibraryItemStorage(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestListLibraryItemStorageResolvesToDatastorePath verifies that the
+// storage_uris reported by ListLibraryItemStorage for a real, uploaded
+// library item file are rooted at the datastore's own summary.url, the way a
+// real vCenter reports them, and not vcsim's internal on-disk temp
+// directory. Regression test for the vcsim change in PR #4114
+// ("vcsim: report a real vCenter-shaped Url for local datastores" and
+// "vcsim: export Datastore.Path() and fix vapi/simulator's content library
+// path"), which made Datastore.Summary.Url a synthesized "ds://" value
+// without updating vapi/simulator's storage_uris to match, causing
+// ResolveLibraryItemStorage's TrimPrefix(uri, ds.Summary.Url) to silently
+// fail to strip the prefix and leak vcsim's real temp directory into the
+// resolved path.
+func TestListLibraryItemStorageResolvesToDatastorePath(t *testing.T) {
+	simulator.Test(func(ctx context.Context, vc *vim25.Client) {
+		rc := rest.NewClient(vc)
+		if err := rc.Login(ctx, simulator.DefaultLogin); !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		vf := find.NewFinder(vc)
+		dc, err := vf.Datacenter(ctx, "*")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		vf.SetDatacenter(dc)
+
+		ds, err := vf.Datastore(ctx, "LocalDS_0")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		m := library.NewManager(rc)
+
+		libID, err := m.CreateLibrary(ctx, library.Library{
+			Name: "test-lib",
+			Type: "LOCAL",
+			Storage: []library.StorageBacking{
+				{
+					DatastoreID: ds.Reference().Value,
+					Type:        "DATASTORE",
+				},
+			},
+		})
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		itemID, err := m.CreateLibraryItem(ctx, library.Item{
+			Name:      "test-item",
+			Type:      "OVF",
+			LibraryID: libID,
+		})
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		sessionID, err := m.CreateLibraryItemUpdateSession(
+			ctx, library.Session{LibraryItemID: itemID})
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		diskPath := "../../library/testdata/ttylinux-pc_i486-16.1-disk1.vmdk"
+		f, err := os.Open(filepath.Clean(diskPath))
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		defer f.Close()
+
+		fi, err := f.Stat()
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		update, err := m.AddLibraryItemFile(ctx, sessionID, library.UpdateFile{
+			Name:       "disk1.vmdk",
+			SourceType: "PUSH",
+			Size:       fi.Size(),
+		})
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		u, err := url.Parse(update.UploadEndpoint.URI)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		p := soap.DefaultUpload
+		p.ContentLength = fi.Size()
+		if !assert.NoError(t, m.Client.Upload(ctx, f, u, &p)) {
+			t.FailNow()
+		}
+
+		if !assert.NoError(
+			t, m.CompleteLibraryItemUpdateSession(ctx, sessionID)) {
+
+			t.FailNow()
+		}
+
+		storage, err := m.ListLibraryItemStorage(ctx, itemID)
+		if !assert.NoError(t, err) || !assert.Len(t, storage, 1) {
+			t.FailNow()
+		}
+		if !assert.Len(t, storage[0].StorageURIs, 1) {
+			t.FailNow()
+		}
+
+		// Before resolving, the reported storage_uris must already be shaped
+		// like a real vCenter's datastore URL, not vcsim's local temp dir.
+		rawURI := storage[0].StorageURIs[0]
+		assert.NotContains(t, rawURI, os.TempDir())
+		assert.NotContains(t, rawURI, "govcsim")
+
+		lf := finder.NewPathFinder(m, vc)
+		if !assert.NoError(
+			t, lf.ResolveLibraryItemStorage(ctx, dc, nil, storage)) {
+
+			t.FailNow()
+		}
+
+		resolved := storage[0].StorageURIs[0]
+		assert.False(
+			t,
+			strings.Contains(resolved, os.TempDir()) ||
+				strings.Contains(resolved, "govcsim"),
+			"resolved storage URI leaked vcsim's internal path: %s", resolved)
+
+		var dp object.DatastorePath
+		assert.True(t, dp.FromString(resolved), "not a datastore path: %s", resolved)
+		assert.Equal(t, "LocalDS_0", dp.Datastore)
+		assert.True(
+			t,
+			strings.HasPrefix(dp.Path, "contentlib-"+libID+"/"+itemID+"/"),
+			"unexpected relative path: %s", dp.Path)
+	})
 }
 
 // TODO(dougm) consider vSAN enablement via simulator.Model

--- a/vapi/simulator/simulator.go
+++ b/vapi/simulator/simulator.go
@@ -2132,16 +2132,36 @@ func (s *handler) libraryItemStorageByID(id string) ([]library.Storage, bool) {
 		return nil, false
 	}
 
+	// StorageURIs is client-facing: on a real vCenter it is a datastore URL,
+	// ex. "ds:///vmfs/volumes/<uuid>/contentlib-<lib>/<item>/<file>", rooted
+	// at the same value the datastore reports via summary.url. libraryPath()
+	// returns vcsim's real on-disk directory instead, which is only
+	// meaningful for vcsim's own file I/O and is never exposed to clients on
+	// a real vCenter. Only the Path field is joined (not the raw URL string)
+	// so a "ds://" scheme isn't collapsed by path.Join's slash cleaning.
+	dsref := types.ManagedObjectReference{
+		Type:  "Datastore",
+		Value: lib.Storage[0].DatastoreID,
+	}
+	ds := s.Map.Get(dsref).(*simulator.Datastore)
+
+	dsURL, err := url.Parse(ds.Summary.Url)
+	if err != nil {
+		log.Printf("invalid datastore url %q: %s", ds.Summary.Url, err)
+		return nil, false
+	}
+
 	storage := make([]library.Storage, len(item.File))
 
 	for i, file := range item.File {
+		u := *dsURL
+		u.Path = path.Join(u.Path, "contentlib-"+lib.ID, id, file.Name)
+
 		storage[i] = library.Storage{
 			StorageBacking: lib.Storage[0],
-			StorageURIs: []string{
-				path.Join(s.libraryPath(lib.Library, id), file.Name),
-			},
-			Name:    file.Name,
-			Version: file.Version,
+			StorageURIs:    []string{u.String()},
+			Name:           file.Name,
+			Version:        file.Version,
 		}
 		if file.Checksum != nil {
 			storage[i].Checksum = *file.Checksum


### PR DESCRIPTION
## Description

PR #4114 ("vcsim: report a real vCenter-shaped Url for local datastores") changed Datastore.Summary.Url/Info.Url for local datastores to a synthesized "ds:///vmfs/volumes/<uuid>/" value, matching real vCenter, and #4114's follow-up commit ("vcsim: export Datastore.Path() and fix vapi/simulator's content library path") moved vapi/simulator's internal file-IO helper, libraryPath(), off of Info.Url and onto the newly exported Datastore.Path() (vcsim's real on-disk directory) so uploads/reads kept working against the real temp dir.

But vapi/simulator's libraryItemStorageByID(), which builds the client-facing storage_uris returned by ListLibraryItemStorage and GetLibraryItemStorage, also called libraryPath() to build those URIs. Before #4114, Info.Url/Summary.Url and libraryPath() both resolved to the same raw temp directory, so this was self-consistent by accident. After #4114 they diverge: storage_uris is still the raw temp path, while Summary.Url is the synthesized ds:// value.

vapi/library/finder.PathFinder.ResolveLibraryItemStorage resolves a storage_uri to a "[datastore] path" by stripping the datastore's Summary.Url prefix. Since the prefix no longer matches, the strip is a silent no-op (strings.TrimPrefix returns its input unchanged on a mismatch) and the resolved path leaks vcsim's raw temp directory, e.g. "[LocalDS_0] tmp/govcsim-.../DC0-LocalDS_0/contentlib-.../disk.vmdk" instead of "[LocalDS_0] contentlib-.../disk.vmdk". Downstream, a consumer that stat's or copies that path against the real datastore gets a "file does not exist" error, since the leaked path doesn't exist relative to the datastore root.

Fix libraryItemStorageByID to build storage_uris from the datastore's own Summary.Url instead of libraryPath()'s real on-disk directory, matching what a real vCenter reports and what
ResolveLibraryItemStorage expects to strip. Only the URL's Path field is joined (not the raw URL string), since path.Join would otherwise collapse the "ds://" scheme's double slash.

Add a regression test that uploads a real file to a library item and round-trips it through ListLibraryItemStorage and
ResolveLibraryItemStorage, asserting the resolved path never contains vcsim's internal temp directory.

## How Has This Been Tested?

- go test ./vapi/...: passes, including the new regression test; the new test fails on main with the leaked temp path shown above.
- go test ./simulator/...: two pre-existing failures (TestFileInfo, TestCreateVm) reproduce identically on unmodified main and are unrelated to this change.
Please describe any manual tests done to verify your changes.
