### PR TITLE
vcsim: report EvalLicense.EditionKey as vcEval, not eval

### DIFF
--- a/simulator/license_manager.go
+++ b/simulator/license_manager.go
@@ -16,7 +16,7 @@ import (
 // EvalLicense is the default license
 var EvalLicense = types.LicenseManagerLicenseInfo{
 	LicenseKey: "00000-00000-00000-00000-00000",
-	EditionKey: "eval",
+	EditionKey: "vcEval",
 	Name:       "Evaluation Mode",
 	Properties: []types.KeyAnyValue{
 		{


### PR DESCRIPTION
The Replaying of the recorded vCenter inventory -> license is returning `eval`. While the real vCenter returns the license as `vcEval`. 

The fix is to ensure we return the `vcEval` to match to what the real vCenter returns for the recorded inventory.


