### PR TITLE
feat(edge): add initial implementation of edge Network

### DIFF
--- a/vapi/namespace/internal/internal.go
+++ b/vapi/namespace/internal/internal.go
@@ -15,6 +15,7 @@ const (
 	SupervisorsSummariesPath                = SupervisorsPath + "/summaries"
 	SupervisorSummaryPath                   = SupervisorsPath + "/%s/summary"
 	SupervisorTopologyPath                  = SupervisorsPath + "/%s/topology"
+	SupervisorNetworkEdgesPath              = SupervisorsPath + "/%s/networks/edges"
 
 	NamespacesPath       = "/api/vcenter/namespaces/instances"
 	NamespacesPathV2     = "/api/vcenter/namespaces/instances/v2"

--- a/vapi/namespace/namespace.go
+++ b/vapi/namespace/namespace.go
@@ -493,6 +493,33 @@ func (c *Manager) GetSupervisorTopology(ctx context.Context, id string) ([]Super
 	return response, err
 }
 
+// SupervisorNetworkEdge describes a network edge configured with a Supervisor.
+// The Edge field is the ID to use as NamespaceEdgeSpec.ID when creating a
+// namespace that should use this edge.
+// GET /api/vcenter/namespace-management/supervisors/{supervisor}/networks/edges
+// Since 9.0.0.0
+type SupervisorNetworkEdge struct {
+	Edge     string `json:"edge"`
+	Provider string `json:"provider"`
+	Name     string `json:"name"`
+}
+
+// SupervisorNetworkEdgesResult
+// GET /api/vcenter/namespace-management/supervisors/{supervisor}/networks/edges
+// Since 9.0.0.0
+type SupervisorNetworkEdgesResult struct {
+	Edges []SupervisorNetworkEdge `json:"edges"`
+}
+
+// GetSupervisorNetworkEdges retrieves the network edges configured with the specified Supervisor.
+// GET /api/vcenter/namespace-management/supervisors/{supervisor}/networks/edges
+func (c *Manager) GetSupervisorNetworkEdges(ctx context.Context, id string) ([]SupervisorNetworkEdge, error) {
+	var response SupervisorNetworkEdgesResult
+	url := c.Resource(fmt.Sprintf(internal.SupervisorNetworkEdgesPath, id))
+	err := c.Do(ctx, url.Request(http.MethodGet), &response)
+	return response.Edges, err
+}
+
 // SizingHint determines the size of the Tanzu Kubernetes Grid
 // Supervisor cluster's kubeapi instances.
 // Note: Only use TinySizingHint in non-production environments.

--- a/vapi/namespace/namespace.go
+++ b/vapi/namespace/namespace.go
@@ -493,28 +493,26 @@ func (c *Manager) GetSupervisorTopology(ctx context.Context, id string) ([]Super
 	return response, err
 }
 
-// SupervisorNetworkEdge describes a network edge configured with a Supervisor.
-// The Edge field is the ID to use as NamespaceEdgeSpec.ID when creating a
-// namespace that should use this edge.
-// GET /api/vcenter/namespace-management/supervisors/{supervisor}/networks/edges
+// SupervisorNetworkEdgeInfo describes a network edge configured with a Supervisor.
+// https://developer.broadcom.com/xapis/vsphere-automation-api/latest/data-structures/Vcenter%20NamespaceManagement%20Supervisors%20Networks%20Edges%20Info/
 // Since 9.0.0.0
-type SupervisorNetworkEdge struct {
+type SupervisorNetworkEdgeInfo struct {
 	Edge     string `json:"edge"`
 	Provider string `json:"provider"`
 	Name     string `json:"name"`
 }
 
-// SupervisorNetworkEdgesResult
-// GET /api/vcenter/namespace-management/supervisors/{supervisor}/networks/edges
+// SupervisorNetworkEdgesListResult
+// https://developer.broadcom.com/xapis/vsphere-automation-api/latest/data-structures/Vcenter%20NamespaceManagement%20Supervisors%20Networks%20Edges%20ListResult/
 // Since 9.0.0.0
-type SupervisorNetworkEdgesResult struct {
-	Edges []SupervisorNetworkEdge `json:"edges"`
+type SupervisorNetworkEdgesListResult struct {
+	Edges []SupervisorNetworkEdgeInfo `json:"edges"`
 }
 
 // GetSupervisorNetworkEdges retrieves the network edges configured with the specified Supervisor.
-// GET /api/vcenter/namespace-management/supervisors/{supervisor}/networks/edges
-func (c *Manager) GetSupervisorNetworkEdges(ctx context.Context, id string) ([]SupervisorNetworkEdge, error) {
-	var response SupervisorNetworkEdgesResult
+// https://developer.broadcom.com/xapis/vsphere-automation-api/latest/api/vcenter/namespace-management/supervisors/supervisor/networks/edges/get/
+func (c *Manager) GetSupervisorNetworkEdges(ctx context.Context, id string) ([]SupervisorNetworkEdgeInfo, error) {
+	var response SupervisorNetworkEdgesListResult
 	url := c.Resource(fmt.Sprintf(internal.SupervisorNetworkEdgesPath, id))
 	err := c.Do(ctx, url.Request(http.MethodGet), &response)
 	return response.Edges, err

--- a/vapi/namespace/namespace_v2.go
+++ b/vapi/namespace/namespace_v2.go
@@ -27,15 +27,16 @@ type NamespaceInstanceSummaryV2 struct {
 // https://developer.broadcom.com/xapis/vsphere-automation-api/9.0/data-structures/Vcenter%20Namespaces%20Instances%20InfoV2
 // Since 8.0.0.1
 type NamespaceInstanceInfoV2 struct {
-	Supervisor           string             `json:"supervisor"`
-	ConfigStatus         string             `json:"config_status"`
-	Stats                Stats              `json:"stats"`
-	Description          string             `json:"description"`
-	StorageSpecs         []StorageSpec      `json:"storage_specs"`
-	VmServiceSpec        VmServiceSpec      `json:"vm_service_spec"`
-	ContentLibraries     []ContentLibraryV2 `json:"content_libraries"`
-	SelfServiceNamespace bool               `json:"self_service_namespace"`
-	NetworkSpec          *NetworkConfigInfo `json:"network_spec,omitempty"`
+	Supervisor           string              `json:"supervisor"`
+	ConfigStatus         string              `json:"config_status"`
+	Stats                Stats               `json:"stats"`
+	Description          string              `json:"description"`
+	StorageSpecs         []StorageSpec       `json:"storage_specs"`
+	VmServiceSpec        VmServiceSpec       `json:"vm_service_spec"`
+	ContentLibraries     []ContentLibraryV2  `json:"content_libraries"`
+	SelfServiceNamespace bool                `json:"self_service_namespace"`
+	NetworkSpec          *NetworkConfigInfo  `json:"network_spec,omitempty"`
+	Edges                []NamespaceEdgeSpec `json:"edges,omitempty"`
 }
 
 // NamespaceInstanceCreateSpecV2
@@ -51,6 +52,7 @@ type NamespaceInstanceCreateSpecV2 struct {
 	SelfServiceNamespace *bool                       `json:"self_service_namespace,omitempty"`
 	NetworkSpec          *NetworkConfigCreateSpec    `json:"network_spec,omitempty"`
 	NamespaceNetwork     *NamespaceNetworkCreateSpec `json:"namespace_network,omitempty"`
+	Edges                *[]NamespaceEdgeSpec        `json:"edges,omitempty"`
 }
 
 type Stats struct {
@@ -64,6 +66,22 @@ type ContentLibraryV2 struct {
 	Writable               bool   `json:"writable"`
 	AllowImport            bool   `json:"allow_import"`
 	ResourceNamingStrategy string `json:"resource_naming_strategy"`
+}
+
+// NamespaceEdgeSpec The Vcenter Namespaces Instances EdgeCreateSpec schema contains the specification required to configure Edge provider association with a namespace.
+// https://developer.broadcom.com/xapis/vsphere-automation-api/9.1.1/data-structures/Vcenter%20Namespaces%20Instances%20EdgeCreateSpec/
+// Since 9.1.0.0
+type NamespaceEdgeSpec struct {
+	// Retrieve ID from api: https://developer.broadcom.com/xapis/vsphere-automation-api/latest/api/vcenter/namespace-management/supervisors/supervisor/networks/edges/get/
+	ID string `json:"id,omitempty"`
+	// Name of the edge provider e.g.: NSX_REGISTERED_AVI
+	EdgeProvider string                `json:"edge_provider,omitempty"`
+	Avi          *NamespaceEdgeAviSpec `json:"avi,omitempty"`
+}
+
+// NamespaceEdgeAviSpec defines the SE-Group used by the namespace to provision LB
+type NamespaceEdgeAviSpec struct {
+	SeGroupName string `json:"se_group_name,omitempty"`
 }
 
 // NamespaceNetworkCreateSpec represents the complete namespace_network field for creation

--- a/vapi/namespace/namespace_v2.go
+++ b/vapi/namespace/namespace_v2.go
@@ -72,9 +72,11 @@ type ContentLibraryV2 struct {
 // https://developer.broadcom.com/xapis/vsphere-automation-api/9.1.1/data-structures/Vcenter%20Namespaces%20Instances%20EdgeCreateSpec/
 // Since 9.1.0.0
 type NamespaceEdgeSpec struct {
-	// Retrieve ID from api: https://developer.broadcom.com/xapis/vsphere-automation-api/latest/api/vcenter/namespace-management/supervisors/supervisor/networks/edges/get/
+	// Retrieve ID from api
+	// https://developer.broadcom.com/xapis/vsphere-automation-api/latest/api/vcenter/namespace-management/supervisors/supervisor/networks/edges/get/
 	ID string `json:"id,omitempty"`
-	// Name of the edge provider e.g.: NSX_REGISTERED_AVI
+	// Vcenter Namespaces Instances EdgeProvider
+	// https://developer.broadcom.com/xapis/vsphere-automation-api/9.1.1/data-structures/Vcenter%20Namespaces%20Instances%20EdgeProvider/index
 	EdgeProvider string                `json:"edge_provider,omitempty"`
 	Avi          *NamespaceEdgeAviSpec `json:"avi,omitempty"`
 }


### PR DESCRIPTION
## Description

add implementation of Edges to support Network Edges in CreateNamespace

Closes: #4126

## How Has This Been Tested?

I wrote some code to test the call against the LAB instance.


```golang
package main

import (
	"context"
	"fmt"
	"log"
	"net/url"
	"strings"

	"github.com/vmware/govmomi"
	"github.com/vmware/govmomi/vapi/namespace"

	"github.com/vmware/govmomi/vapi/rest"
)

func main() {
	ctx := context.Background()

	// vCenter connection details (update these with your actual credentials)
	vcenterURL := "vcf-vc91.example.company.lab"
	username := "USER"
	password := "PASSWORD"


	edgeProvider := "NSX_REGISTERED_AVI"
	seGroupName := "se-group-01"

	log.Println("=== Creating vSphere Client ===")
	client, err := NewVSphereClient(ctx, vcenterURL, username, password)
	if err != nil {
		log.Fatalf("Failed to create vSphere client: %v", err)
	}

	log.Println("=== Finding Supervisors ===")
	// Find supervisors using the namespace manager
	supervisors, err := client.NamespaceManager.GetSupervisorSummaries(ctx)
	if err != nil {
		log.Fatalf("Failed to list supervisors: %v", err)
	}

	if len(supervisors.Items) == 0 {
		log.Fatalf("No supervisors found")
	}

	if len(supervisors.Items) != 1 {
		log.Fatalf("Expected exactly one supervisor, found %d supervisors:", len(supervisors.Items))
	}

	supervisor := supervisors.Items[0]
	log.Printf("Found exactly one supervisor: %s (ID: %s)", supervisor.Supervisor, supervisor.Info.Name)

	log.Println("=== Finding Supervisor Network Edge ===")
	supervisorEdges, err := client.NamespaceManager.GetSupervisorNetworkEdges(ctx, supervisor.Supervisor)
	if err != nil {
		log.Fatalf("Failed to list network edges for supervisor %s: %v", supervisor.Supervisor, err)
	}

	var edgeID string
	for _, e := range supervisorEdges {
		if e.Provider == edgeProvider {
			edgeID = e.Edge
			break
		}
	}
	if edgeID == "" {
		log.Fatalf("No edge with provider %q found on supervisor %s (found: %v)", edgeProvider, supervisor.Supervisor, supervisorEdges)
	}
	log.Printf("Found edge: %s (provider: %s)", edgeID, edgeProvider)

	log.Println("=== Creating Namespace Network Specification ===")

	log.Println("=== Creating Namespace: test123 ===")
	description := "Test namespace with network override"

	namespaceSpec := namespace.NamespaceInstanceCreateSpecV2{
		// Standard govmomi fields
		Namespace:   "test123",
		Supervisor:  supervisor.Supervisor,
		Description: &description,
		NetworkSpec: &namespace.NetworkConfigCreateSpec{
			NetworkProvider: "NSX_VPC",
			VpcNetwork: &namespace.VpcNetworkCreateSpec{
				Vpc: new("/orgs/default/projects/default/vpcs/ns-nonvcfa"),
			},
		},
		Edges: &[]namespace.NamespaceEdgeSpec{
			{
				ID:           edgeID,
				EdgeProvider: edgeProvider,
				Avi:          &namespace.NamespaceEdgeAviSpec{SeGroupName: seGroupName},
			},
		},
	}

	// Test the extended struct with vSphere API
	err = client.NamespaceManager.CreateNamespaceV2(ctx, namespaceSpec)
	if err != nil {
		if strings.Contains(err.Error(), "already exists in this vCenter") {
			log.Println(err.Error())
		} else {

			log.Fatalf("Failed to create namespace: %v", err)
		}
	}

	// Verify the namespace was created
	log.Println("=== Verifying Namespace Creation ===")
	nsInfo, err := client.NamespaceManager.GetNamespaceV2(ctx, namespaceSpec.Namespace)
	if err != nil {
		log.Printf("Warning: Could not verify namespace creation: %v", err)
	} else {
		log.Printf("Namespace verified: %s on supervisor: %s", namespaceSpec.Namespace, nsInfo.Supervisor)
		log.Printf("   Status: %s", nsInfo.ConfigStatus)
		if nsInfo.NetworkSpec != nil {
			log.Printf("   Network Provider: %s", nsInfo.NetworkSpec.NetworkProvider)
			log.Printf("   Private CIDRS: %v", nsInfo.NetworkSpec.VpcNetwork.VpcConfig.PrivateCidrs)
			log.Printf("   Edges: %v", nsInfo.Edges)
		}
	}
}

func NewVSphereClient(ctx context.Context, vcenterURL, username, password string) (*VSphereClient, error) {

	client, err := newGovmomiClient(ctx, vcenterURL, username, password)
	if err != nil {
		return nil, fmt.Errorf("failed to create vSphere client: %w", err)
	}

	// Create REST client for namespace management
	restClient := rest.NewClient(client.Client)

	// Login to REST API with the same credentials
	err = restClient.Login(ctx, url.UserPassword(username, password))
	if err != nil {
		return nil, fmt.Errorf("error logging into REST API: %w", err)
	}

	// Get namespace manager
	namespaceManager := namespace.NewManager(restClient)

	return &VSphereClient{
		Client:           client,
		NamespaceManager: namespaceManager,
	}, nil
}

type VSphereClient struct {
	Client           *govmomi.Client
	NamespaceManager *namespace.Manager
}

func newGovmomiClient(ctx context.Context, vcenterURL, username, password string) (*govmomi.Client, error) {
	vCenterURL := fmt.Sprintf("https://%s:%s@%s/sdk", username, password, vcenterURL)

	// Parse the vCenter URL
	u, err := url.Parse(vCenterURL)
	if err != nil {
		return nil, fmt.Errorf("error parsing URL: %w", err)
	}

	u.User = url.UserPassword(username, password)

	// Create the client
	client, err := govmomi.NewClient(ctx, u, true)
	if err != nil {
		return nil, fmt.Errorf("error creating client: %w", err)
	}
	if !client.IsVC() {
		return nil, fmt.Errorf("not connected to vCenter Server")
	}
	if !client.Client.IsVC() {
		return nil, fmt.Errorf("not connected to vCenter Server")
	}

	return client, nil

}

func listVirtualMachineClasses(ctx context.Context, mgr *namespace.Manager) ([]string, error) {
	// List all virtual machine classes
	vmClasses, err := mgr.ListVmClasses(ctx)
	if err != nil {
		return nil, fmt.Errorf("failed to list virtual machine classes: %w", err)
	}

	var classNames []string
	for _, class := range vmClasses {
		classNames = append(classNames, class.Id)
	}

	return classNames, nil
}

func (v *VSphereClient) ListNamespaces(ctx context.Context) ([]string, error) {
	// List all supervisor namespaces
	nsList, err := v.NamespaceManager.ListNamespaces(ctx)
	if err != nil {
		return nil, fmt.Errorf("failed to list namespaces: %w", err)
	}

	var namespaceNames []string
	for _, ns := range nsList {
		namespaceNames = append(namespaceNames, ns.Namespace)
	}

	return namespaceNames, nil
}

```

example ingress:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: cleanuptest
  namespace: default
spec:
  ingressClassName: avi-lb
  rules:
    - host: cleanuptest.example.local     # an eure Domain anpassen
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: cleanuptest
                port:
                  number: 80
```

## Guidelines

Please read and follow the `CONTRIBUTION` [guidelines] of this project.

[guidelines]: https://github.com/vmware/govmomi/blob/main/CONTRIBUTING.md

